### PR TITLE
Properly set npm debug log filter

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -10,9 +10,6 @@
     <link rel="shortcut icon" type="image/png" href="/favicon.ico">
     <title>Get together | Hubs by Mozilla</title>
     <link href="https://fonts.googleapis.com/css?family=Zilla+Slab:300,300i,400,400i,700" rel="stylesheet">
-
-    <!-- HACK: this has to run after A-Frame but before our bundle, since A-Frame blows away the local storage setting -->
-    <script src="https://cdn.rawgit.com/gfodor/ba8f88d9f34fe9cbe59a01ce3c48420d/raw/03e31f0ef7b9eac5e947bd39e440f34df0701f75/naf-janus-adapter-logging.js" integrity="sha384-4q1V8Q88oeCFriFefFo5uEUtMzbw6K116tFyC9cwbiPr6wEe7050l5HoJUxMvnzj" crossorigin="anonymous"></script>
 </head>
 
 <body>

--- a/src/hub.js
+++ b/src/hub.js
@@ -3,6 +3,7 @@ console.log(`Hubs version: ${process.env.BUILD_VERSION || "?"}`);
 import "./assets/stylesheets/hub.scss";
 
 import "aframe";
+import "./utils/logging";
 import { patchWebGLRenderingContext } from "./utils/webgl";
 patchWebGLRenderingContext();
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -130,12 +130,7 @@ import registerTelemetry from "./telemetry";
 
 import { getAvailableVREntryTypes, VR_DEVICE_AVAILABILITY } from "./utils/vr-caps-detect.js";
 import ConcurrentLoadDetector from "./utils/concurrent-load-detector.js";
-
-function qsTruthy(param) {
-  const val = qs.get(param);
-  // if the param exists but is not set (e.g. "?foo&bar"), its value is the empty string.
-  return val === "" || /1|on|true/i.test(val);
-}
+import qsTruthy from "./utils/qs_truthy";
 
 const isBotMode = qsTruthy("bot");
 const isTelemetryDisabled = qsTruthy("disable_telemetry");

--- a/src/react-components/2d-hud.js
+++ b/src/react-components/2d-hud.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import cx from "classnames";
 
 import styles from "../assets/stylesheets/2d-hud.scss";
+import qsTruthy from "../utils/qs_truthy";
 
 const TopHUD = ({ muted, frozen, spacebubble, onToggleMute, onToggleFreeze, onToggleSpaceBubble }) => (
   <div className={cx(styles.container, styles.top)}>
@@ -39,7 +40,7 @@ TopHUD.propTypes = {
 
 const BottomHUD = ({ onCreateObject }) => (
   <div className={cx(styles.container, styles.bottom)}>
-    {new URLSearchParams(document.location.search).get("mediaTools") === "true" && (
+    {qsTruthy("mediaTools") && (
       <div
         className={cx("ui-interactive", styles.iconButton, styles.large, styles.createObject)}
         title={"Create Object"}

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -1,15 +1,9 @@
 // A-Frame blows away any npm debug log filters so this allow the user to set the log filter
 // via the query string.
 import debug from "debug";
+import qsTruthy from "./qs_truthy";
 
 const qs = new URLSearchParams(location.search);
-
-function qsTruthy(param) {
-  const val = qs.get(param);
-  // if the param exists but is not set (e.g. "?foo&bar"), its value is the empty string.
-  return val === "" || /1|on|true/i.test(val);
-}
-
 const isDebug = qsTruthy("debug");
 const logFilter = qs.get("log_filter") || (isDebug && "naf-janus-adapter:*");
 

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -1,0 +1,18 @@
+// A-Frame blows away any npm debug log filters so this allow the user to set the log filter
+// via the query string.
+import debug from "debug";
+
+const qs = new URLSearchParams(location.search);
+
+function qsTruthy(param) {
+  const val = qs.get(param);
+  // if the param exists but is not set (e.g. "?foo&bar"), its value is the empty string.
+  return val === "" || /1|on|true/i.test(val);
+}
+
+const isDebug = qsTruthy("debug");
+const logFilter = qs.get("log_filter") || (isDebug && "naf-janus-adapter:*");
+
+if (logFilter) {
+  debug.enable(logFilter);
+}

--- a/src/utils/qs_truthy.js
+++ b/src/utils/qs_truthy.js
@@ -1,0 +1,7 @@
+const qs = new URLSearchParams(location.search);
+
+export default function qsTruthy(param) {
+  const val = qs.get(param);
+  // if the param exists but is not set (e.g. "?foo&bar"), its value is the empty string.
+  return val === "" || /1|on|true/i.test(val);
+}


### PR DESCRIPTION
Now that we have moved A-Frame into a 1st party vendor bundle, we can set the npm debug logging without this hack. (In fact, the old hack regressed because now A-Frame loads after the head script tags.)