### PR TITLE
Set matrixNeedsUpdate after loading glTF model (WIP)

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -145,7 +145,6 @@ const inflateEntities = function(node, templates, isRoot, modelToWorldScale) {
   node.matrixAutoUpdate = false;
   node.matrix.identity();
   node.matrix.decompose(node.position, node.rotation, node.scale);
-  el.object3D.matrixNeedsUpdate = true;
 
   el.setObject3D(node.type.toLowerCase(), node);
   if (entityComponents && "nav-mesh" in entityComponents) {
@@ -392,6 +391,8 @@ AFRAME.registerComponent("gltf-model-plus", {
         const el = o.el;
         if (el) rewires.push(() => (o.el = el));
       });
+
+      object3DToSet.traverse(o => (o.matrixNeedsUpdate = true));
 
       this.el.setObject3D("mesh", object3DToSet);
 


### PR DESCRIPTION
This fix ensures that objects in the scene have their matrices initialized on load. I'm still investigating why the old way didn't work sometimes and this does.

This bug can be reproduced with this scene:
https://localhost:8080/scene.html?scene_id=uw4R5Jz

[ShadowExample.spoke.zip](https://github.com/mozilla/hubs/files/2688255/ShadowExample.spoke.zip)

