### PR TITLE
Media cloning and opening

### DIFF
--- a/src/components/clone-media-button.js
+++ b/src/components/clone-media-button.js
@@ -10,11 +10,13 @@ AFRAME.registerComponent("clone-media-button", {
     this.onClick = () => {
       const { src, resize } = this.targetEl.components["media-loader"].data;
       const { entity } = addMedia(src, "#interactable-media", ObjectContentOrigins.URL, true, resize);
-      entity.object3D.position.copy(this.targetEl.object3D.position);
-      entity.object3D.rotation.copy(this.targetEl.object3D.rotation);
-      entity.object3D.scale.copy(this.targetEl.object3D.scale);
+
       entity.object3D.matrixNeedsUpdate = true;
-      entity.object3D.matrixWorldNeedsUpdate = true;
+
+      entity.setAttribute("offset-relative-to", {
+        target: "#player-camera",
+        offset: { x: 0, y: 0, z: -1.5 }
+      });
     };
   },
 

--- a/src/components/clone-media-button.js
+++ b/src/components/clone-media-button.js
@@ -1,0 +1,28 @@
+import { addMedia } from "../utils/media-utils";
+import { ObjectContentOrigins } from "../object-types";
+
+AFRAME.registerComponent("clone-media-button", {
+  init() {
+    NAF.utils.getNetworkedEntity(this.el).then(networkedEl => {
+      this.targetEl = networkedEl;
+    });
+
+    this.onClick = () => {
+      const { src, resize } = this.targetEl.components["media-loader"].data;
+      const { entity } = addMedia(src, "#interactable-media", ObjectContentOrigins.URL, true, resize);
+      entity.object3D.position.copy(this.targetEl.object3D.position);
+      entity.object3D.rotation.copy(this.targetEl.object3D.rotation);
+      entity.object3D.scale.copy(this.targetEl.object3D.scale);
+      entity.object3D.matrixNeedsUpdate = true;
+      entity.object3D.matrixWorldNeedsUpdate = true;
+    };
+  },
+
+  play() {
+    this.el.addEventListener("grab-start", this.onClick);
+  },
+
+  pause() {
+    this.el.removeEventListener("grab-start", this.onClick);
+  }
+});

--- a/src/components/open-media-button.js
+++ b/src/components/open-media-button.js
@@ -1,0 +1,36 @@
+const hubsRegex = /https?:\/\/(hubs.local(:\d+)?|(smoke-)?hubs.mozilla.com)\/(\w+)\/?\S*/g;
+const isHubsUrl = hubsRegex.test.bind(hubsRegex);
+
+AFRAME.registerComponent("open-media-button", {
+  init() {
+    this.label = this.el.querySelector("[text]");
+
+    this.updateSrc = () => {
+      this.src = this.targetEl.components["media-loader"].data.src;
+      this.label.setAttribute("text", "value", isHubsUrl(this.src) ? "visit" : "open link");
+    };
+
+    this.onClick = () => {
+      const directNavigate = isHubsUrl(this.src);
+      if (directNavigate) {
+        location.href = this.src;
+      } else {
+        window.open(this.src);
+      }
+    };
+
+    NAF.utils.getNetworkedEntity(this.el).then(networkedEl => {
+      this.targetEl = networkedEl;
+      this.targetEl.addEventListener("media_resolved", this.updateSrc, { once: true });
+      this.updateSrc();
+    });
+  },
+
+  play() {
+    this.el.addEventListener("grab-start", this.onClick);
+  },
+
+  pause() {
+    this.el.removeEventListener("grab-start", this.onClick);
+  }
+});

--- a/src/components/position-at-box-shape-border.js
+++ b/src/components/position-at-box-shape-border.js
@@ -67,11 +67,9 @@ AFRAME.registerComponent("position-at-box-shape-border", {
         this.targetEl.removeAttribute("animation__show");
       });
 
-      if (this.targetEl.getAttribute("visible") === false) {
-        this.target.scale.setScalar(0.01); // To avoid "pop" of gigantic button first time
-        this.target.matrixNeedsUpdate = true;
-        return;
-      }
+      this.target.scale.setScalar(0.01); // To avoid "pop" of gigantic button first time
+      this.target.matrixNeedsUpdate = true;
+      return;
     }
 
     if (!this.el.getObject3D("mesh")) {
@@ -80,12 +78,22 @@ AFRAME.registerComponent("position-at-box-shape-border", {
 
     const isVisible = this.targetEl.getAttribute("visible");
     const opening = isVisible && !this.wasVisible;
+    const scaleChanged =
+      this.el.object3D.scale.x !== this.previousScaleX ||
+      this.el.object3D.scale.y !== this.previousScaleY ||
+      this.el.object3D.scale.z !== this.previousScaleZ;
+    const isAnimating = this.targetEl.getAttribute("animation__show");
 
-    if (opening) {
+    // If the target is being shown or the scale changed while the opening animation is being run,
+    // we need to start or re-start the animation.
+    if (opening || (scaleChanged && isAnimating)) {
       this._updateBox(true);
     }
 
     this.wasVisible = isVisible;
+    this.previousScaleX = this.el.object3D.scale.x;
+    this.previousScaleY = this.el.object3D.scale.y;
+    this.previousScaleZ = this.el.object3D.scale.z;
   },
 
   _updateBox: (function() {

--- a/src/hub.html
+++ b/src/hub.html
@@ -229,6 +229,12 @@
                             </a-entity>
                             <a-entity mixin="rounded-text-button" class="hide-when-pinned" remove-networked-object-button position="0 -0.125 0.01"> </a-entity>
                             <a-entity text=" value:remove; width:1.75; align:center;" class="hide-when-pinned" text-raycast-hack position="0 -0.125 0.02"></a-entity>
+                            <a-entity mixin="rounded-text-button" open-media-button position="0.25 -0.375 0.01">
+                                <a-entity text="value:open link; width:1.75; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
+                            </a-entity>
+                            <a-entity mixin="rounded-text-button" clone-media-button position="-0.25 -0.375 0.01">
+                                <a-entity text="value:clone; width:1.75; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
+                            </a-entity>
                         </a-entity>
                     </a-entity>
                 </a-entity>

--- a/src/hub.html
+++ b/src/hub.html
@@ -13,13 +13,6 @@
 </head>
 
 <body>
-    <audio id="test-tone">
-        <source src="./assets/sfx/tone.webm" type="audio/webm"/>
-        <source src="./assets/sfx/tone.mp3" type="audio/mpeg"/>
-        <source src="./assets/sfx/tone.ogg" type="audio/ogg"/>
-        <source src="./assets/sfx/tone.wav" type="audio/wav"/>
-    </audio>
-
     <a-scene
         class="grab-cursor"
         renderer="antialias: true; gammaOutput: true; sortObjects: true; physicallyCorrectLights: true;"

--- a/src/hub.js
+++ b/src/hub.js
@@ -79,6 +79,8 @@ import "./components/stop-event-propagation";
 import "./components/animation";
 import "./components/follow-in-lower-fov";
 import "./components/matrix-auto-update";
+import "./components/clone-media-button";
+import "./components/open-media-button";
 
 import ReactDOM from "react-dom";
 import React from "react";

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -72,6 +72,21 @@ async function grantedMicLabels() {
 
 const AUTO_EXIT_TIMER_SECONDS = 10;
 
+import webmTone from "../assets/sfx/tone.webm";
+import mp3Tone from "../assets/sfx/tone.mp3";
+import oggTone from "../assets/sfx/tone.ogg";
+import wavTone from "../assets/sfx/tone.wav";
+const toneClip = document.createElement("audio");
+if (toneClip.canPlayType("audio/webm")) {
+  toneClip.src = webmTone;
+} else if (toneClip.canPlayType("audio/mpeg")) {
+  toneClip.src = mp3Tone;
+} else if (toneClip.canPlayType("audio/ogg")) {
+  toneClip.src = oggTone;
+} else {
+  toneClip.src = wavTone;
+}
+
 class UIRoot extends Component {
   static propTypes = {
     enterScene: PropTypes.func,
@@ -305,7 +320,6 @@ class UIRoot extends Component {
   };
 
   playTestTone = () => {
-    const toneClip = document.querySelector("#test-tone");
     toneClip.currentTime = 0;
     toneClip.play();
     clearTimeout(this.testToneTimeout);
@@ -317,7 +331,6 @@ class UIRoot extends Component {
   };
 
   stopTestTone = () => {
-    const toneClip = document.querySelector("#test-tone");
     toneClip.pause();
     toneClip.currentTime = 0;
     this.setState({ tonePlaying: false });


### PR DESCRIPTION
Adds "clone" and "open link" buttons to the pause menu for media. This allows you to create copies of existing media objects as well as get the open up the original link for them in a new tab. This is a great way to link rooms together or save photos you take with the camera tool.

![image](https://user-images.githubusercontent.com/130735/50196410-df6ab200-02f7-11e9-87ee-d0480d156406.png)


Opening links will require allowing popups, but this only needs to be done once. Hubs links will not need popup blocking disabled, but no special changes have yet been made to the entry flow, so you will get kicked out of VR.

This also fixes the hub.html page to not resolve to the test tone, and instead use the scene's image (from og:image).