### PR TITLE
Refresh expired invite link

### DIFF
--- a/src/react-components/home-root.js
+++ b/src/react-components/home-root.js
@@ -193,7 +193,7 @@ class HomeRoot extends Component {
                     </a>
                   </WithHoverSound>
                   <WithHoverSound>
-                    <a href="https://discord.gg/XzrGUY8" rel="noreferrer noopener">
+                    <a href="https://discord.gg/wHmY4nd" rel="noreferrer noopener">
                       <FormattedMessage id="home.community_link" />
                     </a>
                   </WithHoverSound>


### PR DESCRIPTION
Only problem with this link is that it's generated by me, so that it says, "Jomb invited you to join". 
![image](https://user-images.githubusercontent.com/4072106/51409071-9f286a80-1b15-11e9-8354-2c211372f614.png)

Previously:
![image](https://user-images.githubusercontent.com/4072106/51409067-98015c80-1b15-11e9-951a-da5c8b8142db.png)
