### PR TITLE
Responsive CSS for Hubs Landing Page

### DIFF
--- a/src/assets/stylesheets/hub-create.scss
+++ b/src/assets/stylesheets/hub-create.scss
@@ -13,6 +13,10 @@
     width: 90%;
     height: 300px;
   }
+
+  @media (max-width: 350px) {
+    height: 250px;
+  }
 }
 
 :local(.create-panel) {
@@ -33,6 +37,10 @@
     @media (max-width: 520px) {
       width: 90%;
       height: 300px;
+    }
+
+    @media (max-width: 350px) {
+      height: 250px;
     }
 
     :local(.name) {
@@ -75,6 +83,11 @@
 
     :local(.submit-button) {
       @extend %big-action-button;
+
+      @media (max-width: 350px) {
+        font-size: 16px;
+        padding: 9px 24px;
+      }
     }
 
     :local(.container) {
@@ -203,6 +216,10 @@
 
             svg {
               filter: drop-shadow(0 0 1px #777);
+
+              @media (max-width: 520px) {
+                font-size: 48pt;
+              }
             }
           }
 

--- a/src/assets/stylesheets/hub-create.scss
+++ b/src/assets/stylesheets/hub-create.scss
@@ -200,6 +200,10 @@
             pointer-events: auto;
             cursor: pointer;
             padding: 0;
+
+            svg {
+              filter: drop-shadow(0 0 1px #777);
+            }
           }
 
           :local(.prev) {

--- a/src/assets/stylesheets/hub-create.scss
+++ b/src/assets/stylesheets/hub-create.scss
@@ -4,7 +4,7 @@
   width: 690px;
   height: 460px;
 
-  @media (max-width: 768px) , (max-height: 715px) {
+  @media (max-width: 768px), (max-height: 480px) {
     width: 525px;
     height: 350px;
   }
@@ -29,7 +29,7 @@
     width: 690px;
     height: 460px;
 
-    @media (max-width: 768px) , (max-height: 715px) {
+    @media (max-width: 768px) {
       width: 525px;
       height: 350px;
     }
@@ -40,6 +40,11 @@
     }
 
     @media (max-width: 350px) {
+      height: 250px;
+    }
+
+    @media (max-height: 480px) {
+      width: 375px;
       height: 250px;
     }
 
@@ -68,7 +73,7 @@
         color: white;
       }
 
-      @media (max-width: 768px) , (max-height: 715px) {
+      @media (max-width: 768px), (max-height: 480px) {
         min-width: auto;
         font-size: 1.5em;
         width: 100%;
@@ -84,9 +89,10 @@
     :local(.submit-button) {
       @extend %big-action-button;
 
-      @media (max-width: 350px) {
+      @media (max-width: 350px), (max-height: 480px) {
         font-size: 16px;
         padding: 9px 24px;
+        width: auto;
       }
     }
 
@@ -111,7 +117,7 @@
       overflow: hidden;
       pointer-events: none;
 
-      @media (max-width: 768px) , (max-height: 715px) {
+      @media (max-width: 768px), (max-height: 480px) {
         width: 100%;
       }
 
@@ -153,7 +159,7 @@
             border: none;
             pointer-events: auto;
 
-            @media (max-width: 520px) {
+            @media (max-width: 520px), (max-height: 480px) {
               display: none;
             }
           }
@@ -176,7 +182,7 @@
               color: $light-text;
               font-size: 1.4em;
 
-              @media (max-width: 520px) {
+              @media (max-width: 520px), (max-height: 480px) {
                 display: none;
               }
             }
@@ -186,7 +192,7 @@
               font-size: 1.0em;
               display: inline;
 
-              @media (max-width: 520px) {
+              @media (max-width: 520px), (max-height: 480px) {
                 display: none;
               }
             }
@@ -217,7 +223,7 @@
             svg {
               filter: drop-shadow(0 0 1px #777);
 
-              @media (max-width: 520px) {
+              @media (max-width: 520px), (max-height: 480px) {
                 font-size: 48pt;
               }
             }

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -191,7 +191,7 @@ body {
 }
 
 :local(.footer-content) {
-  padding: 1em 2.25em;
+  padding: 2.25em;
   background-color: white;
   min-height: 80px;
   display: flex;

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -14,44 +14,23 @@ body {
   padding: 0;
   background-color: white;
   color: black;
-}
-
-.home-root {
   @extend %default-font;
-
-  width: 100%;
-  height: 100%;
-  margin: 0;
-  padding: 0;
 }
 
 :local(.home) {
-  position: absolute;
   display: flex;
-  width: 100%;
-  height: 100%;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 :local(.main-content) {
-  width: 100%;
-  height: 100%;
   display: flex;
   flex-direction: column;
-  z-index: 2;
+  flex: 1;
 
   &:local(.noninteractive) {
     pointer-events: none;
   }
-}
-
-:local(.background-video) {
-  position: fixed;
-  top: 0;
-  left: 0;
-  opacity: 0.3;
-  min-width: 100%;
-  min-height: 100%;
-  z-index: 1;
 }
 
 :local(.header-content) {
@@ -61,14 +40,14 @@ body {
   height: 65px;
   display: flex;
 
-  @media (max-width: 768px), (max-height: 715px) {
-    display: none;
+  @media (max-width: 768px) {
+    height: auto;
+    min-height: auto;
+    padding: 1em 0;
   }
 
   :local(.title-and-nav) {
     display: flex;
-    width: $header-section-width;
-    cursor: pointer;
 
     @media (max-width: 768px) {
       justify-content: center;
@@ -78,73 +57,82 @@ body {
       flex: 1 1 $header-section-width;
     }
 
-    :local(.name) {
-      width: 200px;
-    }
-
-    :local(.hubs) {
-      font-size: 2.5em;
-      font-weight: bold;
-      pointer-events: none;
-    }
-
-    :local(.preview) {
-      color: $grey-text;
-      margin-left: 10px;
-      margin-right: 20px;
-      pointer-events: none;
-    }
-
     :local(.links) {
       display: flex;
       align-items: center;
 
+      @media (max-width: 768px) {
+        flex-direction: column;
+      }
+
       a {
-        margin: 0px 32px 0px 0px;
+        display: flex;
+        margin: 0 16px;
         color: black;
         font-weight: bold;
         font-size: 1.4em;
         text-decoration: none;
-      }
-
-      a:first-child {
-        margin-left: 16px;
+        
+        @media (max-width: 768px) {
+          margin-top: 0.5em;
+        }
       }
     }
   }
 }
 
+:local(.video-container) {
+  position: absolute;
+  z-index: -1;
+  top: 0px;
+  left: 0px;
+  bottom: 0px;
+  right: 0px;
+  overflow: hidden;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: 50% 50%;
+  background-image: none;
+}
+
+:local(.background-video) {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  min-width: 100%;
+  min-height: 100%;
+  z-index: -1;
+  overflow: hidden;
+}
+
 :local(.hero-content) {
-  flex: 10;
-  min-height: 740px;
   display: flex;
+  flex: 1;
   flex-direction: column;
   justify-content: center;
   position: relative;
+  min-height: 740px;
+  padding: 2em 0;
+  background-color: rgba(255, 255, 255, 0.7);
 
   @media (max-width: 768px) {
-    padding: 0px;
-    min-height: 490px;
-  }
-
-  @media (max-height: 715px) {
-    justify-content: flex-start;
+    min-height: 680px;
+    padding: 0;
+    padding-bottom: 64px;
+    order: -1;
   }
 
   :local(.attribution) {
     position: absolute;
     right: 12px;
-    top: 12px;
-    color: white;
+    bottom: 12px;
+    color: $dark-grey;
     opacity: 0.8;
 
     a {
       font-weight: bold;
-      color: white;
-    }
-
-    @media (max-width: 768px) {
-      display: none;
+      color: $dark-grey;
     }
   }
 
@@ -164,8 +152,8 @@ body {
       font-size: 1.5em;
       font-weight: bold;
 
-      @media (max-height: 715px) {
-        display: none;
+      @media (max-width: 768px) {
+        font-size: 1em;
       }
     }
   }
@@ -204,17 +192,17 @@ body {
 
 :local(.footer-content) {
   padding: 1em 2.25em;
-  margin: 24px;
-
-  @media (max-width: 768px) {
-    padding: 1em;
-    margin: 0;
-  }
-
+  background-color: white;
   min-height: 80px;
   display: flex;
   align-items: center;
   justify-content: flex-end;
+
+  @media (max-width: 768px) {
+    padding: 0 0 2em 0;
+    margin: 0;
+    justify-content: center;
+  }
 
   :local(.links) {
     text-align: center;
@@ -231,13 +219,18 @@ body {
         width: 113px;
         height: 32px;
         margin: 0;
+        margin-top: 18px;
       }
     }
 
     :local(.top) {
       display: flex;
       justify-content: space-between;
-      align-items: flex-end;
+      align-items: center;
+
+      @media (max-width: 768px) {
+        flex-direction: column;
+      }
     }
 
     :local(.link) {
@@ -246,7 +239,7 @@ body {
       margin: 0 18px;
 
       @media (max-width: 768px) {
-        display: none;
+        margin-top: 18px;
       }
     }
 

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -127,6 +127,7 @@ body {
     top: 12px;
     color: $dark-grey;
     opacity: 0.8;
+    font-size: 12px;
 
     @media (max-width: 768px) {
       bottom: 12px;

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -27,6 +27,7 @@ body {
   display: flex;
   flex-direction: column;
   flex: 1;
+  position: relative;
 
   &:local(.noninteractive) {
     pointer-events: none;

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -41,7 +41,7 @@ body {
   height: 65px;
   display: flex;
 
-  @media (max-width: 768px) {
+  @media (max-width: 768px), (max-height: 480px) {
     height: auto;
     min-height: auto;
     padding: 1em 0;
@@ -50,7 +50,7 @@ body {
   :local(.title-and-nav) {
     display: flex;
 
-    @media (max-width: 768px) {
+    @media (max-width: 768px), (max-height: 480px) {
       justify-content: center;
     }
 
@@ -62,7 +62,7 @@ body {
       display: flex;
       align-items: center;
 
-      @media (max-width: 768px) {
+      @media (max-width: 768px), (max-height: 480px) {
         flex-direction: column;
       }
 
@@ -74,7 +74,7 @@ body {
         font-size: 1.4em;
         text-decoration: none;
         
-        @media (max-width: 768px) {
+        @media (max-width: 768px), (max-height: 480px) {
           margin-top: 0.5em;
         }
       }
@@ -116,7 +116,7 @@ body {
   position: relative;
   padding: 2em 0;
 
-  @media (max-width: 768px) {
+  @media (max-width: 768px), (max-height: 480px) {
     padding: 0;
     padding-bottom: 64px;
     order: -1;
@@ -130,7 +130,7 @@ body {
     opacity: 0.8;
     font-size: 12px;
 
-    @media (max-width: 768px) {
+    @media (max-width: 768px), (max-height: 480px) {
       bottom: 12px;
       top: auto;
     }
@@ -145,6 +145,11 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
+    padding: 2em;
+
+    @media (max-height: 480px) {
+      padding: 1em;
+    }
 
     :local(.logo) {
       max-width: 350px;
@@ -155,8 +160,6 @@ body {
       }
     }
 
-    padding: 2em;
-
     :local(.title) {
       text-align: center;
       font-size: 1.5em;
@@ -164,6 +167,10 @@ body {
 
       @media (max-width: 768px) {
         font-size: 1em;
+      }
+
+      @media (max-height: 480px) {
+        display: none;
       }
     }
   }
@@ -173,7 +180,7 @@ body {
     padding-bottom: 2vw;
     position: relative;
 
-    @media (max-width: 768px) {
+    @media (max-width: 768px), (max-height: 480px) {
       padding: 0.5em;
     }
   }
@@ -201,7 +208,7 @@ body {
 
   :local(.join-button), :local(.spoke-button) {
     a {
-      @media (max-width: 350px) {
+      @media (max-width: 350px), (max-height: 480px) {
         font-size: 0.75em;
         height: 32px;
       }
@@ -216,7 +223,7 @@ body {
   align-items: center;
   justify-content: flex-end;
 
-  @media (max-width: 768px) {
+  @media (max-width: 768px), (max-height: 480px) {
     background-color: white;
     padding: 0 0 2em 0;
     margin: 0;
@@ -234,7 +241,7 @@ body {
       height: 49px;
       margin-left: 18px;
 
-      @media (max-width: 768px) {
+      @media (max-width: 768px), (max-height: 480px) {
         width: 113px;
         height: 32px;
         margin: 0;
@@ -247,7 +254,7 @@ body {
       justify-content: space-between;
       align-items: flex-end;
 
-      @media (max-width: 768px) {
+      @media (max-width: 768px), (max-height: 480px) {
         align-items: center;
         flex-direction: column;
       }
@@ -258,7 +265,7 @@ body {
       font-weight: bold;
       margin: 0 18px;
 
-      @media (max-width: 768px) {
+      @media (max-width: 768px), (max-height: 480px) {
         margin-top: 18px;
       }
     }

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -104,6 +104,7 @@ body {
   min-height: 100%;
   z-index: -1;
   overflow: hidden;
+  opacity: 0.3;
 }
 
 :local(.hero-content) {
@@ -112,12 +113,9 @@ body {
   flex-direction: column;
   justify-content: center;
   position: relative;
-  min-height: 740px;
   padding: 2em 0;
-  background-color: rgba(255, 255, 255, 0.7);
 
   @media (max-width: 768px) {
-    min-height: 680px;
     padding: 0;
     padding-bottom: 64px;
     order: -1;
@@ -126,9 +124,14 @@ body {
   :local(.attribution) {
     position: absolute;
     right: 12px;
-    bottom: 12px;
+    top: 12px;
     color: $dark-grey;
     opacity: 0.8;
+
+    @media (max-width: 768px) {
+      bottom: 12px;
+      top: auto;
+    }
 
     a {
       font-weight: bold;
@@ -142,7 +145,12 @@ body {
     align-items: center;
 
     :local(.logo) {
-      width: 350px;
+      max-width: 350px;
+
+      img {
+        width: 100%;
+        height: auto;
+      }
     }
 
     padding: 2em;
@@ -188,17 +196,26 @@ body {
       background: $spoke-action-color;
     }
   }
+
+  :local(.join-button), :local(.spoke-button) {
+    a {
+      @media (max-width: 350px) {
+        font-size: 0.75em;
+        height: 32px;
+      }
+    }
+  }
 }
 
 :local(.footer-content) {
   padding: 2.25em;
-  background-color: white;
   min-height: 80px;
   display: flex;
   align-items: center;
   justify-content: flex-end;
 
   @media (max-width: 768px) {
+    background-color: white;
     padding: 0 0 2em 0;
     margin: 0;
     justify-content: center;
@@ -226,9 +243,10 @@ body {
     :local(.top) {
       display: flex;
       justify-content: space-between;
-      align-items: center;
+      align-items: flex-end;
 
       @media (max-width: 768px) {
+        align-items: center;
         flex-direction: column;
       }
     }

--- a/src/react-components/home-root.js
+++ b/src/react-components/home-root.js
@@ -173,6 +173,12 @@ class HomeRoot extends Component {
       <IntlProvider locale={lang} messages={messages}>
         <div className={styles.home}>
           <div className={mainContentClassNames}>
+            <div className={styles.videoContainer}>
+              <video playsInline muted loop autoPlay className={styles.backgroundVideo} id="background-video">
+                <source src={homeVideoWebM} type="video/webm" />
+                <source src={homeVideoMp4} type="video/mp4" />
+              </video>
+            </div>
             <div className={styles.headerContent}>
               <div className={styles.titleAndNav} onClick={() => (document.location = "/")}>
                 <div className={styles.links}>
@@ -195,12 +201,6 @@ class HomeRoot extends Component {
               </div>
             </div>
             <div className={styles.heroContent}>
-              <div className={styles.videoContainer}>
-                <video playsInline muted loop autoPlay className={styles.backgroundVideo} id="background-video">
-                  <source src={homeVideoWebM} type="video/webm" />
-                  <source src={homeVideoMp4} type="video/mp4" />
-                </video>
-              </div>
               <div className={styles.attribution}>
                 Medieval Fantasy Book by{" "}
                 <a
@@ -212,7 +212,9 @@ class HomeRoot extends Component {
                 </a>
               </div>
               <div className={styles.container}>
-                <img className={styles.logo} src={hubLogo} />
+                <div className={styles.logo}>
+                  <img src={hubLogo} />
+                </div>
                 <div className={styles.title}>
                   <FormattedMessage id="home.hero_title" />
                 </div>

--- a/src/react-components/home-root.js
+++ b/src/react-components/home-root.js
@@ -195,6 +195,12 @@ class HomeRoot extends Component {
               </div>
             </div>
             <div className={styles.heroContent}>
+              <div className={styles.videoContainer}>
+                <video playsInline muted loop autoPlay className={styles.backgroundVideo} id="background-video">
+                  <source src={homeVideoWebM} type="video/webm" />
+                  <source src={homeVideoMp4} type="video/mp4" />
+                </video>
+              </div>
               <div className={styles.attribution}>
                 Medieval Fantasy Book by{" "}
                 <a
@@ -302,10 +308,6 @@ class HomeRoot extends Component {
               </div>
             </div>
           </div>
-          <video playsInline muted loop autoPlay className={styles.backgroundVideo} id="background-video">
-            <source src={homeVideoWebM} type="video/webm" />
-            <source src={homeVideoMp4} type="video/mp4" />
-          </video>
           {this.state.dialog}
         </div>
       </IntlProvider>


### PR DESCRIPTION
This PR transitions the Hubs landing page from trying to scale to the full screen to a traditional scrolling web page. It shows the subheading, attribution, main nav, and footer on smaller screens by moving them all below the fold and making them flow vertically. I've also made the attribution for the environment in the video more legible and added shadows to the environment picker arrows.

Fixes #686