### PR TITLE
Don't reuse the box-collider orientation quaternion.

### DIFF
--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -34,11 +34,10 @@ AFRAME.GLTFModelPlus.registerComponent(
   "shape",
   (() => {
     const euler = new THREE.Euler();
-    const orientation = new THREE.Quaternion();
     return (el, componentName, componentData) => {
       const { scale, rotation } = componentData;
       euler.set(rotation.x, rotation.y, rotation.z);
-      orientation.setFromEuler(euler);
+      const orientation = new THREE.Quaternion().setFromEuler(euler);
       el.setAttribute(componentName, {
         shape: "box",
         offset: componentData.position,


### PR DESCRIPTION
The box-collider inflator was reusing the orientation Quaternion across colliders. This caused all box colliders to share the same orientation.