### PR TITLE
Feature/oculus go tlc

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "postinstall": "node ./scripts/postinstall.js",
-    "start": "cross-env NODE_ENV=development webpack-dev-server --mode=production",
+    "start": "cross-env NODE_ENV=development webpack-dev-server",
     "build": "rimraf ./public && cross-env NODE_ENV=production webpack --mode=production",
     "doc": "node ./scripts/doc/build.js",
     "prettier": "prettier --write '*.js' 'src/**/*.js'",

--- a/src/hub.js
+++ b/src/hub.js
@@ -446,6 +446,8 @@ const onReady = async () => {
   getAvailableVREntryTypes().then(availableVREntryTypes => {
     if (availableVREntryTypes.gearvr === VR_DEVICE_AVAILABILITY.yes) {
       remountUI({ availableVREntryTypes, forcedVREntryType: "gearvr" });
+    } else if (availableVREntryTypes.isInHMD) {
+      remountUI({ availableVREntryTypes, forcedVREntryType: "vr" });
     } else {
       remountUI({ availableVREntryTypes });
     }

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,9 @@ const qs = queryString.parse(location.search);
 registerTelemetry();
 
 ReactDOM.render(
-  <HomeRoot dialogType={qs.list_signup ? InfoDialog.dialogTypes.updates : null} />,
+  <HomeRoot
+    initialEnvironment={qs.initial_environment}
+    dialogType={qs.list_signup ? InfoDialog.dialogTypes.updates : null}
+  />,
   document.getElementById("home-root")
 );

--- a/src/link.html
+++ b/src/link.html
@@ -8,6 +8,12 @@
     <title>Enter Code | Hubs by Mozilla</title>
     <link href="https://fonts.googleapis.com/css?family=Zilla+Slab:300,300i,400,400i,700" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+    <% if(NODE_ENV === "production") { %>
+    <script src="https://cdn.rawgit.com/aframevr/aframe/1be48d9/dist/aframe-master.min.js" integrity="sha384-SXrfoMHbXpA5RZhIyhgaR6tQ764dDZsbFk3PiokC/tc0+NnW1yaYQMUzWtL06hnq" crossorigin="anonymous"></script>
+    <% } else { %>
+    <script src="https://cdn.rawgit.com/aframevr/aframe/1be48d9/dist/aframe-master.js" integrity="sha384-AmjDGOMbvTrrUFdeVWcBIlXRINIWnO8iwj/4VS21OWbYDsa/7nheOIyPAPJSkR6J" crossorigin="anonymous"></script>
+    <% } %>
 </head>
 
 <body>

--- a/src/react-components/home-root.js
+++ b/src/react-components/home-root.js
@@ -17,7 +17,8 @@ addLocaleData([...en]);
 class HomeRoot extends Component {
   static propTypes = {
     intl: PropTypes.object,
-    dialogType: PropTypes.symbol
+    dialogType: PropTypes.symbol,
+    initialEnvironment: PropTypes.string
   };
 
   state = {
@@ -155,7 +156,12 @@ class HomeRoot extends Component {
                 </div>
               </div>
               <div className="hero-content__create">
-                {this.state.environments.length > 0 && <HubCreatePanel environments={this.state.environments} />}
+                {this.state.environments.length > 0 && (
+                  <HubCreatePanel
+                    initialEnvironment={this.props.initialEnvironment}
+                    environments={this.state.environments}
+                  />
+                )}
               </div>
             </div>
             <div className="footer-content">

--- a/src/react-components/hub-create-panel.js
+++ b/src/react-components/hub-create-panel.js
@@ -15,16 +15,25 @@ const HUB_NAME_PATTERN = "^[A-Za-z0-9-'\":!@#$%^&*(),.?~ ]{4,64}$";
 class HubCreatePanel extends Component {
   static propTypes = {
     intl: PropTypes.object,
-    environments: PropTypes.array
+    environments: PropTypes.array,
+    initialEnvironment: PropTypes.string
   };
 
   constructor(props) {
     super(props);
 
+    let environmentIndex = Math.floor(Math.random() * props.environments.length);
+
+    if (props.initialEnvironment) {
+      environmentIndex = props.environments.findIndex(
+        e => e.name.toLowerCase() === props.initialEnvironment.toLowerCase()
+      );
+    }
+
     this.state = {
       ready: false,
       name: generateHubName(),
-      environmentIndex: Math.floor(Math.random() * props.environments.length),
+      environmentIndex,
       // HACK: expand on small screens by default to ensure scene selection possible.
       // Eventually this could/should be done via media queries.
       expanded: window.innerWidth < 420

--- a/src/utils/vr-caps-detect.js
+++ b/src/utils/vr-caps-detect.js
@@ -46,7 +46,8 @@ export async function getAvailableVREntryTypes() {
   const ua = navigator.userAgent;
   const isSamsungBrowser = browser.name === "chrome" && /SamsungBrowser/.test(ua);
   const isOculusBrowser = /Oculus/.test(ua);
-  const isInHMD = isOculusBrowser;
+  const isFirefoxReality = /Firefox Reality/.test(ua);
+  const isInHMD = isOculusBrowser || isFirefoxReality;
 
   // This needs to be kept up-to-date with the latest browsers that can support VR and Hubs.
   // Checking for navigator.getVRDisplays always passes b/c of polyfill.


### PR DESCRIPTION
This PR closes out a few odds-and-ends:

- Skips the initial step in the entry flow if you are wearing a VR headset already
- Adds a UA test for Firefox Reality
- Stops using `production` mode for webpack dev server in `yarn start`
- Fixes the code entry page, which broke due to an inadvertent dependency on A-Frame which was introduced. (this is OK I guess, because the flow for that page will have the user download A-Frame eventually anyway.)
- Adds the `initial_environment` query string parameter to the landing page, which we are going to need for the user testing in a few weeks