### PR TITLE
Add 360 Images and Videos

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -168,7 +168,7 @@ const inflateEntities = function(node, templates, isRoot, modelToWorldScale) {
     for (const prop in entityComponents) {
       if (entityComponents.hasOwnProperty(prop) && AFRAME.GLTFModelPlus.components.hasOwnProperty(prop)) {
         const { componentName, inflator } = AFRAME.GLTFModelPlus.components[prop];
-        inflator(el, componentName, entityComponents[prop]);
+        inflator(el, componentName, entityComponents[prop], entityComponents);
       }
     }
   }

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -31,7 +31,7 @@ AFRAME.registerComponent("media-loader", {
     contentType: { default: null },
     mediaOptions: {
       default: {},
-      parse: v => (typeof v === "object" ? JSON.parse(v) : v),
+      parse: v => (typeof v === "object" ? v : JSON.parse(v)),
       stringify: JSON.stringify
     }
   },

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -31,13 +31,7 @@ AFRAME.registerComponent("media-loader", {
     contentType: { default: null },
     mediaOptions: {
       default: {},
-      parse: value => {
-        if (typeof value === "object") {
-          return value;
-        }
-
-        return JSON.parse(value);
-      },
+      parse: v => (typeof v === "object" ? JSON.parse(v) : v),
       stringify: JSON.stringify
     }
   },

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -477,7 +477,6 @@ AFRAME.registerComponent("media-image", {
 
       if (this.mesh && this.mesh.map && src !== oldData.src) {
         this.mesh.material.map = null;
-        this.mesh.material.map.dispose();
         this.mesh.material.needsUpdate = true;
         if (this.mesh.map !== errorTexture) {
           textureCache.release(oldData.src);

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -126,17 +126,6 @@ function createVideoTexture(url) {
   });
 }
 
-function createPlaneMesh(texture) {
-  const material = new THREE.MeshBasicMaterial();
-  material.side = THREE.DoubleSide;
-  material.transparent = true;
-  material.map = texture;
-  material.needsUpdate = true;
-
-  const geometry = new THREE.PlaneGeometry();
-  return new THREE.Mesh(geometry, material);
-}
-
 function fitToTexture(el, texture) {
   const ratio =
     (texture.image.videoHeight || texture.image.height || 1.0) /
@@ -330,7 +319,58 @@ AFRAME.registerComponent("media-video", {
     }
   },
 
-  async updateTexture(src) {
+  updatePlaybackState(force) {
+    if (force || (this.networkedEl && !NAF.utils.isMine(this.networkedEl) && this.video)) {
+      if (Math.abs(this.data.time - this.video.currentTime) > this.data.syncTolerance) {
+        this.tryUpdateVideoPlaybackState(this.data.videoPaused, this.data.time);
+      } else {
+        this.tryUpdateVideoPlaybackState(this.data.videoPaused);
+      }
+    }
+  },
+
+  tryUpdateVideoPlaybackState(pause, currentTime) {
+    if (this._playbackStateChangeTimeout) {
+      clearTimeout(this._playbackStateChangeTimeout);
+    }
+
+    if (pause) {
+      this.video.pause();
+
+      if (currentTime) {
+        this.video.currentTime = currentTime;
+      }
+    } else {
+      // Need to deal with the fact play() may fail if user has not interacted with browser yet.
+      this.video
+        .play()
+        .then(() => {
+          if (currentTime) {
+            this.video.currentTime = currentTime;
+          }
+        })
+        .catch(() => {
+          this._playbackStateChangeTimeout = setTimeout(
+            () => this.tryUpdateVideoPlaybackState(pause, currentTime),
+            1000
+          );
+        });
+    }
+  },
+
+  async update(oldData) {
+    const { src } = this.data;
+
+    this.updatePlaybackState();
+
+    if (!src || src === oldData.src) return;
+
+    this.remove();
+    if (this.mesh && this.mesh.material) {
+      this.mesh.material.map = null;
+      this.mesh.material.needsUpdate = true;
+    }
+
     let texture;
     try {
       texture = await createVideoTexture(src);
@@ -375,76 +415,36 @@ AFRAME.registerComponent("media-video", {
       texture = errorTexture;
     }
 
-    if (!this.mesh) {
-      this.mesh = createPlaneMesh(texture);
+    const projection = this.data.projection;
+
+    if (projection !== oldData.projection) {
+      const material = new THREE.MeshBasicMaterial();
+
+      let geometry;
+
+      if (projection === "equirectangular") {
+        geometry = new THREE.SphereBufferGeometry(1, 64, 32);
+        // invert the geometry on the x-axis so that all of the faces point inward
+        geometry.scale(-1, 1, 1);
+      } else {
+        geometry = new THREE.PlaneGeometry();
+        material.side = THREE.DoubleSide;
+      }
+
+      this.mesh = new THREE.Mesh(geometry, material);
       this.el.setObject3D("mesh", this.mesh);
-    } else {
-      const { material } = this.mesh;
-      material.map = texture;
-      material.needsUpdate = true;
-      this.mesh.needsUpdate = true;
     }
 
-    fitToTexture(this.el, texture);
+    this.mesh.material.map = texture;
+    this.mesh.material.needsUpdate = true;
+
+    if (projection === "flat") {
+      fitToTexture(this.el, texture);
+    }
 
     this.updatePlaybackState(true);
 
     this.el.emit("video-loaded");
-  },
-
-  updatePlaybackState(force) {
-    if (force || (this.networkedEl && !NAF.utils.isMine(this.networkedEl) && this.video)) {
-      if (Math.abs(this.data.time - this.video.currentTime) > this.data.syncTolerance) {
-        this.tryUpdateVideoPlaybackState(this.data.videoPaused, this.data.time);
-      } else {
-        this.tryUpdateVideoPlaybackState(this.data.videoPaused);
-      }
-    }
-  },
-
-  tryUpdateVideoPlaybackState(pause, currentTime) {
-    if (this._playbackStateChangeTimeout) {
-      clearTimeout(this._playbackStateChangeTimeout);
-    }
-
-    if (pause) {
-      this.video.pause();
-
-      if (currentTime) {
-        this.video.currentTime = currentTime;
-      }
-    } else {
-      // Need to deal with the fact play() may fail if user has not interacted with browser yet.
-      this.video
-        .play()
-        .then(() => {
-          if (currentTime) {
-            this.video.currentTime = currentTime;
-          }
-        })
-        .catch(() => {
-          this._playbackStateChangeTimeout = setTimeout(
-            () => this.tryUpdateVideoPlaybackState(pause, currentTime),
-            1000
-          );
-        });
-    }
-  },
-
-  update(oldData) {
-    const { src } = this.data;
-
-    this.updatePlaybackState();
-
-    if (!src || src === oldData.src) return;
-
-    this.remove();
-    if (this.mesh && this.mesh.material) {
-      this.mesh.material.map = null;
-      this.mesh.material.needsUpdate = true;
-    }
-
-    this.updateTexture(src);
   },
 
   tick() {

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -422,7 +422,7 @@ AFRAME.registerComponent("media-video", {
 
       let geometry;
 
-      if (projection === "equirectangular") {
+      if (projection === "360-equirectangular") {
         geometry = new THREE.SphereBufferGeometry(1, 64, 32);
         // invert the geometry on the x-axis so that all of the faces point inward
         geometry.scale(-1, 1, 1);
@@ -517,7 +517,7 @@ AFRAME.registerComponent("media-image", {
 
       let geometry;
 
-      if (projection === "equirectangular") {
+      if (projection === "360-equirectangular") {
         geometry = new THREE.SphereBufferGeometry(1, 64, 32);
         // invert the geometry on the x-axis so that all of the faces point inward
         geometry.scale(-1, 1, 1);

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -530,6 +530,7 @@ AFRAME.registerComponent("media-image", {
     }
 
     this.mesh.material.map = texture;
+    this.mesh.material.transparent = texture.format === THREE.RGBAFormat;
     this.mesh.material.needsUpdate = true;
 
     if (projection === "flat") {

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -109,7 +109,9 @@ function mediaInflator(el, componentName, componentData, components) {
     });
   }
 
-  const mediaOptions = {};
+  const mediaOptions = {
+    projection: componentData.projection
+  };
 
   if (componentName === "video") {
     mediaOptions.videoPaused = !componentData.autoPlay;

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -113,6 +113,19 @@ function mediaInflator(el, componentName, componentData, components) {
 
   if (componentName === "video") {
     mediaOptions.videoPaused = !componentData.autoPlay;
+    mediaOptions.volume = componentData.volume;
+    mediaOptions.loop = componentData.loop;
+    mediaOptions.audioType = componentData.audioType;
+
+    if (componentData.audioType === "pannernode") {
+      mediaOptions.distanceModel = componentData.distanceModel;
+      mediaOptions.rolloffFactor = componentData.rolloffFactor;
+      mediaOptions.refDistance = componentData.refDistance;
+      mediaOptions.maxDistance = componentData.maxDistance;
+      mediaOptions.coneInnerAngle = componentData.coneInnerAngle;
+      mediaOptions.coneOuterAngle = componentData.coneOuterAngle;
+      mediaOptions.coneOuterGain = componentData.coneOuterGain;
+    }
   }
 
   el.setAttribute("media-loader", {

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -109,10 +109,20 @@ function mediaInflator(el, componentName, componentData, components) {
     });
   }
 
-  // TODO: Any validation of possible mediaOptions properties.
-  const { src, ...mediaOptions } = componentData;
+  const mediaOptions = {};
 
-  el.setAttribute("media-loader", { src, resize: true, resolve: true, fileIsOwned: true, mediaOptions });
+  if (componentName === "video") {
+    mediaOptions.controls = componentData.controls || true;
+    mediaOptions.videoPaused = !componentData.autoPlay;
+  }
+
+  el.setAttribute("media-loader", {
+    src: componentData.src,
+    resize: true,
+    resolve: true,
+    fileIsOwned: true,
+    mediaOptions
+  });
 }
 
 AFRAME.GLTFModelPlus.registerComponent("image", "image", mediaInflator);

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -98,3 +98,22 @@ AFRAME.GLTFModelPlus.registerComponent("media", "media", (el, componentName, com
     el.setAttribute("media-video", { time: componentData.time });
   }
 });
+
+function mediaInflator(el, componentName, componentData, components) {
+  if (components.networked) {
+    el.setAttribute("networked", {
+      template: "#static-media",
+      owner: "scene",
+      persistent: true,
+      networkId: components.networked.id
+    });
+  }
+
+  // TODO: Any validation of possible mediaOptions properties.
+  const { src, ...mediaOptions } = componentData;
+
+  el.setAttribute("media-loader", { src, resize: true, resolve: true, fileIsOwned: true, mediaOptions });
+}
+
+AFRAME.GLTFModelPlus.registerComponent("image", "image", mediaInflator);
+AFRAME.GLTFModelPlus.registerComponent("video", "video", mediaInflator);

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -102,7 +102,7 @@ AFRAME.GLTFModelPlus.registerComponent("media", "media", (el, componentName, com
 function mediaInflator(el, componentName, componentData, components) {
   if (components.networked) {
     el.setAttribute("networked", {
-      template: "#static-media",
+      template: componentData.controls ? "#static-controlled-media" : "#static-media",
       owner: "scene",
       persistent: true,
       networkId: components.networked.id

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -112,7 +112,6 @@ function mediaInflator(el, componentName, componentData, components) {
   const mediaOptions = {};
 
   if (componentName === "video") {
-    mediaOptions.controls = componentData.controls || true;
     mediaOptions.videoPaused = !componentData.autoPlay;
   }
 

--- a/src/hub.html
+++ b/src/hub.html
@@ -162,6 +162,25 @@
                 </a-entity>
             </template>
 
+            <template id="static-media">
+                <a-entity
+                    class="interactable"
+                    body="type: static; shape: none; mass: 1;"
+                    scale="0.5 0.5 0.5"
+                    animation__spawn="property: scale; delay: 50; dur: 200; from: 0.5 0.5 0.5; to: 1 1 1; easing: easeInQuad"
+                    grabbable
+                    hoverable
+                    hoverable-visuals="cursorController: #cursor-controller"
+                    auto-scale-cannon-physics-body
+                    sound__grab="src: #sound_asset-grab; on: grabbed; poolSize: 1; positional: false;"
+                    sound__graboff ="src: #sound_asset-grab_off; on: ungrabbed; poolSize: 1; positional: false;"
+                    set-sounds-invisible
+                    emit-state-change__grabbed="state: grabbed; transform: rising; event: grabbed;"
+                    emit-state-change__ungrabbed="state: grabbed; transform: falling; event: ungrabbed;"
+                >
+                </a-entity>
+            </template>
+
             <template id="interactable-media">
                 <a-entity
                     class="interactable"

--- a/src/hub.html
+++ b/src/hub.html
@@ -168,6 +168,18 @@
                     body="type: static; shape: none; mass: 1;"
                     scale="0.5 0.5 0.5"
                     animation__spawn="property: scale; delay: 50; dur: 200; from: 0.5 0.5 0.5; to: 1 1 1; easing: easeInQuad"
+                    auto-scale-cannon-physics-body
+                    set-sounds-invisible
+                >
+                </a-entity>
+            </template>
+
+            <template id="static-controlled-media">
+                <a-entity
+                    class="interactable"
+                    body="type: static; shape: none; mass: 1;"
+                    scale="0.5 0.5 0.5"
+                    animation__spawn="property: scale; delay: 50; dur: 200; from: 0.5 0.5 0.5; to: 1 1 1; easing: easeInQuad"
                     grabbable
                     hoverable
                     hoverable-visuals="cursorController: #cursor-controller"

--- a/src/hub.html
+++ b/src/hub.html
@@ -177,6 +177,7 @@
             <template id="static-controlled-media">
                 <a-entity
                     class="interactable"
+                    super-networked-interactable="counter: #media-counter;"
                     body="type: static; shape: none; mass: 1;"
                     scale="0.5 0.5 0.5"
                     animation__spawn="property: scale; delay: 50; dur: 200; from: 0.5 0.5 0.5; to: 1 1 1; easing: easeInQuad"

--- a/src/hub.html
+++ b/src/hub.html
@@ -166,8 +166,6 @@
                 <a-entity
                     class="interactable"
                     body="type: static; shape: none; mass: 1;"
-                    scale="0.5 0.5 0.5"
-                    animation__spawn="property: scale; delay: 50; dur: 200; from: 0.5 0.5 0.5; to: 1 1 1; easing: easeInQuad"
                     auto-scale-cannon-physics-body
                     set-sounds-invisible
                 >
@@ -179,8 +177,6 @@
                     class="interactable"
                     super-networked-interactable="counter: #media-counter;"
                     body="type: static; shape: none; mass: 1;"
-                    scale="0.5 0.5 0.5"
-                    animation__spawn="property: scale; delay: 50; dur: 200; from: 0.5 0.5 0.5; to: 1 1 1; easing: easeInQuad"
                     grabbable
                     hoverable
                     hoverable-visuals="cursorController: #cursor-controller"

--- a/src/network-schemas.js
+++ b/src/network-schemas.js
@@ -110,6 +110,18 @@ function registerNetworkSchemas() {
       {
         component: "media-video",
         property: "time"
+      }
+    ]
+  });
+
+  NAF.schemas.add({
+    template: "#static-controlled-media",
+    components: [
+      // TODO: Optimize checking mediaOptions with requiresNetworkUpdate.
+      "media-loader",
+      {
+        component: "media-video",
+        property: "time"
       },
       {
         component: "media-video",

--- a/src/network-schemas.js
+++ b/src/network-schemas.js
@@ -84,6 +84,7 @@ function registerNetworkSchemas() {
         requiresNetworkUpdate: vectorRequiresUpdate(0.5)
       },
       "scale",
+      // TODO: Optimize checking mediaOptions with requiresNetworkUpdate.
       "media-loader",
       {
         component: "media-video",
@@ -98,6 +99,26 @@ function registerNetworkSchemas() {
         property: "index"
       },
       "pinnable"
+    ]
+  });
+
+  NAF.schemas.add({
+    template: "#static-media",
+    components: [
+      // TODO: Optimize checking mediaOptions with requiresNetworkUpdate.
+      "media-loader",
+      {
+        component: "media-video",
+        property: "time"
+      },
+      {
+        component: "media-video",
+        property: "videoPaused"
+      },
+      {
+        component: "media-pager",
+        property: "index"
+      }
     ]
   });
 


### PR DESCRIPTION
You can now export scenes with 360 Videos from Spoke.

![360video](https://user-images.githubusercontent.com/1753624/50118606-0ac0a480-0205-11e9-9704-46df3b1eaae4.gif)


Adds the projection field to `media-image` and `media-video`. We currently support `flat` (default) and `equirectangular`. Spoke exports video and image nodes with this property.