### PR TITLE
Introduces dedicated CORS proxy service

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -12,10 +12,6 @@ RETICULUM_SERVER="dev.reticulum.io"
 # See here for the server code: https://github.com/MozillaReality/farspark
 FARSPARK_SERVER="farspark-dev.reticulum.io"
 
-# The CORS proxy server. Typically a lightweight node server or Cloudflare worker.
-# See here for example cloudflare worker: https://github.com/mozilla/hubs-ops/blob/master/workers/cors-proxy.js
-CORS_PROXY_SERVER="hubs-proxy.com"
-
 # The root URL under which Hubs expects environment GLTF bundles to be served.
 ASSET_BUNDLE_SERVER="https://asset-bundles-prod.reticulum.io"
 

--- a/.env.defaults
+++ b/.env.defaults
@@ -12,6 +12,10 @@ RETICULUM_SERVER="dev.reticulum.io"
 # See here for the server code: https://github.com/MozillaReality/farspark
 FARSPARK_SERVER="farspark-dev.reticulum.io"
 
+# The CORS proxy server. Typically a lightweight node server or Cloudflare worker.
+# See here for example cloudflare worker: https://github.com/mozilla/hubs-ops/blob/master/workers/cors-proxy.js
+CORS_PROXY_SERVER="hubs-proxy.com"
+
 # The root URL under which Hubs expects environment GLTF bundles to be served.
 ASSET_BUNDLE_SERVER="https://asset-bundles-prod.reticulum.io"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,9 +38,10 @@ pipeline {
           def janusServer = env.JANUS_SERVER
           def reticulumServer = env.RETICULUM_SERVER
           def farsparkServer = env.FARSPARK_SERVER
+          def corsProxyServer = env.CORS_PROXY_SERVER
           def slackURL = env.SLACK_URL
 
-          def habCommand = "sudo /usr/bin/hab-docker-studio -k mozillareality run /bin/bash scripts/hab-build-and-push.sh \\\"${baseAssetsPath}\\\" \\\"${assetBundleServer}\\\" \\\"${janusServer}\\\" \\\"${reticulumServer}\\\" \\\"${farsparkServer}\\\" \\\"${targetS3Url}\\\" \\\"${env.BUILD_NUMBER}\\\" \\\"${env.GIT_COMMIT}\\\""
+          def habCommand = "sudo /usr/bin/hab-docker-studio -k mozillareality run /bin/bash scripts/hab-build-and-push.sh \\\"${baseAssetsPath}\\\" \\\"${assetBundleServer}\\\" \\\"${janusServer}\\\" \\\"${reticulumServer}\\\" \\\"${farsparkServer}\\\" \\\"${corsProxyServer}\\\" \\\"${targetS3Url}\\\" \\\"${env.BUILD_NUMBER}\\\" \\\"${env.GIT_COMMIT}\\\""
           sh "/usr/bin/script --return -c ${shellString(habCommand)} /dev/null"
 
           def gitMessage = sh(returnStdout: true, script: "git log -n 1 --pretty=format:'[%an] %s'").trim()

--- a/package-lock.json
+++ b/package-lock.json
@@ -12690,8 +12690,8 @@
       "dev": true
     },
     "three": {
-      "version": "github:mozillareality/three.js#8b1886c384371c3e6305b757d1db7577c5201a9b",
-      "from": "three@github:mozillareality/three.js#8b1886c384371c3e6305b757d1db7577c5201a9b"
+      "version": "github:mozillareality/three.js#4c144a360a073abb6c4a6fe7d1c03ba76b110573",
+      "from": "github:mozillareality/three.js#4c144a360a073abb6c4a6fe7d1c03ba76b110573"
     },
     "three-bmfont-text": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-linkify": "^0.2.2",
     "screenfull": "^3.3.2",
     "super-hands": "github:mozillareality/aframe-super-hands-component#feature/drawing",
-    "three": "github:mozillareality/three.js#8b1886c384371c3e6305b757d1db7577c5201a9b",
+    "three": "github:mozillareality/three.js#4c144a360a073abb6c4a6fe7d1c03ba76b110573",
     "three-pathfinding": "github:mozillareality/three-pathfinding#hubs/master",
     "three-to-cannon": "1.3.0",
     "uuid": "^3.2.1",

--- a/scripts/hab-build-and-push.sh
+++ b/scripts/hab-build-and-push.sh
@@ -5,9 +5,10 @@ export ASSET_BUNDLE_SERVER=$2
 export JANUS_SERVER=$3
 export RETICULUM_SERVER=$4
 export FARSPARK_SERVER=$5
-export TARGET_S3_URL=$6
-export BUILD_NUMBER=$7
-export GIT_COMMIT=$8
+export CORS_PROXY_SERVER=$6
+export TARGET_S3_URL=$7
+export BUILD_NUMBER=$8
+export GIT_COMMIT=$9
 export BUILD_VERSION="${BUILD_NUMBER} (${GIT_COMMIT})"
 
 # To build + push to S3 run:

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -7,6 +7,7 @@ import cubeMapPosY from "../assets/images/cubemap/posy.jpg";
 import cubeMapNegY from "../assets/images/cubemap/negy.jpg";
 import cubeMapPosZ from "../assets/images/cubemap/posz.jpg";
 import cubeMapNegZ from "../assets/images/cubemap/negz.jpg";
+import { getCustomGLTFParserURLResolver } from "../utils/media-utils";
 
 const GLTFCache = {};
 let CachedEnvMapTexture = null;
@@ -220,6 +221,7 @@ async function loadGLTF(src, contentType, preferredTechnique, onProgress) {
   }
 
   const gltfLoader = new THREE.GLTFLoader();
