### PR TITLE
Use hub ID directly as NAF/Janus room ID

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -201,7 +201,7 @@ const onReady = async () => {
     document.body.removeChild(scene);
   };
 
-  const enterScene = async (mediaStream, enterInVR, janusRoomId) => {
+  const enterScene = async (mediaStream, enterInVR, hubId) => {
     const scene = document.querySelector("a-scene");
     const playerRig = document.querySelector("#player-rig");
     document.querySelector("a-scene canvas").classList.remove("blurred");
@@ -216,7 +216,7 @@ const onReady = async () => {
     document.querySelector("#player-camera").setAttribute("look-controls", "");
 
     scene.setAttribute("networked-scene", {
-      room: janusRoomId,
+      room: hubId,
       serverURL: process.env.JANUS_SERVER
     });
 
@@ -349,7 +349,7 @@ const onReady = async () => {
 
   if (qs.room) {
     // If ?room is set, this is `yarn start`, so just use a default environment and query string room.
-    remountUI({ janusRoomId: qs.room && !isNaN(parseInt(qs.room)) ? parseInt(qs.room) : 1 });
+    remountUI({ hubId: qs.room || "default" });
     initialEnvironmentEl.setAttribute("gltf-bundle", {
       src: DEFAULT_ENVIRONMENT_URL
     });
@@ -379,7 +379,7 @@ const onReady = async () => {
       const hub = data.hubs[0];
       const defaultSpaceTopic = hub.topics[0];
       const gltfBundleUrl = defaultSpaceTopic.assets.find(a => a.asset_type === "gltf_bundle").src;
-      remountUI({ janusRoomId: defaultSpaceTopic.janus_room_id, hubName: hub.name });
+      remountUI({ hubId: hub.hub_id, hubName: hub.name });
       initialEnvironmentEl.setAttribute("gltf-bundle", `src: ${gltfBundleUrl}`);
       hubChannel.setPhoenixChannel(channel);
     })

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -64,9 +64,9 @@ class UIRoot extends Component {
     showProfileEntry: PropTypes.bool,
     availableVREntryTypes: PropTypes.object,
     initialEnvironmentLoaded: PropTypes.bool,
-    janusRoomId: PropTypes.number,
     roomUnavailableReason: PropTypes.string,
     platformUnsupportedReason: PropTypes.string,
+    hubId: PropTypes.string,
     hubName: PropTypes.string,
     occupantCount: PropTypes.number
   };
@@ -488,7 +488,7 @@ class UIRoot extends Component {
       screenfull.request();
     }
 
-    this.props.enterScene(this.state.mediaStream, this.state.enterInVR, this.props.janusRoomId);
+    this.props.enterScene(this.state.mediaStream, this.state.enterInVR, this.props.hubId);
 
     const mediaStream = this.state.mediaStream;
 
@@ -572,7 +572,7 @@ class UIRoot extends Component {
       );
     }
 
-    if (!this.props.initialEnvironmentLoaded || !this.props.availableVREntryTypes || !this.props.janusRoomId) {
+    if (!this.props.initialEnvironmentLoaded || !this.props.availableVREntryTypes || !this.props.hubId) {
       return (
         <IntlProvider locale={lang} messages={messages}>
           <div className="loading-panel">


### PR DESCRIPTION
**Warning: we should think before deploying this code.**

This obsoletes the `janusRoomId` that comes back from the hub Phoenix channel -- we can remove that from Reticulum in the future.

When we deploy this, people who join "the same" hub post-deploy as people who joined it pre-deploy will find themselves into a separate room. The pre-deploy folks will have to refresh to get into the new version of the hub. So maybe we should do it when not many people are using the service. I'm not sure what other reasonable thing we can do to mitigate the disruption -- in the future, we should probably be able to pop up a "Client updated -- please refresh" notice on people's browsers.