### PR TITLE
Switch to non-positional audio

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -178,9 +178,9 @@
                     destroy-at-extreme-distances
                     set-yxz-order
                     pinnable
-                    sound__grab="src: #sound_asset-grab; on: grabbed; poolSize: 1;"
-                    sound__graboff ="src: #sound_asset-grab_off; on: ungrabbed; poolSize: 1;"
-                    sound__pinned ="src: #sound_asset-pinned; on: pinned; poolSize: 1;"
+                    sound__grab="src: #sound_asset-grab; on: grabbed; poolSize: 1; positional: false;"
+                    sound__graboff ="src: #sound_asset-grab_off; on: ungrabbed; poolSize: 1; positional: false;"
+                    sound__pinned ="src: #sound_asset-pinned; on: pinned; poolSize: 1; positional: false;"
                     emit-state-change__grabbed="state: grabbed; transform: rising; event: grabbed;"
                     emit-state-change__ungrabbed="state: grabbed; transform: falling; event: ungrabbed;"
                     emit-state-change__pinned="state: pinned; transform: rising; event: pinned;"
@@ -211,14 +211,14 @@
                     sticky-object="autoLockOnRelease: true; autoLockOnLoad: true; autoLockSpeedLimit: 0;"
                     hoverable
                     scale="0.5 0.5 0.5"
-                    sound__next_pen_color="src: #sound_asset-next_pen_color; on: next_pen_color; poolSize: 2;"
-                    sound__prev_pen_color="src: #sound_asset-prev_pen_color; on: prev_pen_color; poolSize: 2;"
+                    sound__next_pen_color="src: #sound_asset-next_pen_color; on: next_pen_color; poolSize: 2; positional: false;"
+                    sound__prev_pen_color="src: #sound_asset-prev_pen_color; on: prev_pen_color; poolSize: 2; positional: false;"
                     sound__start_draw="src: #sound_asset-start_draw; on: start_draw; poolSize: 2;"
-                    sound__stop_draw="src: #sound_asset-stop_draw; on: stop_draw; poolSize: 2;"
-                    sound__increase_pen_radius="src: #sound_asset-increase_pen_radius; on: increase_pen_radius; poolSize: 2;"
-                    sound__decrease_pen_radius="src: #sound_asset-decrease_pen_radius; on: decrease_pen_radius; poolSize: 2;"
-                    sound__grab="src: #sound_asset-grab; on: grabbed; poolSize: 1;"
-                    sound__graboff ="src: #sound_asset-grab_off; on: ungrabbed; poolSize: 1;"
+                    sound__stop_draw="src: #sound_asset-stop_draw; on: stop_draw; poolSize: 2; positional: false;"
+                    sound__increase_pen_radius="src: #sound_asset-increase_pen_radius; on: increase_pen_radius; poolSize: 2; positional: false;"
+                    sound__decrease_pen_radius="src: #sound_asset-decrease_pen_radius; on: decrease_pen_radius; poolSize: 2; positional: false;"
+                    sound__grab="src: #sound_asset-grab; on: grabbed; poolSize: 1; positional: false;"
+                    sound__graboff ="src: #sound_asset-grab_off; on: ungrabbed; poolSize: 1; positional: false;"
                     emit-state-change__grabbed="state: grabbed; transform: rising; event: grabbed;"
                     emit-state-change__ungrabbed="state: grabbed; transform: falling; event: ungrabbed;"
                 >
@@ -411,7 +411,7 @@
                     class="ui hud mic"
                     material="alphaTest:0.1;"
                     hoverable
-                    sound__hud_hover_start="src: #sound_asset-hud_hover_start; on: mouseover; poolSize: 5;"
+                    sound__hud_hover_start="src: #sound_asset-hud_hover_start; on: mouseover; poolSize: 5; positional: false;"
                 ></a-image>
                 <a-image
                     icon-button="tooltip: #hud-tooltip; tooltipText: Pause; activeTooltipText: Resume; image: #freeze-off; hoverImage: #freeze-off-hover; activeImage: #freeze-on; activeHoverImage: #freeze-on-hover"
