### PR TITLE
Turn off collisions when grabbing objects.

### DIFF
--- a/src/components/sticky-object.js
+++ b/src/components/sticky-object.js
@@ -47,7 +47,7 @@ AFRAME.registerComponent("sticky-object", {
   },
 
   _onRelease() {
-    // Happens if the object is still being heald by another hand
+    // Happens if the object is still being held by another hand
     if (this.el.is("grabbed")) return;
 
     if (

--- a/src/components/sticky-object.js
+++ b/src/components/sticky-object.js
@@ -47,17 +47,21 @@ AFRAME.registerComponent("sticky-object", {
   },
 
   _onRelease() {
+    // Happens if the object is still being heald by another hand
+    if (this.el.is("grabbed")) return;
+
     if (
-      !this.el.is("grabbed") &&
       this.data.autoLockOnRelease &&
       this.el.body.velocity.lengthSquared() < this.data.autoLockSpeedLimit * this.data.autoLockSpeedLimit
     ) {
       this.setLocked(true);
     }
+    this.el.body.collisionResponse = true;
   },
 
   _onGrab() {
     this.setLocked(false);
+    this.el.body.collisionResponse = false;
   },
 
   remove() {


### PR DESCRIPTION
This helps when scaling objects or trying to stick them into other objects. It does make it so you can't hit objects with an object you are holding, but that was quite buggy anyway so it doesnt seem like a big loss. This might cause some issues with sticky-zones at some point but we will revisit that once they are actually being used sicne its likely they have regressed in other ways as well.