### PR TITLE
Set the mass of static media to 0 so that it doesn't fall

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -163,7 +163,7 @@
 
             <template id="static-media">
                 <a-entity
-                    body="type: static; shape: none; mass: 1;"
+                    body="type: static; shape: none; mass: 0;"
                     auto-scale-cannon-physics-body
                     set-sounds-invisible
                 >
@@ -174,7 +174,7 @@
                 <a-entity
                     class="interactable"
                     super-networked-interactable="counter: #media-counter;"
-                    body="type: static; shape: none; mass: 1;"
+                    body="type: static; shape: none; mass: 0;"
                     grabbable
                     hoverable
                     hoverable-visuals="cursorController: #cursor-controller"


### PR DESCRIPTION
This should fix one of the issues when grabbing static media so that you can pause/unpause it.