### PR TITLE
Skip panner node position updates if not moved

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -17,6 +17,7 @@ import "webrtc-adapter";
 import "aframe-slice9-component";
 import "aframe-motion-capture-components";
 import "./utils/audio-context-fix";
+import "./utils/threejs-positional-audio-updatematrixworld";
 import { getReticulumFetchUrl } from "./utils/phoenix-utils";
 
 import nextTick from "./utils/next-tick";

--- a/src/utils/threejs-positional-audio-updatematrixworld.js
+++ b/src/utils/threejs-positional-audio-updatematrixworld.js
@@ -1,0 +1,55 @@
+// Monkeypatch to address performance issue with updating panner nodes
+// TODO this needs to be merged into 3.js
+
+THREE.PositionalAudio.prototype.updateMatrixWorld = (function() {
+  const position = new THREE.Vector3();
+  const quaternion = new THREE.Quaternion();
+
+  const scale = new THREE.Vector3();
+  const orientation = new THREE.Vector3();
+
+  return function updateMatrixWorld(force) {
+    THREE.Object3D.prototype.updateMatrixWorld.call(this, force);
+
+    let setInitial = false;
+
+    if (!this._lastPosition) {
+      setInitial = true;
+      this._lastPosition = new THREE.Vector3();
+      this._lastOrientation = new THREE.Vector3();
+      this._lastListenerPosition = new THREE.Vector3();
+    }
+
+    const panner = this.panner;
+    const listener = panner.context.listener;
+    this.matrixWorld.decompose(position, quaternion, scale);
+    orientation.set(0, 0, 1).applyQuaternion(quaternion);
+
+    // Need to update the position on this node if either the listener moves or this node moves,
+    // because otherwise there are audio artifacts.
+    if (
+      setInitial ||
+      Math.abs(panner.positionX.value - this._lastPosition.x) > Number.EPSILON ||
+      Math.abs(panner.positionY.value - this._lastPosition.y) > Number.EPSILON ||
+      Math.abs(panner.positionZ.value - this._lastPosition.z) > Number.EPSILON ||
+      Math.abs(panner.orientationX.value - this._lastOrientation.x) > Number.EPSILON ||
+      Math.abs(panner.orientationY.value - this._lastOrientation.y) > Number.EPSILON ||
+      Math.abs(panner.orientationZ.value - this._lastOrientation.z) > Number.EPSILON ||
+      Math.abs(listener.positionX.value - this._lastListenerPosition.x) > Number.EPSILON ||
+      Math.abs(listener.positionY.value - this._lastListenerPosition.y) > Number.EPSILON ||
+      Math.abs(listener.positionZ.value - this._lastListenerPosition.z) > Number.EPSILON
+    ) {
+      panner.setPosition(position.x, position.y, position.z);
+      panner.setOrientation(orientation.x, orientation.y, orientation.z);
+      this._lastPosition.x = panner.positionX.value;
+      this._lastPosition.y = panner.positionY.value;
+      this._lastPosition.z = panner.positionZ.value;
+      this._lastListenerPosition.x = listener.positionX.value;
+      this._lastListenerPosition.y = listener.positionY.value;
+      this._lastListenerPosition.z = listener.positionZ.value;
+      this._lastOrientation.x = panner.orientationX.value;
+      this._lastOrientation.y = panner.orientationY.value;
+      this._lastOrientation.z = panner.orientationZ.value;
+    }
+  };
+})();

--- a/src/utils/threejs-positional-audio-updatematrixworld.js
+++ b/src/utils/threejs-positional-audio-updatematrixworld.js
@@ -35,21 +35,25 @@ THREE.PositionalAudio.prototype.updateMatrixWorld = (function() {
       Math.abs(panner.orientationX.value - this._lastOrientation.x) > Number.EPSILON ||
       Math.abs(panner.orientationY.value - this._lastOrientation.y) > Number.EPSILON ||
       Math.abs(panner.orientationZ.value - this._lastOrientation.z) > Number.EPSILON ||
-      Math.abs(listener.positionX.value - this._lastListenerPosition.x) > Number.EPSILON ||
-      Math.abs(listener.positionY.value - this._lastListenerPosition.y) > Number.EPSILON ||
-      Math.abs(listener.positionZ.value - this._lastListenerPosition.z) > Number.EPSILON
+      (!listener.positionX || Math.abs(listener.positionX.value - this._lastListenerPosition.x) > Number.EPSILON) ||
+      (!listener.positionY || Math.abs(listener.positionY.value - this._lastListenerPosition.y) > Number.EPSILON) ||
+      (!listener.positionZ || Math.abs(listener.positionZ.value - this._lastListenerPosition.z) > Number.EPSILON)
     ) {
       panner.setPosition(position.x, position.y, position.z);
       panner.setOrientation(orientation.x, orientation.y, orientation.z);
       this._lastPosition.x = panner.positionX.value;
       this._lastPosition.y = panner.positionY.value;
       this._lastPosition.z = panner.positionZ.value;
-      this._lastListenerPosition.x = listener.positionX.value;
-      this._lastListenerPosition.y = listener.positionY.value;
-      this._lastListenerPosition.z = listener.positionZ.value;
+
       this._lastOrientation.x = panner.orientationX.value;
       this._lastOrientation.y = panner.orientationY.value;
       this._lastOrientation.z = panner.orientationZ.value;
+
+      if (listener.positionX && listener.positionY && listener.positionZ) {
+        this._lastListenerPosition.x = listener.positionX.value;
+        this._lastListenerPosition.y = listener.positionY.value;
+        this._lastListenerPosition.z = listener.positionZ.value;
+      }
     }
   };
 })();

