### PR TITLE
Audio feedback fixes

### DIFF
--- a/src/components/audio-feedback.js
+++ b/src/components/audio-feedback.js
@@ -8,6 +8,7 @@ AFRAME.registerComponent("networked-audio-analyser", {
     this.volume = 0;
     this.prevVolume = 0;
     this.smoothing = 0.3;
+    this.threshold = 0.01;
     this.el.addEventListener("sound-source-set", event => {
       const ctx = THREE.AudioContext.getContext();
       this.analyser = ctx.createAnalyser();
@@ -28,7 +29,11 @@ AFRAME.registerComponent("networked-audio-analyser", {
       const amplitude = (this.levels[i] - 128) / 128;
       sum += amplitude * amplitude;
     }
-    this.volume = this.smoothing * Math.sqrt(sum / this.levels.length) + (1 - this.smoothing) * this.prevVolume;
+    let currVolume = Math.sqrt(sum / this.levels.length);
+    if (currVolume < this.threshold) {
+      currVolume = 0;
+    }
+    this.volume = this.smoothing * currVolume + (1 - this.smoothing) * this.prevVolume;
     this.prevVolume = this.volume;
   }
 });

--- a/src/components/audio-feedback.js
+++ b/src/components/audio-feedback.js
@@ -12,7 +12,7 @@ AFRAME.registerComponent("networked-audio-analyser", {
       const ctx = THREE.AudioContext.getContext();
       this.analyser = ctx.createAnalyser();
       this.analyser.fftSize = 32;
-      this.levels = new Float32Array(this.analyser.frequencyBinCount);
+      this.levels = new Uint8Array(this.analyser.frequencyBinCount);
       event.detail.soundSource.connect(this.analyser);
     });
   },
@@ -20,11 +20,12 @@ AFRAME.registerComponent("networked-audio-analyser", {
   tick: function() {
     if (!this.analyser) return;
 
-    this.analyser.getFloatTimeDomainData(this.levels);
+    // take care with compatibility, e.g. safari doesn't support getFloatTimeDomainData
+    this.analyser.getByteTimeDomainData(this.levels);
 
     let sum = 0;
     for (let i = 0; i < this.levels.length; i++) {
-      const amplitude = this.levels[i];
+      const amplitude = (this.levels[i] - 128) / 128;
       sum += amplitude * amplitude;
     }
     this.volume = this.smoothing * Math.sqrt(sum / this.levels.length) + (1 - this.smoothing) * this.prevVolume;


### PR DESCRIPTION
Contrary to some documentation, Safari doesn't support `getFloatTimeDomainData` (which is a shame since it's more efficient on Firefox and Chrome, but the efficiency doesn't matter much.)