### PR TITLE
Fix up video syncing with pinned objects

### DIFF
--- a/src/components/pinnable.js
+++ b/src/components/pinnable.js
@@ -19,6 +19,9 @@ AFRAME.registerComponent("pinnable", {
     // Fire pinned events when page changes so we can persist the page.
     this.el.addEventListener("pager-page-changed", this._fireEvents);
 
+    // Fire pinned events when video state changes so we can persist the page.
+    this.el.addEventListener("owned-video-state-changed", this._fireEvents);
+
     // Hack: need to wait for the initial grabbable and stretchable components
     // to show up from the template before applying.
     this.el.addEventListener("componentinitialized", this._allowApplyOnceComponentsReady);

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -89,4 +89,12 @@ AFRAME.GLTFModelPlus.registerComponent("media", "media", (el, componentName, com
   if (componentData.pageIndex) {
     el.setAttribute("media-pager", { index: componentData.pageIndex });
   }
+
+  if (componentData.paused !== undefined) {
+    el.setAttribute("media-video", { videoPaused: componentData.paused });
+  }
+
+  if (componentData.time) {
+    el.setAttribute("media-video", { time: componentData.time });
+  }
 });

--- a/src/utils/pinned-entity-to-gltf.js
+++ b/src/utils/pinned-entity-to-gltf.js
@@ -25,6 +25,11 @@ export default function pinnedEntityToGltf(el) {
     if (components["media-pager"]) {
       gltfComponents.media.pageIndex = components["media-pager"].data.index;
     }
+
+    if (components["media-video"] && components["media-video"].data.videoPaused) {
+      gltfComponents.media.paused = true;
+      gltfComponents.media.time = components["media-video"].data.time;
+    }
   }
 
   gltfComponents.pinnable = { pinned: true };


### PR DESCRIPTION
This fixes up two things with pinned videos:

- You can't call play() until the user interacts with the page, so a pinned video won't play on startup until the user clicks on the page. This is mitigated in this PR by retrying until it works.

- Added the ability to pin a paused video. We pin the pause state and time of the pause. If a video isn't paused when it's pinned we just assume if the room clears out it should start from the beginning.