### PR TITLE
Fix revoking SketchfabZipWorker's Object URLs (WIP)

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -275,7 +275,7 @@ async function loadGLTF(src, contentType, preferredTechnique, onProgress) {
 
   if (fileMap) {
     // The GLTF is now cached as a THREE object, we can get rid of the original blobs
-    Object.keys(fileMap).forEach(URL.revokeObjectURL);
+    Object.values(fileMap).forEach(URL.revokeObjectURL);
   }
 
   return gltf;


### PR DESCRIPTION
Currently `revokeObjectURL` is being called with the original file name not the blob URL. However, based on the `chrome://blob-internals` tool it looks like these object URLs are still not being freed.

1. Load Atrium Scene
<img width="1680" alt="screen shot 2018-12-17 at 5 32 41 pm" src="https://user-images.githubusercontent.com/1753624/50126972-06f04a80-0224-11e9-98c3-be8d846ed427.png">

2. Import [Sketchfab model](https://sketchfab.com/models/c51ca76e5c3e4108a3de3f9cfdd48d4e)
<img width="1680" alt="screen shot 2018-12-17 at 5 32 52 pm" src="https://user-images.githubusercontent.com/1753624/50126980-0a83d180-0224-11e9-89dd-8248dfa5d896.png">

3. Remove Sketchfab model
<img width="1680" alt="screen shot 2018-12-17 at 5 33 04 pm" src="https://user-images.githubusercontent.com/1753624/50126983-0d7ec200-0224-11e9-9e08-bd298b6cac98.png">

I believe there should not be any blob being held onto at step 2. Instead all of the blobs created by the SketchfabZipLoader are never freed.