### PR TITLE
Make default WDS config nicer for newbies

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -70,13 +70,11 @@ module.exports = (env, argv) => ({
   },
   devtool: argv.mode === "production" ? "source-map" : "inline-source-map",
   devServer: {
-    open: false,
     https: createHTTPSConfig(),
     host: "0.0.0.0",
     useLocalIp: true,
-    public: "hubs.local:8080",
-    port: 8080,
-    headers: { "Access-Control-Allow-Origin": "*" },
+    allowedHosts: ["hubs.local"],
+    headers: { "Access-Control-Allow-Origin": "hubs.local" },
     before: function(app) {
       // networked-aframe makes HEAD requests to the server for time syncing. Respond with an empty body.
       app.head("*", function(req, res, next) {


### PR DESCRIPTION
Now that dev Reticulum doesn't have restrictive CSP and CORS settings, we don't need to force people to use special hostnames to run against WDS.

- `open` and `port` were just reiterating the WDS defaults.
- Setting `public` to hubs.local:8080 meant that people would get a link to hubs.local:8080 in their terminal, which would be inaccessible unless they had set up their DNS to resolve that name. Now their terminal will show a link using their local IP.
- `allowedHosts` needs to be set now in place of `public` to allow access with the hubs.local domain.
- Adding fully open CORS headers is insecure and shouldn't be the default, so I changed them. The threat vector is a DNS rebinding attack (where the owner of a domain you visit changes the DNS for that domain to point to the IP address of your server, and can then make cross-origin requests to it from their page.)

Now the server should work no matter whether you access it in the browser with localhost, hubs.local, or your IP address.