### PR TITLE
(WIP) Rotate images that have been uploaded.

### DIFF
--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -66,6 +66,12 @@ export const addMedia = (src, resize = false) => {
         const srcUrl = new URL(response.raw);
         srcUrl.searchParams.set("token", response.meta.access_token);
         entity.setAttribute("media-loader", { src: srcUrl.href });
+        // Need to only do this media uploaded from the CAMERA, but how can we tell?
+        entity.object3D.rotation.set(
+          entity.object3D.rotation.x,
+          entity.object3D.rotation.y,
+          entity.object3D.rotation.z + ((screen.orientation.angle - 90) * Math.PI) / 180
+        );
       })
       .catch(() => {
         entity.setAttribute("media-loader", { src: "error" });


### PR DESCRIPTION
Trying to fix issue in https://github.com/mozilla/hubs/issues/451:
>  Portrait photo uploads from phone are rotated

I _only_ need to rotate images that are uploaded from the camera; The images that come from the hard drive have the correct orientation. I'm not sure yet how to detect the difference.