### PR TITLE
Clear loader timeout after image loads in same tick

### DIFF
--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -174,6 +174,7 @@ AFRAME.registerComponent("media-loader", {
         // 2. we don't remove the media-image component -- media-pager uses that internally
         this.el.setAttribute("media-pager", { src: canonicalUrl });
         this.el.addEventListener("image-loaded", this.clearLoadingTimeout, { once: true });
+        this.el.addEventListener("preview-loaded", this.onMediaLoaded, { once: true });
         this.el.setAttribute("position-at-box-shape-border", { dirs: ["forward", "back"] });
       } else if (
         contentType.includes("application/octet-stream") ||
@@ -240,6 +241,7 @@ AFRAME.registerComponent("media-pager", {
           this.prevButton.addEventListener("grab-start", this.onPrev);
 
           this.update();
+          this.el.emit("preview-loaded");
         }, 0);
       } else {
         this.update();

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -173,7 +173,7 @@ AFRAME.registerComponent("media-loader", {
         // 1. we pass the canonical URL to the pager so it can easily make subresource URLs
         // 2. we don't remove the media-image component -- media-pager uses that internally
         this.el.setAttribute("media-pager", { src: canonicalUrl });
-        this.el.addEventListener("preview-loaded", this.onMediaLoaded, { once: true });
+        this.el.addEventListener("image-loaded", this.clearLoadingTimeout, { once: true });
         this.el.setAttribute("position-at-box-shape-border", { dirs: ["forward", "back"] });
       } else if (
         contentType.includes("application/octet-stream") ||
@@ -240,7 +240,6 @@ AFRAME.registerComponent("media-pager", {
           this.prevButton.addEventListener("grab-start", this.onPrev);
 
           this.update();
-          this.el.emit("preview-loaded");
         }, 0);
       } else {
         this.update();


### PR DESCRIPTION
Resolves an issue where pinned PDFs can end up as a permanent loading cube. The root cause is that there's tick(s) between the image being spawned and the clearing of the timeout which, if fired, will spawn the loading cube. The reason for the ticks is because we were waiting on the `preview-loaded` event to fire before clearing the loading cube timeout, which happens at least one tick after the image has loaded. This PR wires things up so we clear the timeout as soon as the image is loaded.