### PR TITLE
Add permission prompt for mic on iOS/Mac to ensure webrtc negotiation works

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -22,6 +22,7 @@ import "aframe-motion-capture-components";
 import "./utils/audio-context-fix";
 import "./utils/threejs-positional-audio-updatematrixworld";
 import "./utils/threejs-world-update";
+import { detectOS } from "detect-browser";
 import { getReticulumFetchUrl } from "./utils/phoenix-utils";
 
 import nextTick from "./utils/next-tick";
@@ -324,6 +325,11 @@ async function runBotMode(scene, entryManager) {
 
 document.addEventListener("DOMContentLoaded", async () => {
   warmSerializeElement();
+
+  // HACK: On iOS, if mic permission is not granted, subscriber webrtc negotiation fails.
+  if (detectOS(navigator.userAgent) === "iOS") {
+    await navigator.mediaDevices.getUserMedia({ audio: true });
+  }
 
   const hubId = qs.get("hub_id") || document.location.pathname.substring(1).split("/")[0];
   console.log(`Hub ID: ${hubId}`);

--- a/src/hub.js
+++ b/src/hub.js
@@ -326,8 +326,10 @@ async function runBotMode(scene, entryManager) {
 document.addEventListener("DOMContentLoaded", async () => {
   warmSerializeElement();
 
-  // HACK: On iOS, if mic permission is not granted, subscriber webrtc negotiation fails.
-  if (detectOS(navigator.userAgent) === "iOS") {
+  // HACK: On iOS & MacOS, if mic permission is not granted, subscriber webrtc negotiation fails.
+  const detectedOS = detectOS(navigator.userAgent);
+
+  if (detectedOS === "iOS" || detectedOS === "Mac OS") {
     await navigator.mediaDevices.getUserMedia({ audio: true });
   }
 


### PR DESCRIPTION
On iOS and Mac OS, webrtc streams can fail to be successfully negotiated until mic permission is granted and a user gesture is performed. This PR forces a mic permission prompt on startup in order to ensure you can hear others in the space in the landing page.