### PR TITLE
import hls light

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -1,7 +1,7 @@
 import GIFWorker from "../workers/gifparsing.worker.js";
 import errorImageSrc from "!!url-loader!../assets/images/media-error.gif";
 import { paths } from "../systems/userinput/paths";
-import HLS from "hls.js";
+import HLS from "hls.js/dist/hls.light.js";
 import { proxiedUrlFor } from "../utils/media-utils";
 import { buildAbsoluteURL } from "url-toolkit";
 


### PR DESCRIPTION
We don't need the extra features that the full build of `hls` provides over `hls-light`, so we use the light version to save on bundle size.

using `hls.js/dist/hls.light.min.js` : 
![image](https://user-images.githubusercontent.com/4072106/52254546-21a97c00-28c3-11e9-865d-dd8152146f4b.png)

using `hls.js/dist/hls.light.js`: 
![image](https://user-images.githubusercontent.com/4072106/52255170-43f0c900-28c6-11e9-8be7-73ab29595539.png)

(I don't yet know why our build step doesn't minify `hls.light.js` to be as small as `hls.light.min.js`)