### PR TITLE
Delay entry telemetry to ensure VR display is presenting

### DIFF
--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -82,9 +82,12 @@ export default class SceneEntryManager {
     cursor.enable();
     cursor.setCursorVisibility(true);
 
-    this.hubChannel.sendEntryEvent().then(() => {
-      this.store.update({ activity: { lastEnteredAt: new Date().toISOString() } });
-    });
+    // Delay sending entry event telemetry so VR display is presenting.
+    setTimeout(() => {
+      this.hubChannel.sendEntryEvent().then(() => {
+        this.store.update({ activity: { lastEnteredAt: new Date().toISOString() } });
+      });
+    }, 5000);
   };
 
   whenSceneLoaded = callback => {

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -1,6 +1,7 @@
 import qsTruthy from "./utils/qs_truthy";
 import screenfull from "screenfull";
 import { inGameActions } from "./input-mappings";
+import nextTick from "./utils/next-tick";
 
 const playerHeight = 1.6;
 const isBotMode = qsTruthy("bot");
@@ -82,12 +83,16 @@ export default class SceneEntryManager {
     cursor.enable();
     cursor.setCursorVisibility(true);
 
-    // Delay sending entry event telemetry so VR display is presenting.
-    setTimeout(() => {
+    // Delay sending entry event telemetry until VR display is presenting.
+    (async () => {
+      while (enterInVR && !(await navigator.getVRDisplays()).find(d => d.isPresenting)) {
+        await nextTick();
+      }
+
       this.hubChannel.sendEntryEvent().then(() => {
         this.store.update({ activity: { lastEnteredAt: new Date().toISOString() } });
       });
-    }, 5000);
+    })();
   };
 
   whenSceneLoaded = callback => {


### PR DESCRIPTION
A change was made somewhere in the WebVR stack on Oculus Go that results in a few frames of latency before the `isPresenting` bit is `true` on the `VRDisplay` after calling `enterVR`. The result is we were mis-attributing Go sessions as Screen sessions. This change delays sending the entry event until there is a presenting VR display when we are entering in VR. 