### PR TITLE
explicitly switch between dynamic and static body types

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "aframe-input-mapping-component": "https://github.com/mozillareality/aframe-input-mapping-component#hubs/master",
     "aframe-motion-capture-components": "https://github.com/mozillareality/aframe-motion-capture-components#1ca616fa67b627e447b23b35a09da175d8387668",
     "aframe-physics-extras": "^0.1.3",
-    "aframe-physics-system": "github:infinitelee/aframe-physics-system#hubs/master",
+    "aframe-physics-system": "github:donmccurdy/aframe-physics-system",
     "aframe-rounded": "^1.0.3",
     "aframe-slice9-component": "^1.0.0",
     "aframe-teleport-controls": "https://github.com/mozillareality/aframe-teleport-controls#hubs/master",

--- a/src/components/super-networked-interactable.js
+++ b/src/components/super-networked-interactable.js
@@ -13,7 +13,7 @@ AFRAME.registerComponent("super-networked-interactable", {
     NAF.utils.getNetworkedEntity(this.el).then(networkedEl => {
       this.networkedEl = networkedEl;
       if (!NAF.utils.isMine(networkedEl)) {
-        this.el.setAttribute("body", { type: "dynamic", mass: 0 });
+        this.el.setAttribute("body", { type: "static", mass: 0 });
       } else {
         this.counter.register(networkedEl);
       }
@@ -46,7 +46,7 @@ AFRAME.registerComponent("super-networked-interactable", {
     this.hand = e.detail.hand;
     if (this.networkedEl && !NAF.utils.isMine(this.networkedEl)) {
       if (NAF.utils.takeOwnership(this.networkedEl)) {
-        this.el.setAttribute("body", { mass: this.data.mass });
+        this.el.setAttribute("body", { type: "dynamic", mass: this.data.mass });
         this.counter.register(this.networkedEl);
       } else {
         this.el.emit("grab-end", { hand: this.hand });
@@ -56,7 +56,7 @@ AFRAME.registerComponent("super-networked-interactable", {
   },
 
   _onOwnershipLost: function() {
-    this.el.setAttribute("body", { mass: 0 });
+    this.el.setAttribute("body", { type: "static", mass: 0 });
     this.el.emit("grab-end", { hand: this.hand });
     this.hand = null;
     this.counter.deregister(this.el);

--- a/yarn.lock
+++ b/yarn.lock
@@ -178,9 +178,9 @@ aframe-physics-extras@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/aframe-physics-extras/-/aframe-physics-extras-0.1.3.tgz#803e2164fb96c0a80f2d1a81458f3277f262b130"
 
-"aframe-physics-system@github:infinitelee/aframe-physics-system#hubs/master":
+"aframe-physics-system@github:donmccurdy/aframe-physics-system":
   version "3.1.2"
-  resolved "https://codeload.github.com/infinitelee/aframe-physics-system/tar.gz/db255b319ba3e51ef4f5ef3654a486bd1db3200a"
+  resolved "https://codeload.github.com/donmccurdy/aframe-physics-system/tar.gz/c142a301e3ce76f88bab817c89daa5b3d4d97815"
   dependencies:
     browserify "^14.3.0"
     budo "^10.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -179,8 +179,8 @@ aframe-physics-extras@^0.1.3:
   resolved "https://registry.yarnpkg.com/aframe-physics-extras/-/aframe-physics-extras-0.1.3.tgz#803e2164fb96c0a80f2d1a81458f3277f262b130"
 
 "aframe-physics-system@github:infinitelee/aframe-physics-system#hubs/master":
-  version "3.1.1"
-  resolved "https://codeload.github.com/infinitelee/aframe-physics-system/tar.gz/80a722ddc9496e4fc867fb3662f61b389d0fd4ca"
+  version "3.1.2"
+  resolved "https://codeload.github.com/infinitelee/aframe-physics-system/tar.gz/db255b319ba3e51ef4f5ef3654a486bd1db3200a"
   dependencies:
     browserify "^14.3.0"
     budo "^10.0.3"


### PR DESCRIPTION
This should be a performance boost when there are many non-owned interactables in the scene because there are calculations that are run only on bodies set to dynamic in CANNON. See instances of `if(this.type !== Body.DYNAMIC)` in https://github.com/schteppe/cannon.js/blob/master/src/objects/Body.js

`aframe-physics-system` PR to allow this here: https://github.com/donmccurdy/aframe-physics-system/pull/97