### PR TITLE
Add the water's missing normal map

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -55,6 +55,7 @@
             <img id="spawn-camera" crossorigin="anonymous" src="./assets/hud/spawn_camera.png">
             <img id="spawn-camera-hover" crossorigin="anonymous" src="./assets/hud/spawn_camera-hover.png">
             <img id="presence-count" crossorigin="anonymous" src="./assets/hud/presence-count.png">
+            <img id="water-normal-map" crossorigin="anonymous" src="./assets/waternormals.jpg">
 
             <a-asset-item id="botdefault" response-type="arraybuffer" src="https://asset-bundles-prod.reticulum.io/bots/BotDefault_Avatar-9f71f8ff22.gltf"></a-asset-item>
             <a-asset-item id="botbobo" response-type="arraybuffer" src="https://asset-bundles-prod.reticulum.io/bots/BotBobo_Avatar-f9740a010b.gltf"></a-asset-item>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4072106/48488784-75ca2600-e7d6-11e8-81c5-9eb4c8a44d72.png)

![image](https://user-images.githubusercontent.com/4072106/48488431-9645b080-e7d5-11e8-986d-c82ac418e7a2.png)

Add the water's missing normap map back in to fix the meeting room (and anything else with water). 

I had a diff of hub.html showing that I added the water-normal-map somehow when I thought I didn't. 
https://github.com/mozilla/hubs/pull/621#discussion_r228286139
So then I went back and removed what I thought was an errant addition I made, causing this regression:
https://github.com/mozilla/hubs/pull/621/commits/38806e5a258e866e419ab0c73d879dff1522c1a2
I think I mistook a change in line numbers for adding the water-normal-map, and then I removed it. I didn't notice the regression because I haven't been to the meeting room lately 
