### PR TITLE
Feature/lobby

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -1,3 +1,4 @@
+import nextTick from "../utils/next-tick";
 import SketchfabZipWorker from "../workers/sketchfab-zip.worker.js";
 import cubeMapPosX from "../assets/images/cubemap/posx.jpg";
 import cubeMapNegX from "../assets/images/cubemap/negx.jpg";
@@ -188,12 +189,6 @@ function attachTemplate(root, name, templateRoot) {
       el.appendChild(root.children[0]);
     }
   }
-}
-
-function nextTick() {
-  return new Promise(resolve => {
-    setTimeout(resolve, 0);
-  });
 }
 
 function getFilesFromSketchfabZip(src) {

--- a/src/components/scene-preview-camera.js
+++ b/src/components/scene-preview-camera.js
@@ -49,7 +49,7 @@ AFRAME.registerComponent("scene-preview-camera", {
       this.el.object3D.rotation.setFromQuaternion(newRot);
     }
 
-    if (t >= 0.99) {
+    if (t >= 0.9999) {
       this.backwards = !this.backwards;
       this.startTime = new Date().getTime();
     }

--- a/src/components/scene-preview-camera.js
+++ b/src/components/scene-preview-camera.js
@@ -7,9 +7,11 @@ function lerp(start, end, t) {
   return (1 - t) * start + t * end;
 }
 
-const DURATION = 90.0;
-
 AFRAME.registerComponent("scene-preview-camera", {
+  schema: {
+    duration: { default: 90, type: "number" }
+  },
+
   init: function() {
     this.startPoint = this.el.object3D.position.clone();
     this.startRotation = new THREE.Quaternion();
@@ -29,7 +31,8 @@ AFRAME.registerComponent("scene-preview-camera", {
   },
 
   tick: function() {
-    const t = (new Date().getTime() - this.startTime) / (1000.0 * DURATION);
+    let t = (new Date().getTime() - this.startTime) / (1000.0 * this.data.duration);
+    t = (t * t) / (2 * (t * t - t) + 1);
 
     const from = this.backwards ? this.targetPoint : this.startPoint;
     const to = this.backwards ? this.startPoint : this.targetPoint;

--- a/src/components/scene-preview-camera.js
+++ b/src/components/scene-preview-camera.js
@@ -33,7 +33,7 @@ AFRAME.registerComponent("scene-preview-camera", {
 
   tick: function() {
     let t = (new Date().getTime() - this.startTime) / (1000.0 * this.data.duration);
-    t = (t * t) / (2 * (t * t - t) + 1);
+    t = (t * t) / (2 * (t * t - t) + 1); // Simple beizer smoothing
 
     const from = this.backwards ? this.targetPoint : this.startPoint;
     const to = this.backwards ? this.startPoint : this.targetPoint;

--- a/src/components/scene-preview-camera.js
+++ b/src/components/scene-preview-camera.js
@@ -9,7 +9,8 @@ function lerp(start, end, t) {
 
 AFRAME.registerComponent("scene-preview-camera", {
   schema: {
-    duration: { default: 90, type: "number" }
+    duration: { default: 90, type: "number" },
+    positionOnly: { default: false, type: "boolean" }
   },
 
   init: function() {
@@ -43,7 +44,10 @@ AFRAME.registerComponent("scene-preview-camera", {
     THREE.Quaternion.slerp(fromRot, toRot, newRot, t);
 
     this.el.object3D.position.set(lerp(from.x, to.x, t), lerp(from.y, to.y, t), lerp(from.z, to.z, t));
-    this.el.object3D.rotation.setFromQuaternion(newRot);
+
+    if (!this.data.positionOnly) {
+      this.el.object3D.rotation.setFromQuaternion(newRot);
+    }
 
     if (t >= 0.99) {
       this.backwards = !this.backwards;

--- a/src/hub.html
+++ b/src/hub.html
@@ -456,7 +456,9 @@
             id="environment-root"
             nav-mesh-helper
             static-body="shape: none;"
-        ></a-entity>
+        >
+            <a-entity id="environment-scene"/>
+        </a-entity>
 
         <a-entity
         super-spawner="

--- a/src/hub.html
+++ b/src/hub.html
@@ -324,13 +324,11 @@
         <!-- Player Rig -->
         <a-entity
             id="player-rig"
-            networked="template: #remote-avatar-template; attachTemplateToLocal: false;"
-            spawn-controller="loadedEvent: bundleloaded; target: #environment-root"
+            spawn-controller="loadedEvent: entered; target: #player-rig"
             wasd-to-analog2d
             character-controller="pivot: #player-camera"
             ik-root
             player-info
-            networked-avatar
             cardboard-controls
         >
           <a-entity
@@ -355,7 +353,6 @@
               id="player-camera"
               class="camera"
               camera
-              position="0 1.6 0"
               personal-space-bubble="radius: 0.4;"
               pitch-yaw-rotator
           >

--- a/src/hub.js
+++ b/src/hub.js
@@ -7,7 +7,6 @@ import "./utils/logging";
 import { patchWebGLRenderingContext } from "./utils/webgl";
 patchWebGLRenderingContext();
 
-import screenfull from "screenfull";
 import "three/examples/js/loaders/GLTFLoader";
 import "networked-aframe/src/index";
 import "naf-janus-adapter";
@@ -27,7 +26,6 @@ import joystick_dpad4 from "./behaviours/joystick-dpad4";
 import msft_mr_axis_with_deadzone from "./behaviours/msft-mr-axis-with-deadzone";
 import { PressedMove } from "./activators/pressedmove";
 import { ReverseY } from "./activators/reversey";
-import { ObjectContentOrigins } from "./object-types";
 
 import "./activators/shortpress";
 
@@ -77,7 +75,8 @@ import HubChannel from "./utils/hub-channel";
 import LinkChannel from "./utils/link-channel";
 import { connectToReticulum } from "./utils/phoenix-utils";
 import { disableiOSZoom } from "./utils/disable-ios-zoom";
-import { addMedia, resolveMedia } from "./utils/media-utils";
+import { resolveMedia } from "./utils/media-utils";
+import RoomEntryManager from "./room-entry-manager";
 
 import "./systems/nav";
 import "./systems/personal-space-bubble";
@@ -98,7 +97,6 @@ const store = window.APP.store;
 
 const qs = new URLSearchParams(location.search);
 const isMobile = AFRAME.utils.device.isMobile();
-const playerHeight = 1.6;
 
 window.APP.quality = qs.get("quality") || isMobile ? "low" : "high";
 
@@ -123,7 +121,7 @@ import "./components/tools/networked-drawing";
 import "./components/tools/drawing-manager";
 
 import registerNetworkSchemas from "./network-schemas";
-import { inGameActions, config as inputConfig } from "./input-mappings";
+import { config as inputConfig } from "./input-mappings";
 import registerTelemetry from "./telemetry";
 
 import { getAvailableVREntryTypes } from "./utils/vr-caps-detect.js";
@@ -179,10 +177,6 @@ function mountUI(scene, props = {}) {
   );
 }
 
-function requestFullscreen() {
-  if (screenfull.enabled && !screenfull.isFullscreen) screenfull.request();
-}
-
 const onReady = async () => {
   const scene = document.querySelector("a-scene");
   const hubChannel = new HubChannel(store);
@@ -199,17 +193,6 @@ const onReady = async () => {
   const remountUI = props => {
     uiProps = { ...uiProps, ...props };
     mountUI(scene, uiProps);
-  };
-
-  const applyProfileFromStore = playerRig => {
-    const displayName = store.state.profile.displayName;
-    playerRig.setAttribute("player-info", {
-      displayName,
-      avatarSrc: "#" + (store.state.profile.avatarId || "botdefault")
-    });
-    const hudController = playerRig.querySelector("[hud-controller]");
-    hudController.setAttribute("hud-controller", { showTip: !store.state.activity.hasFoundFreeze });
-    document.querySelector("a-scene").emit("username-changed", { username: displayName });
   };
 
   const pollForSupportAvailability = callback => {
@@ -229,227 +212,9 @@ const onReady = async () => {
     setInterval(updateIfChanged, 30000);
   };
 
-  const exitScene = () => {
-    if (NAF.connection.adapter && NAF.connection.adapter.localMediaStream) {
-      NAF.connection.adapter.localMediaStream.getTracks().forEach(t => t.stop());
-    }
-    if (hubChannel) {
-      hubChannel.disconnect();
-    }
-    const scene = document.querySelector("a-scene");
-    if (scene) {
-      if (scene.renderer) {
-        scene.renderer.setAnimationLoop(null); // Stop animation loop, TODO A-Frame should do this
-      }
-      document.body.removeChild(scene);
-    }
-    document.body.removeEventListener("touchend", requestFullscreen);
-  };
-
-  const enterScene = async (mediaStream, enterInVR) => {
-    const playerCamera = document.querySelector("#player-camera");
-    playerCamera.removeAttribute("scene-preview-camera");
-    playerCamera.object3D.position.set(0, playerHeight, 0);
-
-    const scene = document.querySelector("a-scene");
-
-    // Get aframe inspector url using the webpack file-loader.
-    const aframeInspectorUrl = require("file-loader?name=assets/js/[name]-[hash].[ext]!aframe-inspector/dist/aframe-inspector.min.js");
-    // Set the aframe-inspector url to our hosted copy.
-    scene.setAttribute("inspector", { url: aframeInspectorUrl });
-
-    if (!isBotMode) {
-      scene.classList.add("no-cursor");
-    }
-
-    const playerRig = document.querySelector("#player-rig");
-
-    if (enterInVR) {
-      scene.enterVR();
-    } else if (AFRAME.utils.device.isMobile()) {
-      document.body.addEventListener("touchend", requestFullscreen);
-    }
-
-    if (!isBotMode) {
-      hubChannel.sendEntryEvent().then(() => {
-        store.update({ activity: { lastEnteredAt: new Date().toISOString() } });
-      });
-    }
-
-    AFRAME.registerInputActions(inGameActions, "default");
-
-    scene.setAttribute("stats-plus", false);
-
-    if (isMobile || qsTruthy("mobile")) {
-      playerRig.setAttribute("virtual-gamepad-controls", {});
-    }
-
-    const applyProfileOnPlayerRig = applyProfileFromStore.bind(null, playerRig);
-    applyProfileOnPlayerRig();
-    store.addEventListener("statechanged", applyProfileOnPlayerRig);
-
-    const avatarScale = parseInt(qs.get("avatar_scale"), 10);
-
-    if (avatarScale) {
-      playerRig.setAttribute("scale", { x: avatarScale, y: avatarScale, z: avatarScale });
-    }
-
-    const videoTracks = mediaStream ? mediaStream.getVideoTracks() : [];
-    let sharingScreen = videoTracks.length > 0;
-
-    const screenEntityId = `${NAF.clientId}-screen`;
-    let screenEntity = document.getElementById(screenEntityId);
-
-    scene.addEventListener("action_share_screen", () => {
-      sharingScreen = !sharingScreen;
-      if (sharingScreen) {
-        for (const track of videoTracks) {
-          mediaStream.addTrack(track);
-        }
-      } else {
-        for (const track of mediaStream.getVideoTracks()) {
-          mediaStream.removeTrack(track);
-        }
-      }
-      NAF.connection.adapter.setLocalMediaStream(mediaStream);
-      screenEntity.setAttribute("visible", sharingScreen);
-    });
-
-    document.body.addEventListener("blocked", ev => {
-      NAF.connection.entities.removeEntitiesOfClient(ev.detail.clientId);
-    });
-
-    document.body.addEventListener("unblocked", ev => {
-      NAF.connection.entities.completeSync(ev.detail.clientId);
-    });
-
-    const offset = { x: 0, y: 0, z: -1.5 };
-    const spawnMediaInfrontOfPlayer = (src, contentOrigin) => {
-      const { entity, orientation } = addMedia(src, "#interactable-media", contentOrigin, true);
-
-      orientation.then(or => {
-        entity.setAttribute("offset-relative-to", {
-          target: "#player-camera",
-          offset,
-          orientation: or
-        });
-      });
-    };
-
-    scene.addEventListener("add_media", e => {
-      const contentOrigin = e.detail instanceof File ? ObjectContentOrigins.FILE : ObjectContentOrigins.URL;
-
-      spawnMediaInfrontOfPlayer(e.detail, contentOrigin);
-    });
-
-    scene.addEventListener("action_spawn_camera", () => {
-      const entity = document.createElement("a-entity");
-      entity.setAttribute("networked", { template: "#interactable-camera" });
-      entity.setAttribute("offset-relative-to", {
-        target: "#player-camera",
-        offset: { x: 0, y: 0, z: -1.5 }
-      });
-      scene.appendChild(entity);
-    });
-
-    scene.addEventListener("object_spawned", e => {
-      if (hubChannel) {
-        hubChannel.sendObjectSpawnedEvent(e.detail.objectType);
-      }
-    });
-
-    document.addEventListener("paste", e => {
-      if (e.target.nodeName === "INPUT") return;
-
-      const url = e.clipboardData.getData("text");
-      const files = e.clipboardData.files && e.clipboardData.files;
-      if (url) {
-        spawnMediaInfrontOfPlayer(url, ObjectContentOrigins.URL);
-      } else {
-        for (const file of files) {
-          spawnMediaInfrontOfPlayer(file, ObjectContentOrigins.CLIPBOARD);
-        }
-      }
-    });
-
-    document.addEventListener("dragover", e => {
-      e.preventDefault();
-    });
-
-    document.addEventListener("drop", e => {
-      e.preventDefault();
-      const url = e.dataTransfer.getData("url");
-      const files = e.dataTransfer.files;
-      if (url) {
-        spawnMediaInfrontOfPlayer(url, ObjectContentOrigins.URL);
-      } else {
-        for (const file of files) {
-          spawnMediaInfrontOfPlayer(file, ObjectContentOrigins.FILE);
-        }
-      }
-    });
-
-    if (!qsTruthy("offline")) {
-      if (isDebug) {
-        NAF.connection.adapter.session.options.verbose = true;
-      }
-
-      if (isBotMode) {
-        playerRig.setAttribute("avatar-replay", {
-          camera: "#player-camera",
-          leftController: "#player-left-controller",
-          rightController: "#player-right-controller"
-        });
-
-        const audioEl = document.createElement("audio");
-        const audioInput = document.querySelector("#bot-audio-input");
-        audioInput.onchange = () => {
-          audioEl.loop = true;
-          audioEl.muted = true;
-          audioEl.crossorigin = "anonymous";
-          audioEl.src = URL.createObjectURL(audioInput.files[0]);
-          document.body.appendChild(audioEl);
-        };
-        const dataInput = document.querySelector("#bot-data-input");
-        dataInput.onchange = () => {
-          const url = URL.createObjectURL(dataInput.files[0]);
-          playerRig.setAttribute("avatar-replay", { recordingUrl: url });
-        };
-        await new Promise(resolve => audioEl.addEventListener("canplay", resolve));
-        mediaStream.addTrack(audioEl.captureStream().getAudioTracks()[0]);
-        audioEl.play();
-      }
-
-      if (mediaStream) {
-        NAF.connection.adapter.setLocalMediaStream(mediaStream);
-
-        if (screenEntity) {
-          screenEntity.setAttribute("visible", sharingScreen);
-        } else if (sharingScreen) {
-          const sceneEl = document.querySelector("a-scene");
-          screenEntity = document.createElement("a-entity");
-          screenEntity.id = screenEntityId;
-          screenEntity.setAttribute("offset-relative-to", {
-            target: "#player-camera",
-            offset: "0 0 -2",
-            on: "action_share_screen"
-          });
-          screenEntity.setAttribute("networked", { template: "#video-template" });
-          sceneEl.appendChild(screenEntity);
-        }
-      }
-
-      // Spawn avatar & remove preview camera
-      const rig = document.querySelector("#player-rig");
-      rig.setAttribute("networked", "template: #remote-avatar-template; attachTemplateToLocal: false;");
-      rig.setAttribute("networked-avatar", "");
-      rig.emit("entered");
-
-      pollForSupportAvailability(isSupportAvailable => {
-        remountUI({ isSupportAvailable });
-      });
-    }
-  };
+  pollForSupportAvailability(isSupportAvailable => {
+    remountUI({ isSupportAvailable });
+  });
 
   const getPlatformUnsupportedReason = () => {
     if (typeof RTCDataChannelEvent === "undefined") {
@@ -459,13 +224,14 @@ const onReady = async () => {
     return null;
   };
 
-  remountUI({ enterScene, exitScene });
+  const entryManager = new RoomEntryManager(hubChannel);
+  remountUI({ enterScene: entryManager.enterScene, exitScene: entryManager.exitScene });
 
   const platformUnsupportedReason = getPlatformUnsupportedReason();
 
   if (platformUnsupportedReason) {
     remountUI({ platformUnsupportedReason: platformUnsupportedReason });
-    exitScene();
+    entryManager.exitScene();
     return;
   }
 
@@ -474,7 +240,7 @@ const onReady = async () => {
     if (qs.get("required_version") !== buildNumber) {
       remountUI({ roomUnavailableReason: "version_mismatch" });
       setTimeout(() => document.location.reload(), 5000);
-      exitScene();
+      entryManager.exitScene();
       return;
     }
   }
@@ -516,7 +282,7 @@ const onReady = async () => {
   environmentRoot.appendChild(initialEnvironmentEl);
 
   const enterSceneWhenReady = hubId => {
-    const enterSceneImmediately = () => enterScene(new MediaStream(), false, hubId);
+    const enterSceneImmediately = () => entryManager.enterScene(new MediaStream(), false, hubId);
     if (scene.hasLoaded) {
       enterSceneImmediately();
     } else {
@@ -626,7 +392,7 @@ const onReady = async () => {
           const isFull = connectError.error && connectError.error.msg.match(/\bfull\b/i);
           console.error(connectError);
           remountUI({ roomUnavailableReason: isFull ? "full" : "connect_error" });
-          exitScene();
+          entryManager.exitScene();
 
           return;
         });
@@ -640,7 +406,7 @@ const onReady = async () => {
     .receive("ok", handleJoinedHubChannel)
     .receive("error", res => {
       if (res.reason === "closed") {
-        exitScene();
+        entryManager.exitScene();
         remountUI({ roomUnavailableReason: "closed" });
       }
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -260,10 +260,6 @@ async function handleHubChannelJoined(entryManager, hubChannel, data) {
     debug: !!isDebug
   });
 
-  if (isBotMode) {
-    entryManager.enterSceneWhenLoaded(new MediaStream(), false);
-  }
-
   while (!scene.components["networked-scene"] || !scene.components["networked-scene"].data) await nextTick();
 
   scene.components["networked-scene"]
@@ -278,6 +274,10 @@ async function handleHubChannelJoined(entryManager, hubChannel, data) {
 
         hubChannel.channel.push("naf", payload);
       };
+
+      if (isBotMode) {
+        entryManager.enterSceneWhenLoaded(new MediaStream(), false);
+      }
     })
     .catch(connectError => {
       // hacky until we get return codes

--- a/src/hub.js
+++ b/src/hub.js
@@ -271,7 +271,7 @@ const onReady = async () => {
       camera.object3D.position.set(cameraPos.x, 2.5, cameraPos.z);
     }
 
-    camera.setAttribute("scene-preview-camera", "positionOnly: true; duration: 30");
+    camera.setAttribute("scene-preview-camera", "positionOnly: true; duration: 60");
 
     // Replace renderer with a noop renderer to reduce bot resource usage.
     if (isBotMode) {

--- a/src/hub.js
+++ b/src/hub.js
@@ -299,7 +299,6 @@ document.addEventListener("DOMContentLoaded", () => {
   window.APP.scene = scene;
 
   registerNetworkSchemas();
-  mountUI({});
   remountUI({ hubChannel, linkChannel, enterScene: entryManager.enterScene, exitScene: entryManager.exitScene });
 
   pollForSupportAvailability(isSupportAvailable => remountUI({ isSupportAvailable }));

--- a/src/hub.js
+++ b/src/hub.js
@@ -76,7 +76,7 @@ import LinkChannel from "./utils/link-channel";
 import { connectToReticulum } from "./utils/phoenix-utils";
 import { disableiOSZoom } from "./utils/disable-ios-zoom";
 import { resolveMedia } from "./utils/media-utils";
-import RoomEntryManager from "./room-entry-manager";
+import SceneEntryManager from "./scene-entry-manager";
 
 import "./systems/nav";
 import "./systems/personal-space-bubble";
@@ -224,7 +224,7 @@ const onReady = async () => {
     return null;
   };
 
-  const entryManager = new RoomEntryManager(hubChannel);
+  const entryManager = new SceneEntryManager(hubChannel);
   remountUI({ enterScene: entryManager.enterScene, exitScene: entryManager.exitScene });
 
   const platformUnsupportedReason = getPlatformUnsupportedReason();

--- a/src/hub.js
+++ b/src/hub.js
@@ -222,9 +222,8 @@ function remountUI(props) {
   mountUI(uiProps);
 }
 
-async function handleHubChannelJoined(entryManager, data) {
-  const scene = entryManager.scene;
-  const hubChannel = entryManager.hubChannel;
+async function handleHubChannelJoined(entryManager, hubChannel, data) {
+  const scene = document.querySelector("a-scene");
 
   if (NAF.connection.isConnected()) {
     // Send complete sync on phoenix re-join.
@@ -371,7 +370,7 @@ document.addEventListener("DOMContentLoaded", () => {
     .join()
     .receive("ok", async data => {
       hubChannel.setPhoenixChannel(channel);
-      await handleHubChannelJoined(entryManager, data);
+      await handleHubChannelJoined(entryManager, hubChannel, data);
     })
     .receive("error", res => {
       if (res.reason === "closed") {

--- a/src/hub.js
+++ b/src/hub.js
@@ -126,7 +126,7 @@ import registerNetworkSchemas from "./network-schemas";
 import { inGameActions, config as inputConfig } from "./input-mappings";
 import registerTelemetry from "./telemetry";
 
-import { getAvailableVREntryTypes, VR_DEVICE_AVAILABILITY } from "./utils/vr-caps-detect.js";
+import { getAvailableVREntryTypes } from "./utils/vr-caps-detect.js";
 import ConcurrentLoadDetector from "./utils/concurrent-load-detector.js";
 
 import qsTruthy from "./utils/qs_truthy";

--- a/src/hub.js
+++ b/src/hub.js
@@ -254,7 +254,6 @@ const onReady = async () => {
 
   const enterScene = async (mediaStream, enterInVR) => {
     const playerCamera = document.querySelector("#player-camera");
-    playerCamera.removeAttribute("scene-preview-camera");
     playerCamera.object3D.position.set(0, playerHeight, 0);
 
     const scene = document.querySelector("a-scene");

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const sceneId = qs.get("scene_id") || (pathname.startsWith("/scenes/") && pathna
 const root = (
   <HomeRoot
     initialEnvironment={qs.get("initial_environment")}
-    sceneId={sceneId}
+    sceneId={sceneId || ""}
     authVerify={qs.has("auth_topic")}
     authTopic={qs.get("auth_topic")}
     authToken={qs.get("auth_token")}

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -11,7 +11,13 @@ import entryStyles from "../assets/stylesheets/entry.scss";
 
 import { lang, messages } from "../utils/i18n";
 import AutoExitWarning from "./auto-exit-warning";
-import { TwoDEntryButton, DeviceEntryButton, GenericEntryButton, SafariEntryButton } from "./entry-buttons.js";
+import {
+  TwoDEntryButton,
+  DeviceEntryButton,
+  GenericEntryButton,
+  DaydreamEntryButton,
+  SafariEntryButton
+} from "./entry-buttons.js";
 import { ProfileInfoHeader } from "./profile-info-header.js";
 import ProfileEntryPanel from "./profile-entry-panel";
 import HelpDialog from "./help-dialog.js";
@@ -682,6 +688,9 @@ class UIRoot extends Component {
             )}
             {this.props.availableVREntryTypes.generic !== VR_DEVICE_AVAILABILITY.no && (
               <GenericEntryButton onClick={this.enterVR} />
+            )}
+            {this.props.availableVREntryTypes.daydream === VR_DEVICE_AVAILABILITY.yes && (
+              <DaydreamEntryButton onClick={this.enterDaydream} subtitle={null} />
             )}
             <DeviceEntryButton onClick={this.attemptLink} isInHMD={this.props.availableVREntryTypes.isInHMD} />
             {this.props.availableVREntryTypes.cardboard !== VR_DEVICE_AVAILABILITY.no && (

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -689,16 +689,6 @@ class UIRoot extends Component {
             {this.props.availableVREntryTypes.generic !== VR_DEVICE_AVAILABILITY.no && (
               <GenericEntryButton onClick={this.enterVR} />
             )}
-            {this.props.availableVREntryTypes.daydream !== VR_DEVICE_AVAILABILITY.no && (
-              <DaydreamEntryButton
-                onClick={this.enterDaydream}
-                subtitle={
-                  this.props.availableVREntryTypes.daydream == VR_DEVICE_AVAILABILITY.maybe
-                    ? "entry.daydream-via-chrome"
-                    : null
-                }
-              />
-            )}
             <DeviceEntryButton onClick={this.attemptLink} isInHMD={this.props.availableVREntryTypes.isInHMD} />
             {this.props.availableVREntryTypes.cardboard !== VR_DEVICE_AVAILABILITY.no && (
               <div className={entryStyles.secondary} onClick={this.enterVR}>

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -15,7 +15,6 @@ import {
   TwoDEntryButton,
   DeviceEntryButton,
   GenericEntryButton,
-  DaydreamEntryButton,
   SafariEntryButton
 } from "./entry-buttons.js";
 import { ProfileInfoHeader } from "./profile-info-header.js";

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -11,12 +11,7 @@ import entryStyles from "../assets/stylesheets/entry.scss";
 
 import { lang, messages } from "../utils/i18n";
 import AutoExitWarning from "./auto-exit-warning";
-import {
-  TwoDEntryButton,
-  DeviceEntryButton,
-  GenericEntryButton,
-  SafariEntryButton
-} from "./entry-buttons.js";
+import { TwoDEntryButton, DeviceEntryButton, GenericEntryButton, SafariEntryButton } from "./entry-buttons.js";
 import { ProfileInfoHeader } from "./profile-info-header.js";
 import ProfileEntryPanel from "./profile-entry-panel";
 import HelpDialog from "./help-dialog.js";

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -75,7 +75,7 @@ class UIRoot extends Component {
     linkChannel: PropTypes.object,
     showProfileEntry: PropTypes.bool,
     availableVREntryTypes: PropTypes.object,
-    initialEnvironmentLoaded: PropTypes.bool,
+    environmentSceneLoaded: PropTypes.bool,
     roomUnavailableReason: PropTypes.string,
     platformUnsupportedReason: PropTypes.string,
     hubId: PropTypes.string,
@@ -639,7 +639,7 @@ class UIRoot extends Component {
       );
     }
 
-    if (!this.props.initialEnvironmentLoaded || !this.props.availableVREntryTypes || !this.props.hubId) {
+    if (!this.props.environmentSceneLoaded || !this.props.availableVREntryTypes || !this.props.hubId) {
       return (
         <IntlProvider locale={lang} messages={messages}>
           <div className="loading-panel">

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -265,9 +265,12 @@ class UIRoot extends Component {
     const hasGrantedMic = await this.hasGrantedMicPermissions();
 
     if (hasGrantedMic) {
+      console.log("a");
       await this.setMediaStreamToDefault();
+      console.log("b");
       this.beginOrSkipAudioSetup();
     } else {
+      console.log("c");
       this.setState({ entryStep: ENTRY_STEPS.mic_grant });
     }
   };

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -265,12 +265,9 @@ class UIRoot extends Component {
     const hasGrantedMic = await this.hasGrantedMicPermissions();
 
     if (hasGrantedMic) {
-      console.log("a");
       await this.setMediaStreamToDefault();
-      console.log("b");
       this.beginOrSkipAudioSetup();
     } else {
-      console.log("c");
       this.setState({ entryStep: ENTRY_STEPS.mic_grant });
     }
   };

--- a/src/room-entry-manager.js
+++ b/src/room-entry-manager.js
@@ -1,0 +1,259 @@
+const playerHeight = 1.6;
+import qsTruthy from "./utils/qs_truthy";
+import screenfull from "screenfull";
+import { inGameActions } from "./input-mappings";
+
+const isBotMode = qsTruthy("bot");
+const isMobile = AFRAME.utils.device.isMobile();
+const isDebug = qsTruthy("debug");
+const qs = new URLSearchParams(location.search);
+const aframeInspectorUrl = require("file-loader?name=assets/js/[name]-[hash].[ext]!aframe-inspector/dist/aframe-inspector.min.js");
+
+import { addMedia } from "./utils/media-utils";
+import { ObjectContentOrigins } from "./object-types";
+
+function requestFullscreen() {
+  if (screenfull.enabled && !screenfull.isFullscreen) screenfull.request();
+}
+
+export default class RoomEntryManager {
+  constructor(hubChannel) {
+    this.hubChannel = hubChannel;
+    this.store = window.APP.store;
+    this.scene = document.querySelector("a-scene");
+    this.playerRig = document.querySelector("#player-rig");
+  }
+
+  enterScene = async (mediaStream, enterInVR) => {
+    const playerCamera = document.querySelector("#player-camera");
+    playerCamera.removeAttribute("scene-preview-camera");
+    playerCamera.object3D.position.set(0, playerHeight, 0);
+
+    // Get aframe inspector url using the webpack file-loader.
+    // Set the aframe-inspector url to our hosted copy.
+    this.scene.setAttribute("inspector", { url: aframeInspectorUrl });
+
+    if (isDebug) {
+      NAF.connection.adapter.session.options.verbose = true;
+    }
+
+    if (enterInVR) {
+      this.scene.enterVR();
+    } else if (AFRAME.utils.device.isMobile()) {
+      document.body.addEventListener("touchend", requestFullscreen);
+    }
+
+    AFRAME.registerInputActions(inGameActions, "default");
+
+    if (isMobile || qsTruthy("mobile")) {
+      this.playerRig.setAttribute("virtual-gamepad-controls", {});
+    }
+
+    this.setupPlayerRig();
+    this.setupScreensharing(mediaStream);
+    this.setupBlocking();
+    this.setupMedia();
+    this.setupCamera();
+
+    if (qsTruthy("offline")) return;
+
+    if (isBotMode) {
+      this.runBot(mediaStream);
+      return;
+    }
+
+    this.scene.classList.add("no-cursor");
+
+    this.hubChannel.sendEntryEvent().then(() => {
+      this.store.update({ activity: { lastEnteredAt: new Date().toISOString() } });
+    });
+
+    if (mediaStream) {
+      NAF.connection.adapter.setLocalMediaStream(mediaStream);
+    }
+
+    this.spawnAvatar();
+  };
+
+  exitScene = () => {
+    if (NAF.connection.adapter && NAF.connection.adapter.localMediaStream) {
+      NAF.connection.adapter.localMediaStream.getTracks().forEach(t => t.stop());
+    }
+    if (this.hubChannel) {
+      this.hubChannel.disconnect();
+    }
+    if (this.scene.renderer) {
+      this.scene.renderer.setAnimationLoop(null); // Stop animation loop, TODO A-Frame should do this
+    }
+    document.body.removeChild(this.scene);
+    document.body.removeEventListener("touchend", requestFullscreen);
+  };
+
+  setupPlayerRig = () => {
+    this.updatePlayerRigWithProfile();
+    this.store.addEventListener("statechanged", this.updatePlayerRigWithProfile);
+
+    const avatarScale = parseInt(qs.get("avatar_scale"), 10);
+
+    if (avatarScale) {
+      this.playerRig.setAttribute("scale", { x: avatarScale, y: avatarScale, z: avatarScale });
+    }
+  };
+
+  updatePlayerRigWithProfile = () => {
+    const displayName = this.store.state.profile.displayName;
+    this.playerRig.setAttribute("player-info", {
+      displayName,
+      avatarSrc: "#" + (this.store.state.profile.avatarId || "botdefault")
+    });
+    const hudController = this.playerRig.querySelector("[hud-controller]");
+    hudController.setAttribute("hud-controller", { showTip: !this.store.state.activity.hasFoundFreeze });
+    document.querySelector("a-scene").emit("username-changed", { username: displayName });
+  };
+
+  setupScreensharing = mediaStream => {
+    const videoTracks = mediaStream ? mediaStream.getVideoTracks() : [];
+    let sharingScreen = videoTracks.length > 0;
+
+    const screenEntityId = `${NAF.clientId}-screen`;
+    let screenEntity = document.getElementById(screenEntityId);
+
+    if (screenEntity) {
+      screenEntity.setAttribute("visible", sharingScreen);
+    } else if (sharingScreen) {
+      const sceneEl = document.querySelector("a-scene");
+      screenEntity = document.createElement("a-entity");
+      screenEntity.id = screenEntityId;
+      screenEntity.setAttribute("offset-relative-to", {
+        target: "#player-camera",
+        offset: "0 0 -2",
+        on: "action_share_screen"
+      });
+      screenEntity.setAttribute("networked", { template: "#video-template" });
+      sceneEl.appendChild(screenEntity);
+    }
+
+    this.scene.addEventListener("action_share_screen", () => {
+      sharingScreen = !sharingScreen;
+      if (sharingScreen) {
+        for (const track of videoTracks) {
+          mediaStream.addTrack(track);
+        }
+      } else {
+        for (const track of mediaStream.getVideoTracks()) {
+          mediaStream.removeTrack(track);
+        }
+      }
+      NAF.connection.adapter.setLocalMediaStream(mediaStream);
+      screenEntity.setAttribute("visible", sharingScreen);
+    });
+  };
+
+  setupBlocking = () => {
+    document.body.addEventListener("blocked", ev => {
+      NAF.connection.entities.removeEntitiesOfClient(ev.detail.clientId);
+    });
+
+    document.body.addEventListener("unblocked", ev => {
+      NAF.connection.entities.completeSync(ev.detail.clientId);
+    });
+  };
+
+  setupMedia = () => {
+    const offset = { x: 0, y: 0, z: -1.5 };
+    const spawnMediaInfrontOfPlayer = (src, contentOrigin) => {
+      const { entity, orientation } = addMedia(src, "#interactable-media", contentOrigin, true);
+
+      orientation.then(or => {
+        entity.setAttribute("offset-relative-to", {
+          target: "#player-camera",
+          offset,
+          orientation: or
+        });
+      });
+    };
+
+    this.scene.addEventListener("add_media", e => {
+      const contentOrigin = e.detail instanceof File ? ObjectContentOrigins.FILE : ObjectContentOrigins.URL;
+
+      spawnMediaInfrontOfPlayer(e.detail, contentOrigin);
+    });
+
+    this.scene.addEventListener("object_spawned", e => {
+      this.hubChannel.sendObjectSpawnedEvent(e.detail.objectType);
+    });
+
+    document.addEventListener("paste", e => {
+      if (e.target.nodeName === "INPUT") return;
+
+      const url = e.clipboardData.getData("text");
+      const files = e.clipboardData.files && e.clipboardData.files;
+      if (url) {
+        spawnMediaInfrontOfPlayer(url, ObjectContentOrigins.URL);
+      } else {
+        for (const file of files) {
+          spawnMediaInfrontOfPlayer(file, ObjectContentOrigins.CLIPBOARD);
+        }
+      }
+    });
+
+    document.addEventListener("dragover", e => e.preventDefault());
+
+    document.addEventListener("drop", e => {
+      e.preventDefault();
+      const url = e.dataTransfer.getData("url");
+      const files = e.dataTransfer.files;
+      if (url) {
+        spawnMediaInfrontOfPlayer(url, ObjectContentOrigins.URL);
+      } else {
+        for (const file of files) {
+          spawnMediaInfrontOfPlayer(file, ObjectContentOrigins.FILE);
+        }
+      }
+    });
+  };
+
+  setupCamera = () => {
+    this.scene.addEventListener("action_spawn_camera", () => {
+      const entity = document.createElement("a-entity");
+      entity.setAttribute("networked", { template: "#interactable-camera" });
+      entity.setAttribute("offset-relative-to", {
+        target: "#player-camera",
+        offset: { x: 0, y: 0, z: -1.5 }
+      });
+      this.scene.appendChild(entity);
+    });
+  };
+
+  spawnAvatar = () => {
+    this.playerRig.setAttribute("networked", "template: #remote-avatar-template; attachTemplateToLocal: false;");
+    this.playerRig.setAttribute("networked-avatar", "");
+    this.playerRig.emit("entered");
+  };
+
+  runBot = async mediaStream => {
+    this.playerRig.setAttribute("avatar-replay", {
+      camera: "#player-camera",
+      leftController: "#player-left-controller",
+      rightController: "#player-right-controller"
+    });
+
+    const audioEl = document.createElement("audio");
+    const audioInput = document.querySelector("#bot-audio-input");
+    audioInput.onchange = () => {
+      audioEl.loop = true;
+      audioEl.muted = true;
+      audioEl.crossorigin = "anonymous";
+      audioEl.src = URL.createObjectURL(audioInput.files[0]);
+      document.body.appendChild(audioEl);
+    };
+    const dataInput = document.querySelector("#bot-data-input");
+    dataInput.onchange = () => {
+      const url = URL.createObjectURL(dataInput.files[0]);
+      this.playerRig.setAttribute("avatar-replay", { recordingUrl: url });
+    };
+    await new Promise(resolve => audioEl.addEventListener("canplay", resolve));
+    mediaStream.addTrack(audioEl.captureStream().getAudioTracks()[0]);
+    audioEl.play();
+  };
+}

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -49,11 +49,11 @@ export default class SceneEntryManager {
       this.playerRig.setAttribute("virtual-gamepad-controls", {});
     }
 
-    this.setupPlayerRig();
-    this.setupScreensharing(mediaStream);
-    this.setupBlocking();
-    this.setupMedia();
-    this.setupCamera();
+    this._setupPlayerRig();
+    this._setupScreensharing(mediaStream);
+    this._setupBlocking();
+    this._setupMedia();
+    this._setupCamera();
 
     if (qsTruthy("offline")) return;
 
@@ -61,10 +61,10 @@ export default class SceneEntryManager {
       NAF.connection.adapter.setLocalMediaStream(mediaStream);
     }
 
-    this.spawnAvatar();
+    this._spawnAvatar();
 
     if (isBotMode) {
-      this.runBot(mediaStream);
+      this._runBot(mediaStream);
       return;
     }
 
@@ -99,9 +99,9 @@ export default class SceneEntryManager {
     document.body.removeEventListener("touchend", requestFullscreen);
   };
 
-  setupPlayerRig = () => {
-    this.updatePlayerRigWithProfile();
-    this.store.addEventListener("statechanged", this.updatePlayerRigWithProfile);
+  _setupPlayerRig = () => {
+    this._updatePlayerRigWithProfile();
+    this.store.addEventListener("statechanged", this._updatePlayerRigWithProfile);
 
     const avatarScale = parseInt(qs.get("avatar_scale"), 10);
 
@@ -110,7 +110,7 @@ export default class SceneEntryManager {
     }
   };
 
-  updatePlayerRigWithProfile = () => {
+  _updatePlayerRigWithProfile = () => {
     const displayName = this.store.state.profile.displayName;
     this.playerRig.setAttribute("player-info", {
       displayName,
@@ -118,10 +118,10 @@ export default class SceneEntryManager {
     });
     const hudController = this.playerRig.querySelector("[hud-controller]");
     hudController.setAttribute("hud-controller", { showTip: !this.store.state.activity.hasFoundFreeze });
-    document.querySelector("a-scene").emit("username-changed", { username: displayName });
+    this.scene.emit("username-changed", { username: displayName });
   };
 
-  setupScreensharing = mediaStream => {
+  _setupScreensharing = mediaStream => {
     const videoTracks = mediaStream ? mediaStream.getVideoTracks() : [];
     let sharingScreen = videoTracks.length > 0;
 
@@ -131,7 +131,6 @@ export default class SceneEntryManager {
     if (screenEntity) {
       screenEntity.setAttribute("visible", sharingScreen);
     } else if (sharingScreen) {
-      const sceneEl = document.querySelector("a-scene");
       screenEntity = document.createElement("a-entity");
       screenEntity.id = screenEntityId;
       screenEntity.setAttribute("offset-relative-to", {
@@ -140,7 +139,7 @@ export default class SceneEntryManager {
         on: "action_share_screen"
       });
       screenEntity.setAttribute("networked", { template: "#video-template" });
-      sceneEl.appendChild(screenEntity);
+      this.scene.appendChild(screenEntity);
     }
 
     this.scene.addEventListener("action_share_screen", () => {
@@ -159,7 +158,7 @@ export default class SceneEntryManager {
     });
   };
 
-  setupBlocking = () => {
+  _setupBlocking = () => {
     document.body.addEventListener("blocked", ev => {
       NAF.connection.entities.removeEntitiesOfClient(ev.detail.clientId);
     });
@@ -169,7 +168,7 @@ export default class SceneEntryManager {
     });
   };
 
-  setupMedia = () => {
+  _setupMedia = () => {
     const offset = { x: 0, y: 0, z: -1.5 };
     const spawnMediaInfrontOfPlayer = (src, contentOrigin) => {
       const { entity, orientation } = addMedia(src, "#interactable-media", contentOrigin, true);
@@ -223,7 +222,7 @@ export default class SceneEntryManager {
     });
   };
 
-  setupCamera = () => {
+  _setupCamera = () => {
     this.scene.addEventListener("action_spawn_camera", () => {
       const entity = document.createElement("a-entity");
       entity.setAttribute("networked", { template: "#interactable-camera" });
@@ -235,13 +234,13 @@ export default class SceneEntryManager {
     });
   };
 
-  spawnAvatar = () => {
+  _spawnAvatar = () => {
     this.playerRig.setAttribute("networked", "template: #remote-avatar-template; attachTemplateToLocal: false;");
     this.playerRig.setAttribute("networked-avatar", "");
     this.playerRig.emit("entered");
   };
 
-  runBot = async mediaStream => {
+  _runBot = async mediaStream => {
     this.playerRig.setAttribute("avatar-replay", {
       camera: "#player-camera",
       leftController: "#player-left-controller",

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -61,6 +61,8 @@ export default class SceneEntryManager {
       NAF.connection.adapter.setLocalMediaStream(mediaStream);
     }
 
+    this.spawnAvatar();
+
     if (isBotMode) {
       this.runBot(mediaStream);
       return;
@@ -71,8 +73,6 @@ export default class SceneEntryManager {
     this.hubChannel.sendEntryEvent().then(() => {
       this.store.update({ activity: { lastEnteredAt: new Date().toISOString() } });
     });
-
-    this.spawnAvatar();
   };
 
   enterSceneWhenLoaded = (mediaStream, enterInVR) => {

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -75,6 +75,16 @@ export default class SceneEntryManager {
     this.spawnAvatar();
   };
 
+  enterSceneWhenLoaded = (mediaStream, enterInVR) => {
+    const enterSceneImmediately = () => this.enterScene(mediaStream, enterInVR);
+
+    if (this.scene.hasLoaded) {
+      enterSceneImmediately();
+    } else {
+      this.scene.addEventListener("loaded", enterSceneImmediately);
+    }
+  };
+
   exitScene = () => {
     if (NAF.connection.adapter && NAF.connection.adapter.localMediaStream) {
       NAF.connection.adapter.localMediaStream.getTracks().forEach(t => t.stop());

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -1,8 +1,8 @@
-const playerHeight = 1.6;
 import qsTruthy from "./utils/qs_truthy";
 import screenfull from "screenfull";
 import { inGameActions } from "./input-mappings";
 
+const playerHeight = 1.6;
 const isBotMode = qsTruthy("bot");
 const isMobile = AFRAME.utils.device.isMobile();
 const isDebug = qsTruthy("debug");

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -57,6 +57,10 @@ export default class SceneEntryManager {
 
     if (qsTruthy("offline")) return;
 
+    if (mediaStream) {
+      NAF.connection.adapter.setLocalMediaStream(mediaStream);
+    }
+
     if (isBotMode) {
       this.runBot(mediaStream);
       return;
@@ -67,10 +71,6 @@ export default class SceneEntryManager {
     this.hubChannel.sendEntryEvent().then(() => {
       this.store.update({ activity: { lastEnteredAt: new Date().toISOString() } });
     });
-
-    if (mediaStream) {
-      NAF.connection.adapter.setLocalMediaStream(mediaStream);
-    }
 
     this.spawnAvatar();
   };

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -16,7 +16,7 @@ function requestFullscreen() {
   if (screenfull.enabled && !screenfull.isFullscreen) screenfull.request();
 }
 
-export default class RoomEntryManager {
+export default class SceneEntryManager {
   constructor(hubChannel) {
     this.hubChannel = hubChannel;
     this.store = window.APP.store;

--- a/src/utils/next-tick.js
+++ b/src/utils/next-tick.js
@@ -1,0 +1,5 @@
+export default function nextTick() {
+  return new Promise(resolve => {
+    setTimeout(resolve, 0);
+  });
+}


### PR DESCRIPTION
This PR:

- Does a ton of refactoring and cleanup of `hub.js`, breaking some code out into `SceneEntryManager` and lifting a bunch of closures into top level functions, among other things. (hopefully this makes @mquander happy :)) There's more I could probably do but this is a good first step.

- Removes the speculative Daydream entry mode

- Changes the hub landing page to connect to Janus and put the user into a spectator mode which automatically pans the camera through the scene, but allows the user to rotate it.

More visual design changes forthcoming but this is a basic "lobby" mode. This has two benefits: it allows the user to see what is going on in the room before entering, and also as a bonus causes avatars, objects, etc, to load before entering VR, which avoids the worst hitching.