### PR TITLE
Show camera tool photos in chat log

### DIFF
--- a/src/assets/stylesheets/presence-log.scss
+++ b/src/assets/stylesheets/presence-log.scss
@@ -34,6 +34,19 @@
     @media (max-width: 1000px) {
       max-width: 75%;
     }
+
+    &:local(.spawn) {
+      display: flex;
+      align-items: center;
+      min-height: 35px;
+      img {
+        max-height: 36px;
+        margin-right: 8px;
+        border: 2px solid rgba(255,255,255,0.15);
+        display: block;
+        border-radius: 5px;
+      }
+    }
   }
 
   :local(.expired) {

--- a/src/assets/stylesheets/presence-log.scss
+++ b/src/assets/stylesheets/presence-log.scss
@@ -35,12 +35,18 @@
       max-width: 75%;
     }
 
-    &:local(.spawn) {
+    &:local(.media) {
       display: flex;
       align-items: center;
       min-height: 35px;
+
+      :local(.mediaBody) {
+        display: flex;
+        flex-direction: column;
+      }
+
       img {
-        max-height: 36px;
+        height: 35px;
         margin-right: 8px;
         border: 2px solid rgba(255,255,255,0.15);
         display: block;

--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -156,6 +156,16 @@ AFRAME.registerComponent("camera-tool", {
         renderer.readRenderTargetPixels(this.renderTarget, 0, 0, width, height, this.snapPixels);
         pixelsToPNG(this.snapPixels, width, height).then(file => {
           const { entity, orientation } = addMedia(file, "#interactable-media", undefined, true);
+          entity.addEventListener(
+            "media_resolved",
+            () => {
+              window.APP.hubChannel.sendMessage(
+                { contentType: "image/jpg", src: entity.components["media-loader"].data.src },
+                "spawn"
+              );
+            },
+            { once: true }
+          );
           orientation.then(() => {
             entity.object3D.position.copy(this.el.object3D.position).add(new THREE.Vector3(0, -0.5, 0));
             entity.object3D.rotation.copy(this.el.object3D.rotation);

--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -159,10 +159,7 @@ AFRAME.registerComponent("camera-tool", {
           entity.addEventListener(
             "media_resolved",
             () => {
-              window.APP.hubChannel.sendMessage(
-                { contentType: "image/jpg", src: entity.components["media-loader"].data.src },
-                "spawn"
-              );
+              this.el.emit("photo_taken", entity.components["media-loader"].data.src);
             },
             { once: true }
           );

--- a/src/hub.js
+++ b/src/hub.js
@@ -294,6 +294,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const linkChannel = new LinkChannel(store);
 
   window.APP.scene = scene;
+  window.APP.hubChannel = hubChannel;
 
   registerNetworkSchemas();
   remountUI({ hubChannel, linkChannel, enterScene: entryManager.enterScene, exitScene: entryManager.exitScene });
@@ -461,11 +462,11 @@ document.addEventListener("DOMContentLoaded", async () => {
     NAF.connection.adapter.onData(data);
   });
 
-  hubPhxChannel.on("message", data => {
-    const userInfo = hubPhxPresence.state[data.session_id];
+  hubPhxChannel.on("message", ({ session_id, type, body }) => {
+    const userInfo = hubPhxPresence.state[session_id];
     if (!userInfo) return;
 
-    addToPresenceLog({ type: "message", name: userInfo.metas[0].profile.displayName, body: data.body });
+    addToPresenceLog({ name: userInfo.metas[0].profile.displayName, type, body });
   });
 
   // Reticulum global channel

--- a/src/hub.js
+++ b/src/hub.js
@@ -294,7 +294,6 @@ document.addEventListener("DOMContentLoaded", async () => {
   const linkChannel = new LinkChannel(store);
 
   window.APP.scene = scene;
-  window.APP.hubChannel = hubChannel;
 
   registerNetworkSchemas();
   remountUI({ hubChannel, linkChannel, enterScene: entryManager.enterScene, exitScene: entryManager.exitScene });

--- a/src/react-components/presence-log.js
+++ b/src/react-components/presence-log.js
@@ -51,18 +51,23 @@ export default class PresenceLog extends Component {
         );
       case "spawn": {
         const { src } = e.body;
+        console.log(styles);
         return (
-          <div key={e.key} className={classNames(entryClasses, styles.spawn)}>
+          <div key={e.key} className={classNames(entryClasses, styles.media)}>
             <a href={src} target="_blank" rel="noopener noreferrer">
               <img src={src} />
             </a>
-            <b>{e.name}</b>:
-            <i>
-              {" took a "}
-              <a href={src} target="_blank" rel="noopener noreferrer">
-                photo
-              </a>
-            </i>
+            <div className={styles.mediaBody}>
+              <span>
+                <b>{e.name}</b>:
+              </span>
+              <span>
+                {"took a "}
+                <a href={src} target="_blank" rel="noopener noreferrer">
+                  photo
+                </a>
+              </span>
+            </div>
           </div>
         );
       }

--- a/src/react-components/presence-log.js
+++ b/src/react-components/presence-log.js
@@ -42,13 +42,30 @@ export default class PresenceLog extends Component {
             <b>{e.oldName}</b> <FormattedMessage id="presence.name_change" /> <b>{e.newName}</b>.
           </div>
         );
-      case "message":
+      case "chat":
         return (
           <div key={e.key} className={classNames(entryClasses)}>
             <b>{e.name}</b>:{" "}
             <Linkify properties={{ target: "_blank", rel: "noopener referrer" }}>{toEmojis(e.body)}</Linkify>
           </div>
         );
+      case "spawn": {
+        const { src } = e.body;
+        return (
+          <div key={e.key} className={classNames(entryClasses, styles.spawn)}>
+            <a href={src} target="_blank" rel="noopener noreferrer">
+              <img src={src} />
+            </a>
+            <b>{e.name}</b>:
+            <i>
+              {" took a "}
+              <a href={src} target="_blank" rel="noopener noreferrer">
+                photo
+              </a>
+            </i>
+          </div>
+        );
+      }
     }
   };
 

--- a/src/react-components/presence-log.js
+++ b/src/react-components/presence-log.js
@@ -51,7 +51,6 @@ export default class PresenceLog extends Component {
         );
       case "spawn": {
         const { src } = e.body;
-        console.log(styles);
         return (
           <div key={e.key} className={classNames(entryClasses, styles.media)}>
             <a href={src} target="_blank" rel="noopener noreferrer">

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -257,6 +257,11 @@ export default class SceneEntryManager {
       });
       this.scene.appendChild(entity);
     });
+
+    this.scene.addEventListener("photo_taken", e => {
+      console.log(e);
+      this.hubChannel.sendMessage({ src: e.detail }, "spawn");
+    });
   };
 
   _spawnAvatar = () => {

--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -91,9 +91,9 @@ export default class HubChannel {
     this.channel.push("events:profile_updated", { profile: this.store.state.profile });
   };
 
-  sendMessage = body => {
-    if (body === "") return;
-    this.channel.push("message", { body });
+  sendMessage = (body, type = "chat") => {
+    if (!body) return;
+    this.channel.push("message", { body, type });
   };
 
   requestSupport = () => {


### PR DESCRIPTION
Shows a simple chat log message when people take photos with the camera tool. This provides a very basic way for getting at the photo without adding any new features. Later we might add features that make it easier to more directly share out photos.

![image](https://user-images.githubusercontent.com/130735/47538626-42ecdc00-d881-11e8-903c-4b0e5836f2f0.png)
