### PR TITLE
Fix up media loading a lot

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -8,6 +8,10 @@ JANUS_SERVER="wss://dev-janus.reticulum.io"
 # See here for the server code: https://github.com/mozilla/reticulum
 RETICULUM_SERVER="dev.reticulum.io"
 
+# The Farspark backend to connect to. Used as a CORS proxy and transformer for in-world media objects.
+# See here for the server code: https://github.com/MozillaReality/farspark
+FARSPARK_SERVER="farspark-dev.reticulum.io"
+
 # The root URL under which Hubs expects environment GLTF bundles to be served.
 ASSET_BUNDLE_SERVER="https://asset-bundles-prod.reticulum.io"
 

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -29,7 +29,7 @@ AFRAME.registerComponent("media-loader", {
   schema: {
     src: { type: "string" },
     resize: { default: false },
-    resolve: { default: true },
+    resolve: { default: false },
     contentType: { default: null }
   },
 

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -9,20 +9,12 @@ gltfLoader.load(loadingObjectSrc, gltf => {
   loadingObject = gltf;
 });
 
-const contentTypeCache = new Map();
-const fetchContentType = async url => {
-  if (contentTypeCache.has(url)) return contentTypeCache.get(url);
-  const contentType = await fetch(url, { method: "HEAD" }).then(r => r.headers.get("content-type"));
-  contentTypeCache.set(url, contentType);
-  return contentType;
+const fetchContentType = url => {
+  return fetch(url, { method: "HEAD" }).then(r => r.headers.get("content-type"));
 };
 
-const contentIndexCache = new Map();
-const fetchMaxContentIndex = async (documentUrl, pageUrl) => {
-  if (contentIndexCache.has(documentUrl)) return contentIndexCache.get(documentUrl);
-  const maxIndex = await fetch(pageUrl).then(r => parseInt(r.headers.get("x-max-content-index")));
-  contentIndexCache.set(documentUrl, maxIndex);
-  return maxIndex;
+const fetchMaxContentIndex = url => {
+  return fetch(url).then(r => parseInt(r.headers.get("x-max-content-index")));
 };
 
 AFRAME.registerComponent("media-loader", {
@@ -207,7 +199,7 @@ AFRAME.registerComponent("media-pager", {
     this.el.addEventListener("image-loaded", async e => {
       // unfortunately, since we loaded the page image in an img tag inside media-image, we have to make a second
       // request for the same page to read out the max-content-index header
-      this.maxIndex = await fetchMaxContentIndex(this.data.src, e.detail.src);
+      this.maxIndex = await fetchMaxContentIndex(e.detail.src);
       // if this is the first image we ever loaded, set up the UI
       if (this.toolbar == null) {
         const template = document.getElementById("paging-toolbar");

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -1,5 +1,5 @@
 import { getBox, getScaleCoefficient } from "../utils/auto-box-collider";
-import { resolveMedia, fetchMaxContentIndex } from "../utils/media-utils";
+import { proxiedUrlFor, resolveMedia, fetchMaxContentIndex } from "../utils/media-utils";
 
 import "three/examples/js/loaders/GLTFLoader";
 import loadingObjectSrc from "../assets/LoadingObject_Atom.glb";
@@ -100,7 +100,7 @@ AFRAME.registerComponent("media-loader", {
 
       if (!src) return;
 
-      const { raw, origin, images, contentType } = await resolveMedia(src, false, index);
+      const { raw, origin, contentType } = await resolveMedia(src, false, index);
 
       // We don't want to emit media_resolved for index updates.
       if (src !== oldData.src) {
@@ -122,13 +122,14 @@ AFRAME.registerComponent("media-loader", {
           async () => {
             this.clearLoadingTimeout();
             if (isPDF) {
-              const maxIndex = await fetchMaxContentIndex(src, images.png);
+              const testImage = proxiedUrlFor(src, index);
+              const maxIndex = await fetchMaxContentIndex(src, testImage);
               this.el.setAttribute("media-pager", { index, maxIndex });
             }
           },
           { once: true }
         );
-        const imageSrc = isPDF ? images.png : raw;
+        const imageSrc = isPDF ? proxiedUrlFor(src, index) : raw;
         const imageContentType = isPDF ? "image/png" : contentType;
 
         if (!isPDF) {

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -420,6 +420,6 @@ AFRAME.registerComponent("media-image", {
 
     fitToTexture(this.el, texture);
 
-    this.el.emit("image-loaded");
+    this.el.emit("image-loaded", { src: this.data.src });
   }
 });

--- a/src/components/super-spawner.js
+++ b/src/components/super-spawner.js
@@ -16,6 +16,11 @@ AFRAME.registerComponent("super-spawner", {
     src: { default: "" },
 
     /**
+     * Whether to use the Reticulum media resolution API to interpret the src URL (e.g. find a video URL for Youtube videos.)
+     */
+    resolve: { default: false },
+
+    /**
      * The template to use for this object
      */
     template: { default: "" },
@@ -117,7 +122,7 @@ AFRAME.registerComponent("super-spawner", {
       return;
     }
 
-    const entity = addMedia(this.data.src, this.data.template, ObjectContentOrigins.SPAWNER).entity;
+    const entity = addMedia(this.data.src, this.data.template, ObjectContentOrigins.SPAWNER, this.data.resolve).entity;
 
     hand.object3D.getWorldPosition(entity.object3D.position);
     hand.object3D.getWorldQuaternion(entity.object3D.quaternion);
@@ -150,7 +155,7 @@ AFRAME.registerComponent("super-spawner", {
     const thisGrabId = nextGrabId++;
     this.heldEntities.set(hand, thisGrabId);
 
-    const entity = addMedia(this.data.src, this.data.template, ObjectContentOrigins.SPAWNER).entity;
+    const entity = addMedia(this.data.src, this.data.template, ObjectContentOrigins.SPAWNER, this.data.resolve).entity;
 
     entity.object3D.position.copy(
       this.data.useCustomSpawnPosition ? this.data.spawnPosition : this.el.object3D.position

--- a/src/hub.js
+++ b/src/hub.js
@@ -76,7 +76,7 @@ import HubChannel from "./utils/hub-channel";
 import LinkChannel from "./utils/link-channel";
 import { connectToReticulum } from "./utils/phoenix-utils";
 import { disableiOSZoom } from "./utils/disable-ios-zoom";
-import { resolveMedia } from "./utils/media-utils";
+import { proxiedUrlFor } from "./utils/media-utils";
 import SceneEntryManager from "./scene-entry-manager";
 
 import "./systems/nav";
@@ -242,9 +242,8 @@ async function handleHubChannelJoined(entryManager, hubChannel, data) {
   const environmentScene = document.querySelector("#environment-scene");
 
   if (glbAsset || hasExtension) {
-    const resolved = await resolveMedia(sceneUrl, false, 0);
     const gltfEl = document.createElement("a-entity");
-    gltfEl.setAttribute("gltf-model-plus", { src: resolved.raw, useCache: false, inflate: true });
+    gltfEl.setAttribute("gltf-model-plus", { src: proxiedUrlFor(sceneUrl), useCache: false, inflate: true });
     gltfEl.addEventListener("model-loaded", () => environmentScene.emit("bundleloaded"));
     environmentScene.appendChild(gltfEl);
   } else {

--- a/src/network-schemas.js
+++ b/src/network-schemas.js
@@ -107,6 +107,10 @@ function registerNetworkSchemas() {
       {
         component: "media-video",
         property: "videoPaused"
+      },
+      {
+        component: "media-pager",
+        property: "index"
       }
     ]
   });

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -185,7 +185,7 @@ export default class SceneEntryManager {
   _setupMedia = () => {
     const offset = { x: 0, y: 0, z: -1.5 };
     const spawnMediaInfrontOfPlayer = (src, contentOrigin) => {
-      const { entity, orientation } = addMedia(src, "#interactable-media", contentOrigin, true);
+      const { entity, orientation } = addMedia(src, "#interactable-media", contentOrigin, true, true);
 
       orientation.then(or => {
         entity.setAttribute("offset-relative-to", {

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -79,13 +79,13 @@ function getOrientation(file, callback) {
 }
 
 let interactableId = 0;
-export const addMedia = (src, template, contentOrigin, resize = false) => {
+export const addMedia = (src, template, contentOrigin, resolve = false, resize = false) => {
   const scene = AFRAME.scenes[0];
 
   const entity = document.createElement("a-entity");
   entity.id = "interactable-media-" + interactableId++;
   entity.setAttribute("networked", { template: template });
-  entity.setAttribute("media-loader", { resize, src: typeof src === "string" ? src : "" });
+  entity.setAttribute("media-loader", { resize, resolve, src: typeof src === "string" ? src : "" });
   scene.appendChild(entity);
 
   const orientation = new Promise(function(resolve) {
@@ -102,7 +102,7 @@ export const addMedia = (src, template, contentOrigin, resize = false) => {
       .then(response => {
         const srcUrl = new URL(response.raw);
         srcUrl.searchParams.set("token", response.meta.access_token);
-        entity.setAttribute("media-loader", { src: srcUrl.href });
+        entity.setAttribute("media-loader", { resolve: false, src: srcUrl.href });
       })
       .catch(() => {
         entity.setAttribute("media-loader", { src: "error" });

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -2,6 +2,17 @@ import { objectTypeForOriginAndContentType } from "../object-types";
 import { getReticulumFetchUrl } from "./phoenix-utils";
 const mediaAPIEndpoint = getReticulumFetchUrl("/api/v1/media");
 
+const commonKnownContentTypes = {
+  gltf: "model/gltf",
+  glb: "model/gltf-binary",
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  pdf: "application/pdf",
+  mp4: "video/mp4",
+  mp3: "audio/mpeg"
+};
+
 // thanks to https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding
 function b64EncodeUnicode(str) {
   // first we use encodeURIComponent to get percent-encoded UTF-8, then we convert the percent-encodings
@@ -28,6 +39,11 @@ export const resolveUrl = async (url, index) => {
   }).then(r => r.json());
   resolveUrlCache.set(cacheKey, resolved);
   return resolved;
+};
+
+export const guessContentType = url => {
+  const extension = new URL(url).pathname.split(".").pop();
+  return commonKnownContentTypes[extension];
 };
 
 export const upload = file => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -245,6 +245,7 @@ module.exports = (env, argv) => ({
         NODE_ENV: argv.mode,
         JANUS_SERVER: process.env.JANUS_SERVER,
         RETICULUM_SERVER: process.env.RETICULUM_SERVER,
+        FARSPARK_SERVER: process.env.FARSPARK_SERVER,
         ASSET_BUNDLE_SERVER: process.env.ASSET_BUNDLE_SERVER,
         EXTRA_ENVIRONMENTS: process.env.EXTRA_ENVIRONMENTS,
         BUILD_VERSION: process.env.BUILD_VERSION


### PR DESCRIPTION
Now that Farspark accepts requests from the client, we can do many nice things:

- You can now tell `media-loader` whether it needs to resolve the URL you give it into a canonical media URL using the Reticulum resolution API before loading. Otherwise, it doesn't have to do that. Basically the only time we do it is when someone pastes a mystery file into the create object box.
- As a result of ambient simplification, `media-pager` can now have all PDF-specific paging logic, drastically simplifying `media-loader`.
- We now try to infer the content type from the extension of the provided URL and don't bother making a HEAD request to test the waters if we think we know what it is. This is a nice optimization since it's handling common cases like "the ducks in our environment" and "the pens you spawn."
- The combination of these things makes PDF paging responsive and nice instead of terrible.

Next easy steps in this process:

- Clean up dead code in Reticulum, since it doesn't need to assemble Farspark URLs anymore.
- Consider making media URL resolution in Reticulum a GET request, which should eliminate the necessity of manual caching on the client.
- Clean up the Farspark API URL space to make it less annoying for the client to assemble Farspark URLs for subresources.

After that we should start thinking about how we want to unify the media resolution and proxying into one service, to further improve efficiency.