### PR TITLE
Remove some frame time

### DIFF
--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -59,6 +59,7 @@
     "autoexit.subtitle": "You have started another session.",
     "autoexit.cancel": "CANCEL",
     "presence.entered_room": "entered the room.",
+    "presence.entered_lobby": "entered the lobby.",
     "presence.join_lobby": "joined the lobby.",
     "presence.leave": "left.",
     "presence.name_change": "is now known as",

--- a/src/components/cursor-controller.js
+++ b/src/components/cursor-controller.js
@@ -98,7 +98,11 @@ AFRAME.registerComponent("cursor-controller", {
       const rightHandPose = userinput.get(paths.actions.rightHand.pose);
 
       this.data.cursor.object3D.visible = this.enabled && !!cursorPose;
-      this.el.setAttribute("line", "visible", this.enabled && !!rightHandPose);
+      const lineVisible = !!(this.enabled && rightHandPose);
+
+      if (this.el.getAttribute("line").visible !== lineVisible) {
+        this.el.setAttribute("line", "visible", lineVisible);
+      }
 
       if (!this.enabled || !cursorPose) {
         return;
@@ -129,11 +133,12 @@ AFRAME.registerComponent("cursor-controller", {
       cameraPos.y = cursor.object3D.position.y;
       cursor.object3D.lookAt(cameraPos);
 
-      this.data.cursor.setAttribute(
-        "material",
-        "color",
-        intersection || isGrabbing ? cursorColorHovered : cursorColorUnhovered
-      );
+      const cursorColor = intersection || isGrabbing ? cursorColorHovered : cursorColorUnhovered;
+
+      if (this.data.cursor.getAttribute("material").color !== cursorColor) {
+        this.data.cursor.setAttribute("material", "color", cursorColor);
+      }
+
       if (this.el.components.line.data.visible) {
         this.el.setAttribute("line", {
           start: cursorPose.position.clone(),

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -75,6 +75,8 @@ export default class SceneEntryManager {
       return;
     }
 
+    this.scene.setAttribute("motion-capture-replayer", "enabled", false);
+
     if (mediaStream) {
       NAF.connection.adapter.setLocalMediaStream(mediaStream);
     }


### PR DESCRIPTION
Does a few optimizations on some fixed costs per frame:

- Disables a `tick` on `motion-player-capture` if we're not running in bot mode
- Avoids calling `setAttribute` on cursor components if not necessary
- Adds a missing translation