### PR TITLE
Do not intersect non-visible objects

### DIFF
--- a/src/components/cursor-controller.js
+++ b/src/components/cursor-controller.js
@@ -75,11 +75,23 @@ AFRAME.registerComponent("cursor-controller", {
     this.dirty = true;
   },
 
+  isVisible: function(obj) {
+    let o = obj;
+
+    while (o) {
+      if (!o.visible) return false;
+      o = o.parent;
+    }
+
+    return true;
+  },
+
   populateEntities: function(selector, target) {
     target.length = 0;
     const els = this.data.objects ? this.el.sceneEl.querySelectorAll(this.data.objects) : this.el.sceneEl.children;
     for (let i = 0; i < els.length; i++) {
-      if (els[i].object3D) {
+      const obj = els[i].object3D;
+      if (obj && this.isVisible(obj)) {
         target.push(els[i].object3D);
       }
     }

--- a/src/components/cursor-controller.js
+++ b/src/components/cursor-controller.js
@@ -92,7 +92,7 @@ AFRAME.registerComponent("cursor-controller", {
     for (let i = 0; i < els.length; i++) {
       const obj = els[i].object3D;
       if (obj && this.isVisible(obj)) {
-        target.push(els[i].object3D);
+        target.push(obj);
       }
     }
   },

--- a/src/systems/frame-scheduler.js
+++ b/src/systems/frame-scheduler.js
@@ -27,8 +27,6 @@ AFRAME.registerSystem("frame-scheduler", {
         entries.splice(idx, 1);
       }
     }
-
-    console.log(this.registry);
   },
 
   tick: function() {


### PR DESCRIPTION
Setting the in-world HUD results in its matrix no longer updating, which results in it being stuck in the floor, which (until this PR) results in being able to click on it and mute yourself, etc. This PR filters out non-visible objects from the raycast intersection set so the cursor no longer interacts with non-visible objects. (Is this a bad idea?)