### PR TITLE
Dump aframe-extras, write nav system ourselves

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -548,13 +548,6 @@
       "resolved": "https://registry.yarnpkg.com/aframe-billboard-component/-/aframe-billboard-component-1.0.0.tgz",
       "integrity": "sha1-EM4kgnKe73OGxYRNZZF1gaYtOtw="
     },
-    "aframe-extras": {
-      "version": "github:MozillaReality/aframe-extras#f545017da417468ffa3b41f57dd32643a32f65b1",
-      "from": "github:MozillaReality/aframe-extras#three-pathfinding-0.7",
-      "requires": {
-        "three-pathfinding": "^0.7.0"
-      }
-    },
     "aframe-input-mapping-component": {
       "version": "github:mozillareality/aframe-input-mapping-component#03932457c5318db243e811d2767fe0c5a8c7e9e0",
       "from": "github:mozillareality/aframe-input-mapping-component#hubs/master"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@fortawesome/react-fontawesome": "^0.1.0",
     "aframe": "github:aframevr/aframe#1be48d9204f0919d6362ef4c4dfa955e4ef64439",
     "aframe-billboard-component": "^1.0.0",
-    "aframe-extras": "github:MozillaReality/aframe-extras#three-pathfinding-0.7",
     "aframe-input-mapping-component": "github:mozillareality/aframe-input-mapping-component#hubs/master",
     "aframe-motion-capture-components": "github:mozillareality/aframe-motion-capture-components#1ca616fa67b627e447b23b35a09da175d8387668",
     "aframe-physics-extras": "^0.1.3",
@@ -55,6 +54,7 @@
     "screenfull": "^3.3.2",
     "super-hands": "github:mozillareality/aframe-super-hands-component#f8f9781d8b4c487bb544b3986000e85ed5f82fcc",
     "three": "github:mozillareality/three.js#8b1886c384371c3e6305b757d1db7577c5201a9b",
+    "three-pathfinding": "^0.7.0",
     "three-to-cannon": "1.3.0",
     "uuid": "^3.2.1",
     "webrtc-adapter": "^6.0.2"

--- a/src/components/character-controller.js
+++ b/src/components/character-controller.js
@@ -18,6 +18,7 @@ AFRAME.registerComponent("character-controller", {
   },
 
   init: function() {
+    this.navZone = "character";
     this.navGroup = null;
     this.navNode = null;
     this.velocity = new THREE.Vector3(0, 0, 0);
@@ -157,23 +158,25 @@ AFRAME.registerComponent("character-controller", {
     };
   })(),
 
-  setPositionOnNavMesh: function(startPosition, endPosition, object3D) {
-    const nav = this.el.sceneEl.systems.nav;
-    if (nav.navMesh) {
+  setPositionOnNavMesh: function(start, end, object3D) {
+    const pathfinder = this.el.sceneEl.systems.nav.pathfinder;
+    const zone = this.navZone;
+    if (zone in pathfinder.zones) {
       if (this.navGroup == null) {
-        this.navGroup = nav.getGroup(endPosition);
+        this.navGroup = pathfinder.getGroup(zone, end);
       }
-      this.navNode = this.navNode || nav.getNode(endPosition, this.navGroup);
-      this.navNode = nav.clampStep(startPosition, endPosition, this.navGroup, this.navNode, object3D.position);
+      this.navNode = this.navNode || pathfinder.getClosestNode(end, zone, this.navGroup, true);
+      this.navNode = pathfinder.clampStep(start, end, this.navNode, zone, this.navGroup, object3D.position);
     }
   },
 
   resetPositionOnNavMesh: function(position, navPosition, object3D) {
-    const nav = this.el.sceneEl.systems.nav;
-    if (nav.navMesh) {
-      this.navGroup = nav.getGroup(position);
-      this.navNode = nav.getNode(navPosition, this.navGroup) || this.navNode;
-      this.navNode = nav.clampStep(position, position, this.navGroup, this.navNode, object3D.position);
+    const pathfinder = this.el.sceneEl.systems.nav.pathfinder;
+    const zone = this.navZone;
+    if (zone in pathfinder.zones) {
+      this.navGroup = pathfinder.getGroup(zone, position);
+      this.navNode = pathfinder.getClosestNode(navPosition, zone, this.navGroup, true) || this.navNode;
+      this.navNode = pathfinder.clampStep(position, position, this.navNode, zone, this.navGroup, object3D.position);
     }
   },
 

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -137,6 +137,9 @@ const inflateEntities = function(node, templates, isRoot) {
   node.matrix.identity();
 
   el.setObject3D(node.type.toLowerCase(), node);
+  if (node.userData.components && "nav-mesh" in node.userData.components) {
+    el.setObject3D("mesh", node);
+  }
 
   // Set the name of the `THREE.Group` to match the name of the node,
   // so that `THREE.PropertyBinding` will find (and later animate)

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -47,4 +47,14 @@ AFRAME.GLTFModelPlus.registerComponent("visible", "visible");
 AFRAME.GLTFModelPlus.registerComponent("spawn-point", "spawn-point");
 AFRAME.GLTFModelPlus.registerComponent("hoverable", "hoverable");
 AFRAME.GLTFModelPlus.registerComponent("sticky-zone", "sticky-zone");
-AFRAME.GLTFModelPlus.registerComponent("nav-mesh", "nav-mesh");
+AFRAME.GLTFModelPlus.registerComponent("nav-mesh", "nav-mesh", (el, _componentName, componentData) => {
+  const nav = AFRAME.scenes[0].systems.nav;
+  const zone = componentData.zone || "character";
+  let found = false;
+  el.object3D.traverse(node => {
+    if (node.isMesh && !found) {
+      found = true;
+      nav.loadMesh(node, zone);
+    }
+  });
+});

--- a/src/hub.js
+++ b/src/hub.js
@@ -93,6 +93,7 @@ import { connectToReticulum } from "./utils/phoenix-utils";
 import { disableiOSZoom } from "./utils/disable-ios-zoom";
 import { addMedia, resolveMedia } from "./utils/media-utils";
 
+import "./systems/nav";
 import "./systems/personal-space-bubble";
 import "./systems/app-mode";
 import "./systems/exit-on-blur";
@@ -117,7 +118,6 @@ window.APP.quality = qs.get("quality") || isMobile ? "low" : "high";
 
 import "aframe-physics-system";
 import "aframe-physics-extras";
-import "aframe-extras/src/pathfinding";
 import "super-hands";
 import "./components/super-networked-interactable";
 import "./components/networked-counter";

--- a/src/systems/nav.js
+++ b/src/systems/nav.js
@@ -1,0 +1,14 @@
+const { Pathfinding } = require("three-pathfinding");
+
+AFRAME.registerSystem("nav", {
+  init: function() {
+    this.pathfinder = new Pathfinding();
+  },
+
+  loadMesh: function(mesh, zone) {
+    this.el.object3D.updateMatrixWorld();
+    const geometry = new THREE.Geometry().fromBufferGeometry(mesh.geometry);
+    geometry.applyMatrix(mesh.matrixWorld);
+    this.pathfinder.setZoneData(zone, Pathfinding.createZone(geometry));
+  }
+});


### PR DESCRIPTION
To date, we have represented navigation meshes in GLTFs like this:

```JSON
{
  ... some other nodes
  {
    "name": "NavMesh",
    "mesh": 1,
    "extras": { "components": { "visible": false, "nav-mesh": {} } }
  }
}
```

That is, the `nav-mesh` component is directly on a mesh node that is meant to serve as the navigation mesh. This worked with the `nav-mesh` A-Frame component packaged in aframe-extras.

In Spoke, we don't attach components to the inside of GLTFs right now, only their root. So we can't attach the `nav-mesh` component to the mesh. Instead, the mesh is somewhere underneath the node with the `nav-mesh` component. Thus, the `nav-mesh` A-Frame component needed to change, or else we needed to change how we were using it. The new rule needs to be to use the first mesh which is found in the scene subtree of the `nav-mesh` component.

It turns out that the `nav-mesh` A-Frame component and associated `nav` system had very little functionality, being thin wrappers for the underlying three-pathfinding library. So it's easiest to just throw them out entirely since they are not quite what we want anyway. That's the only thing we were using aframe-extras for, so now that is thrown out too.