@@ -419,7 +419,7 @@
                     position="0 0 0.005"
                     class="ui hud freeze"
                     hoverable
-                    sound__hud_hover_start="src: #sound_asset-hud_hover_start; on: mouseover; poolSize: 5;"
+                    sound__hud_hover_start="src: #sound_asset-hud_hover_start; on: mouseover; poolSize: 5; positional: false;"
                 ></a-image>
                 <a-image
                     icon-button="tooltip: #hud-tooltip; tooltipText: Pen; activeTooltipText: Pen; image: #spawn-pen; hoverImage: #spawn-pen-hover; activeImage: #spawn-pen; activeHoverImage: #spawn-pen-hover"
@@ -428,7 +428,7 @@
                     class="ui hud penhud"
                     material="alphaTest:0.1;"
                     hoverable
-                    sound__hud_hover_start="src: #sound_asset-hud_hover_start; on: mouseover; poolSize: 5;"
+                    sound__hud_hover_start="src: #sound_asset-hud_hover_start; on: mouseover; poolSize: 5; positional: false;"
                 ></a-image>
                 <a-image
                     icon-button="tooltip: #hud-tooltip; tooltipText: Camera; activeTooltipText: Camera; image: #spawn-camera; hoverImage: #spawn-camera-hover; activeImage: #spawn-camera; activeHoverImage: #spawn-camera-hover"
@@ -437,7 +437,7 @@
                     class="ui hud camera-btn"
                     material="alphaTest:0.1;"
                     hoverable
-                    sound__hud_hover_start="src: #sound_asset-hud_hover_start; on: mouseover; poolSize: 5;"
+                    sound__hud_hover_start="src: #sound_asset-hud_hover_start; on: mouseover; poolSize: 5; positional: false;"
                 ></a-image>
                 <a-rounded visible="false" id="hud-tooltip" height="0.08" width="0.3" color="#000000" position="-0.15 -0.2 0" rotation="-20 0 0" radius="0.025" opacity="0.35" class="hud bg">
                     <a-entity text="value: Mute Mic; align:center;" position="0.15 0.04 0.001" ></a-entity>
@@ -477,7 +477,7 @@
                 scene-sound__action_freeze="on: play_freeze_sound;"
                 sound__action_thaw="positional: false; src: #sound_asset-thaw; on: nothing; poolSize: 2;"
                 scene-sound__action_thaw="on: play_thaw_sound;"
-                sound__hud_action_space_bubble="positional: false; src: #sound_asset-toggle_space_bubble; on: nothing; poolSize: 2;"
+                sound__hud_action_space_bubble="positional: false; src: #sound_asset-toggle_space_bubble; on: nothing; poolSize: 2; positional: false;"
                 scene-sound__hud_action_space_bubble="on: action_space_bubble;"
                 sound__hud_spawn_pen="positional: false; src: #sound_asset-spawn_pen; on: nothing; poolSize: 2;"
                 scene-sound__hud_spawn_pen="on: spawn_pen;"

--- a/src/hub.html
+++ b/src/hub.html
@@ -477,7 +477,7 @@
                 scene-sound__action_freeze="on: play_freeze_sound;"
                 sound__action_thaw="positional: false; src: #sound_asset-thaw; on: nothing; poolSize: 2;"
                 scene-sound__action_thaw="on: play_thaw_sound;"
-                sound__hud_action_space_bubble="positional: false; src: #sound_asset-toggle_space_bubble; on: nothing; poolSize: 2; positional: false;"
+                sound__hud_action_space_bubble="positional: false; src: #sound_asset-toggle_space_bubble; on: nothing; poolSize: 2;"
                 scene-sound__hud_action_space_bubble="on: action_space_bubble;"
                 sound__hud_spawn_pen="positional: false; src: #sound_asset-spawn_pen; on: nothing; poolSize: 2;"
                 scene-sound__hud_spawn_pen="on: spawn_pen;"


### PR DESCRIPTION
Updating the panner nodes' position/orientation every frame is expensive. For sfx that don't really need to be positional, turn it off.