### PR TITLE
Make optional author override on incoming chat

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -649,12 +649,22 @@ document.addEventListener("DOMContentLoaded", async () => {
     NAF.connection.adapter.onData(data);
   });
 
-  hubPhxChannel.on("message", ({ session_id, type, body }) => {
-    const userInfo = hubPhxPresence.state[session_id];
-    if (!userInfo) return;
+  hubPhxChannel.on("message", ({ session_id, type, body, from }) => {
+    const getAuthor = () => {
+      const userInfo = hubPhxPresence.state[session_id];
+      if (from) {
+        return from;
+      } else if (userInfo) {
+        return userInfo.metas[0].profile.displayName;
+      } else {
+        return "Mystery user";
+      }
+    };
+
+    const name = getAuthor();
     const maySpawn = scene.is("entered");
 
-    const incomingMessage = { name: userInfo.metas[0].profile.displayName, type, body, maySpawn };
+    const incomingMessage = { name, type, body, maySpawn };
 
     if (scene.is("vr-mode")) {
       createInWorldLogMessage(incomingMessage);


### PR DESCRIPTION
This is required for messages incoming from Discord right now to get their Discord authors, since Discord users don't participate in presence. We might expect this to change in the future when we have a tighter integration between Discord and Hubs, but it's too early to say exactly how it should be.