### PR TITLE
Fix issues detecting VR input devices

### DIFF
--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -51,6 +51,9 @@ export default class SceneEntryManager {
     }
 
     if (enterInVR) {
+      // HACK - A-Frame calls getVRDisplays at module load, we want to do it here to
+      // force gamepads to become live.
+      navigator.getVRDisplays();
       this.scene.enterVR();
     } else if (AFRAME.utils.device.isMobile()) {
       document.body.addEventListener("touchend", requestFullscreen);

--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -196,6 +196,7 @@ AFRAME.registerSystem("userinput", {
       console.log("frame", this.frame);
       console.log("sets", this.activeSets);
       console.log("bindings", this.activeBindings);
+      console.log("mappings", this.registeredMappings);
       console.log("devices", this.activeDevices);
       console.log("xformStates", this.xformStates);
     }

--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -139,7 +139,8 @@ AFRAME.registerSystem("userinput", {
         this.registeredMappings.delete(isMobile ? touchscreenUserBindings : keyboardMouseUserBindings);
         // add mappings for all active VR input devices
         for (const activeDevice of this.activeDevices) {
-          this.registeredMappings.add(vrGamepadMappings.get(activeDevice.constructor));
+          const mapping = vrGamepadMappings.get(activeDevice.constructor);
+          mapping && this.registeredMappings.add(mapping);
         }
       } else {
         console.log("Using Non-VR bindings.");


### PR DESCRIPTION
This fixes a few issues which cause VR input devices not working correctly:
- [x] If `gamepadconnected` fires before the input system is initialized we may miss the event. Now queries all devices on startup to make sure
- [x] We were only keeping track of the bindings for the last gamepad that was connected. This would break things if a non-vr gamepad's `gamepadconnected` event fired after a VR device. Now turns on/off all bindings for connected VR devices.
- [x] bindings are not removed when a VR input device disconnects
- [x] if you exit VR after all calls to `getVRDisplays` in the app have been made, the Gamepad API does not report gampead state until `getVRDisplays` is called again. Now calls `getVRDisplays` every time we enter VR.