### PR TITLE
Don't clone GLTF environment scenes for no reason

### DIFF
--- a/src/components/gltf-bundle.js
+++ b/src/components/gltf-bundle.js
@@ -28,7 +28,7 @@ AFRAME.registerComponent("gltf-bundle", {
 
       const src = new URL(asset.src, this.baseURL).href;
       const gltfEl = document.createElement("a-entity");
-      gltfEl.setAttribute("gltf-model-plus", { src, inflate: true });
+      gltfEl.setAttribute("gltf-model-plus", { src, useCache: false, inflate: true });
       loaded.push(new Promise(resolve => gltfEl.addEventListener("model-loaded", resolve)));
       this.el.appendChild(gltfEl);
     }

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -279,6 +279,7 @@ AFRAME.registerComponent("gltf-model-plus", {
   schema: {
     src: { type: "string" },
     contentType: { type: "string" },
+    useCache: { default: true },
     inflate: { default: false }
   },
 
@@ -300,6 +301,17 @@ AFRAME.registerComponent("gltf-model-plus", {
     });
   },
 
+  async loadModel(src, contentType, technique, useCache) {
+    if (useCache) {
+      if (!GLTFCache[src]) {
+        GLTFCache[src] = await loadGLTF(src, contentType, technique);
+      }
+      return cloneGltf(GLTFCache[src]);
+    } else {
+      return await loadGLTF(src, contentType, technique);
+    }
+  },
+
   async applySrc(src, contentType) {
     try {
       // If the src attribute is a selector, get the url from the asset item.
@@ -319,11 +331,7 @@ AFRAME.registerComponent("gltf-model-plus", {
         return;
       }
 
-      if (!GLTFCache[src]) {
-        GLTFCache[src] = loadGLTF(src, contentType, this.preferredTechnique);
-      }
-
-      const model = cloneGltf(await GLTFCache[src]);
+      const model = await this.loadModel(src, contentType, this.preferredTechnique, this.data.useCache);
 
       // If we started loading something else already
       // TODO: there should be a way to cancel loading instead

--- a/src/hub.js
+++ b/src/hub.js
@@ -561,7 +561,7 @@ const onReady = async () => {
       if (/\.gltf/i.test(sceneUrl) || /\.glb/i.test(sceneUrl)) {
         const resolved = await resolveMedia(sceneUrl, false, 0);
         const gltfEl = document.createElement("a-entity");
-        gltfEl.setAttribute("gltf-model-plus", { src: resolved.raw, inflate: true });
+        gltfEl.setAttribute("gltf-model-plus", { src: resolved.raw, useCache: false, inflate: true });
         gltfEl.addEventListener("model-loaded", () => initialEnvironmentEl.emit("bundleloaded"));
         initialEnvironmentEl.appendChild(gltfEl);
       } else {


### PR DESCRIPTION
Pretty self-explanatory, there's no reason to do this extra work on the environment and keep it in cache since there's no particular reason to believe people are going to load another copy of it.