### PR TITLE
Add support for compressed KTX textures.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13776,8 +13776,8 @@
       }
     },
     "three": {
-      "version": "github:mozillareality/three.js#4232a02680995013a4ce8a40ec0a982bc71c8c6b",
-      "from": "github:mozillareality/three.js#4232a02680995013a4ce8a40ec0a982bc71c8c6b"
+      "version": "github:mozillareality/three.js#d028de214fe2291b06567142913955614bd47df9",
+      "from": "github:mozillareality/three.js#d028de214fe2291b06567142913955614bd47df9"
     },
     "three-bmfont-text": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-youtube": "^7.8.0",
     "screenfull": "^3.3.2",
     "super-hands": "github:mozillareality/aframe-super-hands-component#feature/drawing",
-    "three": "github:mozillareality/three.js#4232a02680995013a4ce8a40ec0a982bc71c8c6b",
+    "three": "github:mozillareality/three.js#d028de214fe2291b06567142913955614bd47df9",
     "three-mesh-bvh": "github:mquander/three-mesh-bvh#global-three",
     "three-pathfinding": "github:mozillareality/three-pathfinding#hubs/master",
     "three-to-cannon": "1.3.0",

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -4,6 +4,7 @@ import SketchfabZipWorker from "../workers/sketchfab-zip.worker.js";
 import MobileStandardMaterial from "../materials/MobileStandardMaterial";
 import { getCustomGLTFParserURLResolver } from "../utils/media-utils";
 import { MeshBVH, acceleratedRaycast } from "three-mesh-bvh";
+import "three/examples/js/loaders/KTXLoader";
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
 
 const GLTFCache = {};


### PR DESCRIPTION
Updates Three.js to add support for the `MOZ_texture_ktx` extension: https://github.com/MozillaReality/three.js/commit/993394806ffe598bef1ab7849951a625d8b29aa1

The `MOZ_texture_ktx` extension mirrors Microsoft's [`MSFT_texture_dds` extension](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/MSFT_texture_dds) for the KTX container.

.gltf Example:

```
"textures": [
    {
        "source": 0,
        "extensions": {
            "MOZ_texture_ktx": {
                "source": 1
            }
        }
    }
],
"images": [
    {
        "uri": "defaultTexture.png"
    },
    {
        "uri": "KTXTexture.ktx"
    }
]
```

.glb Example:

```
"textures": [
    {
        "source": 0,
        "extensions": {
            "MOZ_texture_ktx": {
                "source": 1
            }
        }
    }
],
"images": [
    {
        "mimeType": "image/png",
        "bufferView": 1
    },
    {
        "mimeType": "image/ktx",
        "bufferView": 2
    }
]
```
