### PR TITLE
Upgrade to lastest AFrame master

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,6 @@ export class App {
     this.quality = quality;
 
     if (this.scene) {
-      console.log("quality-changed", quality);
       this.scene.dispatchEvent(new CustomEvent("quality-changed", { detail: quality }));
     }
 

--- a/src/avatar-selector.html
+++ b/src/avatar-selector.html
@@ -6,9 +6,9 @@
   <title>avatar selector</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   <% if(NODE_ENV === "production") { %>
-    <script src="https://cdn.rawgit.com/brianpeiris/aframe/845825ae694449524c185c44a314d361eead4680/dist/aframe-master.min.js"></script>
+    <script src="https://cdn.rawgit.com/aframevr/aframe/dba7369/dist/aframe-master.min.js" integrity="sha384-cKjxF5vmHB6Jq8O24NlFfpIzDNKSapSmpIKyg6KzGAsliOfbCAJHxE/EZHzw9xU0" crossorigin="anonymous"></script>
   <% } else { %>
-    <script src="https://cdn.rawgit.com/brianpeiris/aframe/845825ae694449524c185c44a314d361eead4680/dist/aframe-master.js"></script>
+    <script src="https://cdn.rawgit.com/aframevr/aframe/dba7369/dist/aframe-master.js" integrity="sha384-lDPOpFIESh74q9UjPSiOy6dIBuvtUzKzBzV9UTvIDW+9eiL3PjlMRBJuTWq8se7Y" crossorigin="anonymous"></script>
   <% } %>
 </head>
 

--- a/src/avatar-selector.html
+++ b/src/avatar-selector.html
@@ -6,9 +6,9 @@
   <title>avatar selector</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   <% if(NODE_ENV === "production") { %>
-    <script src="https://cdn.rawgit.com/aframevr/aframe/dba7369/dist/aframe-master.min.js" integrity="sha384-cKjxF5vmHB6Jq8O24NlFfpIzDNKSapSmpIKyg6KzGAsliOfbCAJHxE/EZHzw9xU0" crossorigin="anonymous"></script>
+    <script src="https://cdn.rawgit.com/aframevr/aframe/3e7a4b3/dist/aframe-master.min.js" integrity="sha384-LQXa4VjhYucs9sVd5yQ3OhBXRea0jrvbHJA8CYLgTnvzxF5uvyhabSo1mX4tT2c6" crossorigin="anonymous"></script>
   <% } else { %>
-    <script src="https://cdn.rawgit.com/aframevr/aframe/dba7369/dist/aframe-master.js" integrity="sha384-lDPOpFIESh74q9UjPSiOy6dIBuvtUzKzBzV9UTvIDW+9eiL3PjlMRBJuTWq8se7Y" crossorigin="anonymous"></script>
+    <script src="https://cdn.rawgit.com/aframevr/aframe/3e7a4b3/dist/aframe-master.js" integrity="sha384-EaMOuyBOi9ERV/lVDwQgz/yFWBDWPsIju5Co6oCZZHXuvbLBO81yPWn80q0BbBn3" crossorigin="anonymous"></script>
   <% } %>
 </head>
 

--- a/src/components/bone-mute-state-indicator.js
+++ b/src/components/bone-mute-state-indicator.js
@@ -14,7 +14,6 @@ AFRAME.registerComponent("bone-mute-state-indicator", {
     this.el.addEventListener("model-loaded", () => {
       this.unmutedBone = this.el.object3D.getObjectByName(this.data.unmutedBoneName);
       this.mutedBone = this.el.object3D.getObjectByName(this.data.mutedBoneName);
-      console.log(this.unmutedBone, this.mutedBone);
       this.modelLoaded = true;
 
       this.updateMuteState();

--- a/src/components/controls-shape-offset.js
+++ b/src/components/controls-shape-offset.js
@@ -2,7 +2,7 @@ import { CONTROLLER_OFFSETS } from "./hand-controls2.js";
 
 AFRAME.registerComponent("controls-shape-offset", {
   schema: {
-    additionalOffset: { default: { x: 0, y: -0.03, z: -0.04 } }
+    additionalOffset: { type: "vec3", default: { x: 0, y: -0.03, z: -0.04 } }
   },
   init: function() {
     this.controller = null;

--- a/src/components/hand-controls2.js
+++ b/src/components/hand-controls2.js
@@ -109,7 +109,8 @@ AFRAME.registerComponent("hand-controls2", {
 
     const controlConfiguration = {
       hand: hand,
-      model: false
+      model: false,
+      orientationOffset: { x: 0, y: 0, z: 0 }
     };
 
     if (hand !== prevData) {

--- a/src/components/hand-controls2.js
+++ b/src/components/hand-controls2.js
@@ -109,8 +109,7 @@ AFRAME.registerComponent("hand-controls2", {
 
     const controlConfiguration = {
       hand: hand,
-      model: false,
-      rotationOffset: 0
+      model: false
     };
 
     if (hand !== prevData) {

--- a/src/components/hide-when-quality.js
+++ b/src/components/hide-when-quality.js
@@ -17,7 +17,6 @@ AFRAME.registerComponent("hide-when-quality", {
   },
 
   updateComponentState(quality) {
-    console.log(quality);
     this.el.setAttribute("visible", quality !== this.data);
   }
 });

--- a/src/components/hud-controller.js
+++ b/src/components/hud-controller.js
@@ -69,8 +69,9 @@ AFRAME.registerComponent("hud-controller", {
       this.lookDir.add(head.position);
       hud.position.x = this.lookDir.x;
       hud.position.z = this.lookDir.z;
-      this.lookEuler.set(0, head.rotation.y, 0);
-      hud.setRotationFromEuler(this.lookEuler);
+      hud.rotation.copy(head.rotation);
+      hud.rotation.x = 0;
+      hud.rotation.z = 0;
     }
     hud.position.y = (this.isYLocked ? this.lockedHeadPositionY : head.position.y) + offset + (1 - t) * offset;
     hud.rotation.x = (1 - t) * THREE.Math.DEG2RAD * 90;

--- a/src/components/hud-controller.js
+++ b/src/components/hud-controller.js
@@ -21,6 +21,8 @@ AFRAME.registerComponent("hud-controller", {
   init() {
     this.isYLocked = false;
     this.lockedHeadPositionY = 0;
+    this.lookDir = new THREE.Vector3();
+    this.lookEuler = new THREE.Euler();
   },
 
   pause() {
@@ -62,12 +64,13 @@ AFRAME.registerComponent("hud-controller", {
     // Reorient the hud only if the user is looking away from the hud, for right now this arbitrarily means the hud is 1/2 way animated away
     // TODO: come up with better huristics for this that maybe account for the user turning away from the hud "too far", also animate the position so that it doesnt just snap.
     if (yawDif >= yawCutoff || pitch < lookCutoff - animRange / 2) {
-      const lookDir = new THREE.Vector3(0, 0, -1);
-      lookDir.applyQuaternion(head.quaternion);
-      lookDir.add(head.position);
-      hud.position.x = lookDir.x;
-      hud.position.z = lookDir.z;
-      hud.setRotationFromEuler(new THREE.Euler(0, head.rotation.y, 0));
+      this.lookDir.set(0, 0, -1);
+      this.lookDir.applyQuaternion(head.quaternion);
+      this.lookDir.add(head.position);
+      hud.position.x = this.lookDir.x;
+      hud.position.z = this.lookDir.z;
+      this.lookEuler.set(0, head.rotation.y, 0);
+      hud.setRotationFromEuler(this.lookEuler);
     }
     hud.position.y = (this.isYLocked ? this.lockedHeadPositionY : head.position.y) + offset + (1 - t) * offset;
     hud.rotation.x = (1 - t) * THREE.Math.DEG2RAD * 90;

--- a/src/components/offset-relative-to.js
+++ b/src/components/offset-relative-to.js
@@ -18,12 +18,6 @@ AFRAME.registerComponent("offset-relative-to", {
     const offsetVector = new THREE.Vector3().copy(this.data.offset);
     this.data.target.object3D.localToWorld(offsetVector);
     this.el.setAttribute("position", offsetVector);
-
-    const headWorldRotation = this.data.target.object3D.getWorldRotation();
-    this.el.setAttribute("rotation", {
-      x: headWorldRotation.x * THREE.Math.RAD2DEG,
-      y: headWorldRotation.y * THREE.Math.RAD2DEG,
-      z: headWorldRotation.z * THREE.Math.RAD2DEG
-    });
+    this.data.target.object3D.getWorldQuaternion(this.el.object3D.quaternion);
   }
 });

--- a/src/components/scene-shadow.js
+++ b/src/components/scene-shadow.js
@@ -1,21 +1,9 @@
 // For use in environment gltf bundles to set scene shadow properties.
 AFRAME.registerComponent("scene-shadow", {
   schema: {
-    autoUpdate: {
-      type: "boolean",
-      default: true
-    },
     type: {
       type: "string",
       default: "pcf"
-    },
-    renderReverseSided: {
-      type: "boolean",
-      default: true
-    },
-    renderSingleSided: {
-      type: "boolean",
-      default: true
     }
   },
   init() {

--- a/src/components/water.js
+++ b/src/components/water.js
@@ -89,7 +89,7 @@ function MobileWater(geometry, options) {
       ${THREE.ShaderChunk["common"]}
       ${THREE.ShaderChunk["packing"]}
       ${THREE.ShaderChunk["bsdfs"]}
-      ${THREE.ShaderChunk["lights_pars"]}
+      ${THREE.ShaderChunk["lights_pars_begin"]}
 
       void main() {
       	vec4 noise = getNoise( worldPosition.xz * size );

--- a/src/hub.html
+++ b/src/hub.html
@@ -13,9 +13,9 @@
     <link href="https://fonts.googleapis.com/css?family=Zilla+Slab:300,300i,400,400i,700" rel="stylesheet">
 
     <% if(NODE_ENV === "production") { %>
-        <script src="https://cdn.rawgit.com/brianpeiris/aframe/845825ae694449524c185c44a314d361eead4680/dist/aframe-master.min.js"></script>
+        <script src="https://rawgit.com/aframevr/aframe/dba7369/dist/aframe-master.min.js"></script>
     <% } else { %>
-        <script src="https://cdn.rawgit.com/brianpeiris/aframe/845825ae694449524c185c44a314d361eead4680/dist/aframe-master.js"></script>
+        <script src="https://rawgit.com/aframevr/aframe/dba7369/dist/aframe-master.js"></script>
     <% } %>
 </head>
 

--- a/src/hub.html
+++ b/src/hub.html
@@ -13,9 +13,9 @@
     <link href="https://fonts.googleapis.com/css?family=Zilla+Slab:300,300i,400,400i,700" rel="stylesheet">
 
     <% if(NODE_ENV === "production") { %>
-        <script src="https://rawgit.com/aframevr/aframe/dba7369/dist/aframe-master.min.js"></script>
+        <script src="https://cdn.rawgit.com/aframevr/aframe/dba7369/dist/aframe-master.min.js" integrity="sha384-cKjxF5vmHB6Jq8O24NlFfpIzDNKSapSmpIKyg6KzGAsliOfbCAJHxE/EZHzw9xU0" crossorigin="anonymous"></script>
     <% } else { %>
-        <script src="https://rawgit.com/aframevr/aframe/dba7369/dist/aframe-master.js"></script>
+        <script src="https://cdn.rawgit.com/aframevr/aframe/dba7369/dist/aframe-master.js" integrity="sha384-lDPOpFIESh74q9UjPSiOy6dIBuvtUzKzBzV9UTvIDW+9eiL3PjlMRBJuTWq8se7Y" crossorigin="anonymous"></script>
     <% } %>
 </head>
 

--- a/src/hub.html
+++ b/src/hub.html
@@ -13,9 +13,9 @@
     <link href="https://fonts.googleapis.com/css?family=Zilla+Slab:300,300i,400,400i,700" rel="stylesheet">
 
     <% if(NODE_ENV === "production") { %>
-        <script src="https://cdn.rawgit.com/aframevr/aframe/dba7369/dist/aframe-master.min.js" integrity="sha384-cKjxF5vmHB6Jq8O24NlFfpIzDNKSapSmpIKyg6KzGAsliOfbCAJHxE/EZHzw9xU0" crossorigin="anonymous"></script>
+        <script src="https://cdn.rawgit.com/aframevr/aframe/3e7a4b3/dist/aframe-master.min.js" integrity="sha384-LQXa4VjhYucs9sVd5yQ3OhBXRea0jrvbHJA8CYLgTnvzxF5uvyhabSo1mX4tT2c6" crossorigin="anonymous"></script>
     <% } else { %>
-        <script src="https://cdn.rawgit.com/aframevr/aframe/dba7369/dist/aframe-master.js" integrity="sha384-lDPOpFIESh74q9UjPSiOy6dIBuvtUzKzBzV9UTvIDW+9eiL3PjlMRBJuTWq8se7Y" crossorigin="anonymous"></script>
+        <script src="https://cdn.rawgit.com/aframevr/aframe/3e7a4b3/dist/aframe-master.js" integrity="sha384-EaMOuyBOi9ERV/lVDwQgz/yFWBDWPsIju5Co6oCZZHXuvbLBO81yPWn80q0BbBn3" crossorigin="anonymous"></script>
     <% } %>
 </head>
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -9,7 +9,7 @@ patchWebGLRenderingContext();
 
 import "aframe-xr";
 import "./vendor/GLTFLoader";
-import "networked-aframe";
+import "networked-aframe/src/index";
 import "naf-janus-adapter";
 import "aframe-teleport-controls";
 import "aframe-input-mapping-component";

--- a/src/react-components/avatar-selector.js
+++ b/src/react-components/avatar-selector.js
@@ -131,7 +131,7 @@ class AvatarSelector extends Component {
       <a-entity key={avatar.id} rotation={`0 ${360 * -i / this.props.avatars.length} 0`}>
         <a-entity position="0 0 5" gltf-model-plus={`src: #${avatar.id}`} inflate="true">
           <template data-selector=".RootScene">
-            <a-entity animation-mixer />
+            <a-entity animation-mixer="" />
           </template>
 
           <a-animation
@@ -168,7 +168,7 @@ class AvatarSelector extends Component {
           </a-entity>
 
           <a-entity position="0 1.5 -5.6" rotation="-10 180 0">
-            <a-entity camera />
+            <a-entity camera="" />
           </a-entity>
 
           <a-entity

--- a/src/vendor/Water.js
+++ b/src/vendor/Water.js
@@ -159,7 +159,7 @@ THREE.Water = function(geometry, options) {
       THREE.ShaderChunk["packing"],
       THREE.ShaderChunk["bsdfs"],
       THREE.ShaderChunk["fog_pars_fragment"],
-      THREE.ShaderChunk["lights_pars"],
+      THREE.ShaderChunk["lights_pars_begin"],
       THREE.ShaderChunk["shadowmap_pars_fragment"],
       THREE.ShaderChunk["shadowmask_pars_fragment"],
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -194,7 +194,7 @@ aframe-slice9-component@^1.0.0:
 
 "aframe-teleport-controls@https://github.com/mozillareality/aframe-teleport-controls#hubs/master":
   version "0.3.2"
-  resolved "https://github.com/mozillareality/aframe-teleport-controls#9e2ef7da57144c4a615eba40a945d4cfa105a092"
+  resolved "https://github.com/mozillareality/aframe-teleport-controls#b241e71b256450cdd7a2331d0ab02cf401029493"
 
 "aframe-xr@github:brianpeiris/aframe-xr#3162aed":
   version "0.0.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2012,8 +2012,8 @@ colormin@^1.0.5:
     has "^1.0.1"
 
 colors@*:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.1.tgz#f4a3d302976aaf042356ba1ade3b1a2c62d9d794"
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.3.tgz#1b152a9c4f6c9f74bc4bb96233ad0b7983b79744"
 
 colors@1.0.3:
   version "1.0.3"
@@ -5448,7 +5448,7 @@ neo-async@^2.5.0:
 
 "networked-aframe@https://github.com/mozillareality/networked-aframe#mr-social-client/master":
   version "0.6.1"
-  resolved "https://github.com/mozillareality/networked-aframe#3e690e113052a7ebf8e2b0a89785843690ba7c7b"
+  resolved "https://github.com/mozillareality/networked-aframe#641b5e44b8514d02925e3efb4289ca36a41c1006"
   dependencies:
     easyrtc "1.1.0"
     express "^4.10.7"


### PR DESCRIPTION
Upgrades AFrame to the [latest master CDN version](https://github.com/aframevr/aframe/commit/3e7a4b3519324a6617a18a626223df61c1615e52). Uses a subresource integrity hash to improve security when fetching resources via CDN.

Updates removed/deprecated APIs such as AFrame shadow properties and the ThreeJS  light parameters shader chunk.

React calls `el.setAttribute("component-name", true)` which results in a warning for invalid schema properties. We now use `<a-entity component-name="" />` to avoid this warning.

We now include networked-aframe's `index.js` file instead of the bundled version. This gives us source map support and generally makes debugging easier.

`networked-aframe` now uses `el.getAttribute()` instead of `el.components.hasOwnProperty()` so that we properly handle the position, rotation, scale, and visible components. Read more [here](https://github.com/MozillaReality/networked-aframe/pull/10).