### PR TITLE
Deduplicate three.js from our bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12907,9 +12907,8 @@
       }
     },
     "three-mesh-bvh": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.0.2.tgz",
-      "integrity": "sha512-b5FADOV9SETD1K4TUmpXbTbCHP1LXZkIdiyK6+QIeBaaLvjV01D2f2H0q29sm9+LkWoqFMVSObfXMCAJinddZQ=="
+      "version": "github:mquander/three-mesh-bvh#5dfd31ecf7a68003a68933036875ba802fd7b9b6",
+      "from": "github:mquander/three-mesh-bvh#global-three"
     },
     "three-pathfinding": {
       "version": "github:mozillareality/three-pathfinding#a52f437eaaf1b608c5f7fed046846bdbd79c75e7",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "screenfull": "^3.3.2",
     "super-hands": "github:mozillareality/aframe-super-hands-component#feature/drawing",
     "three": "github:mozillareality/three.js#4c144a360a073abb6c4a6fe7d1c03ba76b110573",
-    "three-mesh-bvh": "0.0.2",
+    "three-mesh-bvh": "github:mquander/three-mesh-bvh#global-three",
     "three-pathfinding": "github:mozillareality/three-pathfinding#hubs/master",
     "three-to-cannon": "1.3.0",
     "uuid": "^3.2.1",


### PR DESCRIPTION
HT to John for finding this problem. Right now, we can't `import THREE` anywhere in our code or our dependencies, lest we bring in a duplicate version of `THREE` (duplicated from the version that ships with A-Frame.) We have to use the global `THREE`, which is A-Frame's version. So let's use a branch of three-mesh-bvh for now that uses the global `THREE`.