### PR TITLE
Fix bug where pagination causes scaling

### DIFF
--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -119,7 +119,7 @@ export const addMedia = (src, template, contentOrigin, resolve = false, resize =
     entity.addEventListener(eventName, () => {
       clearTimeout(fireLoadingTimeout);
 
-      if (!entity.classList.contains("pen")) {
+      if (!entity.classList.contains("pen") && !entity.getAttribute("animation__spawn-start")) {
         entity.object3D.scale.setScalar(0.5);
         entity.matrixNeedsUpdate = true;
 


### PR DESCRIPTION
The recent animation changes introduced a bug where pagination on PDFs would scale the object down by 50%. This was due to the preamble to the spawn animation being re-run. This PR skips the spawn animation if it's already run on the object.