### PR TITLE
Add proper FxR check

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -444,10 +444,10 @@ const onReady = async () => {
   }
 
   getAvailableVREntryTypes().then(availableVREntryTypes => {
-    if (availableVREntryTypes.gearvr === VR_DEVICE_AVAILABILITY.yes) {
-      remountUI({ availableVREntryTypes, forcedVREntryType: "gearvr" });
-    } else if (availableVREntryTypes.isInHMD) {
+    if (availableVREntryTypes.isInHMD) {
       remountUI({ availableVREntryTypes, forcedVREntryType: "vr" });
+    } else if (availableVREntryTypes.gearvr === VR_DEVICE_AVAILABILITY.yes) {
+      remountUI({ availableVREntryTypes, forcedVREntryType: "gearvr" });
     } else {
       remountUI({ availableVREntryTypes });
     }

--- a/src/utils/vr-caps-detect.js
+++ b/src/utils/vr-caps-detect.js
@@ -50,7 +50,7 @@ export async function getAvailableVREntryTypes() {
   // This needs to be kept up-to-date with the latest browsers that can support VR and Hubs.
   // Checking for navigator.getVRDisplays always passes b/c of polyfill.
   const isWebVRCapableBrowser = window.hasNativeWebVRImplementation;
-  const isFirefoxReality = /Firefox for Android/.test(ua) && isWebVRCapableBrowser;
+  const isFirefoxReality = ('buildID' in navigator) && isWebVRCapableBrowser;
   const isInHMD = isOculusBrowser || isFirefoxReality;
 
   const isDaydreamCapableBrowser = !!(isWebVRCapableBrowser && browser.name === "chrome" && !isSamsungBrowser);

--- a/src/utils/vr-caps-detect.js
+++ b/src/utils/vr-caps-detect.js
@@ -50,7 +50,7 @@ export async function getAvailableVREntryTypes() {
   // This needs to be kept up-to-date with the latest browsers that can support VR and Hubs.
   // Checking for navigator.getVRDisplays always passes b/c of polyfill.
   const isWebVRCapableBrowser = window.hasNativeWebVRImplementation;
-  const isFirefoxReality = "buildID" in navigator && isWebVRCapableBrowser;
+  const isFirefoxReality = window.orientation === 0 && "buildID" in navigator && isWebVRCapableBrowser;
   const isInHMD = isOculusBrowser || isFirefoxReality;
 
   const isDaydreamCapableBrowser = !!(isWebVRCapableBrowser && browser.name === "chrome" && !isSamsungBrowser);

--- a/src/utils/vr-caps-detect.js
+++ b/src/utils/vr-caps-detect.js
@@ -46,12 +46,12 @@ export async function getAvailableVREntryTypes() {
   const ua = navigator.userAgent;
   const isSamsungBrowser = browser.name === "chrome" && /SamsungBrowser/.test(ua);
   const isOculusBrowser = /Oculus/.test(ua);
-  const isFirefoxReality = /Firefox Reality/.test(ua);
-  const isInHMD = isOculusBrowser || isFirefoxReality;
 
   // This needs to be kept up-to-date with the latest browsers that can support VR and Hubs.
   // Checking for navigator.getVRDisplays always passes b/c of polyfill.
   const isWebVRCapableBrowser = window.hasNativeWebVRImplementation;
+  const isFirefoxReality = /Firefox for Android/.test(ua) && isWebVRCapableBrowser;
+  const isInHMD = isOculusBrowser || isFirefoxReality;
 
   const isDaydreamCapableBrowser = !!(isWebVRCapableBrowser && browser.name === "chrome" && !isSamsungBrowser);
   const isIDevice = AFRAME.utils.device.isIOS();

--- a/src/utils/vr-caps-detect.js
+++ b/src/utils/vr-caps-detect.js
@@ -50,7 +50,7 @@ export async function getAvailableVREntryTypes() {
   // This needs to be kept up-to-date with the latest browsers that can support VR and Hubs.
   // Checking for navigator.getVRDisplays always passes b/c of polyfill.
   const isWebVRCapableBrowser = window.hasNativeWebVRImplementation;
-  const isFirefoxReality = ('buildID' in navigator) && isWebVRCapableBrowser;
+  const isFirefoxReality = "buildID" in navigator && isWebVRCapableBrowser;
   const isInHMD = isOculusBrowser || isFirefoxReality;
 
   const isDaydreamCapableBrowser = !!(isWebVRCapableBrowser && browser.name === "chrome" && !isSamsungBrowser);


### PR DESCRIPTION
My speculative FxR check is wrong since we are using the Fennec UA. This seems like a sane check but wanted to make sure I wasn't missing something.

To be clear, we are *not* using user agent checks to determine device capabilities -- we're using them to determine if the user is currently already in a HMD. My understanding is there's no other way to do this right now.