### PR TITLE
Support env var for adding environments to picker

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -11,6 +11,10 @@ RETICULUM_SERVER="dev.reticulum.io"
 # The root URL under which Hubs expects environment GLTF bundles to be served.
 ASSET_BUNDLE_SERVER="https://asset-bundles-prod.reticulum.io"
 
+# A comma-separated list of environment URLs to make available in the picker, besides the defaults.
+# These URLs are expected to be relative to ASSET_BUNDLE_SERVER.
+EXTRA_ENVIRONMENTS=
+
 # The root URL under which Hubs expects static assets to be served.
 BASE_ASSETS_PATH=/
 

--- a/src/assets/environments/environments.js
+++ b/src/assets/environments/environments.js
@@ -1,9 +1,11 @@
-export const ENVIRONMENT_URLS = [
-  process.env.ASSET_BUNDLE_SERVER + "/rooms/meetingroom/MeetingRoom.bundle.json",
-  process.env.ASSET_BUNDLE_SERVER + "/rooms/atrium/Atrium.bundle.json",
-  process.env.ASSET_BUNDLE_SERVER + "/rooms/MedievalFantasyBook/MedievalFantasyBook.bundle.json",
-  process.env.ASSET_BUNDLE_SERVER + "/rooms/rooftopbuilding1/RooftopBuilding1.bundle.json",
-  process.env.ASSET_BUNDLE_SERVER + "/rooms/wideopenspace/WideOpenSpace.bundle.json"
+const BASE_ENVIRONMENTS = [
+  "/rooms/meetingroom/MeetingRoom.bundle.json",
+  "/rooms/atrium/Atrium.bundle.json",
+  "/rooms/MedievalFantasyBook/MedievalFantasyBook.bundle.json",
+  "/rooms/rooftopbuilding1/RooftopBuilding1.bundle.json",
+  "/rooms/wideopenspace/WideOpenSpace.bundle.json"
 ];
+const ALL_ENVIRONMENTS = (process.env.EXTRA_ENVIRONMENTS || "").split(",").concat(BASE_ENVIRONMENTS);
 
+export const ENVIRONMENT_URLS = ALL_ENVIRONMENTS.map(x => process.env.ASSET_BUNDLE_SERVER + x);
 export const DEFAULT_ENVIRONMENT_URL = ENVIRONMENT_URLS[0];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -231,6 +231,7 @@ module.exports = (env, argv) => ({
         JANUS_SERVER: process.env.JANUS_SERVER,
         RETICULUM_SERVER: process.env.RETICULUM_SERVER,
         ASSET_BUNDLE_SERVER: process.env.ASSET_BUNDLE_SERVER,
+        EXTRA_ENVIRONMENTS: process.env.EXTRA_ENVIRONMENTS,
         BUILD_VERSION: process.env.BUILD_VERSION
       })
     })


### PR DESCRIPTION
This is a cleaned-up version of #500. I may put the proxying stuff back in also later, to save someone running the mr-social-assets server from having to click through a mixed-content warning or a self-signed SSL cert warning.