### PR TITLE
Add mediaOptions property to media-loader and video/image inflators

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -168,7 +168,7 @@ const inflateEntities = function(node, templates, isRoot, modelToWorldScale) {
     for (const prop in entityComponents) {
       if (entityComponents.hasOwnProperty(prop) && AFRAME.GLTFModelPlus.components.hasOwnProperty(prop)) {
         const { componentName, inflator } = AFRAME.GLTFModelPlus.components[prop];
-        inflator(el, componentName, entityComponents[prop]);
+        inflator(el, componentName, entityComponents[prop], entityComponents);
       }
     }
   }

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -31,7 +31,7 @@ AFRAME.registerComponent("media-loader", {
     contentType: { default: null },
     mediaOptions: {
       default: {},
-      parse: v => (typeof v === "object" ? JSON.parse(v) : v),
+      parse: v => (typeof v === "object" ? v : JSON.parse(v)),
       stringify: JSON.stringify
     }
   },

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -31,13 +31,7 @@ AFRAME.registerComponent("media-loader", {
     contentType: { default: null },
     mediaOptions: {
       default: {},
-      parse: value => {
-        if (typeof value === "object") {
-          return value;
-        }
-
-        return JSON.parse(value);
-      },
+      parse: v => (typeof v === "object" ? JSON.parse(v) : v),
       stringify: JSON.stringify
     }
   },

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -113,6 +113,19 @@ function mediaInflator(el, componentName, componentData, components) {
 
   if (componentName === "video") {
     mediaOptions.videoPaused = !componentData.autoPlay;
+    mediaOptions.volume = componentData.volume;
+    mediaOptions.loop = componentData.loop;
+    mediaOptions.audioType = componentData.audioType;
+
+    if (componentData.audioType === "pannernode") {
+      mediaOptions.distanceModel = componentData.distanceModel;
+      mediaOptions.rolloffFactor = componentData.rolloffFactor;
+      mediaOptions.refDistance = componentData.refDistance;
+      mediaOptions.maxDistance = componentData.maxDistance;
+      mediaOptions.coneInnerAngle = componentData.coneInnerAngle;
+      mediaOptions.coneOuterAngle = componentData.coneOuterAngle;
+      mediaOptions.coneOuterGain = componentData.coneOuterGain;
+    }
   }
 
   el.setAttribute("media-loader", {

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -109,10 +109,20 @@ function mediaInflator(el, componentName, componentData, components) {
     });
   }
 
-  // TODO: Any validation of possible mediaOptions properties.
-  const { src, ...mediaOptions } = componentData;
+  const mediaOptions = {};
 
-  el.setAttribute("media-loader", { src, resize: true, resolve: true, fileIsOwned: true, mediaOptions });
+  if (componentName === "video") {
+    mediaOptions.controls = componentData.controls || true;
+    mediaOptions.videoPaused = !componentData.autoPlay;
+  }
+
+  el.setAttribute("media-loader", {
+    src: componentData.src,
+    resize: true,
+    resolve: true,
+    fileIsOwned: true,
+    mediaOptions
+  });
 }
 
 AFRAME.GLTFModelPlus.registerComponent("image", "image", mediaInflator);

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -98,3 +98,22 @@ AFRAME.GLTFModelPlus.registerComponent("media", "media", (el, componentName, com
     el.setAttribute("media-video", { time: componentData.time });
   }
 });
+
+function mediaInflator(el, componentName, componentData, components) {
+  if (components.networked) {
+    el.setAttribute("networked", {
+      template: "#static-media",
+      owner: "scene",
+      persistent: true,
+      networkId: components.networked.id
+    });
+  }
+
+  // TODO: Any validation of possible mediaOptions properties.
+  const { src, ...mediaOptions } = componentData;
+
+  el.setAttribute("media-loader", { src, resize: true, resolve: true, fileIsOwned: true, mediaOptions });
+}
+
+AFRAME.GLTFModelPlus.registerComponent("image", "image", mediaInflator);
+AFRAME.GLTFModelPlus.registerComponent("video", "video", mediaInflator);

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -102,7 +102,7 @@ AFRAME.GLTFModelPlus.registerComponent("media", "media", (el, componentName, com
 function mediaInflator(el, componentName, componentData, components) {
   if (components.networked) {
     el.setAttribute("networked", {
-      template: "#static-media",
+      template: componentData.controls ? "#static-controlled-media" : "#static-media",
       owner: "scene",
       persistent: true,
       networkId: components.networked.id

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -112,7 +112,6 @@ function mediaInflator(el, componentName, componentData, components) {
   const mediaOptions = {};
 
   if (componentName === "video") {
-    mediaOptions.controls = componentData.controls || true;
     mediaOptions.videoPaused = !componentData.autoPlay;
   }
 

--- a/src/hub.html
+++ b/src/hub.html
@@ -162,6 +162,25 @@
                 </a-entity>
             </template>
 
+            <template id="static-media">
+                <a-entity
+                    class="interactable"
+                    body="type: static; shape: none; mass: 1;"
+                    scale="0.5 0.5 0.5"
+                    animation__spawn="property: scale; delay: 50; dur: 200; from: 0.5 0.5 0.5; to: 1 1 1; easing: easeInQuad"
+                    grabbable
+                    hoverable
+                    hoverable-visuals="cursorController: #cursor-controller"
+                    auto-scale-cannon-physics-body
+                    sound__grab="src: #sound_asset-grab; on: grabbed; poolSize: 1; positional: false;"
+                    sound__graboff ="src: #sound_asset-grab_off; on: ungrabbed; poolSize: 1; positional: false;"
+                    set-sounds-invisible
+                    emit-state-change__grabbed="state: grabbed; transform: rising; event: grabbed;"
+                    emit-state-change__ungrabbed="state: grabbed; transform: falling; event: ungrabbed;"
+                >
+                </a-entity>
+            </template>
+
             <template id="interactable-media">
                 <a-entity
                     class="interactable"

--- a/src/hub.html
+++ b/src/hub.html
@@ -168,6 +168,18 @@
                     body="type: static; shape: none; mass: 1;"
                     scale="0.5 0.5 0.5"
                     animation__spawn="property: scale; delay: 50; dur: 200; from: 0.5 0.5 0.5; to: 1 1 1; easing: easeInQuad"
+                    auto-scale-cannon-physics-body
+                    set-sounds-invisible
+                >
+                </a-entity>
+            </template>
+
+            <template id="static-controlled-media">
+                <a-entity
+                    class="interactable"
+                    body="type: static; shape: none; mass: 1;"
+                    scale="0.5 0.5 0.5"
+                    animation__spawn="property: scale; delay: 50; dur: 200; from: 0.5 0.5 0.5; to: 1 1 1; easing: easeInQuad"
                     grabbable
                     hoverable
                     hoverable-visuals="cursorController: #cursor-controller"

--- a/src/hub.html
+++ b/src/hub.html
@@ -177,6 +177,7 @@
             <template id="static-controlled-media">
                 <a-entity
                     class="interactable"
+                    super-networked-interactable="counter: #media-counter;"
                     body="type: static; shape: none; mass: 1;"
                     scale="0.5 0.5 0.5"
                     animation__spawn="property: scale; delay: 50; dur: 200; from: 0.5 0.5 0.5; to: 1 1 1; easing: easeInQuad"

--- a/src/hub.html
+++ b/src/hub.html
@@ -166,8 +166,6 @@
                 <a-entity
                     class="interactable"
                     body="type: static; shape: none; mass: 1;"
-                    scale="0.5 0.5 0.5"
-                    animation__spawn="property: scale; delay: 50; dur: 200; from: 0.5 0.5 0.5; to: 1 1 1; easing: easeInQuad"
                     auto-scale-cannon-physics-body
                     set-sounds-invisible
                 >
@@ -179,8 +177,6 @@
                     class="interactable"
                     super-networked-interactable="counter: #media-counter;"
                     body="type: static; shape: none; mass: 1;"
-                    scale="0.5 0.5 0.5"
-                    animation__spawn="property: scale; delay: 50; dur: 200; from: 0.5 0.5 0.5; to: 1 1 1; easing: easeInQuad"
                     grabbable
                     hoverable
                     hoverable-visuals="cursorController: #cursor-controller"

--- a/src/network-schemas.js
+++ b/src/network-schemas.js
@@ -110,6 +110,18 @@ function registerNetworkSchemas() {
       {
         component: "media-video",
         property: "time"
+      }
+    ]
+  });
+
+  NAF.schemas.add({
+    template: "#static-controlled-media",
+    components: [
+      // TODO: Optimize checking mediaOptions with requiresNetworkUpdate.
+      "media-loader",
+      {
+        component: "media-video",
+        property: "time"
       },
       {
         component: "media-video",

--- a/src/network-schemas.js
+++ b/src/network-schemas.js
@@ -84,6 +84,7 @@ function registerNetworkSchemas() {
         requiresNetworkUpdate: vectorRequiresUpdate(0.5)
       },
       "scale",
+      // TODO: Optimize checking mediaOptions with requiresNetworkUpdate.
       "media-loader",
       {
         component: "media-video",
@@ -98,6 +99,26 @@ function registerNetworkSchemas() {
         property: "index"
       },
       "pinnable"
+    ]
+  });
+
+  NAF.schemas.add({
+    template: "#static-media",
+    components: [
+      // TODO: Optimize checking mediaOptions with requiresNetworkUpdate.
+      "media-loader",
+      {
+        component: "media-video",
+        property: "time"
+      },
+      {
+        component: "media-video",
+        property: "videoPaused"
+      },
+      {
+        component: "media-pager",
+        property: "index"
+      }
     ]
   });
 


### PR DESCRIPTION
Media exported from Spoke can now be imported into Hubs. Spoke also includes some additional options for media like spatial audio options for videos.

<img width="1077" alt="screen shot 2018-12-17 at 1 56 55 pm" src="https://user-images.githubusercontent.com/1753624/50118166-bcf76c80-0203-11e9-94b6-68288748cb02.png">

- Adds the `mediaOptions` property to `media-loader` properties on this object will be set on the media component on load.
- Adds the `static-media` and `static-controlled-media` network templates.
  - `static-controlled-media` is non-interactable (no physics) but can be grabbed to toggle play/pause on a video.
  - `static-media` has no grabbable behavior or cursor highlight effects.
- Adds the `image` and `video` gltf component inflators.
  - The `video` inflator accepts two properties:
    - `controls` determines what template to use. `image` always uses `static-media`.
    - `autoPlay` determines whether the first network owner sets `videoPaused` to false/true.
- Adds a number of new properties to the `media-video` component:
    - volume
    - loop
    - audioType (Currently accepted values are "stereo" or "pannernode")
    - distanceModel
    - rolloffFactor
    - refDistance
    - maxDistance
    - coneInnerAngle
    - coneOuterAngle
    - coneOuterGain
    - See https://developer.mozilla.org/en-US/docs/Web/API/PannerNode for more info on these properties.