### PR TITLE
Only import lodash.merge instead of full library

### DIFF
--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -1,5 +1,5 @@
 import { Validator } from "jsonschema";
-import { merge } from "lodash";
+import merge from "lodash/merge";
 
 const LOCAL_STORE_KEY = "___hubs_store";
 const STORE_STATE_CACHE_KEY = Symbol();


### PR DESCRIPTION
I was digging around our webpack bundle in dev tools and noticed we accidentally imported the whole lodash library. Now we just import the merge function.