### PR TITLE
set initial pos/rot/scale for photos immediately

### DIFF
--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -223,6 +223,10 @@ AFRAME.registerComponent("camera-tool", {
         renderer.readRenderTargetPixels(this.renderTarget, 0, 0, width, height, this.snapPixels);
         pixelsToPNG(this.snapPixels, width, height).then(file => {
           const { entity, orientation } = addMedia(file, "#interactable-media", undefined, true);
+          entity.object3D.position.copy(this.el.object3D.position).add(new THREE.Vector3(0, -0.5, 0));
+          entity.object3D.rotation.copy(this.el.object3D.rotation);
+          entity.object3D.matrixNeedsUpdate = true;
+
           entity.addEventListener(
             "media_resolved",
             () => {
@@ -231,9 +235,6 @@ AFRAME.registerComponent("camera-tool", {
             { once: true }
           );
           orientation.then(() => {
-            entity.object3D.position.copy(this.el.object3D.position).add(new THREE.Vector3(0, -0.5, 0));
-            entity.object3D.rotation.copy(this.el.object3D.rotation);
-            entity.object3D.matrixNeedsUpdate = true;
             sceneEl.emit("object_spawned", { objectType: ObjectTypes.CAMERA });
           });
         });


### PR DESCRIPTION
Currently, we spawn a photo and then a tick or two later move it below the camera. This results in a race condition between the initial full sync (from phoenix) and the updated position message (from janus.) Since there is no ordering between these two channels, if the janus message arrives first then the pos/rot/scale is overwritten to the origin by the phoenix message. This resolves it by ensuring the photo is properly positioned for the initial sync.