### PR TITLE
Restore custom inflators for gltf-model-plus

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -9,13 +9,6 @@ import cubeMapNegZ from "../assets/images/cubemap/negz.jpg";
 const GLTFCache = {};
 let CachedEnvMapTexture = null;
 
-AFRAME.GLTFModelPlus = {
-  components: {},
-  registerComponent(componentKey, componentName) {
-    AFRAME.GLTFModelPlus.components[componentKey] = componentName;
-  }
-};
-
 function inflateComponent(el, componentName, componentData) {
   if (!AFRAME.components[componentName]) {
     throw new Error(`Inflator failed. "${componentName}" component does not exist.`);
@@ -28,6 +21,15 @@ function inflateComponent(el, componentName, componentData) {
     el.setAttribute(componentName, componentData);
   }
 }
+
+AFRAME.GLTFModelPlus = {
+  // eslint-disable-next-line no-unused-vars
+  components: {},
+  registerComponent(componentKey, componentName, inflator) {
+    inflator = inflator || inflateComponent;
+    AFRAME.GLTFModelPlus.components[componentKey] = { inflator, componentName };
+  }
+};
 
 // From https://gist.github.com/cdata/f2d7a6ccdec071839bc1954c32595e87
 // Tracking glTF cloning here: https://github.com/mrdoob/three.js/issues/11573
@@ -153,8 +155,8 @@ const inflateEntities = function(node, templates, isRoot) {
   if (entityComponents) {
     for (const prop in entityComponents) {
       if (entityComponents.hasOwnProperty(prop) && AFRAME.GLTFModelPlus.components.hasOwnProperty(prop)) {
-        const componentName = AFRAME.GLTFModelPlus.components[prop];
-        inflateComponent(el, componentName, entityComponents[prop]);
+        const { componentName, inflator } = AFRAME.GLTFModelPlus.components[prop];
+        inflator(el, componentName, entityComponents[prop]);
       }
     }
   }


### PR DESCRIPTION
[I removed this functionality](https://github.com/mozilla/hubs/pull/532) because nobody was using it, but then not four hours later [Brian came up with a way to use it](https://github.com/mozilla/hubs/pull/536). It sounds like we agree that it's reasonable to keep it around, so here it is.