### PR TITLE
Feature/desktop vr tlc

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -3,6 +3,7 @@
   "rules": {
     "indentation": 2,
 		"selector-pseudo-class-no-unknown": [true, { "ignorePseudoClasses": ["local"] }],
+		"selector-type-no-unknown": [true, { "ignoreTypes": ["/^a-/"] }],
 		"no-descending-specificity": false
   }
 }

--- a/src/assets/stylesheets/hub.scss
+++ b/src/assets/stylesheets/hub.scss
@@ -9,7 +9,7 @@
 @import 'info-dialog';
 
 body.vr-mode {
-  a-scene.fullscreen {
+  a-scene {
     .a-canvas {
       width: 200% !important;
     }

--- a/src/assets/stylesheets/hub.scss
+++ b/src/assets/stylesheets/hub.scss
@@ -7,7 +7,14 @@
 @import 'entry';
 @import 'audio';
 @import 'info-dialog';
-@import 'shared';
+
+body.vr-mode {
+  a-scene.fullscreen {
+    .a-canvas {
+      width: 200% !important;
+    }
+  }
+}
 
 .a-enter-vr, .a-orientation-modal {
   display: none;

--- a/src/assets/stylesheets/presence-log.scss
+++ b/src/assets/stylesheets/presence-log.scss
@@ -133,6 +133,7 @@
 :local(.presence-log-in-room) {
   position: absolute;
   bottom: 165px;
+  z-index: 1;
 
   :local(.presence-log-entry) {
     background-color: $hud-panel-background;

--- a/src/assets/stylesheets/ui-root.scss
+++ b/src/assets/stylesheets/ui-root.scss
@@ -14,6 +14,7 @@
     @extend %fa-icon-button;
     pointer-events: auto;
     position: absolute;
+    z-index: 1;
     top: 0px;
     right: 14px;
 
@@ -28,6 +29,12 @@
       width: 36px;
       height: 36px;
     }
+  }
+}
+
+body.vr-mode {
+  :local(.ui) {
+    pointer-events: auto;
   }
 }
 
@@ -118,6 +125,7 @@
 
 :local(.nag-corner-button) {
   position: absolute;
+  z-index: 1;
   bottom: 42px;
   width: 100%;
   display: flex;
@@ -154,6 +162,7 @@
   @extend %unselectable;
   text-align: right;
   position: absolute;
+  z-index: 1;
   top: 0;
   left: 16px;
   margin: 16px 0;
@@ -239,6 +248,7 @@
   }
 
   position: absolute;
+  z-index: 2;
   left: 16px;
   bottom: 20px;
   width: 33%;

--- a/src/components/controls-shape-offset.js
+++ b/src/components/controls-shape-offset.js
@@ -1,4 +1,4 @@
-import { CONTROLLER_OFFSETS } from "./hand-controls2.js";
+import { LEFT_CONTROLLER_OFFSETS, RIGHT_CONTROLLER_OFFSETS } from "./hand-controls2.js";
 
 /**
  * Sets the offset of the aframe-physics shape on this entity based on the current VR controller type
@@ -7,11 +7,12 @@ import { CONTROLLER_OFFSETS } from "./hand-controls2.js";
  */
 AFRAME.registerComponent("controls-shape-offset", {
   schema: {
-    additionalOffset: { type: "vec3", default: { x: 0, y: -0.03, z: -0.04 } }
+    additionalOffset: { type: "vec3", default: { x: 0, y: 0, z: -0.04 } }
   },
   init: function() {
     this.controller = null;
     this.shapeAdded = false;
+    this.isLeft = this.el.getAttribute("hand-controls2") === "left";
 
     this._handleControllerConnected = this._handleControllerConnected.bind(this);
     this.el.addEventListener("controllerconnected", this._handleControllerConnected);
@@ -24,8 +25,9 @@ AFRAME.registerComponent("controls-shape-offset", {
   tick: function() {
     if (!this.shapeAdded && this.controller) {
       this.shapeAdded = true;
-      const hasOffset = CONTROLLER_OFFSETS.hasOwnProperty(this.controller);
-      const offset = hasOffset ? CONTROLLER_OFFSETS[this.controller] : CONTROLLER_OFFSETS.default;
+      const offsets = this.isLeft ? LEFT_CONTROLLER_OFFSETS : RIGHT_CONTROLLER_OFFSETS;
+      const hasOffset = offsets.hasOwnProperty(this.controller);
+      const offset = hasOffset ? offsets[this.controller] : offsets.default;
       const position = new THREE.Vector3();
       const quaternion = new THREE.Quaternion();
       const scale = new THREE.Vector3();
@@ -34,8 +36,8 @@ AFRAME.registerComponent("controls-shape-offset", {
       quaternion.conjugate();
 
       const shape = {
-        shape: "sphere",
-        radius: "0.02",
+        shape: "box",
+        halfExtents: { x: 0.03, y: 0.04, z: 0.05 },
         orientation: quaternion,
         offset: position
       };

--- a/src/components/cursor-controller.js
+++ b/src/components/cursor-controller.js
@@ -13,7 +13,7 @@ AFRAME.registerComponent("cursor-controller", {
     cursor: { type: "selector" },
     camera: { type: "selector" },
     far: { default: 3 },
-    near: { default: 0 },
+    near: { default: 0.06 },
     cursorColorHovered: { default: "#2F80ED" },
     cursorColorUnhovered: { default: "#FFFFFF" },
     rayObject: { type: "selector" },

--- a/src/components/hand-controls2.js
+++ b/src/components/hand-controls2.js
@@ -19,7 +19,7 @@ export const LEFT_CONTROLLER_OFFSETS = {
   "oculus-touch-controls": new THREE.Matrix4().makeTranslation(-0.025, -0.03, 0.1),
   "oculus-go-controls": new THREE.Matrix4(),
   "vive-controls": new THREE.Matrix4().compose(
-    new THREE.Vector3(0, -0.017, 0.13),
+    new THREE.Vector3(0, 0, 0.13),
     new THREE.Quaternion().setFromEuler(new THREE.Euler(-40 * THREE.Math.DEG2RAD, 0, 0)),
     new THREE.Vector3(1, 1, 1)
   ),
@@ -37,7 +37,7 @@ export const RIGHT_CONTROLLER_OFFSETS = {
   "oculus-touch-controls": new THREE.Matrix4().makeTranslation(0.025, -0.03, 0.1),
   "oculus-go-controls": new THREE.Matrix4(),
   "vive-controls": new THREE.Matrix4().compose(
-    new THREE.Vector3(0, -0.017, 0.13),
+    new THREE.Vector3(0, 0, 0.13),
     new THREE.Quaternion().setFromEuler(new THREE.Euler(-40 * THREE.Math.DEG2RAD, 0, 0)),
     new THREE.Vector3(1, 1, 1)
   ),

--- a/src/components/hand-controls2.js
+++ b/src/components/hand-controls2.js
@@ -14,9 +14,27 @@ const POSES = {
 
 // TODO: If the hands or controllers are mispositioned, then rightHand.controllerPose and rightHand.pose
 //       should be bound differently.
-export const CONTROLLER_OFFSETS = {
+export const LEFT_CONTROLLER_OFFSETS = {
   default: new THREE.Matrix4(),
-  "oculus-touch-controls": new THREE.Matrix4().makeTranslation(0, -0.015, 0.04),
+  "oculus-touch-controls": new THREE.Matrix4().makeTranslation(-0.025, -0.03, 0.1),
+  "oculus-go-controls": new THREE.Matrix4(),
+  "vive-controls": new THREE.Matrix4().compose(
+    new THREE.Vector3(0, -0.017, 0.13),
+    new THREE.Quaternion().setFromEuler(new THREE.Euler(-40 * THREE.Math.DEG2RAD, 0, 0)),
+    new THREE.Vector3(1, 1, 1)
+  ),
+  "windows-motion-controls": new THREE.Matrix4().compose(
+    new THREE.Vector3(0, -0.017, 0.13),
+    new THREE.Quaternion().setFromEuler(new THREE.Euler(-40 * THREE.Math.DEG2RAD, 0, 0)),
+    new THREE.Vector3(1, 1, 1)
+  ),
+  "daydream-controls": new THREE.Matrix4().makeTranslation(0, 0, -0.04),
+  "gearvr-controls": new THREE.Matrix4()
+};
+
+export const RIGHT_CONTROLLER_OFFSETS = {
+  default: new THREE.Matrix4(),
+  "oculus-touch-controls": new THREE.Matrix4().makeTranslation(0.025, -0.03, 0.1),
   "oculus-go-controls": new THREE.Matrix4(),
   "vive-controls": new THREE.Matrix4().compose(
     new THREE.Vector3(0, -0.017, 0.13),
@@ -40,11 +58,18 @@ export const CONTROLLER_OFFSETS = {
 AFRAME.registerComponent("hand-controls2", {
   schema: { default: "left" },
 
-  getControllerOffset() {
-    if (CONTROLLER_OFFSETS[this.connectedController] === undefined) {
-      return CONTROLLER_OFFSETS.default;
+  getLeftControllerOffset() {
+    if (LEFT_CONTROLLER_OFFSETS[this.connectedController] === undefined) {
+      return LEFT_CONTROLLER_OFFSETS.default;
     }
-    return CONTROLLER_OFFSETS[this.connectedController];
+    return LEFT_CONTROLLER_OFFSETS[this.connectedController];
+  },
+
+  getRightControllerOffset() {
+    if (RIGHT_CONTROLLER_OFFSETS[this.connectedController] === undefined) {
+      return RIGHT_CONTROLLER_OFFSETS.default;
+    }
+    return RIGHT_CONTROLLER_OFFSETS[this.connectedController];
   },
 
   init() {

--- a/src/components/hand-controls2.js
+++ b/src/components/hand-controls2.js
@@ -12,8 +12,6 @@ const POSES = {
   mrpDown: "mrpDown"
 };
 
-// TODO: If the hands or controllers are mispositioned, then rightHand.controllerPose and rightHand.pose
-//       should be bound differently.
 export const LEFT_CONTROLLER_OFFSETS = {
   default: new THREE.Matrix4(),
   "oculus-touch-controls": new THREE.Matrix4().makeTranslation(-0.025, -0.03, 0.1),

--- a/src/components/ik-controller.js
+++ b/src/components/ik-controller.js
@@ -180,11 +180,11 @@ AFRAME.registerComponent("ik-controller", {
     rootToChest.multiplyMatrices(hips.matrix, chest.matrix);
     invRootToChest.getInverse(rootToChest);
 
-    this.updateHand(this.hands.left, leftHand, leftController);
-    this.updateHand(this.hands.right, rightHand, rightController);
+    this.updateHand(this.hands.left, leftHand, leftController, true);
+    this.updateHand(this.hands.right, rightHand, rightController, false);
   },
 
-  updateHand(handState, handObject3D, controller) {
+  updateHand(handState, handObject3D, controller, isLeft) {
     const hand = handObject3D.el;
     const handMatrix = handObject3D.matrix;
     const controllerObject3D = controller.object3D;
@@ -201,7 +201,7 @@ AFRAME.registerComponent("ik-controller", {
       const handControls = controller.components["hand-controls2"];
 
       if (handControls) {
-        handMatrix.multiply(handControls.getControllerOffset());
+        handMatrix.multiply(isLeft ? handControls.getLeftControllerOffset() : handControls.getRightControllerOffset());
       }
 
       handMatrix.multiply(handState.rotation);

--- a/src/hub.html
+++ b/src/hub.html
@@ -342,6 +342,7 @@
                 class="camera"
                 camera
                 personal-space-bubble="radius: 0.4;"
+                rotation
                 pitch-yaw-rotator
             >
                 <a-entity

--- a/src/hub.js
+++ b/src/hub.js
@@ -317,6 +317,9 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   window.APP.scene = scene;
 
+  scene.addEventListener("enter-vr", () => document.body.classList.add("vr-mode"));
+  scene.addEventListener("exit-vr", () => document.body.classList.remove("vr-mode"));
+
   registerNetworkSchemas();
 
   remountUI({

--- a/src/hub.js
+++ b/src/hub.js
@@ -317,7 +317,17 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   window.APP.scene = scene;
 
-  scene.addEventListener("enter-vr", () => document.body.classList.add("vr-mode"));
+  scene.addEventListener("enter-vr", () => {
+    document.body.classList.add("vr-mode");
+
+    if (!scene.is("entered")) {
+      // If VR headset is activated, refreshing page will fire vrdisplayactivate
+      // which puts A-Frame in VR mode, so exit VR mode whenever it is attempted
+      // to be entered and we haven't entered the room yet.
+      scene.exitVR();
+    }
+  });
+
   scene.addEventListener("exit-vr", () => document.body.classList.remove("vr-mode"));
 
   registerNetworkSchemas();


### PR DESCRIPTION
This PR makes a number of improvements to desktop VR mode:

- Stretches the canvas so only one eye buffer is visible on the screen
- Fixes the issue where the app automatically re-enters VR mode on refresh after a successful entry
- Enables the OS cursor so the desktop UI can be used
- Greatly improves the alignment of virtual hands on Oculus and adds a more forgiving box collider to the palm
- Sets the min cursor distance to a non zero value so it's clear that you need to physically grab objects and aren't grabbing them by pulling them to you
- Fixes a bug introduced by the camera rotation not being YXZ ordered that caused WASD to be wrong and the HUD to be mis-oriented. (This should eventually be replaced by the `set-rotation-yxz` component on the `feature/pinning-persistence` branch

Note that using 2d mode with VR controllers plugged in is still broken because the cursor pose path is written to twice, once by the vive/oculus control bindings and once by the keyboard/mouse bindings, regardless of how the user decides to enter.