### PR TITLE
Don't take all of lodash as a runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "classnames": "^2.2.5",
     "copy-to-clipboard": "^3.0.8",
     "copy-webpack-plugin": "^4.5.1",
+    "deepmerge": "^2.1.1",
     "detect-browser": "^2.1.0",
     "event-target-shim": "^3.0.1",
     "form-urlencoded": "^2.0.4",

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -1,5 +1,5 @@
 import { Validator } from "jsonschema";
-import merge from "lodash/merge";
+import merge from "deepmerge";
 
 const LOCAL_STORE_KEY = "___hubs_store";
 const STORE_STATE_CACHE_KEY = Symbol();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2501,6 +2501,10 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+deepmerge@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.1.1.tgz#e862b4e45ea0555072bf51e7fd0d9845170ae768"
+
 define-properties@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"


### PR DESCRIPTION
For some reason this was only in our devDependencies even though we were really depending on it. In any case, we don't really have a good reason to depend on it. Shaves off a few dozen kilobytes of JS.

Perhaps in the future we will get some kind of tree shaking with webpack working, but that might be difficult given how odd the A-Frame ecosystem stuff is.