### PR TITLE
Add optional GA tracking telemetry

### DIFF
--- a/src/avatar-selector.js
+++ b/src/avatar-selector.js
@@ -27,7 +27,7 @@ import AvatarSelector from "./react-components/avatar-selector";
 
 addLocaleData([...en]);
 
-registerTelemetry();
+registerTelemetry("/avatars", "Hubs Avatar Picker");
 
 function getHashArg(arg) {
   return new URLSearchParams(location.hash.replace(/^#/, "?")).get(arg);

--- a/src/hub.html
+++ b/src/hub.html
@@ -15,6 +15,14 @@
         // Google Chrome on iOS correctly. We can remove this when we upgrade a-frame past 0.8.2.
         if (!window.WebVRConfig) { window.WebVRConfig = {}; }
     </script>
+    <!-- Google Analytics -->
+    <!-- NOTE GA tracking is disabled by default. You'll need to set the GA_TRACKING_ID build variable to enable it. -->
+    <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    </script>
 </head>
 
 <body>

--- a/src/hub.js
+++ b/src/hub.js
@@ -162,7 +162,7 @@ const loadingEnvironmentURL =
   "https://hubs-proxy.com/https://uploads-prod.reticulum.io/files/58c034aa-ff17-4d3c-a6cc-c9095bb4822c.glb";
 
 if (!isBotMode && !isTelemetryDisabled) {
-  registerTelemetry();
+  registerTelemetry("/hub", "Room Landing Page");
 }
 
 disableiOSZoom();

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,14 @@
     <link rel="shortcut icon" type="image/png" href="/favicon.ico"/>
     <title>Get together | Hubs by Mozilla</title>
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,700" rel="stylesheet">
+    <!-- Google Analytics -->
+    <!-- NOTE GA tracking is disabled by default. You'll need to set the GA_TRACKING_ID build variable to enable it. -->
+    <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    </script>
 </head>
 
 <body>

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import { createAndRedirectToNewHub, connectToReticulum } from "./utils/phoenix-u
 import Store from "./storage/store";
 
 const qs = new URLSearchParams(location.search);
-registerTelemetry();
+registerTelemetry("/home", "Hubs Home Page");
 
 const { pathname } = document.location;
 const sceneId = qs.get("scene_id") || (pathname.startsWith("/scenes/") && pathname.substring(1).split("/")[1]);

--- a/src/link.html
+++ b/src/link.html
@@ -8,6 +8,14 @@
     <title>Enter Code | Hubs by Mozilla</title>
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,700" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <!-- Google Analytics -->
+    <!-- NOTE GA tracking is disabled by default. You'll need to set the GA_TRACKING_ID build variable to enable it. -->
+    <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    </script>
 </head>
 
 <body>

--- a/src/link.js
+++ b/src/link.js
@@ -8,7 +8,7 @@ import { connectToReticulum } from "./utils/phoenix-utils";
 import Store from "./storage/store";
 import { detectInHMD } from "./utils/vr-caps-detect.js";
 
-registerTelemetry();
+registerTelemetry("/link", "Hubs Device Link");
 
 const socket = connectToReticulum();
 const store = new Store();

--- a/src/scene.html
+++ b/src/scene.html
@@ -15,6 +15,14 @@
         // Google Chrome on iOS correctly. We can remove this when we upgrade a-frame past 0.8.2.
         if (!window.WebVRConfig) { window.WebVRConfig = {}; }
     </script>
+    <!-- Google Analytics -->
+    <!-- NOTE GA tracking is disabled by default. You'll need to set the GA_TRACKING_ID build variable to enable it. -->
+    <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    </script>
 </head>
 
 <body>

--- a/src/scene.js
+++ b/src/scene.js
@@ -39,8 +39,6 @@ import "./components/controls-shape-offset";
 
 import registerTelemetry from "./telemetry";
 
-registerTelemetry();
-
 disableiOSZoom();
 
 function mountUI(scene, props = {}) {
@@ -94,6 +92,12 @@ const onReady = async () => {
 
   const res = await fetch(getReticulumFetchUrl(`/api/v1/scenes/${sceneId}`)).then(r => r.json());
   const sceneInfo = res.scenes[0];
+
+  if (sceneInfo.allow_promotion) {
+    registerTelemetry(`/scene/${sceneId}`, `Hubs Scene: ${sceneInfo.title}`);
+  } else {
+    registerTelemetry("/scene", "Hubs Non-Promotable Scene Page");
+  }
 
   const modelUrl = sceneInfo.model_url;
   console.log(`Scene Model URL: ${modelUrl}`);

--- a/src/spoke.html
+++ b/src/spoke.html
@@ -17,6 +17,14 @@
     <link rel="shortcut icon" type="image/png" href="/favicon-spoke.ico">
     <title>Spoke by Mozilla</title>
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,700" rel="stylesheet">
+    <!-- Google Analytics -->
+    <!-- NOTE GA tracking is disabled by default. You'll need to set the GA_TRACKING_ID build variable to enable it. -->
+    <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    </script>
 </head>
 
 <body>

--- a/src/spoke.js
+++ b/src/spoke.js
@@ -14,7 +14,7 @@ import YouTube from "react-youtube";
 
 import registerTelemetry from "./telemetry";
 
-registerTelemetry();
+registerTelemetry("/spoke", "Spoke Landing Page");
 
 import en from "react-intl/locale-data/en";
 import { lang, messages } from "./utils/i18n";

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -1,7 +1,30 @@
 import Raven from "raven-js";
 
-export default function registerTelemetry() {
-  if (process.env.NODE_ENV === "production") {
-    Raven.config("https://013d6a364fed43cdb0539a61d520597a@sentry.prod.mozaws.net/370").install();
+const ga = window.ga;
+
+export default function registerTelemetry(trackedPage, trackedTitle) {
+  const sentryDsn = process.env.SENTRY_DSN;
+  const gaTrackingId = process.env.GA_TRACKING_ID;
+
+  if (sentryDsn) {
+    console.log("Tracking: Sentry DSN: " + sentryDsn);
+    Raven.config(sentryDsn).install();
+  }
+
+  if (ga && gaTrackingId) {
+    console.log("Tracking: Google Analytics ID: " + gaTrackingId);
+
+    ga("create", gaTrackingId, "auto");
+
+    if (trackedPage) {
+      ga("set", "page", trackedPage);
+    }
+
+    if (trackedTitle) {
+      ga("set", "title", trackedTitle);
+    }
+
+    console.log(ga);
+    ga("send", "pageview");
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -300,7 +300,8 @@ module.exports = (env, argv) => ({
         NON_CORS_PROXY_DOMAINS: process.env.NON_CORS_PROXY_DOMAINS,
         ASSET_BUNDLE_SERVER: process.env.ASSET_BUNDLE_SERVER,
         EXTRA_ENVIRONMENTS: process.env.EXTRA_ENVIRONMENTS,
-        BUILD_VERSION: process.env.BUILD_VERSION
+        BUILD_VERSION: process.env.BUILD_VERSION,
+        GA_TRACKING_ID: process.env.GA_TRACKING_ID
       })
     })
   ]


### PR DESCRIPTION
This PR adds GA instrumentation (if configured) to track page landing loads for the main hubs entry pages.

- We do not track individual room URLs, but roll up every room page load into a single logical /hub path
- Scene URLs are collapsed similarly unless the scene is marked as promotable