### PR TITLE
Add hubs.local as valid domain for webpack dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ To bundle javascript and generate the html templates, run:
 yarn build
 ```
 
+## hubs.local Host Entry
+
+When running the full stack for Hubs (which includes [Reticulum](https://github.com/mozilla/reticulum))
+locally it is necessary to add a `hosts` entry pointing `hubs.local` to your local server's IP.
+This will allow the CSP checks to pass that are served up by Reticulum so you can test the whole app.
+
 ## Query Params
 
 - `room` - Id of the room (an integer) that you want to join

--- a/scripts/build_local_reticulum.sh
+++ b/scripts/build_local_reticulum.sh
@@ -4,4 +4,4 @@ if [ ! -e ../reticulum ]; then
   echo "This script assumes reticulum is checked out in a sibling to this folder."
 fi
 
-rm -rf ../reticulum/priv/static ; GENERATE_SMOKE_TESTS=true BASE_ASSETS_PATH=https://hubs.test:4000/ yarn build -- --output-path ../reticulum/priv/static 
+rm -rf ../reticulum/priv/static ; GENERATE_SMOKE_TESTS=true BASE_ASSETS_PATH=https://hubs.local:4000/ yarn build -- --output-path ../reticulum/priv/static 

--- a/scripts/build_local_reticulum.sh
+++ b/scripts/build_local_reticulum.sh
@@ -4,4 +4,4 @@ if [ ! -e ../reticulum ]; then
   echo "This script assumes reticulum is checked out in a sibling to this folder."
 fi
 
-rm -rf ../reticulum/priv/static ; GENERATE_SMOKE_TESTS=true BASE_ASSETS_PATH=https://localhost:4000/ yarn build -- --output-path ../reticulum/priv/static 
+rm -rf ../reticulum/priv/static ; GENERATE_SMOKE_TESTS=true BASE_ASSETS_PATH=https://hubs.test:4000/ yarn build -- --output-path ../reticulum/priv/static 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,7 @@ function createHTTPSConfig() {
               },
               {
                 type: 2,
-                value: "hubs.test"
+                value: "hubs.local"
               }
             ]
           }
@@ -97,7 +97,7 @@ const config = {
     https: createHTTPSConfig(),
     host: "0.0.0.0",
     useLocalIp: true,
-    public: "hubs.test:8080",
+    public: "hubs.local:8080",
     port: 8080,
     before: function(app) {
       // networked-aframe makes HEAD requests to the server for time syncing. Respond with an empty body.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,10 @@ function createHTTPSConfig() {
               {
                 type: 2,
                 value: "localhost"
+              },
+              {
+                type: 2,
+                value: "hubs.test"
               }
             ]
           }
@@ -93,6 +97,7 @@ const config = {
     https: createHTTPSConfig(),
     host: "0.0.0.0",
     useLocalIp: true,
+    public: "hubs.test:8080",
     port: 8080,
     before: function(app) {
       // networked-aframe makes HEAD requests to the server for time syncing. Respond with an empty body.


### PR DESCRIPTION
In order to support running the full stack on a VM, this PR (along with https://github.com/mozilla/reticulum/pull/39) sets things up so you can set `hubs.test` in your local `hosts` file to any IP you'd like to use for testing.