### PR TITLE
Make web workers go into engine bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -161,7 +161,7 @@ module.exports = (env, argv) => ({
     splitChunks: {
       cacheGroups: {
         engine: {
-          test: /[\\/]node_modules[\\/](aframe|cannon|three\.js)/,
+          test: /([\\/]src[\\/]workers|[\\/]node_modules[\\/](aframe|cannon|three\.js))/,
           priority: 100,
           name: "engine",
           chunks: "all"


### PR DESCRIPTION
The Sketchfab worker pulls in jszip, which is very large, so it's important that we don't have to download it separately in the avatar selector and hub pages.