### PR TITLE
Ignore pastes on active input elements

### DIFF
--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -221,7 +221,7 @@ export default class SceneEntryManager {
     });
 
     document.addEventListener("paste", e => {
-      if (e.target.nodeName === "INPUT") return;
+      if (e.target.nodeName === "INPUT" && document.activeElement === e.target) return;
 
       const url = e.clipboardData.getData("text");
       const files = e.clipboardData.files && e.clipboardData.files;


### PR DESCRIPTION
This PR fixes an issue where Ctrl-V stopped working with the introduction of a text field into the DOM (the chat box entry.) The reason is that the `paste` event seems to set `e.target` to the topmost target in the DOM that could be pasted into, regardless of if it is the focused element or not.  This additional check added will ensure that if that element is not the focused element (ie we're pasting into the canvas) then it will fall through.