### PR TITLE
Small build fixups

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,6 +8,8 @@
   ],
   "plugins": [
     [ "react-intl", { "messagesDir": "./public/messages", "enforceDescriptions": false } ],
-    [ "transform-react-jsx-img-import" ]
+    "transform-react-jsx-img-import",
+    "transform-class-properties",
+    "transform-object-rest-spread"
   ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -119,10 +119,7 @@ module.exports = (env, argv) => ({
         include: [path.resolve(__dirname, "src")],
         // Exclude JS assets in node_modules because they are already transformed and often big.
         exclude: [path.resolve(__dirname, "node_modules")],
-        loader: "babel-loader",
-        query: {
-          plugins: ["transform-class-properties", "transform-object-rest-spread"]
-        }
+        loader: "babel-loader"
       },
       {
         test: /\.(scss|css)$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -125,7 +125,7 @@ module.exports = (env, argv) => ({
         }
       },
       {
-        test: /\.scss$/,
+        test: /\.(scss|css)$/,
         loader: ExtractTextPlugin.extract({
           fallback: "style-loader",
           use: [
@@ -139,20 +139,6 @@ module.exports = (env, argv) => ({
             },
             "sass-loader"
           ]
-        })
-      },
-      {
-        test: /\.css$/,
-        use: ExtractTextPlugin.extract({
-          fallback: "style-loader",
-          use: {
-            loader: "css-loader",
-            options: {
-              name: "[path][name]-[hash].[ext]",
-              localIdentName: "[name]__[local]__[hash:base64:5]",
-              camelCase: true
-            }
-          }
         })
       },
       {


### PR DESCRIPTION
Self-explanatory.

All CSS is valid SCSS, so we don't have to have separate loader chains setting redundant options for SCSS and CSS files.