### PR TITLE
Remove Farspark resolution logic from gltf-model-plus

### DIFF
--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -152,8 +152,8 @@ AFRAME.registerComponent("media-loader", {
         );
         this.el.addEventListener("model-error", this.onError, { once: true });
         this.el.setAttribute("gltf-model-plus", {
-          src,
-          contentType,
+          src: raw,
+          contentType: contentType,
           inflate: true
         });
       } else {


### PR DESCRIPTION
**We can't merge this until the recent Farspark changes are configured in prod to provide Farspark URLs for subresources inside proxied GLTF files.**

Now this logic is applied in media-loader, which means we don't need to do it for GLTF components that don't need to be proxied (e.g. all of the normal Hubs assets) and we can throw out a bunch of complexity.