### PR TITLE
Don't do FFT just to get volume

### DIFF
--- a/src/components/audio-feedback.js
+++ b/src/components/audio-feedback.js
@@ -33,20 +33,6 @@ AFRAME.registerComponent("networked-audio-analyser", {
 });
 
 /**
- * Sets an entity's color base on audioFrequencyChange events.
- * @component matcolor-audio-feedback
- */
-AFRAME.registerComponent("matcolor-audio-feedback", {
-  tick() {
-    const audioAnalyser = this.el.components["networked-audio-analyser"];
-
-    if (!audioAnalyser || !this.mat) return;
-
-    this.object3D.mesh.color.setScalar(1 + audioAnalyser.volume * 16);
-  }
-});
-
-/**
  * Sets an entity's scale base on audioFrequencyChange events.
  * @namespace avatar
  * @component scale-audio-feedback


### PR DESCRIPTION
A time-domain array of float samples is what the browser (both Chrome and FF) actually has, and it's also sufficient for computing a volume level, so don't do extra work to get frequency-domain byte samples out.

I tested this and it looked reasonably good to me and similar to the existing implementation with smoothing = 0.3 -- the exact parameter value is a matter of taste.