### PR TITLE
Room creators can now kick users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -518,7 +518,9 @@
       "requires": {
         "@tweenjs/tween.js": "^16.8.0",
         "browserify-css": "^0.8.2",
+        "debug": "github:ngokevin/debug#ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a",
         "deep-assign": "^2.0.0",
+        "document-register-element": "github:dmarcos/document-register-element#8ccc532b7f3744be954574caf3072a5fd260ca90",
         "envify": "^3.4.1",
         "load-bmfont": "^1.2.3",
         "object-assign": "^4.0.1",
@@ -532,11 +534,7 @@
       "dependencies": {
         "debug": {
           "version": "github:ngokevin/debug#ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a",
-          "from": "github:ngokevin/debug#ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a"
-        },
-        "document-register-element": {
-          "version": "github:dmarcos/document-register-element#8ccc532b7f3744be954574caf3072a5fd260ca90",
-          "from": "github:dmarcos/document-register-element#8ccc532b7f3744be954574caf3072a5fd260ca90"
+          "from": "github:ngokevin/debug#noTimestamp"
         },
         "three": {
           "version": "0.94.0",
@@ -3914,6 +3912,10 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "document-register-element": {
+      "version": "github:dmarcos/document-register-element#8ccc532b7f3744be954574caf3072a5fd260ca90",
+      "from": "github:dmarcos/document-register-element#8ccc532b7"
     },
     "dom-converter": {
       "version": "0.1.4",
@@ -9023,9 +9025,9 @@
       "dev": true
     },
     "naf-janus-adapter": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/naf-janus-adapter/-/naf-janus-adapter-0.13.2.tgz",
-      "integrity": "sha512-mr7xrHTlz9V2ZCIrh9HjN5qL6Yqoebgw5roG4jEUJHGV3pSQY7mtOd6DEqpDFcuGRr2RE0mTpe/L4UdZhQmImw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/naf-janus-adapter/-/naf-janus-adapter-1.0.0.tgz",
+      "integrity": "sha512-v6M+egu1DgEHRq7JCQGlxztynstr1IyQjan2N/HA7FXa5g2j1gp7wXO9yQekyOAtXIDfhOH38XUrZzNBeAXu9Q==",
       "requires": {
         "debug": "^3.1.0",
         "minijanus": "0.6.2",
@@ -9033,9 +9035,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -9126,7 +9128,7 @@
       "dev": true
     },
     "networked-aframe": {
-      "version": "github:mozillareality/networked-aframe#e9d9c0fb0f781c11f7ced41538268aee8170872a",
+      "version": "github:mozillareality/networked-aframe#9f9358bf7fbc281987106307b588d9c5350613be",
       "from": "github:mozillareality/networked-aframe#master",
       "requires": {
         "buffered-interpolation": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "jszip": "^3.1.5",
     "markdown-it": "^8.4.2",
     "moving-average": "^1.0.0",
-    "naf-janus-adapter": "^0.13.2",
+    "naf-janus-adapter": "^1.0.0",
     "networked-aframe": "github:mozillareality/networked-aframe#master",
     "nipplejs": "github:mozillareality/nipplejs#mr-social-client/master",
     "phoenix": "github:gfodor/phoenix-js#master",

--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -60,6 +60,7 @@
     "audio.granted-next": "Next",
     "exit.subtitle.exited": "Your session has ended. Refresh your browser to start a new one.",
     "exit.subtitle.closed": "This room is no longer available.",
+    "exit.subtitle.kicked": "You have been kicked from the room.",
     "exit.subtitle.left": "You have left the room.",
     "exit.subtitle.full": "This room is full, please try again later.",
     "exit.subtitle.connect_error": "Unable to connect to this room, please try again later.",

--- a/src/components/kick-button.js
+++ b/src/components/kick-button.js
@@ -1,8 +1,3 @@
-/**
- * Registers a click handler and invokes the kick method on the NAF adapter for the owner associated with its entity.
- * @namespace network
- * @component kick-button
- */
 AFRAME.registerComponent("kick-button", {
   init() {
     this.onClick = () => {

--- a/src/components/kick-button.js
+++ b/src/components/kick-button.js
@@ -1,0 +1,29 @@
+/**
+ * Registers a click handler and invokes the kick method on the NAF adapter for the owner associated with its entity.
+ * @namespace network
+ * @component kick-button
+ */
+AFRAME.registerComponent("kick-button", {
+  init() {
+    this.onClick = () => {
+      this.kick(this.owner);
+    };
+    NAF.utils.getNetworkedEntity(this.el).then(networkedEl => {
+      this.owner = networkedEl.components.networked.data.owner;
+    });
+  },
+
+  play() {
+    this.el.addEventListener("grab-start", this.onClick);
+  },
+
+  pause() {
+    this.el.removeEventListener("grab-start", this.onClick);
+  },
+
+  async kick(clientId) {
+    const { permsToken } = await this.el.sceneEl.systems.permissions.fetchPermissions();
+    NAF.connection.adapter.kick(clientId, permsToken);
+    window.APP.hubChannel.kick(clientId);
+  }
+});

--- a/src/components/visible-if-permitted.js
+++ b/src/components/visible-if-permitted.js
@@ -1,0 +1,8 @@
+AFRAME.registerComponent("visible-if-permitted", {
+  schema: {
+    type: "string"
+  },
+  init() {
+    this.el.object3D.visible = this.el.sceneEl.systems.permissions.can(this.data);
+  }
+});

--- a/src/hub.html
+++ b/src/hub.html
@@ -139,7 +139,9 @@
                             <a-entity personal-space-invader="radius: 0.2; useMaterial: true;" bone-visibility>
                                 <a-entity billboard matrix-auto-update visibility-while-frozen="withinDistance: 10;">
                                     <a-entity hoverable mixin="rounded-text-button" block-button ui-class-while-frozen position="0 0 .35"> </a-entity>
-                                    <a-entity visibility-while-frozen="withinDistance: 10;" text="value:Block; width:2.5; align:center;" position="0 0 0.36"></a-entity>
+                                    <a-entity text="value:Block; width:2.5; align:center;" position="0 0 0.36"></a-entity>
+                                    <a-entity hoverable mixin="rounded-text-button" visible-if-permitted="kick_users" kick-button ui-class-while-frozen position="0 -0.25 .35"> </a-entity>
+                                    <a-entity text="value:Kick; width:2.5; align:center;"  visible-if-permitted="kick_users" position="0 -0.25 0.36"></a-entity>
                                 </a-entity>
                             </a-entity>
                         </template>

--- a/src/hub.html
+++ b/src/hub.html
@@ -139,7 +139,7 @@
                             <a-entity personal-space-invader="radius: 0.2; useMaterial: true;" bone-visibility>
                                 <a-entity billboard matrix-auto-update visibility-while-frozen="withinDistance: 10;">
                                     <a-entity hoverable mixin="rounded-text-button" block-button ui-class-while-frozen position="0 0 .35"> </a-entity>
-                                    <a-entity text="value:Block; width:2.5; align:center;" position="0 0 0.36"></a-entity>
+                                    <a-entity text="value:Hide; width:2.5; align:center;" position="0 0 0.36"></a-entity>
                                     <a-entity hoverable mixin="rounded-text-button" visible-if-permitted="kick_users" kick-button ui-class-while-frozen position="0 -0.25 .35"> </a-entity>
                                     <a-entity text="value:Kick; width:2.5; align:center;"  visible-if-permitted="kick_users" position="0 -0.25 0.36"></a-entity>
                                 </a-entity>

--- a/src/hub.js
+++ b/src/hub.js
@@ -356,6 +356,7 @@ async function handleHubChannelJoined(entryManager, hubChannel, messageDispatch,
     });
 
     while (!scene.components["networked-scene"] || !scene.components["networked-scene"].data) await nextTick();
+
     scene.components["networked-scene"]
       .connect()
       .then(() => {
@@ -622,6 +623,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     .receive("ok", async data => {
       hubChannel.setPhoenixChannel(hubPhxChannel);
       hubChannel.setPermissionsFromToken(data.perms_token);
+      scene.addEventListener("adapter-ready", ({ detail: adapter }) => adapter.setJoinToken(data.perms_token));
       subscriptions.setHubChannel(hubChannel);
       subscriptions.setSubscribed(data.subscriptions.web_push);
       remountUI({ initialIsSubscribed: subscriptions.isSubscribed() });

--- a/src/hub.js
+++ b/src/hub.js
@@ -574,6 +574,13 @@ document.addEventListener("DOMContentLoaded", async () => {
   });
 
   const socket = connectToReticulum(isDebug);
+
+  socket.onClose(() => {
+    // The socket should only close of the server has explicitly killed it.
+    entryManager.exitScene();
+    remountUI({ roomUnavailableReason: "left" });
+  });
+
   remountUI({ sessionId: socket.params().session_id });
 
   // Hub local channel

--- a/src/hub.js
+++ b/src/hub.js
@@ -575,10 +575,13 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   const socket = connectToReticulum(isDebug);
 
-  socket.onClose(() => {
-    // The socket should only close of the server has explicitly killed it.
-    entryManager.exitScene();
-    remountUI({ roomUnavailableReason: "left" });
+  socket.onClose(e => {
+    // The socket should close normally if the server has explicitly killed it.
+    const NORMAL_CLOSURE = 1000;
+    if (e.code === NORMAL_CLOSURE) {
+      entryManager.exitScene();
+      remountUI({ roomUnavailableReason: "kicked" });
+    }
   });
 
   remountUI({ sessionId: socket.params().session_id });

--- a/src/hub.js
+++ b/src/hub.js
@@ -51,6 +51,8 @@ import "./components/freeze-controller";
 import "./components/icon-button";
 import "./components/text-button";
 import "./components/block-button";
+import "./components/kick-button";
+import "./components/visible-if-permitted";
 import "./components/visibility-while-frozen";
 import "./components/stats-plus";
 import "./components/networked-avatar";
@@ -101,6 +103,7 @@ import { createInWorldLogMessage } from "./react-components/chat-message";
 import "./systems/nav";
 import "./systems/personal-space-bubble";
 import "./systems/app-mode";
+import "./systems/permissions";
 import "./systems/exit-on-blur";
 import "./systems/camera-tools";
 import "./systems/userinput/userinput";
@@ -480,6 +483,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const linkChannel = new LinkChannel(store);
 
   window.APP.scene = scene;
+  window.APP.hubChannel = hubChannel;
 
   scene.addEventListener("enter-vr", () => {
     document.body.classList.add("vr-mode");
@@ -623,7 +627,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     .receive("ok", async data => {
       hubChannel.setPhoenixChannel(hubPhxChannel);
       hubChannel.setPermissionsFromToken(data.perms_token);
-      scene.addEventListener("adapter-ready", ({ detail: adapter }) => adapter.setJoinToken(data.perms_token));
+      scene.addEventListener("adapter-ready", ({ detail: adapter }) => {
+        adapter.setClientId(socket.params().session_id);
+        adapter.setJoinToken(data.perms_token);
+      });
       subscriptions.setHubChannel(hubChannel);
       subscriptions.setSubscribed(data.subscriptions.web_push);
       remountUI({ initialIsSubscribed: subscriptions.isSubscribed() });

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -771,7 +771,7 @@ class UIRoot extends Component {
         <div>
           <FormattedMessage id={exitSubtitleId} />
           <p />
-          {this.props.roomUnavailableReason !== "left" && (
+          {!["left", "kicked"].includes(this.props.roomUnavailableReason) && (
             <div>
               You can also{" "}
               <WithHoverSound>

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -80,6 +80,7 @@ export default class SceneEntryManager {
 
     this._setupPlayerRig();
     this._setupBlocking();
+    this._setupKicking();
     this._setupMedia(mediaStream);
     this._setupCamera();
 
@@ -165,6 +166,12 @@ export default class SceneEntryManager {
     const hudController = this.playerRig.querySelector("[hud-controller]");
     hudController.setAttribute("hud-controller", { showTip: !this.store.state.activity.hasFoundFreeze });
     this.scene.emit("username-changed", { username: displayName });
+  };
+
+  _setupKicking = () => {
+    document.body.addEventListener("kicked", ev => {
+      NAF.connection.entities.removeEntitiesOfClient(ev.detail.clientId);
+    });
   };
 
   _setupBlocking = () => {

--- a/src/systems/permissions.js
+++ b/src/systems/permissions.js
@@ -1,0 +1,8 @@
+AFRAME.registerSystem("permissions", {
+  can(permissionName) {
+    return window.APP.hubChannel.permissions[permissionName];
+  },
+  fetchPermissions() {
+    return window.APP.hubChannel.fetchPermissions();
+  }
+});

--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -203,7 +203,7 @@ export default class HubChannel {
   fetchPermissions = () => {
     return new Promise((resolve, reject) => {
       this.channel
-        .push("get_perms_token")
+        .push("refresh_perms_token")
         .receive("ok", res => {
           this.setPermissionsFromToken(res.perms_token);
           resolve({ permsToken: res.perms_token, permissions: this._permissions });

--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -22,6 +22,10 @@ export default class HubChannel {
     return this._signedIn;
   }
 
+  get permissions() {
+    return this._permissions;
+  }
+
   setPhoenixChannel = channel => {
     this.channel = channel;
   };
@@ -194,6 +198,22 @@ export default class HubChannel {
       payload.file_id = fileId;
     }
     this.channel.push("unpin", payload);
+  };
+
+  fetchPermissions = () => {
+    return new Promise((resolve, reject) => {
+      this.channel
+        .push("get_perms_token")
+        .receive("ok", res => {
+          this.setPermissionsFromToken(res.perms_token);
+          resolve({ permsToken: res.perms_token, permissions: this._permissions });
+        })
+        .receive("error", reject);
+    });
+  };
+
+  kick = sessionId => {
+    this.channel.push("kick", { session_id: sessionId });
   };
 
   requestSupport = () => {


### PR DESCRIPTION
If you are the creator of a room, and you are logged in, you can now kick users. They will leave the room along with the media they own.

![image](https://user-images.githubusercontent.com/79419/52038033-c0aa2e80-24e5-11e9-8240-692bf900572d.png)

- We now set the NAF adapter's `clientId` explicitly before connecting. The clientId is set to the same uuid used for the Phoenix socket `session_id`, so that we can correlate NAF clients to phoenix sockets when kicking.
- NAF adapter now has a `joinToken`, which is just the `perms_token` (though joining is not enforced yet).
- Adds a "Kick" button in avatar menus
- Permissions are refreshed before dispatching a kick message to both reticulum and janus. Janus cuts off their RTC traffic and reticulum kills their phoenix socket. The clicked client is exited from the scene and its owned entities are removed.
- Adds a `permissions` system in A-Frame that allows you to fetch and query permissions
- `window.APP` now has `hubChannel`
- Adds a `visible-if-permitted` component which shows entities only if the given permission is granted
- Renamed "Block" button to "Hide"

Goes with:
https://github.com/mozilla/reticulum/pull/114
https://github.com/mozilla/hubs-ops/pull/44
https://github.com/mozilla/janus-plugin-sfu/pull/29
https://github.com/mozilla/naf-janus-adapter/pull/70
https://github.com/MozillaReality/networked-aframe/pull/22