### PR TITLE
Remove keyboard shortcuts, fix up immediate entry mode

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -307,6 +307,8 @@ async function runBotMode(scene, entryManager) {
 
 document.addEventListener("DOMContentLoaded", async () => {
   const scene = document.querySelector("a-scene");
+  scene.removeAttribute("keyboard-shortcuts"); // Remove F and ESC hotkeys from aframe
+
   const hubChannel = new HubChannel(store);
   const entryManager = new SceneEntryManager(hubChannel);
   entryManager.init();

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -440,7 +440,7 @@ class UIRoot extends Component {
     if (!this.props.forcedVREntryType || !this.props.forcedVREntryType.endsWith("_now")) {
       this.goToEntryStep(ENTRY_STEPS.audio_setup);
     } else {
-      setTimeout(this.onAudioReadyButton, 3000); // Need to wait otherwise input doesn't work :/
+      this.onAudioReadyButton();
     }
   };
 


### PR DESCRIPTION
Removes the incredibly annoying F and ESC keybindings a-frame injects by default, and also fixes up the _now mode to enter in one click (ideally it would just enter on load, but this functionality regressed during the UX redesign so this is a half-way fix for now.)