### PR TITLE
Don't use BVH for grouped geometries, bump max depth

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -385,15 +385,23 @@ AFRAME.registerComponent("gltf-model-plus", {
       // generate acceleration structures for raycasting against
       object3DToSet.traverse(obj => {
         // note that we might already have a bounds tree if this was a clone of an object with one
-        if (obj.isMesh && obj.geometry.isBufferGeometry && !obj.geometry.boundsTree) {
-          const geo = obj.geometry;
-          const triCount = geo.index ? geo.index.count / 3 : geo.attributes.position.count / 3;
-          // only bother using memory and time making a BVH if there are a reasonable number of tris,
-          // and if there are too many it's too painful and large to tolerate doing it (at least until
-          // we put this in a web worker)
-          if (triCount > 1000 && triCount < 1000000) {
-            geo.boundsTree = new MeshBVH(obj.geometry, { strategy: 0, maxDepth: 20 });
-            geo.setIndex(geo.boundsTree.index);
+        const hasBufferGeometry = obj.isMesh && obj.geometry.isBufferGeometry;
+        const hasBoundsTree = hasBufferGeometry && obj.geometry.boundsTree;
+        if (hasBufferGeometry && !hasBoundsTree) {
+          // we can't currently build a BVH for geometries with groups, because the groups rely on the
+          // existing ordering of the index, which we kill as a result of building the tree
+          if (obj.geometry.groups && obj.geometry.groups.length) {
+            console.warn("BVH construction not supported for geometry with groups; raycasting may suffer.");
+          } else {
+            const geo = obj.geometry;
+            const triCount = geo.index ? geo.index.count / 3 : geo.attributes.position.count / 3;
+            // only bother using memory and time making a BVH if there are a reasonable number of tris,
+            // and if there are too many it's too painful and large to tolerate doing it (at least until
+            // we put this in a web worker)
+            if (triCount > 1000 && triCount < 1000000) {
+              geo.boundsTree = new MeshBVH(obj.geometry, { strategy: 0, maxDepth: 30 });
+              geo.setIndex(geo.boundsTree.index);
+            }
           }
         }
       });


### PR DESCRIPTION
BVH construction doesn't work for [geometries with groups](https://threejs.org/docs/#api/en/core/BufferGeometry), because those groups depend on the existing ordering of the index and won't tolerate reordering. For now, just don't build a BVH and be slightly sad. Later we can fix the BVH construction to work well in this case.