--- a/src/utils/threejs-positional-audio-updatematrixworld.js
+++ b/src/utils/threejs-positional-audio-updatematrixworld.js
@@ -26,7 +26,7 @@ THREE.PositionalAudio.prototype.updateMatrixWorld = (function() {
     orientation.set(0, 0, 1).applyQuaternion(quaternion);
 
     // Need to update the position on this node if either the listener moves or this node moves,
-    // because otherwise there are audio artifacts.
+    // because otherwise there are audio artifacts in Chrome.
     if (
       setInitial ||
       Math.abs(panner.positionX.value - this._lastPosition.x) > Number.EPSILON ||
@@ -35,9 +35,9 @@ THREE.PositionalAudio.prototype.updateMatrixWorld = (function() {
       Math.abs(panner.orientationX.value - this._lastOrientation.x) > Number.EPSILON ||
       Math.abs(panner.orientationY.value - this._lastOrientation.y) > Number.EPSILON ||
       Math.abs(panner.orientationZ.value - this._lastOrientation.z) > Number.EPSILON ||
-      (!listener.positionX || Math.abs(listener.positionX.value - this._lastListenerPosition.x) > Number.EPSILON) ||
-      (!listener.positionY || Math.abs(listener.positionY.value - this._lastListenerPosition.y) > Number.EPSILON) ||
-      (!listener.positionZ || Math.abs(listener.positionZ.value - this._lastListenerPosition.z) > Number.EPSILON)
+      (listener.positionX && Math.abs(listener.positionX.value - this._lastListenerPosition.x) > Number.EPSILON) ||
+      (listener.positionY && Math.abs(listener.positionY.value - this._lastListenerPosition.y) > Number.EPSILON) ||
+      (listener.positionZ && Math.abs(listener.positionZ.value - this._lastListenerPosition.z) > Number.EPSILON)
     ) {
       panner.setPosition(position.x, position.y, position.z);
       panner.setOrientation(orientation.x, orientation.y, orientation.z);

--- a/src/utils/threejs-positional-audio-updatematrixworld.js
+++ b/src/utils/threejs-positional-audio-updatematrixworld.js
@@ -29,25 +29,26 @@ THREE.PositionalAudio.prototype.updateMatrixWorld = (function() {
     // because otherwise there are audio artifacts in Chrome.
     if (
       setInitial ||
-      Math.abs(panner.positionX.value - this._lastPosition.x) > Number.EPSILON ||
-      Math.abs(panner.positionY.value - this._lastPosition.y) > Number.EPSILON ||
-      Math.abs(panner.positionZ.value - this._lastPosition.z) > Number.EPSILON ||
-      Math.abs(panner.orientationX.value - this._lastOrientation.x) > Number.EPSILON ||
-      Math.abs(panner.orientationY.value - this._lastOrientation.y) > Number.EPSILON ||
-      Math.abs(panner.orientationZ.value - this._lastOrientation.z) > Number.EPSILON ||
+      Math.abs(position.x - this._lastPosition.x) > Number.EPSILON ||
+      Math.abs(position.y - this._lastPosition.y) > Number.EPSILON ||
+      Math.abs(position.z - this._lastPosition.z) > Number.EPSILON ||
+      Math.abs(orientation.x - this._lastOrientation.x) > Number.EPSILON ||
+      Math.abs(orientation.y - this._lastOrientation.y) > Number.EPSILON ||
+      Math.abs(orientation.z - this._lastOrientation.z) > Number.EPSILON ||
       (listener.positionX && Math.abs(listener.positionX.value - this._lastListenerPosition.x) > Number.EPSILON) ||
       (listener.positionY && Math.abs(listener.positionY.value - this._lastListenerPosition.y) > Number.EPSILON) ||
       (listener.positionZ && Math.abs(listener.positionZ.value - this._lastListenerPosition.z) > Number.EPSILON)
     ) {
       panner.setPosition(position.x, position.y, position.z);
       panner.setOrientation(orientation.x, orientation.y, orientation.z);
-      this._lastPosition.x = panner.positionX.value;
-      this._lastPosition.y = panner.positionY.value;
-      this._lastPosition.z = panner.positionZ.value;
 
-      this._lastOrientation.x = panner.orientationX.value;
-      this._lastOrientation.y = panner.orientationY.value;
-      this._lastOrientation.z = panner.orientationZ.value;
+      this._lastPosition.x = position.x;
+      this._lastPosition.y = position.y;
+      this._lastPosition.z = position.z;
+
+      this._lastOrientation.x = orientation.x;
+      this._lastOrientation.y = orientation.y;
+      this._lastOrientation.z = orientation.z;
 
       if (listener.positionX && listener.positionY && listener.positionZ) {
         this._lastListenerPosition.x = listener.positionX.value;


### PR DESCRIPTION
This monkeypatches the `updateMatrixWorld` routine in the `PositionalAudio` node to not keep calling `setPosition`, which is expensive, unless the audio dynamics have changed.