### PR TITLE
Feature/debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ yarn build
 - `mobile` - Force mobile mode
 - `no_stats` - Disable performance stats
 - `vr_entry_type` - Either "gearvr" or "daydream". Used internally to force a VR entry type
+- `disable_telemetry` - If `true` disables Sentry telemetry.
+- `log_filter` - A `debug` style filter for setting the logging level.
+- `debug` - If `true` performs verbose logging of Janus and NAF traffic.
 
 ## Additional Resources
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -246,9 +246,12 @@ const onReady = async () => {
 
     scene.setAttribute("networked-scene", {
       room: hubId,
-      serverURL: process.env.JANUS_SERVER,
-      debug: isDebug
+      serverURL: process.env.JANUS_SERVER
     });
+
+    if (isDebug) {
+      scene.setAttribute("networked-scene", { debug: true });
+    }
 
     scene.setAttribute("stats-plus", false);
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -6,6 +6,7 @@ import { patchWebGLRenderingContext } from "./utils/webgl";
 patchWebGLRenderingContext();
 
 import "aframe-xr";
+import debug from "debug";
 import "./vendor/GLTFLoader";
 import "networked-aframe/src/index";
 import "naf-janus-adapter";
@@ -129,9 +130,17 @@ function qsTruthy(param) {
 }
 
 const isBotMode = qsTruthy("bot");
+const isTelemetryDisabled = qsTruthy("disable_telemetry");
+const isDebug = qsTruthy("debug");
+const logFilter = qs["log_filter"] || (isDebug && "naf-janus-adapter:*");
 
-if (!isBotMode) {
+if (!isBotMode && !isTelemetryDisabled) {
   registerTelemetry();
+}
+
+// NOTE: this needs to happen after a-frame's `utils/debug.js` file has been eval'ed because it overwrites any prior debug settings :/
+if (logFilter) {
+  debug.enable(logFilter);
 }
 
 disableiOSZoom();
@@ -237,7 +246,8 @@ const onReady = async () => {
 
     scene.setAttribute("networked-scene", {
       room: hubId,
-      serverURL: process.env.JANUS_SERVER
+      serverURL: process.env.JANUS_SERVER,
+      debug: isDebug
     });
 
     scene.setAttribute("stats-plus", false);
@@ -310,11 +320,16 @@ const onReady = async () => {
       scene.components["networked-scene"].connect().catch(connectError => {
         // hacky until we get return codes
         const isFull = connectError.error && connectError.error.msg.match(/\bfull\b/i);
+        console.error(connectError);
         remountUI({ roomUnavailableReason: isFull ? "full" : "connect_error" });
         exitScene();
 
         return;
       });
+
+      if (isDebug) {
+        NAF.connection.adapter.session.options.verbose = true;
+      }
 
       if (isBotMode) {
         playerRig.setAttribute("avatar-replay", {


### PR DESCRIPTION
This PR:

- Adds `disable_telemetry` to turn off Sentry
- Adds `log_filter` to allow overriding the debug log level
- Adds a simple `debug=true` flag to enable verbose logging
- Logs Janus connection errors to the console