### PR TITLE
Simplify prod/dev build configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-dom": "^16.1.1",
     "react-intl": "^2.4.0",
     "screenfull": "^3.3.2",
-    "super-hands": "https://github.com/mozillareality/aframe-super-hands-component#hubs/master",
+    "super-hands": "https://github.com/mozillareality/aframe-super-hands-component#f8f9781d8b4c487bb544b3986000e85ed5f82fcc",
     "uuid": "^3.2.1",
     "webrtc-adapter": "^6.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "scripts": {
     "postinstall": "node ./scripts/postinstall.js",
-    "start": "cross-env NODE_ENV=development webpack-dev-server",
-    "build": "rimraf ./public && cross-env NODE_ENV=production webpack --mode=production",
+    "start": "webpack-dev-server --mode=development",
+    "build": "rimraf ./public && webpack --mode=production",
     "doc": "node ./scripts/doc/build.js",
     "prettier": "prettier --write '*.js' 'src/**/*.js'",
     "lint:js": "eslint '*.js' 'scripts/**/*.js' 'src/**/*.js'",
@@ -67,7 +67,6 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "copy-webpack-plugin": "^4.5.1",
-    "cross-env": "^5.1.3",
     "css-loader": "^1.0.0",
     "dotenv": "^5.0.1",
     "eslint": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2060,13 +2060,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-env@^5.1.3:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
-  dependencies:
-    cross-spawn "^6.0.5"
-    is-windows "^1.0.0"
-
 cross-spawn@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
@@ -4202,7 +4195,7 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
-is-windows@^1.0.0, is-windows@^1.0.1, is-windows@^1.0.2:
+is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6900,9 +6900,9 @@ style-loader@^0.20.2:
     loader-utils "^1.1.0"
     schema-utils "^0.4.5"
 
-"super-hands@https://github.com/mozillareality/aframe-super-hands-component#hubs/master":
+"super-hands@https://github.com/mozillareality/aframe-super-hands-component#f8f9781d8b4c487bb544b3986000e85ed5f82fcc":
   version "3.0.0"
-  resolved "https://github.com/mozillareality/aframe-super-hands-component#ae01ff079032177fd8cd16a2881d459b71318207"
+  resolved "https://github.com/mozillareality/aframe-super-hands-component#f8f9781d8b4c487bb544b3986000e85ed5f82fcc"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This is the normal modern webpack way to control whether the webpack config is in "production" or "development" mode, not by using `NODE_ENV`.