### PR TITLE
Upgrade naf-janus-adapter, enable websocket data transport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8933,9 +8933,9 @@
       "dev": true
     },
     "naf-janus-adapter": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/naf-janus-adapter/-/naf-janus-adapter-0.11.0.tgz",
-      "integrity": "sha512-jLwcs4TRj7Dur0bF9RjP9UyjIkdKpwNZ3q/zCXT+ytrHGRXWt4rX+9acdpg2QVEmPMumN+rr9NUPliNWpRxD3w==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/naf-janus-adapter/-/naf-janus-adapter-0.12.0.tgz",
+      "integrity": "sha512-Zt2QC/7o2haXgaqerby+DCaDYth8CDtsbMBZettsQg4wufDKbK41xhej/KM9Wwgkfopu6YiK6CK4G1kcOgL/RA==",
       "requires": {
         "debug": "^3.1.0",
         "minijanus": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "jsonschema": "^1.2.2",
     "jszip": "^3.1.5",
     "moving-average": "^1.0.0",
-    "naf-janus-adapter": "^0.11.0",
+    "naf-janus-adapter": "^0.12.0",
     "networked-aframe": "github:mozillareality/networked-aframe#master",
     "nipplejs": "github:mozillareality/nipplejs#mr-social-client/master",
     "phoenix": "^1.3.0",

--- a/src/hub.js
+++ b/src/hub.js
@@ -414,6 +414,9 @@ const onReady = async () => {
         return;
       });
 
+      NAF.connection.adapter.reliableTransport = "websocket";
+      NAF.connection.adapter.unreliableTransport = "websocket";
+
       if (isDebug) {
         NAF.connection.adapter.session.options.verbose = true;
       }


### PR DESCRIPTION
What it says on the tin. This is a maybe-temporary fix to address reliable messaging and stability stuff while we figure out what to do about Janus SCTP going forward.