### PR TITLE
Add dep for babel-plugin-transform-object-rest-spread

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1537,7 +1537,7 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
@@ -1885,7 +1885,7 @@
     },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.26.0",
-      "resolved": "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "babel-loader": "^7.1.3",
     "babel-plugin-react-intl": "^2.4.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-react-jsx-img-import": "^0.1.4",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",


### PR DESCRIPTION
[We use this explicitly in our .babelrc](https://github.com/mozilla/hubs/blob/master/.babelrc#L31). Before, it was just working by coincidence, because it happens to be that this plugin is also a transitive dependency of our current Webpack version.