### PR TITLE
Remove moment as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,6 @@
     "event-target-shim": "^3.0.1",
     "form-urlencoded": "^2.0.4",
     "jsonschema": "^1.2.2",
-    "moment": "^2.22.0",
-    "moment-timezone": "^0.5.14",
     "moving-average": "^1.0.0",
     "naf-janus-adapter": "^0.10.1",
     "networked-aframe": "https://github.com/mozillareality/networked-aframe#mr-social-client/master",

--- a/src/hub.js
+++ b/src/hub.js
@@ -1,5 +1,4 @@
 import "./assets/stylesheets/hub.scss";
-import moment from "moment-timezone";
 import queryString from "query-string";
 
 import { patchWebGLRenderingContext } from "./utils/webgl";
@@ -334,7 +333,7 @@ const onReady = async () => {
       document.body.addEventListener("connected", () => {
         if (!isBotMode) {
           hubChannel.sendEntryEvent().then(() => {
-            store.update({ activity: { lastEnteredAt: moment().toJSON() } });
+            store.update({ activity: { lastEnteredAt: new Date().toISOString() } });
           });
         }
         remountUI({ occupantCount: NAF.connection.adapter.publisher.initialOccupants.length + 1 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5406,16 +5406,6 @@ module-deps@^6.0.0:
     through2 "^2.0.0"
     xtend "^4.0.0"
 
-moment-timezone@^0.5.14:
-  version "0.5.14"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.14.tgz#4eb38ff9538b80108ba467a458f3ed4268ccfcb1"
-  dependencies:
-    moment ">= 2.9.0"
-
-"moment@>= 2.9.0", moment@^2.22.0:
-  version "2.22.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.0.tgz#7921ade01017dd45186e7fee5f424f0b8663a730"
-
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
This was 400KB of functionality we didn't really need.

The only functionality difference here should be that the `isNewDayWindow` and `isNewMonthWindow` flags are based on fixed intervals of 3600 * 24 and 3600 * 24 * 30 seconds respectively, instead of being one month or day of calendar time. Frankly, this seems better to me for most kinds of analytics anyone would want to do. @gfodor should take a look and decide whether he finds that desirable or undesirable -- we could do it either way if we wanted.