### PR TITLE
Hacky fix for button position on cloned objects

### DIFF
--- a/src/components/text-button.js
+++ b/src/components/text-button.js
@@ -13,6 +13,8 @@ AFRAME.registerComponent("text-button", {
   },
 
   init() {
+    // TODO: This is a bit of a hack to deal with position "component" not setting matrixNeedsUpdate. Come up with a better solution.
+    this.el.object3D.matrixNeedsUpdate = true;
     this.onHover = () => {
       this.hovering = true;
       this.updateButtonState();


### PR DESCRIPTION
When cloning objects the clone, open link, track, and target buttons are sometimes incorrectly positioned (at 0,0,0). This seems to only happen in Firefox, and only on hubs room links. The issue has to do with the matrixNeedsUpdate flag not getting set for the `position` "component". From what I can tell this should basically always happen but there are timing issues which cause it not to most of the time. Not 100% clear on why the borwser differences matter, but its likely to do with instantiating the templates, since we noticed differences here in the past.

This fix does not solve the underlying problem, it just fixes it for these buttons in particular. The real fix likely requires patching aframe such that when it is applying the `position` "component" it sets this bit. Might be a bit hard to monkey patch in, and unless the THREE change for this flag actually lands means we will need to be on a long term fork of aframe for it.