### PR TITLE
Add shadow bias and shadow radius properties to lights

### DIFF
--- a/src/components/directional-light.js
+++ b/src/components/directional-light.js
@@ -40,7 +40,7 @@ AFRAME.registerComponent("directional-light", {
       light.shadow.bias = this.data.shadowBias;
     }
 
-    if (this.data.radius !== prevData.radius) {
+    if (this.data.shadowRadius !== prevData.shadowRadius) {
       light.shadow.radius = this.data.radius;
     }
 

--- a/src/components/directional-light.js
+++ b/src/components/directional-light.js
@@ -5,7 +5,9 @@ AFRAME.registerComponent("directional-light", {
     color: { type: "color" },
     intensity: { default: 1.0 },
     castShadow: { default: true },
-    shadowMapResolution: { default: [512, 512] }
+    shadowMapResolution: { default: [512, 512] },
+    shadowBias: { default: 0 },
+    shadowRadius: { default: 1 }
   },
 
   init() {
@@ -32,6 +34,14 @@ AFRAME.registerComponent("directional-light", {
 
     if (this.data.castShadow !== prevData.castShadow) {
       light.castShadow = this.data.castShadow;
+    }
+
+    if (this.data.shadowBias !== prevData.shadowBias) {
+      light.shadow.bias = this.data.shadowBias;
+    }
+
+    if (this.data.radius !== prevData.radius) {
+      light.shadow.radius = this.data.radius;
     }
 
     const [width, height] = this.data.shadowMapResolution;

--- a/src/components/point-light.js
+++ b/src/components/point-light.js
@@ -41,7 +41,7 @@ AFRAME.registerComponent("point-light", {
       light.shadow.bias = this.data.shadowBias;
     }
 
-    if (this.data.radius !== prevData.radius) {
+    if (this.data.shadowRadius !== prevData.shadowRadius) {
       light.shadow.radius = this.data.radius;
     }
 

--- a/src/components/point-light.js
+++ b/src/components/point-light.js
@@ -4,7 +4,9 @@ AFRAME.registerComponent("point-light", {
     intensity: { default: 1.0 },
     range: { default: 0 },
     castShadow: { default: true },
-    shadowMapResolution: { default: [512, 512] }
+    shadowMapResolution: { default: [512, 512] },
+    shadowBias: { default: 0 },
+    shadowRadius: { default: 1 }
   },
 
   init() {
@@ -33,6 +35,14 @@ AFRAME.registerComponent("point-light", {
 
     if (this.data.castShadow !== prevData.castShadow) {
       light.castShadow = this.data.castShadow;
+    }
+
+    if (this.data.shadowBias !== prevData.shadowBias) {
+      light.shadow.bias = this.data.shadowBias;
+    }
+
+    if (this.data.radius !== prevData.radius) {
+      light.shadow.radius = this.data.radius;
     }
 
     const [width, height] = this.data.shadowMapResolution;

--- a/src/components/spot-light.js
+++ b/src/components/spot-light.js
@@ -6,7 +6,9 @@ AFRAME.registerComponent("spot-light", {
     innerConeAngle: { default: 0 },
     outerConeAngle: { default: Math.PI / 4.0 },
     castShadow: { default: true },
-    shadowMapResolution: { default: [512, 512] }
+    shadowMapResolution: { default: [512, 512] },
+    shadowBias: { default: 0 },
+    shadowRadius: { default: 1 }
   },
 
   init() {
@@ -44,6 +46,14 @@ AFRAME.registerComponent("spot-light", {
 
     if (this.data.castShadow !== prevData.castShadow) {
       light.castShadow = this.data.castShadow;
+    }
+
+    if (this.data.shadowBias !== prevData.shadowBias) {
+      light.shadow.bias = this.data.shadowBias;
+    }
+
+    if (this.data.radius !== prevData.radius) {
+      light.shadow.radius = this.data.radius;
     }
 
     const [width, height] = this.data.shadowMapResolution;

--- a/src/components/spot-light.js
+++ b/src/components/spot-light.js
@@ -52,7 +52,7 @@ AFRAME.registerComponent("spot-light", {
       light.shadow.bias = this.data.shadowBias;
     }
 
-    if (this.data.radius !== prevData.radius) {
+    if (this.data.shadowRadius !== prevData.shadowRadius) {
       light.shadow.radius = this.data.radius;
     }
 


### PR DESCRIPTION
`shadowBias` and `shadowRadius` are now exported from Spoke. Bias is used to eliminate shadow artifacts such as shadow acne which can result when meshes cast a shadow on themselves. Radius is used to blur the edges of a shadow and make them less sharp.