### PR TITLE
Making the chat box easier to spot

### DIFF
--- a/src/assets/stylesheets/ui-root.scss
+++ b/src/assets/stylesheets/ui-root.scss
@@ -212,7 +212,7 @@ body.vr-mode {
   overflow: hidden;
   resize: none;
   background-color: transparent;
-  color: black;
+  color: $darkest-transparent;
   padding: 8px 1.25em;
   line-height: 28px;
   font-size: 1.1em;
@@ -223,7 +223,7 @@ body.vr-mode {
 }
 
 :local(.message-entry-input)::placeholder{
-  color: $dark-grey;
+  color: $light-grey;
   font-weight: 300;
   font-style: italic;
 }
@@ -252,10 +252,10 @@ body.vr-mode {
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: $darker-grey;
+  background-color: $action-color;
   border-radius: 16px;
   pointer-events: auto;
-  opacity: 0.3;
+  opacity: 0.9;
   transition: opacity 0.15s linear;
 
   :local(.message-entry-input-in-room) {


### PR DESCRIPTION
This refers to #810, one part of a series of enhancements to the chatbox.

- [x] Make the existing chat box easier to spot when you're in the room
This is probably just a matter of adding some contrast to it so that it's visible in both light and dark scenes.

I decided to follow the pink/red schema and just give it a coloured background: 
![demo](https://user-images.githubusercontent.com/9853904/52090209-ab351300-257e-11e9-9225-67a34cf0a3b5.gif)

Let me know your thoughts if you folks like it, or there's something I missed, etc.