### PR TITLE
Make source maps pop out in production again

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -157,7 +157,7 @@ module.exports = (env, argv) => ({
 
   optimization: {
     // necessary due to https://github.com/visionmedia/debug/issues/547
-    minimizer: [new UglifyJsPlugin({ uglifyOptions: { compress: { collapse_vars: false } } })],
+    minimizer: [new UglifyJsPlugin({ sourceMap: true, uglifyOptions: { compress: { collapse_vars: false } } })],
     splitChunks: {
       cacheGroups: {
         engine: {


### PR DESCRIPTION
I think this regressed in https://github.com/mozilla/hubs/pull/461. When you specify your own `minimizer`, Webpack doesn't respect your `devtool` setting anymore.

Resolves https://github.com/mozilla/hubs/issues/503.