### PR TITLE
Bump naf-janus-adapter to 0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "moment": "^2.22.0",
     "moment-timezone": "^0.5.14",
     "moving-average": "^1.0.0",
-    "naf-janus-adapter": "^0.8.0",
+    "naf-janus-adapter": "^0.9.0",
     "networked-aframe": "https://github.com/mozillareality/networked-aframe#mr-social-client/master",
     "nipplejs": "https://github.com/mozillareality/nipplejs#mr-social-client/master",
     "phoenix": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5400,9 +5400,9 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-naf-janus-adapter@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/naf-janus-adapter/-/naf-janus-adapter-0.8.0.tgz#61fa7185c17437f9a33b9b97b1508eb9293b4f22"
+naf-janus-adapter@^0.9.0:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/naf-janus-adapter/-/naf-janus-adapter-0.9.1.tgz#57a2ab0f57bc0b6014502e520cc7e0be49999da1"
   dependencies:
     debug "^3.1.0"
     minijanus "0.6.0"


### PR DESCRIPTION
This includes our important renegotiation timing hack to make Gear VR Chrome work reliably.