### PR TITLE
Video Overlays (WIP)

### DIFF
--- a/src/components/hover-menu.js
+++ b/src/components/hover-menu.js
@@ -1,0 +1,64 @@
+AFRAME.registerComponent("hover-menu", {
+  multiple: true,
+  schema: {
+    template: { type: "selector" },
+    dirs: { type: "array" }
+  },
+
+  async init() {
+    this.onHoverStateChange = this.onHoverStateChange.bind(this);
+    this.onFrozenStateChange = this.onFrozenStateChange.bind(this);
+
+    this.hovering = this.el.parentNode.is("hovered");
+
+    await this.getHoverMenu();
+    this.applyHoverState();
+  },
+
+  getHoverMenu() {
+    if (this.menuPromise) return this.menuPromise;
+    return (this.menuPromise = new Promise(resolve => {
+      const menu = this.el.appendChild(document.importNode(this.data.template.content, true).children[0]);
+      // we have to wait a tick for the attach callbacks to get fired for the elements in a template
+      setTimeout(() => {
+        this.menu = menu;
+        this.el.setAttribute("position-at-box-shape-border", {
+          target: ".video-toolbar",
+          dirs: this.data.dirs,
+          animate: false,
+          scale: false
+        });
+        resolve(this.menu);
+      });
+    }));
+  },
+
+  onFrozenStateChange(e) {
+    if (!e.detail === "frozen") return;
+    this.applyHoverState();
+  },
+
+  onHoverStateChange(e) {
+    this.hovering = e.type === "hover-start";
+    this.applyHoverState();
+  },
+
+  applyHoverState() {
+    if (!this.menu) return;
+    this.menu.object3D.visible = !this.el.sceneEl.is("frozen") && this.hovering;
+  },
+
+  play() {
+    this.el.addEventListener("hover-start", this.onHoverStateChange);
+    this.el.addEventListener("hover-end", this.onHoverStateChange);
+    this.el.sceneEl.addEventListener("stateadded", this.onFrozenStateChange);
+    this.el.sceneEl.addEventListener("stateremoved", this.onFrozenStateChange);
+  },
+
+  pause() {
+    this.el.removeEventListener("hover-start", this.onHoverStateChange);
+    this.el.removeEventListener("hover-end", this.onHoverStateChange);
+    this.el.sceneEl.removeEventListener("stateadded", this.onFrozenStateChange);
+    this.el.sceneEl.removeEventListener("stateremoved", this.onFrozenStateChange);
+  }
+});

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -180,8 +180,8 @@ AFRAME.registerComponent("media-loader", {
           "media-video",
           Object.assign({}, this.data.mediaOptions, { src: accessibleUrl, time: startTime, contentType })
         );
-        if (this.el.components["position-at-box-shape-border"]) {
-          this.el.setAttribute("position-at-box-shape-border", { dirs: ["forward", "back"] });
+        if (this.el.components["position-at-box-shape-border__freeze"]) {
+          this.el.setAttribute("position-at-box-shape-border__freeze", { dirs: ["forward", "back"] });
         }
       } else if (contentType.startsWith("image/")) {
         this.el.removeAttribute("gltf-model-plus");

--- a/src/components/position-at-box-shape-border.js
+++ b/src/components/position-at-box-shape-border.js
@@ -40,7 +40,9 @@ AFRAME.registerComponent("position-at-box-shape-border", {
   multiple: true,
   schema: {
     target: { type: "string" },
-    dirs: { default: ["left", "right", "forward", "back"] }
+    dirs: { default: ["left", "right", "forward", "back"] },
+    animate: { default: true },
+    scale: { default: true }
   },
 
   init() {
@@ -87,7 +89,7 @@ AFRAME.registerComponent("position-at-box-shape-border", {
     // If the target is being shown or the scale changed while the opening animation is being run,
     // we need to start or re-start the animation.
     if (opening || (scaleChanged && isAnimating)) {
-      this._updateBox(true);
+      this._updateBox(this.data.animate);
     }
 
     this.wasVisible = isVisible;
@@ -151,7 +153,7 @@ AFRAME.registerComponent("position-at-box-shape-border", {
       const distance = Math.sqrt(minSquareDistance);
       const scale = this.halfExtents[inverseHalfExtents[targetHalfExtentStr]] * distance;
       const targetScale = Math.min(2.0, Math.max(0.5, scale * tempParentWorldScale.x));
-      const finalScale = targetScale / tempParentWorldScale.x;
+      const finalScale = this.data.scale ? targetScale / tempParentWorldScale.x : 1;
 
       if (animate) {
         this.targetEl.removeAttribute("animation__show");

--- a/src/hub.html
+++ b/src/hub.html
@@ -202,7 +202,7 @@
                     hoverable-visuals="cursorController: #cursor-controller"
                     auto-scale-cannon-physics-body
                     sticky-object="autoLockOnRelease: true; autoLockOnLoad: true;"
-                    position-at-box-shape-border="target:.freeze-menu;"
+                    position-at-box-shape-border__freeze="target:.freeze-menu;"
                     destroy-at-extreme-distances
                     set-yxz-order
                     pinnable
@@ -232,13 +232,6 @@
                             </a-entity>
                             <a-entity mixin="rounded-text-button" clone-media-button position="-0.25 -0.375 0.01">
                                 <a-entity text="value:clone; width:1.75; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
-                            </a-entity>
-
-                            <a-entity class="video-seek-back-button" mixin="rounded-text-button" position="-0.4 0 0.01" slice9="width: 0.2" visible="false">
-                                <a-entity text="value: <; width:1.75; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
-                            </a-entity>
-                            <a-entity class="video-seek-forward-button" mixin="rounded-text-button" position="0.4 0 0.01" slice9="width: 0.2" visible="false">
-                                <a-entity text="value: >; width:1.75; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
                             </a-entity>
                         </a-entity>
                     </a-entity>
@@ -327,6 +320,20 @@
                     <a-entity class="next-button" position="0.3 0 0">
                         <a-entity mixin="rounded-text-button" slice9="width: 0.2"> </a-entity>
                         <a-entity text=" value:>; width:2; align:center;" text-raycast-hack position="0 0 0.01"></a-entity>
+                    </a-entity>
+                </a-entity>
+            </template>
+
+            <template id="video-hover-menu">
+                <a-entity class="ui interactable-ui video-toolbar" mixin="button-container">
+                    <a-entity class="video-seek-back-button" mixin="rounded-text-button" position="-0.3 0 0.01" scale="0.6 0.6 0.6" slice9="width: 0.2; opacity: 0.8;" visible="false">
+                        <a-entity text="value: <; width:1.75; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
+                    </a-entity>
+                    <a-entity class="video-playpause-button" mixin="rounded-text-button" position="0 0 0.01" scale="1 1 1" slice9="width: 0.2; opacity: 0.8;" visible="false">
+                        <a-entity text="value: ||; width:1.75; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
+                    </a-entity>
+                    <a-entity class="video-seek-forward-button" mixin="rounded-text-button" position="0.3 0 0.01" scale="0.6 0.6 0.6" slice9="width: 0.2; opacity: 0.8;" visible="false">
+                        <a-entity text="value: >; width:1.75; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
                     </a-entity>
                 </a-entity>
             </template>

--- a/src/hub.js
+++ b/src/hub.js
@@ -81,6 +81,7 @@ import "./components/follow-in-lower-fov";
 import "./components/matrix-auto-update";
 import "./components/clone-media-button";
 import "./components/open-media-button";
+import "./components/hover-menu";
 
 import ReactDOM from "react-dom";
 import React from "react";


### PR DESCRIPTION
Move video playback controls into an overlay that is shown on hover instead of in the pause menu. Also add feedback for volume level and playback position.

This PR adds a component `hover-menu` which can specify a template to show on hover of the entity (or any child entities). The menu is automatically hidden when paused to not conflict with the pause menu. Components wishing to use the hover menu can call `getMenu()` on the component to get a reference to the instantiated menu element (and then query for whatever sub elements they want).