### PR TITLE
Fix invisible HUD being clickable

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -398,9 +398,10 @@
         >
             <a-entity
                 id="player-hud"
-                hud-controller="head: #player-camera;"
+                vr-mode-toggle-class="class: ui"
                 vr-mode-toggle-visibility
                 vr-mode-toggle-playing__hud-controller
+                hud-controller="head: #player-camera;"
             >
                 <a-entity in-world-hud="haptic:#player-right-controller;raycaster:#player-right-controller;" rotation="30 0 0">
                     <a-rounded height="0.08" width="0.2" color="#000000" position="-0.30 0.125 0" radius="0.040" opacity="0.35" class="hud bg"></a-rounded>
@@ -413,7 +414,7 @@
                     icon-button="tooltip: #hud-tooltip; tooltipText: Mute Mic; activeTooltipText: Unmute Mic; image: #mute-off; hoverImage: #mute-off-hover; activeImage: #mute-on; activeHoverImage: #mute-on-hover"
                     scale="0.1 0.1 0.1"
                     position="-0.17 0 0.001"
-                    class="ui hud mic"
+                    class="hud mic"
                     material="alphaTest:0.1;"
                     hoverable
                     sound__hud_hover_start="src: #sound_asset-hud_hover_start; on: mouseover; poolSize: 5; positional: false;"
@@ -423,7 +424,7 @@
                     icon-button="tooltip: #hud-tooltip; tooltipText: Pause; activeTooltipText: Resume; image: #freeze-off; hoverImage: #freeze-off-hover; activeImage: #freeze-on; activeHoverImage: #freeze-on-hover"
                     scale="0.2 0.2 0.2"
                     position="0 0 0.005"
-                    class="ui hud freeze"
+                    class="hud freeze"
                     hoverable
                     sound__hud_hover_start="src: #sound_asset-hud_hover_start; on: mouseover; poolSize: 5; positional: false;"
                     set-sounds-invisible
@@ -432,7 +433,7 @@
                     icon-button="tooltip: #hud-tooltip; tooltipText: Pen; activeTooltipText: Pen; image: #spawn-pen; hoverImage: #spawn-pen-hover; activeImage: #spawn-pen; activeHoverImage: #spawn-pen-hover"
                     scale="0.1 0.1 0.1"
                     position="0.17 0 0.001"
-                    class="ui hud penhud"
+                    class="hud penhud"
                     material="alphaTest:0.1;"
                     hoverable
                     sound__hud_hover_start="src: #sound_asset-hud_hover_start; on: mouseover; poolSize: 5; positional: false;"
@@ -442,7 +443,7 @@
                     icon-button="tooltip: #hud-tooltip; tooltipText: Camera; activeTooltipText: Camera; image: #spawn-camera; hoverImage: #spawn-camera-hover; activeImage: #spawn-camera; activeHoverImage: #spawn-camera-hover"
                     scale="0.1 0.1 0.1"
                     position="0.28 0 0.001"
-                    class="ui hud camera-btn"
+                    class="hud camera-btn"
                     material="alphaTest:0.1;"
                     hoverable
                     sound__hud_hover_start="src: #sound_asset-hud_hover_start; on: mouseover; poolSize: 5; positional: false;"

--- a/src/systems/app-mode.js
+++ b/src/systems/app-mode.js
@@ -159,3 +159,41 @@ AFRAME.registerComponent("vr-mode-toggle-playing", {
     this.el.components[componentName][inVRMode !== this.data.invert ? "play" : "pause"]();
   }
 });
+
+/**
+ * Toggle a CSS class based upon app mode.
+ * @namespace vr-mode
+ * @component vr-mode-toggle-class
+ */
+AFRAME.registerComponent("vr-mode-toggle-class", {
+  multiple: true,
+  schema: {
+    invert: { type: "boolean", default: false },
+    class: { type: "string", default: false }
+  },
+
+  init() {
+    this.updateComponentState = this.updateComponentState.bind(this);
+  },
+
+  play() {
+    this.updateComponentState();
+    this.el.sceneEl.addEventListener("enter-vr", this.updateComponentState);
+    this.el.sceneEl.addEventListener("exit-vr", this.updateComponentState);
+  },
+
+  pause() {
+    this.el.sceneEl.removeEventListener("enter-vr", this.updateComponentState);
+    this.el.sceneEl.removeEventListener("exit-vr", this.updateComponentState);
+  },
+
+  updateComponentState() {
+    const inVRMode = this.el.sceneEl.is("vr-mode");
+
+    if (inVRMode) {
+      this.el.classList.add(this.data.class);
+    } else {
+      this.el.classList.remove(this.data.class);
+    }
+  }
+});

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -187,6 +187,7 @@ export function injectCustomShaderChunks(obj) {
     // hover/toggle state, so for now just skip these while we figure out a more correct
     // solution.
     if (object.el.classList.contains("ui")) return;
+    if (object.el.classList.contains("hud")) return;
     if (object.el.getAttribute("text-button")) return;
 
     object.material = object.material.clone();


### PR DESCRIPTION
This PR fixes an issue where the invisible HUD is hit by the cursor raycaster, allowing interactions:

- Adds the `vr-mode-toggle-class` component which allows setting a CSS class iff vr mode is activated (the line endings oddly were windows so that's why the whole file is re-written)

- Adds `hud` to the list of whitelisted CSS classes to skip when rewriting materials for vertex shader injection

- Turns off the `ui` class on the individual button elements and moves it up to the root entity, so it can be toggled on/off in one place when the HUD becomes visible/invisible (which disables cursor interactions when not in VR mode)