### PR TITLE
fix expiry date for Chrome Origin-Trial token (see issue #320)

### DIFF
--- a/scripts/default.env
+++ b/scripts/default.env
@@ -1,7 +1,7 @@
 # This origin trial token is used to enable WebVR and Gamepad Extensions on Chrome 62+
 # You can find more information about getting your own origin trial token here: https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md
 ORIGIN_TRIAL_TOKEN="AgN/JtqSF6qpD3OZk8KgM5/UYqUUrwc166cOQSRCqvU+TIpHWdiwBUWH5V1K/jJkdtBrO4Q5I0XSGm16uB/Y4QQAAABVeyJvcmlnaW4iOiJodHRwczovL2h1YnMubW96aWxsYS5jb206NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xTTYyIiwiZXhwaXJ5IjoxNTI4MjQ1ODI1fQ=="
-ORIGIN_TRIAL_EXPIRES="2018-05-15"
+ORIGIN_TRIAL_EXPIRES="2018-06-05"
 JANUS_SERVER="wss://prod-janus.reticulum.io"
 DEV_RETICULUM_SERVER="dev.reticulum.io"
 ASSET_BUNDLE_SERVER="https://asset-bundles-prod.reticulum.io"


### PR DESCRIPTION
from https://github.com/mozilla/hubs/issues/320#issuecomment-386713861:

> through the [`check-token` page](https://googlechrome.github.io/OriginTrials/check-token.html), I was able to verify the current Origin-Trial token expires on June 5, 2018.
> 
> there are extended WebVR trials too (sigh) and now _WebXR_ trials as well (both filed under issue #365).