### PR TITLE
Set matrix auto update to default in gltf model plus

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -258,7 +258,7 @@ async function loadGLTF(src, contentType, preferredTechnique, onProgress) {
   const envMap = await CachedEnvMapTexture;
 
   gltf.scene.traverse(object => {
-    object.matrixAutoUpdate = false;
+    object.matrixAutoUpdate = THREE.Object3D.DefaultMatrixAutoUpdate;
 
     if (object.material && object.material.type === "MeshStandardMaterial") {
       if (preferredTechnique === "KHR_materials_unlit") {

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -258,6 +258,7 @@ async function loadGLTF(src, contentType, preferredTechnique, onProgress) {
   const envMap = await CachedEnvMapTexture;
 
   gltf.scene.traverse(object => {
+    // GLTFLoader sets matrixAutoUpdate on animated objects, we want to keep the defaults
     object.matrixAutoUpdate = THREE.Object3D.DefaultMatrixAutoUpdate;
 
     if (object.material && object.material.type === "MeshStandardMaterial") {


### PR DESCRIPTION
Fixes issue where gltf-model-plus is flipping auto matrix update off in three.js scenes where the default was not changed.