### PR TITLE
UX tweaks to cloning

### DIFF
--- a/src/components/clone-media-button.js
+++ b/src/components/clone-media-button.js
@@ -10,11 +10,13 @@ AFRAME.registerComponent("clone-media-button", {
     this.onClick = () => {
       const { src, resize } = this.targetEl.components["media-loader"].data;
       const { entity } = addMedia(src, "#interactable-media", ObjectContentOrigins.URL, true, resize);
-      entity.object3D.position.copy(this.targetEl.object3D.position);
-      entity.object3D.rotation.copy(this.targetEl.object3D.rotation);
-      entity.object3D.scale.copy(this.targetEl.object3D.scale);
+
       entity.object3D.matrixNeedsUpdate = true;
-      entity.object3D.matrixWorldNeedsUpdate = true;
+
+      entity.setAttribute("offset-relative-to", {
+        target: "#player-camera",
+        offset: { x: 0, y: 0, z: -1.5 }
+      });
     };
   },
 

--- a/src/components/position-at-box-shape-border.js
+++ b/src/components/position-at-box-shape-border.js
@@ -79,9 +79,9 @@ AFRAME.registerComponent("position-at-box-shape-border", {
     const isVisible = this.targetEl.getAttribute("visible");
     const opening = isVisible && !this.wasVisible;
     const scaleChanged =
-      this.el.object3D.scale.x !== this.previousTargetScaleX ||
-      this.el.object3D.scale.y !== this.previousTargetScaleY ||
-      this.el.object3D.scale.z !== this.previousTargetScaleZ;
+      this.el.object3D.scale.x !== this.previousScaleX ||
+      this.el.object3D.scale.y !== this.previousScaleY ||
+      this.el.object3D.scale.z !== this.previousScaleZ;
     const isAnimating = this.targetEl.getAttribute("animation__show");
 
     // If the target is being shown or the scale changed while the opening animation is being run,
@@ -91,9 +91,9 @@ AFRAME.registerComponent("position-at-box-shape-border", {
     }
 
     this.wasVisible = isVisible;
-    this.previousTargetScaleX = this.el.object3D.scale.x;
-    this.previousTargetScaleY = this.el.object3D.scale.y;
-    this.previousTargetScaleZ = this.el.object3D.scale.z;
+    this.previousScaleX = this.el.object3D.scale.x;
+    this.previousScaleY = this.el.object3D.scale.y;
+    this.previousScaleZ = this.el.object3D.scale.z;
   },
 
   _updateBox: (function() {

--- a/src/components/position-at-box-shape-border.js
+++ b/src/components/position-at-box-shape-border.js
@@ -67,11 +67,9 @@ AFRAME.registerComponent("position-at-box-shape-border", {
         this.targetEl.removeAttribute("animation__show");
       });
 
-      if (this.targetEl.getAttribute("visible") === false) {
-        this.target.scale.setScalar(0.01); // To avoid "pop" of gigantic button first time
-        this.target.matrixNeedsUpdate = true;
-        return;
-      }
+      this.target.scale.setScalar(0.01); // To avoid "pop" of gigantic button first time
+      this.target.matrixNeedsUpdate = true;
+      return;
     }
 
     if (!this.el.getObject3D("mesh")) {
@@ -80,12 +78,22 @@ AFRAME.registerComponent("position-at-box-shape-border", {
 
     const isVisible = this.targetEl.getAttribute("visible");
     const opening = isVisible && !this.wasVisible;
+    const scaleChanged =
+      this.el.object3D.scale.x !== this.previousTargetScaleX ||
+      this.el.object3D.scale.y !== this.previousTargetScaleY ||
+      this.el.object3D.scale.z !== this.previousTargetScaleZ;
+    const isAnimating = this.targetEl.getAttribute("animation__show");
 
-    if (opening) {
+    // If the target is being shown or the scale changed while the opening animation is being run,
+    // we need to start or re-start the animation.
+    if (opening || (scaleChanged && isAnimating)) {
       this._updateBox(true);
     }
 
     this.wasVisible = isVisible;
+    this.previousTargetScaleX = this.el.object3D.scale.x;
+    this.previousTargetScaleY = this.el.object3D.scale.y;
+    this.previousTargetScaleZ = this.el.object3D.scale.z;
   },
 
   _updateBox: (function() {


### PR DESCRIPTION
This PR:

- Positions cloned objects in front of the player camera, so they are not stacked on top of each other (since typically you'll be hitting the clone button on something slightly offset to the camera, etc.)

- Fixes a visual issue where the menu is too big for a few frames if a new object is spawned during pause mode