### PR TITLE
Add visual indicator to bubble toggling and invading and tweak params

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -256,7 +256,6 @@
                 class="camera"
                 camera
                 position="0 1.6 0"
-                personal-space-bubble="radius: 0.4"
             >
                 <a-entity
                     id="gaze-teleport"
@@ -329,6 +328,7 @@
 
                 <template data-selector=".Neck">
                     <a-entity>
+                        <a-entity personal-space-bubble="radius: 1" position="0 -0.3 0"></a-entity>
                         <a-entity class="nametag" visible="false" text ></a-entity>
                     </a-entity>
                 </template>


### PR DESCRIPTION
Shows an expanding bubble on toggling the space bubble on/off and flashes the bubble (with a cooldown) when personal space is invaded. This should hopefully help users understand what the bubble toggle does and how the bubble works in general.

Also moved the space bubble to the chest instead of head, bumped the radius to 1m and decreased the transparency of invading avatars further.

Fixes #328