### PR TITLE
fix autoplay background video on homepage for iOS

### DIFF
--- a/src/react-components/home-root.js
+++ b/src/react-components/home-root.js
@@ -35,28 +35,19 @@ class HomeRoot extends Component {
 
   loadHomeVideo = () => {
     const videoEl = document.querySelector("#background-video");
-    function initVideo() {
-      videoEl.playbackRate = 0.75;
-      videoEl.play();
-      function toggleVideo() {
-        // Play the video if the window/tab is visible.
-        if (!("hasFocus" in document)) {
-          return;
-        }
-        if (document.hasFocus()) {
-          videoEl.play();
-        } else {
-          videoEl.pause();
-        }
+    videoEl.playbackRate = 0.75;
+    function toggleVideo() {
+      // Play the video if the window/tab is visible.
+      if (document.hasFocus()) {
+        videoEl.play();
+      } else {
+        videoEl.pause();
       }
+    }
+    if ("hasFocus" in document) {
       document.addEventListener("visibilitychange", toggleVideo);
       window.addEventListener("focus", toggleVideo);
       window.addEventListener("blur", toggleVideo);
-    }
-    if (videoEl.readyState >= videoEl.HAVE_FUTURE_DATA) {
-      initVideo();
-    } else {
-      videoEl.addEventListener("canplay", initVideo);
     }
   };
 
@@ -208,7 +199,7 @@ class HomeRoot extends Component {
               </div>
             </div>
           </div>
-          <video playsInline muted loop className="background-video" id="background-video">
+          <video playsInline muted loop autoPlay className="background-video" id="background-video">
             <source src={homeVideoWebM} type="video/webm" />
             <source src={homeVideoMp4} type="video/mp4" />
           </video>


### PR DESCRIPTION
this works on Android. and even though the usage of `videoEl.play()` seems to be correct per [Safari for iOS' `<video>` policies](https://webkit.org/blog/6784/new-video-policies-for-ios/), for some reason in Safari for iOS, both `videoEl.readyState` and the `canplay` event is not firing. the automatic playback is fixed by adding back the `autoplay` attribute to the `<video>` element. here we still keep the logic for pausing the video on tab/window `visibilitychange`/`blur`/`focus`. apologies for the regression! 😭 I'll make sure I look at the next smoke-test before this is merged and pushed out. thank you!