### PR TITLE
Add now entry type

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ yarn build
 - `quality` - Either "low" or "high". Force assets to a certain quality level
 - `mobile` - Force mobile mode
 - `no_stats` - Disable performance stats
-- `vr_entry_type` - Either "gearvr" or "daydream". Used internally to force a VR entry type
+- `vr_entry_type` - Either "2d", "vr", or "daydream". Used internally to force a VR entry type. Add "_now" to the end of the value to skip the audio check.
 - `disable_telemetry` - If `true` disables Sentry telemetry.
 - `log_filter` - A `debug` style filter for setting the logging level.
 - `debug` - If `true` performs verbose logging of Janus and NAF traffic.

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -159,11 +159,11 @@ class UIRoot extends Component {
   handleForcedVREntryType = () => {
     if (!this.props.forcedVREntryType) return;
 
-    if (this.props.forcedVREntryType === "daydream") {
+    if (this.props.forcedVREntryType.startsWith("daydream")) {
       this.enterDaydream();
-    } else if (this.props.forcedVREntryType === "vr") {
+    } else if (this.props.forcedVREntryType.startsWith("vr")) {
       this.enterVR();
-    } else if (this.props.forcedVREntryType === "2d") {
+    } else if (this.props.forcedVREntryType.startsWith("2d")) {
       this.enter2D();
     }
   };
@@ -250,7 +250,7 @@ class UIRoot extends Component {
 
     if (hasGrantedMic) {
       await this.setMediaStreamToDefault();
-      this.beginAudioSetup();
+      this.beginOrSkipAudioSetup();
     } else {
       this.setState({ entryStep: ENTRY_STEPS.mic_grant });
     }
@@ -411,10 +411,10 @@ class UIRoot extends Component {
       if (hasAudio) {
         this.setState({ entryStep: ENTRY_STEPS.mic_granted });
       } else {
-        this.beginAudioSetup();
+        this.beginOrSkipAudioSetup();
       }
     } else {
-      this.beginAudioSetup();
+      this.beginOrSkipAudioSetup();
     }
   };
 
@@ -422,8 +422,12 @@ class UIRoot extends Component {
     this.setState({ showProfileEntry: false });
   };
 
-  beginAudioSetup = () => {
-    this.setState({ entryStep: ENTRY_STEPS.audio_setup });
+  beginOrSkipAudioSetup = () => {
+    if (!this.props.forcedVREntryType || !this.props.forcedVREntryType.endsWith("_now")) {
+      this.setState({ entryStep: ENTRY_STEPS.audio_setup });
+    } else {
+      setTimeout(this.onAudioReadyButton, 3000); // Need to wait otherwise input doesn't work :/
+    }
   };
 
   fetchMicDevices = () => {


### PR DESCRIPTION
This PR makes it so you can add `_now` to the end of the `vr_entry_type` query string parameter to skip the audio setup (and potentially other steps if we add them later.) Very useful for quick debug cycle.