### PR TITLE
Don't use Farspark to proxy CORS-accessible stuff

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -7,6 +7,7 @@ import cubeMapPosY from "../assets/images/cubemap/posy.jpg";
 import cubeMapNegY from "../assets/images/cubemap/negy.jpg";
 import cubeMapPosZ from "../assets/images/cubemap/posz.jpg";
 import cubeMapNegZ from "../assets/images/cubemap/negz.jpg";
+import { loadProxyable } from "../utils/media-utils.js";
 
 const GLTFCache = {};
 let CachedEnvMapTexture = null;
@@ -219,7 +220,7 @@ async function loadGLTF(src, contentType, preferredTechnique, onProgress) {
   const gltfLoader = new THREE.GLTFLoader();
   gltfLoader.setLazy(true);
 
-  const { parser } = await new Promise((resolve, reject) => gltfLoader.load(gltfUrl, resolve, onProgress, reject));
+  const { parser } = await loadProxyable(gltfLoader, gltfUrl, onProgress);
 
   const materials = parser.json.materials;
   if (materials) {

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -1,5 +1,5 @@
 import { getBox, getScaleCoefficient } from "../utils/auto-box-collider";
-import { guessContentType, proxiedUrlFor, resolveUrl } from "../utils/media-utils";
+import { guessContentType, proxiedUrlFor, fetchProxyable, resolveUrl } from "../utils/media-utils";
 import { addAnimationComponents } from "../utils/animation";
 
 import "three/examples/js/loaders/GLTFLoader";
@@ -11,7 +11,7 @@ gltfLoader.load(loadingObjectSrc, gltf => {
 });
 
 const fetchContentType = url => {
-  return fetch(url, { method: "HEAD" }).then(r => r.headers.get("content-type"));
+  return fetchProxyable(url, { method: "HEAD" }).then(r => r.headers.get("content-type"));
 };
 
 const fetchMaxContentIndex = url => {
@@ -124,15 +124,7 @@ AFRAME.registerComponent("media-loader", {
 
       // if the component creator didn't know the content type, we didn't get it from reticulum, and
       // we don't think we can infer it from the extension, we need to make a HEAD request to find it out
-      contentType = contentType || guessContentType(canonicalUrl);
-
-      if (contentType == null) {
-        try {
-          contentType = await fetchContentType(accessibleUrl);
-        } catch (err) {
-          contentType = await fetchContentType(proxiedUrlFor(canonicalUrl));
-        }
-      }
+      contentType = contentType || guessContentType(canonicalUrl) || (await fetchContentType(accessibleUrl));
 
       // We don't want to emit media_resolved for index updates.
       if (src !== oldData.src) {

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -1,6 +1,6 @@
 import GIFWorker from "../workers/gifparsing.worker.js";
 import errorImageSrc from "!!url-loader!../assets/images/media-error.gif";
-import { fetchProxyable, proxiedUrlFor } from "../utils/media-utils.js";
+import { fetchProxyable, loadProxyable, proxiedUrlFor } from "../utils/media-utils.js";
 
 class GIFTexture extends THREE.Texture {
   constructor(frames, delays, disposals) {
@@ -145,23 +145,13 @@ function fitToTexture(el, texture) {
 
 const textureLoader = new THREE.TextureLoader();
 textureLoader.setCrossOrigin("anonymous");
-function loadTexturePromise(url) {
-  return new Promise((resolve, reject) => {
-    textureLoader.load(url, texture => resolve(texture), null, xhr => reject(xhr));
-  });
-}
 
 function createImageTexture(url) {
-  return loadTexturePromise(url)
-    .catch(ev => {
-      console.warn(`Error loading image; retrying with CORS proxy. (${ev.error})`);
-      return loadTexturePromise(proxiedUrlFor(url));
-    })
-    .then(texture => {
-      texture.encoding = THREE.sRGBEncoding;
-      texture.minFilter = THREE.LinearFilter;
-      return texture;
-    });
+  return loadProxyable(textureLoader, url).then(texture => {
+    texture.encoding = THREE.sRGBEncoding;
+    texture.minFilter = THREE.LinearFilter;
+    return texture;
+  });
 }
 
 function disposeTexture(texture) {

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -1,6 +1,6 @@
 import GIFWorker from "../workers/gifparsing.worker.js";
 import errorImageSrc from "!!url-loader!../assets/images/media-error.gif";
-import { proxiedUrlFor } from "../utils/media-utils.js";
+import { fetchProxyable, proxiedUrlFor } from "../utils/media-utils.js";
 
 class GIFTexture extends THREE.Texture {
   constructor(frames, delays, disposals) {
@@ -65,12 +65,11 @@ async function createGIFTexture(url) {
         img.src = frames[i];
       }
     };
-    fetch(url, { mode: "cors" })
+    fetchProxyable(url, { mode: "cors" })
       .then(r => r.arrayBuffer())
       .then(rawImageData => {
         worker.postMessage(rawImageData, [rawImageData]);
-      })
-      .catch(reject);
+      });
   });
 }
 

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -38,6 +38,14 @@ export const fetchProxyable = url => {
   });
 };
 
+export const loadProxyable = (loader, url) => {
+  const load = url => new Promise((resolve, reject) => loader.load(url, resolve, null, reject));
+  return load(url).catch(ev => {
+    console.warn(`Error loading ${url}; retrying with CORS proxy. (${ev.error})`);
+    return load(proxiedUrlFor(url));
+  });
+};
+
 const resolveUrlCache = new Map();
 export const resolveUrl = async (url, index) => {
   const cacheKey = `${url}|${index}`;

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -38,8 +38,8 @@ export const fetchProxyable = url => {
   });
 };
 
-export const loadProxyable = (loader, url) => {
-  const load = url => new Promise((resolve, reject) => loader.load(url, resolve, null, reject));
+export const loadProxyable = (loader, url, onProgress) => {
+  const load = url => new Promise((resolve, reject) => loader.load(url, resolve, onProgress, reject));
   return load(url).catch(ev => {
     console.warn(`Error loading ${url}; retrying with CORS proxy. (${ev.error})`);
     return load(proxiedUrlFor(url));

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -30,6 +30,14 @@ export const proxiedUrlFor = (url, index) => {
   return `https://${process.env.FARSPARK_SERVER}/0/${method}/0/0/0/${index || 0}/${encodedUrl}`;
 };
 
+export const fetchProxyable = url => {
+  const opts = { mode: "cors" };
+  return fetch(url, opts).catch(err => {
+    console.warn(`Error loading ${url}; retrying with CORS proxy. (${err})`);
+    return fetch(proxiedUrlFor(url), opts);
+  });
+};
+
 const resolveUrlCache = new Map();
 export const resolveUrl = async (url, index) => {
   const cacheKey = `${url}|${index}`;


### PR DESCRIPTION
**WIP - we need to iron out CSP stuff before merging this.**

We now pass the canonical URL for media down into all of the media view components and into `gltf-model-plus`, and each one will gracefully handle the case where the media turns out to not be CORS-accessible. (The methodology for each one looks quite different because of the different ways they load the media and try to get errors out.)

Tested with a variety of media sources. Note that, contrary to what we thought, Youtube URLs retrieved via youtube-dl are not CORS-accessible. However, Sketchfab and Google Poly URLs are, so this will reduce latency and Farspark load a lot in rooms where people are loading 3D models in particular.