### PR TITLE
Fix distance check when not visible

### DIFF
--- a/src/components/visible-while-frozen.js
+++ b/src/components/visible-while-frozen.js
@@ -42,8 +42,8 @@ AFRAME.registerComponent("visible-while-frozen", {
       getLastWorldPosition(this.cam, this.camWorldPos);
       this.objWorldPos.copy(this.el.object3D.position);
 
-      if (!isVisible && isFrozen) {
-        // Edge case, if the object is not visible, and the scene isFrozen, force a
+      if (!isVisible) {
+        // Edge case, if the object is not visible force a
         // matrix update every frame since the main matrix update loop will not do it.
         this.el.object3D.updateMatrices(true, true);
       }

--- a/src/components/visible-while-frozen.js
+++ b/src/components/visible-while-frozen.js
@@ -36,18 +36,17 @@ AFRAME.registerComponent("visible-while-frozen", {
     const isFrozen = this.el.sceneEl.is("frozen");
 
     let isWithinDistance = true;
-    const isVisible = this.el.getAttribute("visible");
+    const isVisible = this.el.object3D.visible;
 
     if (this.data.withinDistance !== undefined) {
-      getLastWorldPosition(this.cam, this.camWorldPos);
-      this.objWorldPos.copy(this.el.object3D.position);
-
       if (!isVisible) {
-        // Edge case, if the object is not visible force a
-        // matrix update every frame since the main matrix update loop will not do it.
+        // Edge case, if the object is not visible force a matrix update
+        // since the main matrix update loop will not do it.
         this.el.object3D.updateMatrices(true, true);
       }
 
+      getLastWorldPosition(this.cam, this.camWorldPos);
+      this.objWorldPos.copy(this.el.object3D.position);
       this.el.object3D.localToWorld(this.objWorldPos);
 
       isWithinDistance =

--- a/src/components/visible-while-frozen.js
+++ b/src/components/visible-while-frozen.js
@@ -36,10 +36,18 @@ AFRAME.registerComponent("visible-while-frozen", {
     const isFrozen = this.el.sceneEl.is("frozen");
 
     let isWithinDistance = true;
+    const isVisible = this.el.getAttribute("visible");
 
     if (this.data.withinDistance !== undefined) {
       getLastWorldPosition(this.cam, this.camWorldPos);
       this.objWorldPos.copy(this.el.object3D.position);
+
+      if (!isVisible && isFrozen) {
+        // Edge case, if the object is not visible, and the scene isFrozen, force a
+        // matrix update every frame since the main matrix update loop will not do it.
+        this.el.object3D.updateMatrices(true, true);
+      }
+
       this.el.object3D.localToWorld(this.objWorldPos);
 
       isWithinDistance =
@@ -48,7 +56,7 @@ AFRAME.registerComponent("visible-while-frozen", {
 
     const shouldBeVisible = isFrozen && isWithinDistance;
 
-    if (this.el.getAttribute("visible") !== shouldBeVisible) {
+    if (isVisible !== shouldBeVisible) {
       this.el.setAttribute("visible", shouldBeVisible);
     }
   },


### PR DESCRIPTION
This PR fixes an issue where the distance check is not working in the visible while frozen component since we no longer update world matrices every frame for invisible objects.