### PR TITLE
Don't do meaningless stuff with empty media components

### DIFF
--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -224,31 +224,36 @@ AFRAME.registerComponent("media-pager", {
     this.toolbar = null;
     this.onNext = this.onNext.bind(this);
     this.onPrev = this.onPrev.bind(this);
-    this.el.addEventListener("image-loaded", async e => {
-      // unfortunately, since we loaded the page image in an img tag inside media-image, we have to make a second
-      // request for the same page to read out the max-content-index header
-      this.maxIndex = await fetchMaxContentIndex(e.detail.src);
-      // if this is the first image we ever loaded, set up the UI
-      if (this.toolbar == null) {
-        const template = document.getElementById("paging-toolbar");
-        this.el.querySelector(".interactable-ui").appendChild(document.importNode(template.content, true));
-        this.toolbar = this.el.querySelector(".paging-toolbar");
-        // we have to wait a tick for the attach callbacks to get fired for the elements in a template
-        setTimeout(() => {
-          this.nextButton = this.el.querySelector(".next-button [text-button]");
-          this.prevButton = this.el.querySelector(".prev-button [text-button]");
-          this.pageLabel = this.el.querySelector(".page-label");
 
-          this.nextButton.addEventListener("grab-start", this.onNext);
-          this.prevButton.addEventListener("grab-start", this.onPrev);
+    // we kind of have to deal with the "empty case" for this component, because networked-aframe
+    // will instantiate a null version of it for all media objects thanks to how it handles component schemas
+    if (this.data.src) {
+      this.el.addEventListener("image-loaded", async e => {
+        // unfortunately, since we loaded the page image in an img tag inside media-image, we have to make a second
+        // request for the same page to read out the max-content-index header
+        this.maxIndex = await fetchMaxContentIndex(e.detail.src);
+        // if this is the first image we ever loaded, set up the UI
+        if (this.toolbar == null) {
+          const template = document.getElementById("paging-toolbar");
+          this.el.querySelector(".interactable-ui").appendChild(document.importNode(template.content, true));
+          this.toolbar = this.el.querySelector(".paging-toolbar");
+          // we have to wait a tick for the attach callbacks to get fired for the elements in a template
+          setTimeout(() => {
+            this.nextButton = this.el.querySelector(".next-button [text-button]");
+            this.prevButton = this.el.querySelector(".prev-button [text-button]");
+            this.pageLabel = this.el.querySelector(".page-label");
 
+            this.nextButton.addEventListener("grab-start", this.onNext);
+            this.prevButton.addEventListener("grab-start", this.onPrev);
+
+            this.update();
+            this.el.emit("preview-loaded");
+          }, 0);
+        } else {
           this.update();
-          this.el.emit("preview-loaded");
-        }, 0);
-      } else {
-        this.update();
-      }
-    });
+        }
+      });
+    }
   },
 
   update() {

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -253,6 +253,10 @@ AFRAME.registerComponent("media-video", {
 
     this.lastUpdate = 0;
 
+    // we kind of have to deal with the "empty case" for this component, because networked-aframe
+    // will instantiate a null version of it for all media objects thanks to how it handles component schemas
+    if (!this.data.src) return;
+
     NAF.utils.getNetworkedEntity(this.el).then(networkedEl => {
       this.networkedEl = networkedEl;
       this.updatePlaybackState();


### PR DESCRIPTION
When you have any networked-aframe schema for a component, that component will be instantiated every time a networked object with the given schema is instantiated, even if no data for it is present. In this case, that causes `media-pager` and `media-video` components to appear on all networked objects, regardless of whether the instantiator has a pager or a video. If the pager is actually on a plain image media object, it will even pick up on the `image-loaded` event and present the pager UI in some cases.

It seems like the easiest way to deal with this without changing networked-aframe's behavior is to just make no-op pager and video components behave politely.