### PR TITLE
Use postMessage bidireactionally for managing avatar state

### DIFF
--- a/src/avatar-selector.js
+++ b/src/avatar-selector.js
@@ -40,8 +40,7 @@ function postAvatarIdToParent(newAvatarId) {
   window.parent.postMessage({ avatarId: newAvatarId }, location.origin);
 }
 
-function mountUI() {
-  const avatarId = getHashArg("avatar_id");
+function mountUI(avatarId) {
   ReactDOM.render(
     <IntlProvider locale={lang} messages={messages}>
       <AvatarSelector {...{ avatars, avatarId, onChange: postAvatarIdToParent }} />
@@ -50,5 +49,18 @@ function mountUI() {
   );
 }
 
-window.addEventListener("hashchange", mountUI);
-document.addEventListener("DOMContentLoaded", mountUI);
+window.addEventListener("message", e => {
+  if (e.source !== window.parent) {
+    return;
+  }
+
+  const avatarId = e.data.avatarId;
+
+  if (document.readyState === "complete") {
+    mountUI(avatarId);
+  } else {
+    document.addEventListener("DOMContentLoaded", () => {
+      mountUI(avatarId);
+    });
+  }
+});

--- a/src/react-components/avatar-selector.js
+++ b/src/react-components/avatar-selector.js
@@ -179,6 +179,16 @@ class AvatarSelector extends Component {
           />
           <a-entity hide-when-quality="low" light="type: ambient; color: #FFF" />
         </a-scene>
+        <WithHoverSound>
+          <button className="avatar-selector__previous-button" onClick={this.emitChangeToPrevious}>
+            <FontAwesomeIcon icon={faAngleLeft} />
+          </button>
+        </WithHoverSound>
+        <WithHoverSound>
+          <button className="avatar-selector__next-button" onClick={this.emitChangeToNext}>
+            <FontAwesomeIcon icon={faAngleRight} />
+          </button>
+        </WithHoverSound>
       </div>
     );
   }

--- a/src/react-components/profile-entry-panel.js
+++ b/src/react-components/profile-entry-panel.js
@@ -56,6 +56,13 @@ class ProfileEntryPanel extends Component {
       return;
     }
     this.setState({ avatarId: e.data.avatarId });
+
+    // Send it back down to cause avatar picker UI to update.
+    this.sendAvatarStateToIframe();
+  };
+
+  sendAvatarStateToIframe = () => {
+    this.avatarSelector.contentWindow.postMessage({ avatarId: this.state.avatarId }, location.origin);
   };
 
   componentDidMount() {
@@ -121,8 +128,18 @@ class ProfileEntryPanel extends Component {
                 </div>
                 <iframe
                   className={styles.avatarSelector}
-                  src={`/avatar-selector.html#avatar_id=${this.state.avatarId}`}
-                  ref={ifr => (this.avatarSelector = ifr)}
+                  src={`/avatar-selector.html`}
+                  ref={ifr => {
+                    if (this.avatarSelector === ifr) return;
+
+                    this.avatarSelector = ifr;
+
+                    if (this.avatarSelector) {
+                      this.avatarSelector.onload = () => {
+                        this.sendAvatarStateToIframe();
+                      };
+                    }
+                  }}
                 />
                 <a
                   className="custom-url-link"


### PR DESCRIPTION
This fixes an issue due to the use of the URL hash as a way of transmitting avatar id state into and out of the avatar selector. Because we now do a history.pop() when closing a modal, it ended up breaking the "accept" button. This PR updates things to use postmessage to synchronize the state exclusively.