### PR TITLE
Create audio listener for video elements if one does not already exist

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -238,6 +238,16 @@ AFRAME.registerComponent("media-video", {
       this.networkedEl = networkedEl;
       this.updatePlaybackState();
     });
+
+    // from a-sound
+    const sceneEl = this.el.sceneEl;
+    sceneEl.audioListener = sceneEl.audioListener || new THREE.AudioListener();
+    if (sceneEl.camera) {
+      sceneEl.camera.add(sceneEl.audioListener);
+    }
+    sceneEl.addEventListener("camera-set-active", function(evt) {
+      evt.detail.cameraEl.getObject3D("camera").add(sceneEl.audioListener);
+    });
   },
 
   // aframe component play, unrelated to video


### PR DESCRIPTION
This fixes videos currently not being spawnable in the "wide open space" when alone due to it having no spawners (which have `sound` components that set up audio listener)