### PR TITLE
Don't whitelist CORS-blocked domains in dev

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -12,7 +12,7 @@ FARSPARK_SERVER="farspark-dev.reticulum.io"
 ASSET_BUNDLE_SERVER="https://asset-bundles-prod.reticulum.io"
 
 # Comma-separated list of domains which are known to not need CORS proxying
-NON_CORS_PROXY_DOMAINS="hubs.local,reticulum.io"
+NON_CORS_PROXY_DOMAINS="hubs.local,dev.reticulum.io"
 
 # A comma-separated list of environment URLs to make available in the picker, besides the defaults.
 # These URLs are expected to be relative to ASSET_BUNDLE_SERVER.


### PR DESCRIPTION
For example, without this change, you can't paste any media or models from production Hubs.

The Jenkins job to build production already overrides this to have `hubs.mozilla.com,reticulum.io` so changing it here only affects local work.

(By the way, this works because this environment variable is strange -- it's not actually a list of domains, it's a list of suffixes. Any domain that ends in one of these suffixes will be whitelisted. So `dev.reticulum.io` matches things like `uploads-dev.reticulum.io`. We should fix this at some point.)