### PR TITLE
Use components defined as a gltf extension

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -101,7 +101,8 @@ const inflateEntities = function(node, templates, isRoot) {
 
   const hubsComponents = node.userData.gltfExtensions && node.userData.gltfExtensions.HUBS_components;
 
-  // We can remove support for legacy components when our environments are updated to match Spoke output.
+  // We can remove support for legacy components when our environment, avatar and interactable models are
+  // updated to match Spoke output.
   const legacyComponents = node.userData.components;
 
   const entityComponents = hubsComponents || legacyComponents;

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -99,7 +99,14 @@ const inflateEntities = function(node, templates, isRoot) {
     }
   }
 
-  const nodeHasBehavior = node.userData.components || node.name in templates;
+  const hubsComponents = node.userData.gltfExtensions && node.userData.gltfExtensions.HUBS_components;
+
+  // We can remove support for legacy components when our environments are updated to match Spoke output.
+  const legacyComponents = node.userData.components;
+
+  const entityComponents = hubsComponents || legacyComponents;
+
+  const nodeHasBehavior = !!entityComponents || node.name in templates;
   if (!nodeHasBehavior && !childEntities.length && !isRoot) {
     return null; // we don't need an entity for this node
   }
@@ -137,7 +144,7 @@ const inflateEntities = function(node, templates, isRoot) {
   node.matrix.identity();
 
   el.setObject3D(node.type.toLowerCase(), node);
-  if (node.userData.components && "nav-mesh" in node.userData.components) {
+  if (entityComponents && "nav-mesh" in entityComponents) {
     el.setObject3D("mesh", node);
   }
 
@@ -154,7 +161,6 @@ const inflateEntities = function(node, templates, isRoot) {
     node.parent.animations = node.animations;
   }
 
-  const entityComponents = node.userData.components;
   if (entityComponents) {
     for (const prop in entityComponents) {
       if (entityComponents.hasOwnProperty(prop) && AFRAME.GLTFModelPlus.components.hasOwnProperty(prop)) {


### PR DESCRIPTION
For https://github.com/MozillaReality/Spoke/issues/43

We want to move our custom components into a proper GLTF extension namespace instead of just dumping components into `extras`.

This change maintains backwards compatibility for existing environments and gltf models.