### PR TITLE
Fix mic permissions handling on apple devices

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -10,6 +10,11 @@
     <link rel="shortcut icon" type="image/png" href="/favicon.ico">
     <title>Get together | Hubs by Mozilla</title>
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,700" rel="stylesheet">
+    <script>
+        // HACK Chrome on iOS breaks completely if we don't do this because a-frame's webvr-polyfill doesn't recognize
+        // Google Chrome on iOS correctly. We can remove this when we upgrade a-frame past 0.8.2.
+        if (!window.WebVRConfig) { window.WebVRConfig = {}; }
+    </script>
 </head>
 
 <body>

--- a/src/hub.js
+++ b/src/hub.js
@@ -22,7 +22,7 @@ import "aframe-motion-capture-components";
 import "./utils/audio-context-fix";
 import "./utils/threejs-positional-audio-updatematrixworld";
 import "./utils/threejs-world-update";
-import { detectOS } from "detect-browser";
+import { detectOS, detect } from "detect-browser";
 import { getReticulumFetchUrl } from "./utils/phoenix-utils";
 
 import nextTick from "./utils/next-tick";
@@ -354,11 +354,16 @@ async function runBotMode(scene, entryManager) {
 document.addEventListener("DOMContentLoaded", async () => {
   warmSerializeElement();
 
-  // HACK: On iOS & MacOS, if mic permission is not granted, subscriber webrtc negotiation fails.
+  // HACK: On Safari for iOS & MacOS, if mic permission is not granted, subscriber webrtc negotiation fails.
   const detectedOS = detectOS(navigator.userAgent);
-
-  if (detectedOS === "iOS" || detectedOS === "Mac OS") {
-    await navigator.mediaDevices.getUserMedia({ audio: true });
+  const browser = detect();
+  if (["iOS", "Mac OS"].includes(detectedOS) && ["safari", "ios"].includes(browser.name)) {
+    try {
+      await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch(e) {
+      remountUI({ showSafariMicDialog: true });
+      return;
+    }
   }
 
   const hubId = qs.get("hub_id") || document.location.pathname.substring(1).split("/")[0];

--- a/src/react-components/safari-mic-dialog.js
+++ b/src/react-components/safari-mic-dialog.js
@@ -1,0 +1,24 @@
+import React, { Component } from "react";
+import DialogContainer from "./dialog-container.js";
+
+export default class SafariMicDialog extends Component {
+  render() {
+    return (
+      <DialogContainer title="Microphone Access Required" {...this.props}>
+        <div>
+          <div>
+            Hubs requires microphone permissions in Safari. <br />
+            Please reload and allow microphone access to continue.
+          </div>
+          <div className="invite-form">
+            <div className="invite-form__buttons">
+              <button className="invite-form__action-button" onClick={() => location.reload()}>
+                Reload
+              </button>
+            </div>
+          </div>
+        </div>
+      </DialogContainer>
+    );
+  }
+}

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -28,6 +28,7 @@ import InviteDialog from "./invite-dialog.js";
 import InviteTeamDialog from "./invite-team-dialog.js";
 import LinkDialog from "./link-dialog.js";
 import SafariDialog from "./safari-dialog.js";
+import SafariMicDialog from "./safari-mic-dialog.js";
 import SignInDialog from "./sign-in-dialog.js";
 import WebRTCScreenshareUnsupportedDialog from "./webrtc-screenshare-unsupported-dialog.js";
 import WebVRRecommendDialog from "./webvr-recommend-dialog.js";
@@ -118,7 +119,8 @@ class UIRoot extends Component {
     signInMessageId: PropTypes.string,
     signInCompleteMessageId: PropTypes.string,
     signInContinueTextId: PropTypes.string,
-    onContinueAfterSignIn: PropTypes.func
+    onContinueAfterSignIn: PropTypes.func,
+    showSafariMicDialog: PropTypes.bool
   };
 
   state = {
@@ -162,6 +164,13 @@ class UIRoot extends Component {
     signedIn: false,
     videoShareMediaSource: null
   };
+
+  constructor(props) {
+    super(props);
+    if (props.showSafariMicDialog) {
+      this.state.dialog = <SafariMicDialog closable={false} />;
+    }
+  }
 
   componentDidUpdate(prevProps) {
     const { hubChannel, showSignInDialog } = this.props;
@@ -1079,7 +1088,9 @@ class UIRoot extends Component {
 
   render() {
     const isExited = this.state.exited || this.props.roomUnavailableReason || this.props.platformUnsupportedReason;
-    const isLoading = !this.props.environmentSceneLoaded || !this.props.availableVREntryTypes || !this.props.hubId;
+    const isLoading =
+      !this.props.showSafariMicDialog &&
+      (!this.props.environmentSceneLoaded || !this.props.availableVREntryTypes || !this.props.hubId);
 
     if (isExited) return this.renderExitedPane();
     if (isLoading) return this.renderLoader();


### PR DESCRIPTION
- Restricts the hack introduced in #790 to Safari on iOS and macOS so that Firefox and Chrome aren't blocked
- Adds a info dialog insisting on mic permissions in Safari
- Also fixes a separate bug that broke hubs in Chrome on iOS