### PR TITLE
Support MultiMaterials in loaded glTF models

### DIFF
--- a/src/components/environment-map.js
+++ b/src/components/environment-map.js
@@ -1,3 +1,4 @@
+import { forEachMaterial } from "../utils/material-utils";
 import cubeMapPosX from "../assets/images/cubemap/posx.jpg";
 import cubeMapNegX from "../assets/images/cubemap/negx.jpg";
 import cubeMapPosY from "../assets/images/cubemap/posy.jpg";
@@ -35,10 +36,12 @@ AFRAME.registerComponent("environment-map", {
 
   applyEnvironmentMap(object3D) {
     object3D.traverse(object => {
-      if (object.material && object.material.isMeshStandardMaterial) {
-        object.material.envMap = this.environmentMap;
-        object.material.needsUpdate = true;
-      }
+      forEachMaterial(object, material => {
+        if (material.isMeshStandardMaterial) {
+          material.envMap = this.environmentMap;
+          material.needsUpdate = true;
+        }
+      });
     });
   }
 });

--- a/src/components/gamma-factor.js
+++ b/src/components/gamma-factor.js
@@ -1,3 +1,5 @@
+import { forEachMaterial } from "../utils/material-utils";
+
 AFRAME.registerComponent("gamma-factor", {
   schema: {
     gammaFactor: { type: "number", default: 2.2 }
@@ -26,18 +28,10 @@ AFRAME.registerComponent("gamma-factor", {
       return;
     }
 
-    sceneEl.object3D.traverse(function(node) {
-      if (!node.isMesh) {
-        return;
-      }
-
-      if (Array.isArray(node.material)) {
-        node.material.forEach(function(material) {
-          material.needsUpdate = true;
-        });
-      } else {
-        node.material.needsUpdate = true;
-      }
+    sceneEl.object3D.traverse(node => {
+      forEachMaterial(node, material => {
+        material.needsUpdate = true;
+      });
     });
   }
 });

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -1,4 +1,5 @@
 import nextTick from "../utils/next-tick";
+import { forEachMaterial } from "../utils/material-utils";
 import SketchfabZipWorker from "../workers/sketchfab-zip.worker.js";
 import MobileStandardMaterial from "../materials/MobileStandardMaterial";
 import { getCustomGLTFParserURLResolver } from "../utils/media-utils";
@@ -245,11 +246,11 @@ async function loadGLTF(src, contentType, preferredTechnique, onProgress) {
     // GLTFLoader sets matrixAutoUpdate on animated objects, we want to keep the defaults
     object.matrixAutoUpdate = THREE.Object3D.DefaultMatrixAutoUpdate;
 
-    if (object.material && object.material.type === "MeshStandardMaterial") {
-      if (preferredTechnique === "KHR_materials_unlit") {
+    forEachMaterial(object, material => {
+      if (material.isMeshStandardMaterial && preferredTechnique === "KHR_materials_unlit") {
         object.material = MobileStandardMaterial.fromStandardMaterial(object.material);
       }
-    }
+    });
   });
 
   if (fileMap) {

--- a/src/systems/personal-space-bubble.js
+++ b/src/systems/personal-space-bubble.js
@@ -1,3 +1,5 @@
+import { forEachMaterial } from "../utils/material-utils";
+
 const invaderPos = new AFRAME.THREE.Vector3();
 const bubblePos = new AFRAME.THREE.Vector3();
 
@@ -181,8 +183,10 @@ AFRAME.registerComponent("personal-space-invader", {
 
   setInvading(invading) {
     if (this.targetMesh && this.targetMesh.material) {
-      this.targetMesh.material.opacity = invading ? this.data.invadingOpacity : 1;
-      this.targetMesh.material.transparent = invading;
+      forEachMaterial(this.targetMesh, material => {
+        material.opacity = invading ? this.data.invadingOpacity : 1;
+        material.transparent = invading;
+      });
     } else {
       this.el.object3D.visible = !invading;
     }

--- a/src/utils/material-utils.js
+++ b/src/utils/material-utils.js
@@ -1,0 +1,19 @@
+export function forEachMaterial(object3D, fn) {
+  if (!object3D.material) return;
+
+  if (Array.isArray(object3D.material)) {
+    object3D.material.forEach(fn);
+  } else {
+    fn(object3D.material);
+  }
+}
+
+export function mapMaterials(object3D, fn) {
+  if (!object3D.material) return;
+
+  if (Array.isArray(object3D.material)) {
+    return object3D.material.map(fn);
+  } else {
+    return fn(object3D.material);
+  }
+}

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -1,6 +1,7 @@
 import { objectTypeForOriginAndContentType } from "../object-types";
 import { getReticulumFetchUrl } from "./phoenix-utils";
 import mediaHighlightFrag from "./media-highlight-frag.glsl";
+import { mapMaterials } from "./material-utils";
 
 const nonCorsProxyDomains = (process.env.NON_CORS_PROXY_DOMAINS || "").split(",");
 if (process.env.CORS_PROXY_SERVER) {
@@ -238,31 +239,34 @@ export function injectCustomShaderChunks(obj) {
   const shaderUniforms = new Map();
 
   obj.traverse(object => {
-    if (!object.material || !validMaterials.includes(object.material.type)) {
-      return;
-    }
+    if (!object.material) return;
 
-    // HACK, this routine inadvertently leaves the A-Frame shaders wired to the old, dark
-    // material, so maps cannot be updated at runtime. This breaks UI elements who have
-    // hover/toggle state, so for now just skip these while we figure out a more correct
-    // solution.
-    if (object.el.classList.contains("ui")) return;
-    if (object.el.classList.contains("hud")) return;
-    if (object.el.getAttribute("text-button")) return;
+    object.material = mapMaterials(object, material => {
+      if (!validMaterials.includes(material.type)) {
+        return material;
+      }
 
-    object.material = object.material.clone();
-    object.material.onBeforeCompile = shader => {
-      if (!vertexRegex.test(shader.vertexShader)) return;
+      // HACK, this routine inadvertently leaves the A-Frame shaders wired to the old, dark
+      // material, so maps cannot be updated at runtime. This breaks UI elements who have
+      // hover/toggle state, so for now just skip these while we figure out a more correct
+      // solution.
+      if (object.el.classList.contains("ui")) return;
+      if (object.el.classList.contains("hud")) return;
+      if (object.el.getAttribute("text-button")) return;
 
-      shader.uniforms.hubs_EnableSweepingEffect = { value: false };
-      shader.uniforms.hubs_SweepParams = { value: [0, 0] };
-      shader.uniforms.hubs_InteractorOnePos = { value: [0, 0, 0] };
-      shader.uniforms.hubs_InteractorTwoPos = { value: [0, 0, 0] };
-      shader.uniforms.hubs_HighlightInteractorOne = { value: false };
-      shader.uniforms.hubs_HighlightInteractorTwo = { value: false };
-      shader.uniforms.hubs_Time = { value: 0 };
+      const newMaterial = material.clone();
+      newMaterial.onBeforeCompile = shader => {
+        if (!vertexRegex.test(shader.vertexShader)) return;
 
-      const vchunk = `
+        shader.uniforms.hubs_EnableSweepingEffect = { value: false };
+        shader.uniforms.hubs_SweepParams = { value: [0, 0] };
+        shader.uniforms.hubs_InteractorOnePos = { value: [0, 0, 0] };
+        shader.uniforms.hubs_InteractorTwoPos = { value: [0, 0, 0] };
+        shader.uniforms.hubs_HighlightInteractorOne = { value: false };
+        shader.uniforms.hubs_HighlightInteractorTwo = { value: false };
+        shader.uniforms.hubs_Time = { value: 0 };
+
+        const vchunk = `
         if (hubs_HighlightInteractorOne || hubs_HighlightInteractorTwo) {
           vec4 wt = modelMatrix * vec4(transformed, 1);
 
@@ -271,30 +275,32 @@ export function injectCustomShaderChunks(obj) {
         }
       `;
 
-      const vlines = shader.vertexShader.split("\n");
-      const vindex = vlines.findIndex(line => vertexRegex.test(line));
-      vlines.splice(vindex + 1, 0, vchunk);
-      vlines.unshift("varying vec3 hubs_WorldPosition;");
-      vlines.unshift("uniform bool hubs_HighlightInteractorOne;");
-      vlines.unshift("uniform bool hubs_HighlightInteractorTwo;");
-      shader.vertexShader = vlines.join("\n");
+        const vlines = shader.vertexShader.split("\n");
+        const vindex = vlines.findIndex(line => vertexRegex.test(line));
+        vlines.splice(vindex + 1, 0, vchunk);
+        vlines.unshift("varying vec3 hubs_WorldPosition;");
+        vlines.unshift("uniform bool hubs_HighlightInteractorOne;");
+        vlines.unshift("uniform bool hubs_HighlightInteractorTwo;");
+        shader.vertexShader = vlines.join("\n");
 
-      const flines = shader.fragmentShader.split("\n");
-      const findex = flines.findIndex(line => fragRegex.test(line));
-      flines.splice(findex + 1, 0, mediaHighlightFrag);
-      flines.unshift("varying vec3 hubs_WorldPosition;");
-      flines.unshift("uniform bool hubs_EnableSweepingEffect;");
-      flines.unshift("uniform vec2 hubs_SweepParams;");
-      flines.unshift("uniform bool hubs_HighlightInteractorOne;");
-      flines.unshift("uniform vec3 hubs_InteractorOnePos;");
-      flines.unshift("uniform bool hubs_HighlightInteractorTwo;");
-      flines.unshift("uniform vec3 hubs_InteractorTwoPos;");
-      flines.unshift("uniform float hubs_Time;");
-      shader.fragmentShader = flines.join("\n");
+        const flines = shader.fragmentShader.split("\n");
+        const findex = flines.findIndex(line => fragRegex.test(line));
+        flines.splice(findex + 1, 0, mediaHighlightFrag);
+        flines.unshift("varying vec3 hubs_WorldPosition;");
+        flines.unshift("uniform bool hubs_EnableSweepingEffect;");
+        flines.unshift("uniform vec2 hubs_SweepParams;");
+        flines.unshift("uniform bool hubs_HighlightInteractorOne;");
+        flines.unshift("uniform vec3 hubs_InteractorOnePos;");
+        flines.unshift("uniform bool hubs_HighlightInteractorTwo;");
+        flines.unshift("uniform vec3 hubs_InteractorTwoPos;");
+        flines.unshift("uniform float hubs_Time;");
+        shader.fragmentShader = flines.join("\n");
 
-      shaderUniforms.set(object.material.uuid, shader.uniforms);
-    };
-    object.material.needsUpdate = true;
+        shaderUniforms.set(newMaterial.uuid, shader.uniforms);
+      };
+      newMaterial.needsUpdate = true;
+      return newMaterial;
+    });
   });
 
   return shaderUniforms;


### PR DESCRIPTION
- Added the `forEachMaterial` and `mapMaterials` utility methods that support iterating over the `object3D.material` property.
- Changed all instances where we were modifying materials on unknown meshes (loaded via gltf-model-plus) to use these utility methods.