### PR TITLE
Move hand-pose state out of an inflated gltf-model-plus entity.

### DIFF
--- a/src/components/hand-poses.js
+++ b/src/components/hand-poses.js
@@ -26,7 +26,7 @@ AFRAME.registerComponent("hand-pose", {
     this.from.play();
 
     const getNetworkedAvatar = el => {
-      let networkedAvatar = el.components["networked-avatar"];
+      const networkedAvatar = el.components["networked-avatar"];
       if (networkedAvatar) {
         return networkedAvatar;
       }

--- a/src/components/hand-poses.js
+++ b/src/components/hand-poses.js
@@ -26,7 +26,7 @@ AFRAME.registerComponent("hand-pose-state", {
     this.el.removeEventListener("model-loaded", this.setSelfAsStore);
   },
   setSelfAsStore(e) {
-    let poseEl = e.target.querySelector(`[hand-pose__${this.id}]`);
+    const poseEl = e.target.querySelector(`[hand-pose__${this.id}]`);
     poseEl.components[`hand-pose__${this.id}`].store = this;
   }
 });

--- a/src/components/hand-poses.js
+++ b/src/components/hand-poses.js
@@ -18,16 +18,15 @@ AFRAME.registerComponent("hand-pose-state", {
   },
   init() {
     this.setSelfAsStore = this.setSelfAsStore.bind(this);
-    this.setSelfAsStore();
   },
-  setSelfAsStore() {
-    let poseEl = this.el.querySelector(`[hand-pose__${this.id}]`);
-    if (!poseEl) {
-      window.setTimeout(() => {
-        this.setSelfAsStore();
-      }, 3000);
-      return;
-    }
+  play() {
+    this.el.addEventListener("model-loaded", this.setSelfAsStore);
+  },
+  pause() {
+    this.el.removeEventListener("model-loaded", this.setSelfAsStore);
+  },
+  setSelfAsStore(e) {
+    let poseEl = e.target.querySelector(`[hand-pose__${this.id}]`);
     poseEl.components[`hand-pose__${this.id}`].store = this;
   }
 });

--- a/src/components/networked-avatar.js
+++ b/src/components/networked-avatar.js
@@ -2,8 +2,5 @@ AFRAME.registerComponent("networked-avatar", {
   schema: {
     left_hand_pose: { default: 0 },
     right_hand_pose: { default: 0 }
-  },
-  init() {
-    console.log("networked-avatar", this.el);
   }
 });

--- a/src/components/networked-avatar.js
+++ b/src/components/networked-avatar.js
@@ -1,0 +1,9 @@
+AFRAME.registerComponent("networked-avatar", {
+  schema: {
+    left_hand_pose: { default: 0 },
+    right_hand_pose: { default: 0 }
+  },
+  init() {
+    console.log("networked-avatar", this.el);
+  }
+});

--- a/src/hub.html
+++ b/src/hub.html
@@ -62,7 +62,7 @@
 
                     <a-entity class="right-controller"></a-entity>
 
-                    <a-entity class="model" gltf-model-plus="inflate: true">
+                    <a-entity class="model" hand-pose-state__left hand-pose-state__right gltf-model-plus="inflate: true">
                         <template data-selector=".RootScene">
                             <a-entity ik-controller hand-pose__left hand-pose__right animation-mixer space-invader-mesh="meshSelector: .Bot_Skinned"></a-entity>
                         </template>
@@ -224,15 +224,18 @@
                 app-mode-toggle-attribute__line="mode: hud; property: visible;"
             ></a-entity>
 
-            <a-entity gltf-model-plus="inflate: true;" class="model">
+            <a-entity gltf-model-plus="inflate: true;"
+                      hand-pose-state__left
+                      hand-pose-state__right
+                      class="model">
                 <template data-selector=".RootScene">
                     <a-entity
                         ik-controller
                         animation-mixer
                         hand-pose__left
                         hand-pose__right
-                        hand-pose-controller__left="eventSrc:#player-left-controller"
-                        hand-pose-controller__right="eventSrc:#player-right-controller"
+                        hand-pose-controller__left="store:#player-rig [hand-pose-state__left];eventSrc:#player-left-controller"
+                        hand-pose-controller__right="store:#player-rig [hand-pose-state__right];eventSrc:#player-right-controller"
                     ></a-entity>
                 </template>
 

--- a/src/hub.html
+++ b/src/hub.html
@@ -55,14 +55,14 @@
             </template>
 
             <template id="remote-avatar-template">
-                <a-entity ik-root player-info>
+                <a-entity networked-avatar ik-root player-info>
                     <a-entity class="camera"></a-entity>
 
                     <a-entity class="left-controller"></a-entity>
 
                     <a-entity class="right-controller"></a-entity>
 
-                    <a-entity class="model" hand-pose-state__left hand-pose-state__right gltf-model-plus="inflate: true">
+                    <a-entity class="model" gltf-model-plus="inflate: true">
                         <template data-selector=".RootScene">
                             <a-entity ik-controller hand-pose__left hand-pose__right animation-mixer space-invader-mesh="meshSelector: .Bot_Skinned"></a-entity>
                         </template>
@@ -166,6 +166,7 @@
             app-mode-toggle-playing__character-controller="mode: hud; invert: true;"
             app-mode-toggle-playing__wasd-to-analog2d="mode: hud; invert: true;"
             player-info
+            networked-avatar
         >
 
             <a-entity
@@ -225,8 +226,6 @@
             ></a-entity>
 
             <a-entity gltf-model-plus="inflate: true;"
-                      hand-pose-state__left
-                      hand-pose-state__right
                       class="model">
                 <template data-selector=".RootScene">
                     <a-entity
@@ -234,8 +233,8 @@
                         animation-mixer
                         hand-pose__left
                         hand-pose__right
-                        hand-pose-controller__left="store:#player-rig [hand-pose-state__left];eventSrc:#player-left-controller"
-                        hand-pose-controller__right="store:#player-rig [hand-pose-state__right];eventSrc:#player-right-controller"
+                        hand-pose-controller__left="networkedAvatar:#player-rig;eventSrc:#player-left-controller"
+                        hand-pose-controller__right="networkedAvatar:#player-rig;eventSrc:#player-right-controller"
                     ></a-entity>
                 </template>
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -50,6 +50,7 @@ import "./components/gltf-model-plus";
 import "./components/gltf-bundle";
 import "./components/hud-controller";
 import "./components/stats-plus";
+import "./components/networked-avatar";
 
 import ReactDOM from "react-dom";
 import React from "react";

--- a/src/network-schemas.js
+++ b/src/network-schemas.js
@@ -9,16 +9,7 @@ function registerNetworkSchemas() {
       },
       "scale",
       "player-info",
-      {
-        selector: ".model",
-        component: "hand-pose-state__left",
-        property: "pose"
-      },
-      {
-        selector: ".model",
-        component: "hand-pose-state__right",
-        property: "pose"
-      },
+      "networked-avatar",
       {
         selector: ".camera",
         component: "position"

--- a/src/network-schemas.js
+++ b/src/network-schemas.js
@@ -10,13 +10,13 @@ function registerNetworkSchemas() {
       "scale",
       "player-info",
       {
-        selector: ".RootScene",
-        component: "hand-pose__left",
+        selector: ".model",
+        component: "hand-pose-state__left",
         property: "pose"
       },
       {
-        selector: ".RootScene",
-        component: "hand-pose__right",
+        selector: ".model",
+        component: "hand-pose-state__right",
         property: "pose"
       },
       {

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -103,6 +103,7 @@ class UIRoot extends Component {
 
   componentDidMount() {
     this.setupTestTone();
+    this.props.concurrentLoadDetector.addEventListener("concurrentload", this.onConcurrentLoad);
     this.micLevelMovingAverage = MovingAverage(100);
     this.props.scene.addEventListener("loaded", this.onSceneLoaded);
     this.props.scene.addEventListener("stateadded", this.onAframeStateChanged);

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -103,7 +103,6 @@ class UIRoot extends Component {
 
   componentDidMount() {
     this.setupTestTone();
-    this.props.concurrentLoadDetector.addEventListener("concurrentload", this.onConcurrentLoad);
     this.micLevelMovingAverage = MovingAverage(100);
     this.props.scene.addEventListener("loaded", this.onSceneLoaded);
     this.props.scene.addEventListener("stateadded", this.onAframeStateChanged);


### PR DESCRIPTION
This PR moves the hand pose state onto a component on the entity with the `gltf-model-plus` component, thus side-stepping the race condition caused by trying to network state on components that are created by `gltf-model-plus`, possibly _after_ the first network update.