### PR TITLE
Spoke spawner node

### DIFF
--- a/src/components/super-spawner.js
+++ b/src/components/super-spawner.js
@@ -23,6 +23,11 @@ AFRAME.registerComponent("super-spawner", {
     resolve: { default: false },
 
     /**
+     * Whether to resize the media on load.
+     */
+    resize: { default: false },
+
+    /**
      * The template to use for this object
      */
     template: { default: "" },
@@ -164,7 +169,13 @@ AFRAME.registerComponent("super-spawner", {
     const thisGrabId = nextGrabId++;
     this.heldEntities.set(hand, thisGrabId);
 
-    const entity = addMedia(this.data.src, this.data.template, ObjectContentOrigins.SPAWNER, this.data.resolve).entity;
+    const entity = addMedia(
+      this.data.src,
+      this.data.template,
+      ObjectContentOrigins.SPAWNER,
+      this.data.resolve,
+      this.data.resize
+    ).entity;
 
     entity.object3D.position.copy(
       this.data.useCustomSpawnPosition ? this.data.spawnPosition : this.el.object3D.position

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -140,3 +140,27 @@ function mediaInflator(el, componentName, componentData, components) {
 
 AFRAME.GLTFModelPlus.registerComponent("image", "image", mediaInflator);
 AFRAME.GLTFModelPlus.registerComponent("video", "video", mediaInflator);
+
+AFRAME.GLTFModelPlus.registerComponent("spawner", "spawner", (el, componentName, componentData) => {
+  el.setAttribute("media-loader", {
+    src: componentData.src,
+    resolve: true,
+    fileIsOwned: true
+  });
+  el.setAttribute("css-class", "interactable");
+  el.setAttribute("super-spawner", {
+    src: componentData.src,
+    resolve: true,
+    resize: true,
+    template: "#interactable-media"
+  });
+  el.setAttribute("body", {
+    mass: 0,
+    type: "static",
+    shape: "none"
+  });
+  el.setAttribute("collision-filter", {
+    collisionForces: false
+  });
+  el.setAttribute("hoverable", "");
+});


### PR DESCRIPTION
Added support for creating interactable object spawners to Spoke. You can now place spawners that spawn non-duck objects!

![spawnernode](https://user-images.githubusercontent.com/1753624/50862642-09d8e980-1351-11e9-891b-09c0e13c21a3.gif)
