### PR TITLE
Support for HLS Video (Twitch, Crunchyroll, Youtube Live, Twitter, and more)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -518,9 +518,7 @@
       "requires": {
         "@tweenjs/tween.js": "^16.8.0",
         "browserify-css": "^0.8.2",
-        "debug": "github:ngokevin/debug#ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a",
         "deep-assign": "^2.0.0",
-        "document-register-element": "github:dmarcos/document-register-element#8ccc532b7f3744be954574caf3072a5fd260ca90",
         "envify": "^3.4.1",
         "load-bmfont": "^1.2.3",
         "object-assign": "^4.0.1",
@@ -534,7 +532,11 @@
       "dependencies": {
         "debug": {
           "version": "github:ngokevin/debug#ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a",
-          "from": "github:ngokevin/debug#noTimestamp"
+          "from": "github:ngokevin/debug#ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a"
+        },
+        "document-register-element": {
+          "version": "github:dmarcos/document-register-element#8ccc532b7f3744be954574caf3072a5fd260ca90",
+          "from": "github:dmarcos/document-register-element#8ccc532b7f3744be954574caf3072a5fd260ca90"
         },
         "three": {
           "version": "0.94.0",
@@ -3908,10 +3910,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "document-register-element": {
-      "version": "github:dmarcos/document-register-element#8ccc532b7f3744be954574caf3072a5fd260ca90",
-      "from": "github:dmarcos/document-register-element#8ccc532b7"
-    },
     "dom-converter": {
       "version": "0.1.4",
       "resolved": "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.1.4.tgz",
@@ -6429,6 +6427,15 @@
       "resolved": "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
+    },
+    "hls.js": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-0.12.2.tgz",
+      "integrity": "sha512-lQBSXggw9OzEuaUllUBoSxPcf7neFgnEiDRfCdCNdIPtUeV7vXZ0OeASx6EWtZTBiqSSPigoOX1Y+AR5dA1Feg==",
+      "requires": {
+        "eventemitter3": "3.1.0",
+        "url-toolkit": "^2.1.6"
+      }
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -13370,6 +13377,11 @@
       "resolved": "https://registry.yarnpkg.com/url-to-options/-/url-to-options-1.0.1.tgz",
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
       "dev": true
+    },
+    "url-toolkit": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.1.6.tgz",
+      "integrity": "sha512-UaZ2+50am4HwrV2crR/JAf63Q4VvPYphe63WGeoJxeu8gmOm0qxPt+KsukfakPNrX9aymGNEkkaoICwn+OuvBw=="
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "detect-browser": "^2.1.0",
     "event-target-shim": "^3.0.1",
     "form-urlencoded": "^2.0.4",
+    "hls.js": "^0.12.2",
     "jsonschema": "^1.2.2",
     "jszip": "^3.1.5",
     "markdown-it": "^8.4.2",

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -1,6 +1,9 @@
 import GIFWorker from "../workers/gifparsing.worker.js";
 import errorImageSrc from "!!url-loader!../assets/images/media-error.gif";
 import { paths } from "../systems/userinput/paths";
+import HLS from "hls.js";
+import { proxiedUrlFor } from "../utils/media-utils";
+import { buildAbsoluteURL } from "url-toolkit";
 
 class GIFTexture extends THREE.Texture {
   constructor(frames, delays, disposals) {
@@ -82,7 +85,7 @@ const isIOS = AFRAME.utils.device.isIOS();
  * @param {string} src - Url to a video file.
  * @returns {Element} Video element.
  */
-async function createVideoEl(src) {
+async function createVideoEl() {
   const videoEl = document.createElement("video");
   videoEl.setAttribute("playsinline", "");
   videoEl.setAttribute("webkit-playsinline", "");
@@ -94,43 +97,84 @@ async function createVideoEl(src) {
   videoEl.preload = "auto";
   videoEl.crossOrigin = "anonymous";
 
-  if (!src.startsWith("hubs://")) {
-    videoEl.src = src;
-  } else {
-    const streamClientId = src.substring(7).split("/")[1]; // /clients/<client id>/video is only URL for now
-    const stream = await NAF.connection.adapter.getMediaStream(streamClientId, "video");
-    videoEl.srcObject = new MediaStream(stream.getVideoTracks());
-  }
-
   return videoEl;
 }
 
-function createVideoTexture(url) {
+function createVideoTexture(url, contentType) {
   return new Promise(async (resolve, reject) => {
-    const videoEl = await createVideoEl(url);
+    const videoEl = await createVideoEl();
 
     const texture = new THREE.VideoTexture(videoEl);
     texture.minFilter = THREE.LinearFilter;
     texture.encoding = THREE.sRGBEncoding;
 
-    videoEl.addEventListener("loadedmetadata", () => resolve(texture), { once: true });
-    videoEl.onerror = reject;
+    if (url.startsWith("hubs://")) {
+      const streamClientId = url.substring(7).split("/")[1]; // /clients/<client id>/video is only URL for now
+      const stream = await NAF.connection.adapter.getMediaStream(streamClientId, "video");
+      videoEl.srcObject = new MediaStream(stream.getVideoTracks());
+      // If hls.js is supported we always use it as it gives us better events
+    } else if (AFRAME.utils.material.isHLS(url, contentType)) {
+      if (HLS.isSupported()) {
+        const corsProxyPrefix = `https://${process.env.CORS_PROXY_SERVER}/`;
+        const baseUrl = url.startsWith(corsProxyPrefix) ? url.substring(corsProxyPrefix.length) : url;
+        const hls = new HLS({
+          xhrSetup: (xhr, u) => {
+            if (u.startsWith(corsProxyPrefix)) {
+              u = u.substring(corsProxyPrefix.length);
+            }
 
-    // If iOS and video is HLS, do some hacks.
-    if (
-      isIOS &&
-      AFRAME.utils.material.isHLS(
-        videoEl.src || videoEl.getAttribute("src"),
-        videoEl.type || videoEl.getAttribute("type")
-      )
-    ) {
-      // Actually BGRA. Tell shader to correct later.
-      texture.format = THREE.RGBAFormat;
-      texture.needsCorrectionBGRA = true;
-      // Apparently needed for HLS. Tell shader to correct later.
-      texture.flipY = false;
-      texture.needsCorrectionFlipY = true;
+            // HACK HLS.js resolves relative urls internally, but our CORS proxying screws it up. Resolve relative to the original unproxied url.
+            // TODO extend HLS.js to allow overriding of its internal resolving instead
+            if (!u.startsWith("http")) {
+              u = buildAbsoluteURL(baseUrl, u.startsWith("/") ? u : `/${u}`);
+            }
+
+            xhr.open("GET", proxiedUrlFor(u));
+          }
+        });
+        texture.hls = hls;
+        hls.loadSource(url);
+        hls.attachMedia(videoEl);
+        hls.on(HLS.Events.ERROR, function(event, data) {
+          console.error(event, data);
+          if (data.fatal) {
+            switch (data.type) {
+              case HLS.ErrorTypes.NETWORK_ERROR:
+                // try to recover network error
+                hls.startLoad();
+                break;
+              case HLS.ErrorTypes.MEDIA_ERROR:
+                hls.recoverMediaError();
+                break;
+              default:
+                reject(event);
+                return;
+            }
+          }
+        });
+        // If not, see if native support will work
+      } else if (videoEl.canPlayType(contentType)) {
+        videoEl.src = url;
+        videoEl.onerror = reject;
+
+        // HACK aframe iOS HLS video hacks
+        if (isIOS) {
+          // Actually BGRA. Tell shader to correct later.
+          texture.format = THREE.RGBAFormat;
+          texture.needsCorrectionBGRA = true;
+          // Apparently needed for HLS. Tell shader to correct later.
+          texture.flipY = false;
+          texture.needsCorrectionFlipY = true;
+        }
+      } else {
+        reject("HLS unsupported");
+      }
+    } else {
+      videoEl.src = url;
+      videoEl.onerror = reject;
     }
+
+    videoEl.addEventListener("loadedmetadata", () => resolve(texture), { once: true });
   });
 }
 
@@ -173,6 +217,11 @@ function disposeTexture(texture) {
     video.src = "";
     video.load();
   }
+
+  if (texture.hls) {
+    texture.hls.destroy();
+  }
+
   texture.dispose();
 }
 
@@ -227,6 +276,7 @@ errorImage.onload = () => {
 AFRAME.registerComponent("media-video", {
   schema: {
     src: { type: "string" },
+    contentType: { type: "string" },
     volume: { type: "number", default: 0.5 },
     loop: { type: "boolean", default: true },
     audioType: { type: "string", default: "pannernode" },
@@ -290,8 +340,8 @@ AFRAME.registerComponent("media-video", {
     this.el.addEventListener("grab-end", this._grabEnd);
     this.seekForwardButton.addEventListener("grab-start", this.seekForward);
     this.seekBackButton.addEventListener("grab-start", this.seekBack);
-    this.seekForwardButton.object3D.visible = true;
-    this.seekBackButton.object3D.visible = true;
+    this.seekForwardButton.object3D.visible = !this.videoIsLive;
+    this.seekBackButton.object3D.visible = !this.videoIsLive;
   },
 
   // aframe component pause, unrelated to video
@@ -305,14 +355,14 @@ AFRAME.registerComponent("media-video", {
   },
 
   seekForward() {
-    if (NAF.utils.isMine(this.networkedEl) || NAF.utils.takeOwnership(this.networkedEl)) {
+    if ((!this.videoIsLive && NAF.utils.isMine(this.networkedEl)) || NAF.utils.takeOwnership(this.networkedEl)) {
       this.video.currentTime += 30;
       this.el.setAttribute("media-video", "time", this.video.currentTime);
     }
   },
 
   seekBack() {
-    if (NAF.utils.isMine(this.networkedEl) || NAF.utils.takeOwnership(this.networkedEl)) {
+    if ((!this.videoIsLive && NAF.utils.isMine(this.networkedEl)) || NAF.utils.takeOwnership(this.networkedEl)) {
       this.video.currentTime -= 10;
       this.el.setAttribute("media-video", "time", this.video.currentTime);
     }
@@ -381,7 +431,7 @@ AFRAME.registerComponent("media-video", {
       delete this._playbackStateChangeTimeout;
     }
 
-    if (currentTime !== undefined) {
+    if (!this.videoIsLive && currentTime !== undefined) {
       this.video.currentTime = currentTime;
     }
 
@@ -410,7 +460,7 @@ AFRAME.registerComponent("media-video", {
 
     let texture;
     try {
-      texture = await createVideoTexture(src);
+      texture = await createVideoTexture(src, this.data.contentType);
 
       // No way to cancel promises, so if src has changed while we were creating the texture just throw it away.
       if (this.data.src !== src) {
@@ -437,6 +487,18 @@ AFRAME.registerComponent("media-video", {
 
         this.audio.setNodeSource(texture.audioSource);
         this.el.setObject3D("sound", this.audio);
+      }
+
+      if (texture.hls) {
+        const updateLiveState = () => {
+          this.videoIsLive = texture.hls.levels[texture.hls.currentLevel].details.live;
+          this.seekForwardButton.object3D.visible = !this.videoIsLive;
+          this.seekBackButton.object3D.visible = !this.videoIsLive;
+        };
+        texture.hls.on(HLS.Events.LEVEL_SWITCHED, updateLiveState);
+        if (texture.hls.currentLevel >= 0) {
+          updateLiveState();
+        }
       }
 
       this.video = texture.image;
@@ -496,7 +558,15 @@ AFRAME.registerComponent("media-video", {
       this.el.setAttribute("media-video", "volume", THREE.Math.clamp(this.data.volume + volumeMod, 0, 1));
     }
 
-    if (this.data.videoPaused || !this.video || !this.networkedEl || !NAF.utils.isMine(this.networkedEl)) return;
+    if (
+      this.data.videoPaused ||
+      this.videoIsLive ||
+      !this.video ||
+      !this.networkedEl ||
+      !NAF.utils.isMine(this.networkedEl)
+    ) {
+      return;
+    }
 
     const now = performance.now();
     if (now - this.lastUpdate > this.data.tickRate) {

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -3,6 +3,9 @@ import { getReticulumFetchUrl } from "./phoenix-utils";
 import mediaHighlightFrag from "./media-highlight-frag.glsl";
 
 const nonCorsProxyDomains = (process.env.NON_CORS_PROXY_DOMAINS || "").split(",");
+if (process.env.CORS_PROXY_SERVER) {
+  nonCorsProxyDomains.push(process.env.CORS_PROXY_SERVER);
+}
 const mediaAPIEndpoint = getReticulumFetchUrl("/api/v1/media");
 
 const commonKnownContentTypes = {


### PR DESCRIPTION
Playing video from sites using HLS is now supported. This includes live streaming sites like Twitch and Youtube Live, as well as VOD streaming video sources like Crunchyroll and Twitter.

![image](https://user-images.githubusercontent.com/130735/51011025-a3e49180-150b-11e9-88b7-7085274152fa.png)

When the source is a live stream seek controls will be hidden and video syncing will be disabled (since the stream syncs itself). When native HLS support is available it will only be used if hls.js itself is not supported (due to media extensions not being supported) since it is still a useful interface for event and error handling.

Biggest hack is to do with proxying of relative urls. Since HLS.js internally tries to resolve the relative urls against the proxied url, we have to unpack the proxied url, and the resolve it against the original base url ourself. This would be more cleanly done by extending hls.js to expose its url resolving in an overridable way.