### PR TITLE
Add iOS audio context fix

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -17,6 +17,7 @@ import "aframe-billboard-component";
 import "aframe-rounded";
 import "webrtc-adapter";
 import "aframe-slice9-component";
+import "./utils/ios-audio-context-fix";
 
 import trackpad_dpad4 from "./behaviours/trackpad-dpad4";
 import joystick_dpad4 from "./behaviours/joystick-dpad4";

--- a/src/utils/ios-audio-context-fix.js
+++ b/src/utils/ios-audio-context-fix.js
@@ -1,0 +1,23 @@
+/**
+ * Mobile Safari will start Audio contexts in a "suspended" state.
+ * A user interaction (touch event) is needed in order to resume the AudioContext.
+ */
+const iDevices = /\biPhone.*Mobile|\biPod|\biPad|AppleCoreMedia/;
+
+if (iDevices.test(navigator.userAgent)) {
+  document.addEventListener("DOMContentLoaded", () => {
+    const ctx = THREE.AudioContext.getContext();
+
+    function resume() {
+      ctx.resume();
+
+      setTimeout(function() {
+        if (ctx.state === "running") {
+          document.body.removeEventListener("touchend", resume, false);
+        }
+      }, 0);
+    }
+
+    document.body.addEventListener("touchend", resume, false);
+  });
+}


### PR DESCRIPTION
Mobile Safari will start Audio contexts in a "suspended" state. A user interaction (touch event) is needed in order to resume the AudioContext. https://medium.com/@laziel/ios9-safari-web-audio-starts-in-suspended-mode-9c810848b142

This was causing users on mobile safari to not be able to hear other users.