### PR TITLE
Update networked-aframe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9007,7 +9007,7 @@
       "dev": true
     },
     "networked-aframe": {
-      "version": "github:mozillareality/networked-aframe#41ffa558180471227f7c25533cd37dcf58a1f3a9",
+      "version": "github:mozillareality/networked-aframe#e9d9c0fb0f781c11f7ced41538268aee8170872a",
       "from": "github:mozillareality/networked-aframe#master",
       "requires": {
         "buffered-interpolation": "^0.2.4",


### PR DESCRIPTION
Update networked-aframe to fix a bug that causes pagers to appear on media objects that don't need them. https://github.com/MozillaReality/networked-aframe/pull/21