### PR TITLE
Fix Oculus Go and Vive Focus bindings in Firefox Reality

### DIFF
--- a/src/systems/userinput/bindings/oculus-go-user.js
+++ b/src/systems/userinput/bindings/oculus-go-user.js
@@ -3,283 +3,285 @@ import { sets } from "../sets";
 import { xforms } from "./xforms";
 import { addSetsToBindings } from "./utils";
 
-const touchpad = "/vars/oculusgo/touchpad";
-const touchpadRising = "/vars/oculusgo/touchpad/rising";
-const touchpadFalling = "/vars/oculusgo/touchpad/falling";
-const triggerRising = "/vars/oculusgo/trigger/rising";
-const triggerFalling = "/vars/oculusgo/trigger/falling";
-const dpadNorth = "/vars/oculusgo/dpad/north";
-const dpadSouth = "/vars/oculusgo/dpad/south";
-const dpadEast = "/vars/oculusgo/dpad/east";
-const dpadWest = "/vars/oculusgo/dpad/west";
-const dpadCenter = "/vars/oculusgo/dpad/center";
-const dpadCenterStrip = "/vars/oculusgo/dpad/centerStrip";
+export default function generate3DOFTriggerBindings(device) {
+  const touchpad = device.v("touchpad");
+  const touchpadRising = device.v("touchpad/rising");
+  const touchpadFalling = device.v("touchpad/falling");
+  const triggerRising = device.v("trigger/rising");
+  const triggerFalling = device.v("trigger/falling");
+  const dpadNorth = device.v("dpad/north");
+  const dpadSouth = device.v("dpad/south");
+  const dpadEast = device.v("dpad/east");
+  const dpadWest = device.v("dpad/west");
+  const dpadCenter = device.v("dpad/center");
+  const dpadCenterStrip = device.v("dpad/centerStrip");
 
-const grabBinding = {
-  src: {
-    value: triggerRising
-  },
-  dest: { value: paths.actions.cursor.grab },
-  xform: xforms.copy,
-  priority: 200
-};
+  const grabBinding = {
+    src: {
+      value: triggerRising
+    },
+    dest: { value: paths.actions.cursor.grab },
+    xform: xforms.copy,
+    priority: 200
+  };
 
-export const oculusGoUserBindings = addSetsToBindings({
-  [sets.global]: [
-    {
-      src: {
-        value: paths.device.oculusgo.button("trigger").pressed
+  return addSetsToBindings({
+    [sets.global]: [
+      {
+        src: {
+          value: device.button("trigger").pressed
+        },
+        dest: { value: triggerRising },
+        xform: xforms.rising
       },
-      dest: { value: triggerRising },
-      xform: xforms.rising
-    },
-    {
-      src: {
-        value: paths.device.oculusgo.button("trigger").pressed
+      {
+        src: {
+          value: device.button("trigger").pressed
+        },
+        dest: { value: triggerFalling },
+        xform: xforms.falling
       },
-      dest: { value: triggerFalling },
-      xform: xforms.falling
-    },
-    {
-      src: {
-        value: paths.device.oculusgo.button("touchpad").pressed
+      {
+        src: {
+          value: device.button("touchpad").pressed
+        },
+        dest: { value: touchpadRising },
+        xform: xforms.rising,
+        priority: 100
       },
-      dest: { value: touchpadRising },
-      xform: xforms.rising,
-      priority: 100
-    },
-    {
-      src: {
-        value: paths.device.oculusgo.button("touchpad").pressed
+      {
+        src: {
+          value: device.button("touchpad").pressed
+        },
+        dest: { value: touchpadFalling },
+        xform: xforms.falling,
+        priority: 100
       },
-      dest: { value: touchpadFalling },
-      xform: xforms.falling,
-      priority: 100
-    },
-    {
-      src: {
-        x: paths.device.oculusgo.axis("touchpadX"),
-        y: paths.device.oculusgo.axis("touchpadY")
+      {
+        src: {
+          x: device.axis("touchpadX"),
+          y: device.axis("touchpadY")
+        },
+        dest: { value: touchpad },
+        xform: xforms.compose_vec2
       },
-      dest: { value: touchpad },
-      xform: xforms.compose_vec2
-    },
-    {
-      src: {
-        value: touchpad
+      {
+        src: {
+          value: touchpad
+        },
+        dest: {
+          north: dpadNorth,
+          south: dpadSouth,
+          east: dpadEast,
+          west: dpadWest,
+          center: dpadCenter
+        },
+        xform: xforms.vec2dpad(0.8)
       },
-      dest: {
-        north: dpadNorth,
-        south: dpadSouth,
-        east: dpadEast,
-        west: dpadWest,
-        center: dpadCenter
+      {
+        src: [dpadNorth, dpadSouth, dpadCenter],
+        dest: { value: dpadCenterStrip },
+        xform: xforms.any
       },
-      xform: xforms.vec2dpad(0.8)
-    },
-    {
-      src: [dpadNorth, dpadSouth, dpadCenter],
-      dest: { value: dpadCenterStrip },
-      xform: xforms.any
-    },
-    {
-      src: {
-        value: dpadCenterStrip,
-        bool: paths.device.oculusgo.button("touchpad").pressed
+      {
+        src: {
+          value: dpadCenterStrip,
+          bool: device.button("touchpad").pressed
+        },
+        dest: {
+          value: paths.actions.ensureFrozen
+        },
+        priority: 100,
+        xform: xforms.copyIfTrue
       },
-      dest: {
-        value: paths.actions.ensureFrozen
+      {
+        src: { value: touchpadFalling },
+        dest: {
+          value: paths.actions.thaw
+        },
+        xform: xforms.copy
       },
-      priority: 100,
-      xform: xforms.copyIfTrue
-    },
-    {
-      src: { value: touchpadFalling },
-      dest: {
-        value: paths.actions.thaw
+      {
+        src: {
+          value: dpadEast,
+          bool: touchpadRising
+        },
+        dest: {
+          value: paths.actions.snapRotateRight
+        },
+        xform: xforms.copyIfTrue,
+        priority: 100
       },
-      xform: xforms.copy
-    },
-    {
-      src: {
-        value: dpadEast,
-        bool: touchpadRising
+      {
+        src: {
+          value: dpadWest,
+          bool: touchpadRising
+        },
+        dest: {
+          value: paths.actions.snapRotateLeft
+        },
+        xform: xforms.copyIfTrue,
+        priority: 100
       },
-      dest: {
-        value: paths.actions.snapRotateRight
-      },
-      xform: xforms.copyIfTrue,
-      priority: 100
-    },
-    {
-      src: {
-        value: dpadWest,
-        bool: touchpadRising
-      },
-      dest: {
-        value: paths.actions.snapRotateLeft
-      },
-      xform: xforms.copyIfTrue,
-      priority: 100
-    },
 
-    {
-      src: {
-        value: triggerRising
+      {
+        src: {
+          value: triggerRising
+        },
+        dest: { value: paths.actions.rightHand.startTeleport },
+        xform: xforms.copy,
+        priority: 100
       },
-      dest: { value: paths.actions.rightHand.startTeleport },
-      xform: xforms.copy,
-      priority: 100
-    },
 
-    {
-      src: { value: paths.device.oculusgo.pose },
-      dest: { value: paths.actions.cursor.pose },
-      xform: xforms.copy
-    },
-    {
-      src: { value: paths.device.oculusgo.pose },
-      dest: { value: paths.actions.rightHand.pose },
-      xform: xforms.copy
-    },
+      {
+        src: { value: device.pose },
+        dest: { value: paths.actions.cursor.pose },
+        xform: xforms.copy
+      },
+      {
+        src: { value: device.pose },
+        dest: { value: paths.actions.rightHand.pose },
+        xform: xforms.copy
+      },
 
-    {
-      src: { value: paths.device.oculusgo.button("touchpad").touched },
-      dest: { value: paths.actions.rightHand.thumb },
-      xform: xforms.copy
-    },
-    {
-      src: { value: paths.device.oculusgo.button("trigger").pressed },
-      dest: { value: paths.actions.rightHand.index },
-      xform: xforms.copy
-    },
-    {
-      src: { value: paths.device.oculusgo.button("trigger").pressed },
-      dest: { value: paths.actions.rightHand.middleRingPinky },
-      xform: xforms.copy
-    }
-  ],
+      {
+        src: { value: device.button("touchpad").touched },
+        dest: { value: paths.actions.rightHand.thumb },
+        xform: xforms.copy
+      },
+      {
+        src: { value: device.button("trigger").pressed },
+        dest: { value: paths.actions.rightHand.index },
+        xform: xforms.copy
+      },
+      {
+        src: { value: device.button("trigger").pressed },
+        dest: { value: paths.actions.rightHand.middleRingPinky },
+        xform: xforms.copy
+      }
+    ],
 
-  [sets.cursorHoveringOnInteractable]: [grabBinding],
-  [sets.cursorHoveringOnUI]: [grabBinding],
+    [sets.cursorHoveringOnInteractable]: [grabBinding],
+    [sets.cursorHoveringOnUI]: [grabBinding],
 
-  [sets.cursorHoldingInteractable]: [
-    {
-      src: {
-        value: triggerFalling
+    [sets.cursorHoldingInteractable]: [
+      {
+        src: {
+          value: triggerFalling
+        },
+        dest: { value: paths.actions.cursor.drop },
+        xform: xforms.copy,
+        priority: 200
       },
-      dest: { value: paths.actions.cursor.drop },
-      xform: xforms.copy,
-      priority: 200
-    },
-    {
-      src: {
-        value: paths.device.oculusgo.axis("touchpadY"),
-        touching: paths.device.oculusgo.button("touchpad").touched
+      {
+        src: {
+          value: device.axis("touchpadY"),
+          touching: device.button("touchpad").touched
+        },
+        dest: { value: paths.actions.cursor.modDelta },
+        xform: xforms.touch_axis_scroll()
       },
-      dest: { value: paths.actions.cursor.modDelta },
-      xform: xforms.touch_axis_scroll()
-    },
-    {
-      src: { value: dpadCenterStrip },
-      priority: 200,
-      xform: xforms.noop
-    }
-  ],
+      {
+        src: { value: dpadCenterStrip },
+        priority: 200,
+        xform: xforms.noop
+      }
+    ],
 
-  [sets.rightHandTeleporting]: [
-    {
-      src: {
-        value: triggerFalling
-      },
-      dest: { value: paths.actions.rightHand.stopTeleport },
-      xform: xforms.copy,
-      priority: 100
-    }
-  ],
+    [sets.rightHandTeleporting]: [
+      {
+        src: {
+          value: triggerFalling
+        },
+        dest: { value: paths.actions.rightHand.stopTeleport },
+        xform: xforms.copy,
+        priority: 100
+      }
+    ],
 
-  [sets.cursorHoldingPen]: [
-    {
-      src: {
-        value: triggerRising
+    [sets.cursorHoldingPen]: [
+      {
+        src: {
+          value: triggerRising
+        },
+        dest: { value: paths.actions.cursor.startDrawing },
+        xform: xforms.copy,
+        priority: 300
       },
-      dest: { value: paths.actions.cursor.startDrawing },
-      xform: xforms.copy,
-      priority: 300
-    },
-    {
-      src: {
-        value: triggerFalling
+      {
+        src: {
+          value: triggerFalling
+        },
+        dest: { value: paths.actions.cursor.stopDrawing },
+        xform: xforms.copy,
+        priority: 300
       },
-      dest: { value: paths.actions.cursor.stopDrawing },
-      xform: xforms.copy,
-      priority: 300
-    },
-    {
-      src: {
-        value: paths.device.oculusgo.axis("touchpadX"),
-        touching: paths.device.oculusgo.button("touchpad").touched
+      {
+        src: {
+          value: device.axis("touchpadX"),
+          touching: device.button("touchpad").touched
+        },
+        dest: { value: paths.actions.cursor.scalePenTip },
+        xform: xforms.touch_axis_scroll(-0.1)
       },
-      dest: { value: paths.actions.cursor.scalePenTip },
-      xform: xforms.touch_axis_scroll(-0.1)
-    },
-    {
-      src: {
-        value: dpadCenterStrip,
-        bool: touchpadFalling
+      {
+        src: {
+          value: dpadCenterStrip,
+          bool: touchpadFalling
+        },
+        dest: { value: paths.actions.cursor.drop },
+        xform: xforms.copyIfTrue,
+        priority: 300
       },
-      dest: { value: paths.actions.cursor.drop },
-      xform: xforms.copyIfTrue,
-      priority: 300
-    },
-    {
-      src: {
-        value: dpadEast,
-        bool: touchpadRising
+      {
+        src: {
+          value: dpadEast,
+          bool: touchpadRising
+        },
+        dest: {
+          value: paths.actions.cursor.penPrevColor
+        },
+        xform: xforms.copyIfTrue,
+        priority: 200
       },
-      dest: {
-        value: paths.actions.cursor.penPrevColor
-      },
-      xform: xforms.copyIfTrue,
-      priority: 200
-    },
-    {
-      src: {
-        value: dpadWest,
-        bool: touchpadRising
-      },
-      dest: {
-        value: paths.actions.cursor.penNextColor
-      },
-      xform: xforms.copyIfTrue,
-      priority: 200
-    }
-  ],
+      {
+        src: {
+          value: dpadWest,
+          bool: touchpadRising
+        },
+        dest: {
+          value: paths.actions.cursor.penNextColor
+        },
+        xform: xforms.copyIfTrue,
+        priority: 200
+      }
+    ],
 
-  [sets.cursorHoldingCamera]: [
-    {
-      src: {
-        value: triggerRising
+    [sets.cursorHoldingCamera]: [
+      {
+        src: {
+          value: triggerRising
+        },
+        dest: { value: paths.actions.cursor.takeSnapshot },
+        xform: xforms.copy,
+        priority: 300
       },
-      dest: { value: paths.actions.cursor.takeSnapshot },
-      xform: xforms.copy,
-      priority: 300
-    },
-    {
-      src: {
-        value: triggerFalling
+      {
+        src: {
+          value: triggerFalling
+        },
+        xform: xforms.noop,
+        priority: 300
       },
-      xform: xforms.noop,
-      priority: 300
-    },
-    {
-      src: {
-        value: dpadCenterStrip,
-        bool: touchpadFalling
-      },
-      dest: { value: paths.actions.cursor.drop },
-      xform: xforms.copyIfTrue,
-      priority: 300
-    }
-  ]
-});
+      {
+        src: {
+          value: dpadCenterStrip,
+          bool: touchpadFalling
+        },
+        dest: { value: paths.actions.cursor.drop },
+        xform: xforms.copyIfTrue,
+        priority: 300
+      }
+    ]
+  });
+}

--- a/src/systems/userinput/devices/gear-vr-controller.js
+++ b/src/systems/userinput/devices/gear-vr-controller.js
@@ -1,0 +1,50 @@
+import { paths } from "../paths";
+import { Pose } from "../pose";
+
+export class GearVRControllerDevice {
+  constructor(gamepad) {
+    this.gamepad = gamepad;
+    this.buttonMap = [{ name: "touchpad", buttonId: 0 }, { name: "trigger", buttonId: 1 }];
+    this.axisMap = [{ name: "touchpadX", axisId: 0 }, { name: "touchpadY", axisId: 1 }];
+
+    this.rayObjectRotation = new THREE.Quaternion();
+    this.selector = `#player-${gamepad.hand}-controller`;
+    this.pose = new Pose();
+  }
+
+  write(frame) {
+    if (this.gamepad.connected) {
+      this.gamepad.buttons.forEach((button, i) => {
+        const buttonPath = paths.device.gamepad(this.gamepad.index).button(i);
+        frame[buttonPath.pressed] = !!button.pressed;
+        frame[buttonPath.touched] = !!button.touched;
+        frame[buttonPath.value] = button.value;
+      });
+      this.gamepad.axes.forEach((axis, i) => {
+        frame[paths.device.gamepad(this.gamepad.index).axis(i)] = axis;
+      });
+
+      this.buttonMap.forEach(button => {
+        const outpath = paths.device.gearVRController.button(button.name);
+        frame[outpath.pressed] = !!frame[paths.device.gamepad(this.gamepad.index).button(button.buttonId).pressed];
+        frame[outpath.touched] = !!frame[paths.device.gamepad(this.gamepad.index).button(button.buttonId).touched];
+        frame[outpath.value] = frame[paths.device.gamepad(this.gamepad.index).button(button.buttonId).value];
+      });
+      this.axisMap.forEach(axis => {
+        frame[paths.device.gearVRController.axis(axis.name)] =
+          frame[paths.device.gamepad(this.gamepad.index).axis(axis.axisId)];
+      });
+
+      // TODO ideally we should just be getting pose from the gamepad
+      if (!this.rayObject) {
+        this.rayObject = document.querySelector(this.selector).object3D;
+      }
+      this.rayObject.updateMatrixWorld();
+      this.rayObjectRotation.setFromRotationMatrix(this.rayObject.matrixWorld);
+      this.pose.position.setFromMatrixPosition(this.rayObject.matrixWorld);
+      this.pose.direction.set(0, 0, -1).applyQuaternion(this.rayObjectRotation);
+      this.pose.fromOriginAndDirection(this.pose.position, this.pose.direction);
+      frame[paths.device.gearVRController.pose] = this.pose;
+    }
+  }
+}

--- a/src/systems/userinput/paths.js
+++ b/src/systems/userinput/paths.js
@@ -126,7 +126,26 @@ paths.device.oculusgo = {
   axis: axisName => {
     return `${oculusgo}axis/${axisName}`;
   },
-  pose: `${oculusgo}pose`
+  pose: `${oculusgo}pose`,
+  v: name => {
+    return `/vars/oculusgo/${name}`;
+  }
+};
+
+const gearVRController = "/device/gearVRController/";
+paths.device.gearVRController = {
+  button: buttonName => ({
+    pressed: `${gearVRController}button/${buttonName}/pressed`,
+    touched: `${gearVRController}button/${buttonName}/touched`,
+    value: `${gearVRController}button/${buttonName}/value`
+  }),
+  axis: axisName => {
+    return `${gearVRController}axis/${axisName}`;
+  },
+  pose: `${gearVRController}pose`,
+  v: name => {
+    return `/vars/gearVRController/${name}`;
+  }
 };
 
 const daydream = "/device/daydream/";

--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -1,10 +1,12 @@
 import { sets } from "./sets";
+import { paths } from "./paths";
 
 import { MouseDevice } from "./devices/mouse";
 import { KeyboardDevice } from "./devices/keyboard";
 import { HudDevice } from "./devices/hud";
 import { XboxControllerDevice } from "./devices/xbox-controller";
 import { OculusGoControllerDevice } from "./devices/oculus-go-controller";
+import { GearVRControllerDevice } from "./devices/gear-vr-controller";
 import { OculusTouchControllerDevice } from "./devices/oculus-touch-controller";
 import { DaydreamControllerDevice } from "./devices/daydream-controller";
 import { ViveControllerDevice } from "./devices/vive-controller";
@@ -15,11 +17,14 @@ import { AppAwareTouchscreenDevice } from "./devices/app-aware-touchscreen";
 import { keyboardMouseUserBindings } from "./bindings/keyboard-mouse-user";
 import { touchscreenUserBindings } from "./bindings/touchscreen-user";
 import { keyboardDebuggingBindings } from "./bindings/keyboard-debugging";
-import { oculusGoUserBindings } from "./bindings/oculus-go-user";
 import { oculusTouchUserBindings } from "./bindings/oculus-touch-user";
 import { viveUserBindings } from "./bindings/vive-user";
 import { xboxControllerUserBindings } from "./bindings/xbox-controller-user";
 import { daydreamUserBindings } from "./bindings/daydream-user";
+
+import generate3DOFTriggerBindings from "./bindings/oculus-go-user";
+const oculusGoUserBindings = generate3DOFTriggerBindings(paths.device.oculusgo);
+const gearVRControllerUserBindings = generate3DOFTriggerBindings(paths.device.gearVRController);
 
 import { resolveActionSets } from "./resolve-action-sets";
 import { GamepadDevice } from "./devices/gamepad";
@@ -174,6 +179,7 @@ AFRAME.registerSystem("userinput", {
     vrGamepadMappings.set(ViveControllerDevice, viveUserBindings);
     vrGamepadMappings.set(OculusTouchControllerDevice, oculusTouchUserBindings);
     vrGamepadMappings.set(OculusGoControllerDevice, oculusGoUserBindings);
+    vrGamepadMappings.set(GearVRControllerDevice, gearVRControllerUserBindings);
     vrGamepadMappings.set(DaydreamControllerDevice, daydreamUserBindings);
 
     const nonVRGamepadMappings = new Map();
@@ -223,6 +229,9 @@ AFRAME.registerSystem("userinput", {
         gamepadDevice = new OculusTouchControllerDevice(e.gamepad);
       } else if (e.gamepad.id === "Oculus Go Controller") {
         gamepadDevice = new OculusGoControllerDevice(e.gamepad);
+        // Note that FXR reports Vive Focus' controller as GearVR, so this is primarily to support that
+      } else if (e.gamepad.id === "Gear VR Controller") {
+        gamepadDevice = new GearVRControllerDevice(e.gamepad);
       } else if (e.gamepad.id === "Daydream Controller") {
         gamepadDevice = new DaydreamControllerDevice(e.gamepad);
       } else if (e.gamepad.id.includes("Xbox")) {


### PR DESCRIPTION
Firefox Reality names both the Vive Focus and Oculus Go controllers Gear VR Controller". This adds bindings for "Gear VR Controller" to handle those cases, as well as the actual GearVR Controller. If these get renamed later we can add new bindings to support them easily.