+  gltfLoader.customURLResolver = getCustomGLTFParserURLResolver(gltfUrl);
   gltfLoader.setLazy(true);
 
   const { parser } = await new Promise((resolve, reject) => gltfLoader.load(gltfUrl, resolve, onProgress, reject));

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -143,16 +143,12 @@ AFRAME.registerComponent("media-loader", {
         contentType = (result.meta && result.meta.expected_content_type) || contentType;
       }
 
-      // if the component creator didn't know the content type, we didn't get it from reticulum, and
-      // we don't think we can infer it from the extension, we need to make a HEAD request to find it out
-      contentType = contentType || guessContentType(canonicalUrl);
-
       // todo: we don't need to proxy for many things if the canonical URL has permissive CORS headers
-      accessibleUrl = proxiedUrlFor(canonicalUrl, null, contentType);
+      accessibleUrl = proxiedUrlFor(canonicalUrl, null);
 
       // if the component creator didn't know the content type, we didn't get it from reticulum, and
       // we don't think we can infer it from the extension, we need to make a HEAD request to find it out
-      contentType = contentType || (await fetchContentType(accessibleUrl));
+      contentType = contentType || guessContentType(canonicalUrl) || (await fetchContentType(accessibleUrl));
 
       // We don't want to emit media_resolved for index updates.
       if (src !== oldData.src) {

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -143,12 +143,16 @@ AFRAME.registerComponent("media-loader", {
         contentType = (result.meta && result.meta.expected_content_type) || contentType;
       }
 
+      // if the component creator didn't know the content type, we didn't get it from reticulum, and
+      // we don't think we can infer it from the extension, we need to make a HEAD request to find it out
+      contentType = contentType || guessContentType(canonicalUrl);
+
       // todo: we don't need to proxy for many things if the canonical URL has permissive CORS headers
-      accessibleUrl = proxiedUrlFor(canonicalUrl);
+      accessibleUrl = proxiedUrlFor(canonicalUrl, null, contentType);
 
       // if the component creator didn't know the content type, we didn't get it from reticulum, and
       // we don't think we can infer it from the extension, we need to make a HEAD request to find it out
-      contentType = contentType || guessContentType(canonicalUrl) || (await fetchContentType(accessibleUrl));
+      contentType = contentType || (await fetchContentType(accessibleUrl));
 
       // We don't want to emit media_resolved for index updates.
       if (src !== oldData.src) {

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -23,15 +23,21 @@ function b64EncodeUnicode(str) {
   return btoa(encodeURIComponent(str).replace(CHAR_RE, (_, p1) => String.fromCharCode("0x" + p1)));
 }
 
-export const proxiedUrlFor = (url, index) => {
+export const proxiedUrlFor = (url, index, contentType) => {
   if (!(url.startsWith("http:") || url.startsWith("https:"))) return url;
 
   // farspark doesn't know how to read '=' base64 padding characters
   const base64Url = b64EncodeUnicode(url).replace(/=+$/g, "");
-  // translate base64 + to - and / to _ for URL safety
-  const encodedUrl = base64Url.replace(/\+/g, "-").replace(/\//g, "_");
-  const method = index != null ? "extract" : "raw";
-  return `https://${process.env.FARSPARK_SERVER}/0/${method}/0/0/0/${index || 0}/${encodedUrl}`;
+
+  if (index != null) {
+    // translate base64 + to - and / to _ for URL safety
+    const encodedUrl = base64Url.replace(/\+/g, "-").replace(/\//g, "_");
+    const method = index != null ? "extract" : "raw";
+    return `https://${process.env.FARSPARK_SERVER}/0/${method}/0/0/0/${index || 0}/${encodedUrl}`;
+  } else {
+    const encodedUrl = encodeURIComponent(url);
+    return `https://${process.env.CORS_PROXY_SERVER}/${encodedUrl}`;
+  }
 };
 
 const resolveUrlCache = new Map();

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -29,7 +29,7 @@ export const proxiedUrlFor = (url, index) => {
   // farspark doesn't know how to read '=' base64 padding characters
   const base64Url = b64EncodeUnicode(url).replace(/=+$/g, "");
 
-  if (index != null) {
+  if (index != null || !process.env.CORS_PROXY_SERVER) {
     // translate base64 + to - and / to _ for URL safety
     const encodedUrl = base64Url.replace(/\+/g, "-").replace(/\//g, "_");
     const method = index != null ? "extract" : "raw";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -269,6 +269,7 @@ module.exports = (env, argv) => ({
         JANUS_SERVER: process.env.JANUS_SERVER,
         RETICULUM_SERVER: process.env.RETICULUM_SERVER,
         FARSPARK_SERVER: process.env.FARSPARK_SERVER,
+        CORS_PROXY_SERVER: process.env.CORS_PROXY_SERVER,
         ASSET_BUNDLE_SERVER: process.env.ASSET_BUNDLE_SERVER,
         EXTRA_ENVIRONMENTS: process.env.EXTRA_ENVIRONMENTS,
         BUILD_VERSION: process.env.BUILD_VERSION


### PR DESCRIPTION
We now have a simple CORS proxy up at `hubs-proxy.com` using a Cloudflare worker (https://github.com/mozilla/hubs-ops/blob/master/workers/cors-proxy.js) -- this PR:

- Updates the proxied URLs to only go to farspark if they have an `index`
- Sets a custom URL resolver on the three.js GLTF loader (which depends on https://github.com/MozillaReality/three.js/pull/1 being merged) to properly CORS proxy assets

Once this PR is merged the role of farspark now drops to image resizing and PDF page extracting. Video and GLTF content serving is decoupled from farspark.