### PR TITLE
Fix scaling of spawned objects

### DIFF
--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -151,7 +151,6 @@ AFRAME.GLTFModelPlus.registerComponent("spawner", "spawner", (el, componentName,
   el.setAttribute("super-spawner", {
     src: componentData.src,
     resolve: true,
-    resize: true,
     template: "#interactable-media"
   });
   el.setAttribute("body", {

--- a/src/hub.html
+++ b/src/hub.html
@@ -194,8 +194,6 @@
                     class="interactable"
                     super-networked-interactable="counter: #media-counter;"
                     body="type: dynamic; shape: none; mass: 1;"
-                    scale="0.5 0.5 0.5"
-                    animation__spawn="property: scale; delay: 50; dur: 200; from: 0.5 0.5 0.5; to: 1 1 1; easing: easeInQuad"
                     grabbable
                     stretchable="useWorldPosition: true; usePhysics: never"
                     hoverable

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -179,15 +179,14 @@ export const addMedia = (src, template, contentOrigin, resolve = false, resize =
       clearTimeout(fireLoadingTimeout);
 
       if (!entity.classList.contains("pen") && !entity.getAttribute("animation__spawn-start")) {
-        entity.object3D.scale.setScalar(0.5);
         entity.matrixNeedsUpdate = true;
 
         entity.setAttribute("animation__spawn-start", {
           property: "scale",
           delay: 50,
           dur: 300,
-          from: { x: 0.5, y: 0.5, z: 0.5 },
-          to: { x: 1.0, y: 1.0, z: 1.0 },
+          from: { x: entity.object3D.scale.x / 2, y: entity.object3D.scale.y / 2, z: entity.object3D.scale.z / 2 },
+          to: { x: entity.object3D.scale.x, y: entity.object3D.scale.y, z: entity.object3D.scale.z },
           easing: "easeOutElastic"
         });
       }

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -179,15 +179,13 @@ export const addMedia = (src, template, contentOrigin, resolve = false, resize =
       clearTimeout(fireLoadingTimeout);
 
       if (!entity.classList.contains("pen") && !entity.getAttribute("animation__spawn-start")) {
-        entity.matrixNeedsUpdate = true;
-
         entity.setAttribute("animation__spawn-start", {
           property: "scale",
-          delay: 50,
-          dur: 300,
-          from: { x: entity.object3D.scale.x / 2, y: entity.object3D.scale.y / 2, z: entity.object3D.scale.z / 2 },
+          delay: 0,
+          dur: 200,
+          from: { x: entity.object3D.scale.x / 4, y: entity.object3D.scale.y / 4, z: entity.object3D.scale.z / 4 },
           to: { x: entity.object3D.scale.x, y: entity.object3D.scale.y, z: entity.object3D.scale.z },
-          easing: "easeOutElastic"
+          easing: "easeInQuad"
         });
       }
 


### PR DESCRIPTION
Currently spawned objects are resized by the media loader and animated between 0.5 and 1.0 scale. This PR makes it so that spawned objects use the scale of the spawner and are animated between 50% and 100% of the spawner scale. 