### PR TITLE
Set HTML prefix for smoke outputs

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -259,7 +259,7 @@ module.exports = () => {
         } else if (plugin instanceof LodashTemplatePlugin) {
           return new LodashTemplatePlugin({
             ...plugin.options,
-            imports: { ...plugin.options.imports, HTML_PREFIX: "smoke-" }
+            imports: { ...plugin.options.imports, HTML_PREFIX: SMOKE_PREFIX }
           });
         }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -223,7 +223,7 @@ const config = {
       // expose these variables to the lodash template
       // ex: <%= ORIGIN_TRIAL_TOKEN %>
       imports: {
-        HTML_PREFIX: process.env.GENERATE_SMOKE_TESTS ? SMOKE_PREFIX : "",
+        HTML_PREFIX: "",
         NODE_ENV: process.env.NODE_ENV,
         ORIGIN_TRIAL_EXPIRES: process.env.ORIGIN_TRIAL_EXPIRES,
         ORIGIN_TRIAL_TOKEN: process.env.ORIGIN_TRIAL_TOKEN
@@ -256,6 +256,11 @@ module.exports = () => {
               filename: SMOKE_PREFIX + plugin.options.filename
             })
           );
+        } else if (plugin instanceof LodashTemplatePlugin) {
+          return new LodashTemplatePlugin({
+            ...plugin.options,
+            imports: { ...plugin.options.imports, HTML_PREFIX: "smoke-" }
+          });
         }
 
         return plugin;


### PR DESCRIPTION
Fixes an issue causing the HTML prefix to always be set to `smoke-`, which causes the app to always use the smoke box for the avatar selector.