### PR TITLE
Eliminate separate build for smoke- pages

### DIFF
--- a/scripts/hab-build-and-push.sh
+++ b/scripts/hab-build-and-push.sh
@@ -30,7 +30,7 @@ ln -s "$(hab pkg path core/coreutils)/bin/env" /usr/bin/env
 hab pkg install -b core/coreutils core/bash core/node core/yarn core/git core/aws-cli
 
 yarn install --cache-folder .yarn
-GENERATE_SMOKE_TESTS=true yarn build --output-path build
+yarn build --output-path build
 mkdir build/pages
 mv build/*.html build/pages
 

--- a/src/hub.html
+++ b/src/hub.html
@@ -22,7 +22,7 @@
     <script src="https://cdn.rawgit.com/gfodor/ba8f88d9f34fe9cbe59a01ce3c48420d/raw/03e31f0ef7b9eac5e947bd39e440f34df0701f75/naf-janus-adapter-logging.js" integrity="sha384-4q1V8Q88oeCFriFefFo5uEUtMzbw6K116tFyC9cwbiPr6wEe7050l5HoJUxMvnzj" crossorigin="anonymous"></script>
 </head>
 
-<body data-html-prefix="<%= HTML_PREFIX %>">
+<body>
     <audio id="test-tone">
         <source src="./assets/sfx/tone.webm" type="audio/webm"/>
         <source src="./assets/sfx/tone.mp3" type="audio/mpeg"/>

--- a/src/hub.js
+++ b/src/hub.js
@@ -164,7 +164,6 @@ function mountUI(scene, props = {}) {
   const disableAutoExitOnConcurrentLoad = qsTruthy("allow_multi");
   const forcedVREntryType = qs.get("vr_entry_type");
   const enableScreenSharing = qsTruthy("enable_screen_sharing");
-  const htmlPrefix = document.body.dataset.htmlPrefix || "";
   const showProfileEntry = !store.state.activity.hasChangedName;
 
   ReactDOM.render(
@@ -176,7 +175,6 @@ function mountUI(scene, props = {}) {
         forcedVREntryType,
         enableScreenSharing,
         store,
-        htmlPrefix,
         showProfileEntry,
         ...props
       }}

--- a/src/react-components/profile-entry-panel.js
+++ b/src/react-components/profile-entry-panel.js
@@ -8,7 +8,6 @@ class ProfileEntryPanel extends Component {
     store: PropTypes.object,
     messages: PropTypes.object,
     finished: PropTypes.func,
-    htmlPrefix: PropTypes.string,
     intl: PropTypes.object
   };
 
@@ -103,7 +102,7 @@ class ProfileEntryPanel extends Component {
               </div>
               <iframe
                 className="profile-entry__avatar-selector"
-                src={`/${this.props.htmlPrefix}avatar-selector.html#avatar_id=${this.state.avatarId}`}
+                src={`/avatar-selector.html#avatar_id=${this.state.avatarId}`}
                 ref={ifr => (this.avatarSelector = ifr)}
               />
             </div>

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -63,7 +63,6 @@ class UIRoot extends Component {
     store: PropTypes.object,
     scene: PropTypes.object,
     linkChannel: PropTypes.object,
-    htmlPrefix: PropTypes.string,
     showProfileEntry: PropTypes.bool,
     availableVREntryTypes: PropTypes.object,
     initialEnvironmentLoaded: PropTypes.bool,
@@ -853,11 +852,7 @@ class UIRoot extends Component {
                 <div className={dialogBoxContentsClassNames}>{dialogContents}</div>
 
                 {this.state.showProfileEntry && (
-                  <ProfileEntryPanel
-                    finished={this.onProfileFinished}
-                    store={this.props.store}
-                    htmlPrefix={this.props.htmlPrefix}
-                  />
+                  <ProfileEntryPanel finished={this.onProfileFinished} store={this.props.store} />
                 )}
               </div>
             )}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,8 +11,6 @@ const CopyWebpackPlugin = require("copy-webpack-plugin");
 const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 const _ = require("lodash");
 
-const SMOKE_PREFIX = "smoke-";
-
 function createHTTPSConfig() {
   if (process.env.NODE_ENV === "production") {
     return false;
@@ -260,7 +258,6 @@ const config = {
       // expose these variables to the lodash template
       // ex: <%= ORIGIN_TRIAL_TOKEN %>
       imports: {
-        HTML_PREFIX: process.env.GENERATE_SMOKE_TESTS ? SMOKE_PREFIX : "",
         NODE_ENV: process.env.NODE_ENV,
         ORIGIN_TRIAL_EXPIRES: process.env.ORIGIN_TRIAL_EXPIRES,
         ORIGIN_TRIAL_TOKEN: process.env.ORIGIN_TRIAL_TOKEN
@@ -279,29 +276,4 @@ const config = {
   ]
 };
 
-module.exports = () => {
-  if (process.env.GENERATE_SMOKE_TESTS && process.env.BASE_ASSETS_PATH) {
-    const smokeConfig = Object.assign({}, config, {
-      // Set the public path for to point to the correct assets on the smoke-test build.
-      output: Object.assign({}, config.output, {
-        publicPath: process.env.BASE_ASSETS_PATH.replace("://", `://${SMOKE_PREFIX}`)
-      }),
-      // For this config
-      plugins: config.plugins.map(plugin => {
-        if (plugin instanceof HTMLWebpackPlugin) {
-          return new HTMLWebpackPlugin(
-            Object.assign({}, plugin.options, {
-              filename: SMOKE_PREFIX + plugin.options.filename
-            })
-          );
-        }
-
-        return plugin;
-      })
-    });
-
-    return [config, smokeConfig];
-  } else {
-    return config;
-  }
-};
+module.exports = { config };


### PR DESCRIPTION
This isn't relevant now given the cleaned-up client deploy process.

Once this is merged, we can eliminate the smoke-assets Cloudfront distributions.