### PR TITLE
Prevent scene-preview-camera from being added multiple times

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -274,7 +274,13 @@ async function handleHubChannelJoined(entryManager, hubChannel, messageDispatch,
   if (!isLegacyBundle) {
     const gltfEl = document.createElement("a-entity");
     gltfEl.setAttribute("gltf-model-plus", { src: proxiedUrlFor(sceneUrl), useCache: false, inflate: true });
-    gltfEl.addEventListener("model-loaded", () => environmentScene.emit("bundleloaded"));
+    gltfEl.addEventListener(
+      "model-loaded",
+      () => {
+        environmentScene.emit("bundleloaded");
+      },
+      { once: true }
+    );
     environmentScene.appendChild(gltfEl);
   } else {
     // Deprecated


### PR DESCRIPTION
When scenes have a spawner, the model-loaded event bubbles and the `scene-preview-camera` gets added multiple times. This PR only listens for the model-loaded event once on the environment scene.