### PR TITLE
Fix false positive detection of Firefox on Android as a standalone HMD

### DIFF
--- a/src/utils/vr-caps-detect.js
+++ b/src/utils/vr-caps-detect.js
@@ -63,8 +63,7 @@ export async function getAvailableVREntryTypes() {
     : VR_DEVICE_AVAILABILITY.no;
 
   const displays = isWebVRCapableBrowser ? await navigator.getVRDisplays() : [];
-  const isFirefoxReality = window.orientation === 0 && "buildID" in navigator && displays.length > 0;
-  const isInHMD = isOculusBrowser || isFirefoxReality;
+  const isInHMD = isOculusBrowser;
 
   const screen = isInHMD
     ? VR_DEVICE_AVAILABILITY.no


### PR DESCRIPTION
We can't readily tell the difference between Firefox Reality and Firefox on Android, so just remove this check for now.