### PR TITLE
Slightly widen "what's new" page content

### DIFF
--- a/src/assets/stylesheets/whats-new.scss
+++ b/src/assets/stylesheets/whats-new.scss
@@ -41,7 +41,7 @@ html, body, #ui-root, .container {
 
 .content {
   padding: 1em;
-  width: 40em;
+  width: 45em;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
As long as these headlines are taken from the GitHub PR title, they should probably have enough space to display without wrapping as long as the GitHub PR title displays without wrapping.