### PR TITLE
Fixed billboard component for AFrame 0.9.0 / Three v101

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -682,9 +682,9 @@
       }
     },
     "aframe-billboard-component": {
-      "version": "1.0.0",
-      "resolved": "https://registry.yarnpkg.com/aframe-billboard-component/-/aframe-billboard-component-1.0.0.tgz",
-      "integrity": "sha1-EM4kgnKe73OGxYRNZZF1gaYtOtw="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aframe-billboard-component/-/aframe-billboard-component-2.0.0.tgz",
+      "integrity": "sha512-kmtPo1wFWmsJc7RMgl4XgZyBGSgWH+q2qbYGWTHwnOforcDrVFgAY0K4xVpNc14Buvo6JK1Lzk3NiAsGleV1JA=="
     },
     "aframe-inspector": {
       "version": "0.8.3",
@@ -5654,8 +5654,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5673,13 +5672,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5692,18 +5689,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5806,8 +5800,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5817,7 +5810,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5830,20 +5822,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5860,7 +5849,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5933,8 +5921,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5944,7 +5931,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6020,8 +6006,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6051,7 +6036,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6069,7 +6053,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6108,13 +6091,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.2.0",
     "@fortawesome/react-fontawesome": "^0.1.0",
     "aframe": "github:mozillareality/aframe#ccbf0a6a5b6ae02bd94dd49578e0995022a03a58",
-    "aframe-billboard-component": "^1.0.0",
+    "aframe-billboard-component": "^2.0.0",
     "aframe-inspector": "^0.8.3",
     "aframe-motion-capture-components": "github:mozillareality/aframe-motion-capture-components#aframe090",
     "aframe-physics-extras": "github:mozillareality/aframe-physics-extras#bugfix/physics-collider-world",


### PR DESCRIPTION
ThreeJS [fixed `object3D.lookAt()`](https://github.com/mrdoob/three.js/commit/7504c8a06c76db1cbe6f30ddd4ef305d6a774aba#diff-67b76c11cf60452cd34cbaeadab83d05).  I [updated aframe-billboard-component](https://github.com/robertlong/aframe-billboard-component/commit/6f6724ae225df50859b61cc71035de548164b9e9) to reflect the changes. 
This PR fixes #886 