### PR TITLE
Bug/initial preview camera

### DIFF
--- a/src/components/pitch-yaw-rotator.js
+++ b/src/components/pitch-yaw-rotator.js
@@ -1,4 +1,6 @@
 const degToRad = THREE.Math.degToRad;
+const radToDeg = THREE.Math.radToDeg;
+
 AFRAME.registerComponent("pitch-yaw-rotator", {
   schema: {
     minPitch: { default: -50 },
@@ -15,6 +17,11 @@ AFRAME.registerComponent("pitch-yaw-rotator", {
     this.pitch += deltaPitch;
     this.pitch = Math.max(minPitch, Math.min(maxPitch, this.pitch));
     this.yaw += deltaYaw;
+  },
+
+  set(pitch, yaw) {
+    this.pitch = radToDeg(pitch);
+    this.yaw = radToDeg(yaw);
   },
 
   tick() {

--- a/src/components/scene-preview-camera.js
+++ b/src/components/scene-preview-camera.js
@@ -29,12 +29,13 @@ AFRAME.registerComponent("scene-preview-camera", {
 
     this.startTime = new Date().getTime();
     this.backwards = false;
+    this.ranOnePass = false;
   },
 
   tick: function() {
     let t = (new Date().getTime() - this.startTime) / (1000.0 * this.data.duration);
 
-    if (!this.backwards) {
+    if (!this.ranOnePass) {
       t = t * (2 - t);
     } else {
       t = t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
@@ -55,6 +56,7 @@ AFRAME.registerComponent("scene-preview-camera", {
     }
 
     if (t >= 0.9999) {
+      this.ranOnePass = true;
       this.backwards = !this.backwards;
       this.startTime = new Date().getTime();
     }

--- a/src/components/scene-preview-camera.js
+++ b/src/components/scene-preview-camera.js
@@ -33,7 +33,12 @@ AFRAME.registerComponent("scene-preview-camera", {
 
   tick: function() {
     let t = (new Date().getTime() - this.startTime) / (1000.0 * this.data.duration);
-    t = (t * t) / (2 * (t * t - t) + 1); // Simple beizer smoothing
+
+    if (!this.backwards) {
+      t = t * (2 - t);
+    } else {
+      t = t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+    }
 
     const from = this.backwards ? this.targetPoint : this.startPoint;
     const to = this.backwards ? this.startPoint : this.targetPoint;

--- a/src/hub.js
+++ b/src/hub.js
@@ -188,6 +188,7 @@ function setupLobbyCamera() {
   }
 
   camera.setAttribute("scene-preview-camera", "positionOnly: true; duration: 60");
+  camera.components["pitch-yaw-rotator"].set(camera.object3D.rotation.x / 2, camera.object3D.rotation.y);
 }
 
 let uiProps = {};


### PR DESCRIPTION
This PR:

- Fixes a bug where the initial preview camera's rotation is wrong for a uploaded scene, since the yaw/pitch rotator overwrites it

- Changes the panning curves to be ease-out and then ease-in-out so the initial load pans at max velocity