### PR TITLE
Update IK controller to skip unneeded work

### DIFF
--- a/src/components/ik-controller.js
+++ b/src/components/ik-controller.js
@@ -1,4 +1,14 @@
 const { Vector3, Quaternion, Matrix4, Euler } = THREE;
+
+function quaternionAlmostEquals(epsilon, u, v) {
+  return (
+    (Math.abs(u.x - v.x) < epsilon || Math.abs(-u.x - v.x) < epsilon) &&
+    (Math.abs(u.y - v.y) < epsilon || Math.abs(-u.y - v.y) < epsilon) &&
+    (Math.abs(u.z - v.z) < epsilon || Math.abs(-u.z - v.z) < epsilon) &&
+    (Math.abs(u.w - v.w) < epsilon || Math.abs(-u.w - v.w) < epsilon)
+  );
+}
+
 /**
  * Provides access to the end effectors for IK.
  * @namespace avatar
@@ -51,6 +61,9 @@ AFRAME.registerComponent("ik-controller", {
   },
 
   init() {
+    this._runScheduledWork = this._runScheduledWork.bind(this);
+    this._updateIsInView = this._updateIsInView.bind(this);
+
     this.flipY = new Matrix4().makeRotationY(Math.PI);
 
     this.cameraForward = new Matrix4();
@@ -82,6 +95,16 @@ AFRAME.registerComponent("ik-controller", {
         rotation: new Matrix4().makeRotationFromEuler(new Euler(Math.PI / 2, Math.PI / 2, 0))
       }
     };
+
+    this.isInView = true;
+
+    this.el.sceneEl.systems["frame-scheduler"].schedule(this._runScheduledWork, "ik");
+    this.cameraMirrorSystem = this.el.sceneEl.systems["camera-mirror"];
+    this.playerCamera = document.querySelector("#player-camera").getObject3D("camera");
+  },
+
+  remove() {
+    this.el.sceneEl.systems["frame-scheduler"].unschedule(this._runScheduledWork, "ik");
   },
 
   update(oldData) {
@@ -127,6 +150,9 @@ AFRAME.registerComponent("ik-controller", {
       .addVectors(this.chest.position, this.neck.position)
       .add(this.head.position)
       .negate();
+
+    this.lastCameraTransform = new THREE.Matrix4();
+    this.hasConvergedHips = false;
   },
 
   tick(time, dt) {
@@ -136,62 +162,79 @@ AFRAME.registerComponent("ik-controller", {
 
     const root = this.ikRoot.el.object3D;
     const { camera, leftController, rightController } = this.ikRoot;
-    const {
-      hips,
-      head,
-      neck,
-      chest,
-      cameraForward,
-      headTransform,
-      invMiddleEyeToHead,
-      invHipsToHeadVector,
-      flipY,
-      cameraYRotation,
-      cameraYQuaternion,
-      invHipsQuaternion,
-      leftHand,
-      rightHand,
-      rootToChest,
-      invRootToChest
-    } = this;
 
-    // Camera faces the -Z direction. Flip it along the Y axis so that it is +Z.
     camera.object3D.updateMatrix();
-    cameraForward.multiplyMatrices(camera.object3D.matrix, flipY);
 
-    // Compute the head position such that the hmd position would be in line with the middleEye
-    headTransform.multiplyMatrices(cameraForward, invMiddleEyeToHead);
+    const hasNewCameraTransform = !this.lastCameraTransform.equals(camera.object3D.matrix);
 
-    // Then position the hips such that the head is aligned with headTransform
-    // (which positions middleEye in line with the hmd)
-    hips.position.setFromMatrixPosition(headTransform).add(invHipsToHeadVector);
+    // Optimization: if the camera hasn't moved and the hips converged to the target orientation on a previous frame,
+    // then the avatar does not need any IK this frame.
+    //
+    // Update in-view avatars every frame, and update out-of-view avatars via frame scheduler.
+    if (this.forceIkUpdate || (this.isInView && (hasNewCameraTransform || !this.hasConvergedHips))) {
+      if (hasNewCameraTransform) {
+        this.lastCameraTransform.copy(camera.object3D.matrix);
+      }
 
-    // Animate the hip rotation to follow the Y rotation of the camera with some damping.
-    cameraYRotation.setFromRotationMatrix(cameraForward, "YXZ");
-    cameraYRotation.x = 0;
-    cameraYRotation.z = 0;
-    cameraYQuaternion.setFromEuler(cameraYRotation);
-    Quaternion.slerp(hips.quaternion, cameraYQuaternion, hips.quaternion, (this.data.rotationSpeed * dt) / 1000);
+      const {
+        hips,
+        head,
+        neck,
+        chest,
+        cameraForward,
+        headTransform,
+        invMiddleEyeToHead,
+        invHipsToHeadVector,
+        flipY,
+        cameraYRotation,
+        cameraYQuaternion,
+        invHipsQuaternion,
+        rootToChest,
+        invRootToChest
+      } = this;
 
-    // Take the head orientation computed from the hmd, remove the Y rotation already applied to it by the hips,
-    // and apply it to the head
-    invHipsQuaternion.copy(hips.quaternion).inverse();
-    head.quaternion.setFromRotationMatrix(headTransform).premultiply(invHipsQuaternion);
+      // Camera faces the -Z direction. Flip it along the Y axis so that it is +Z.
+      cameraForward.multiplyMatrices(camera.object3D.matrix, flipY);
 
-    hips.updateMatrix();
-    rootToChest.multiplyMatrices(hips.matrix, chest.matrix);
-    invRootToChest.getInverse(rootToChest);
+      // Compute the head position such that the hmd position would be in line with the middleEye
+      headTransform.multiplyMatrices(cameraForward, invMiddleEyeToHead);
 
-    root.matrixNeedsUpdate = true;
-    neck.matrixNeedsUpdate = true;
-    head.matrixNeedsUpdate = true;
-    chest.matrixNeedsUpdate = true;
+      // Then position the hips such that the head is aligned with headTransform
+      // (which positions middleEye in line with the hmd)
+      hips.position.setFromMatrixPosition(headTransform).add(invHipsToHeadVector);
 
-    this.updateHand(this.hands.left, leftHand, leftController, true);
-    this.updateHand(this.hands.right, rightHand, rightController, false);
+      // Animate the hip rotation to follow the Y rotation of the camera with some damping.
+      cameraYRotation.setFromRotationMatrix(cameraForward, "YXZ");
+      cameraYRotation.x = 0;
+      cameraYRotation.z = 0;
+      cameraYQuaternion.setFromEuler(cameraYRotation);
+      Quaternion.slerp(hips.quaternion, cameraYQuaternion, hips.quaternion, (this.data.rotationSpeed * dt) / 1000);
+
+      this.hasConvergedHips = quaternionAlmostEquals(0.0001, cameraYQuaternion, hips.quaternion);
+
+      // Take the head orientation computed from the hmd, remove the Y rotation already applied to it by the hips,
+      // and apply it to the head
+      invHipsQuaternion.copy(hips.quaternion).inverse();
+      head.quaternion.setFromRotationMatrix(headTransform).premultiply(invHipsQuaternion);
+
+      hips.updateMatrix();
+      rootToChest.multiplyMatrices(hips.matrix, chest.matrix);
+      invRootToChest.getInverse(rootToChest);
+
+      root.matrixNeedsUpdate = true;
+      neck.matrixNeedsUpdate = true;
+      head.matrixNeedsUpdate = true;
+      chest.matrixNeedsUpdate = true;
+    }
+
+    const { leftHand, rightHand } = this;
+
+    this.updateHand(this.hands.left, leftHand, leftController, true, this.isInView);
+    this.updateHand(this.hands.right, rightHand, rightController, false, this.isInView);
+    this.forceIkUpdate = false;
   },
 
-  updateHand(handState, handObject3D, controller, isLeft) {
+  updateHand(handState, handObject3D, controller, isLeft, isInView) {
     const hand = handObject3D.el;
     const handMatrix = handObject3D.matrix;
     const controllerObject3D = controller.object3D;
@@ -203,7 +246,8 @@ AFRAME.registerComponent("ik-controller", {
 
     handObject3D.visible = !handHiddenByPersonalSpace && controllerObject3D.visible;
 
-    if (controllerObject3D.visible) {
+    // Optimization: skip IK update if not in view and not forced by frame scheduler
+    if (controllerObject3D.visible && (isInView || this.forceIkUpdate)) {
       handMatrix.multiplyMatrices(this.invRootToChest, controllerObject3D.matrix);
 
       const handControls = controller.components["hand-controls2"];
@@ -218,5 +262,38 @@ AFRAME.registerComponent("ik-controller", {
       handObject3D.rotation.setFromRotationMatrix(handMatrix);
       handObject3D.matrixNeedsUpdate = true;
     }
-  }
+  },
+
+  _runScheduledWork() {
+    // Every scheduled run, we force an IK update on the next frame (so at most one avatar with forced IK per frame)
+    // and also update the this.isInView bit on the avatar which is used to determine if an IK update should be run
+    // every frame.
+    this.forceIkUpdate = true;
+
+    this._updateIsInView();
+  },
+
+  _updateIsInView: (function() {
+    const frustum = new THREE.Frustum();
+    const frustumMatrix = new THREE.Matrix4();
+    const cameraWorld = new THREE.Vector3();
+    const isInViewOfCamera = (screenCamera, pos) => {
+      frustumMatrix.multiplyMatrices(screenCamera.projectionMatrix, screenCamera.matrixWorldInverse);
+      frustum.setFromMatrix(frustumMatrix);
+      return frustum.containsPoint(pos);
+    };
+
+    return function() {
+      // Take into account the mirror camera if it is enabled.
+      const mirrorCamera = this.cameraMirrorSystem.mirrorCamera;
+
+      const camera = this.ikRoot.camera.object3D;
+      camera.updateMatrices(true, true);
+      camera.getWorldPosition(cameraWorld);
+
+      this.isInView =
+        isInViewOfCamera(this.playerCamera, cameraWorld) ||
+        (mirrorCamera && isInViewOfCamera(mirrorCamera, cameraWorld));
+    };
+  })()
 });

--- a/src/components/ik-controller.js
+++ b/src/components/ik-controller.js
@@ -1,11 +1,16 @@
 const { Vector3, Quaternion, Matrix4, Euler } = THREE;
 
 function quaternionAlmostEquals(epsilon, u, v) {
+  // Note: q and -q represent same rotation
   return (
-    (Math.abs(u.x - v.x) < epsilon || Math.abs(-u.x - v.x) < epsilon) &&
-    (Math.abs(u.y - v.y) < epsilon || Math.abs(-u.y - v.y) < epsilon) &&
-    (Math.abs(u.z - v.z) < epsilon || Math.abs(-u.z - v.z) < epsilon) &&
-    (Math.abs(u.w - v.w) < epsilon || Math.abs(-u.w - v.w) < epsilon)
+    (Math.abs(u.x - v.x) < epsilon &&
+      Math.abs(u.y - v.y) < epsilon &&
+      Math.abs(u.z - v.z) < epsilon &&
+      Math.abs(u.w - v.w) < epsilon) ||
+    (Math.abs(-u.x - v.x) < epsilon &&
+      Math.abs(-u.y - v.y) < epsilon &&
+      Math.abs(-u.z - v.z) < epsilon &&
+      Math.abs(-u.w - v.w) < epsilon)
   );
 }
 

--- a/src/components/ik-controller.js
+++ b/src/components/ik-controller.js
@@ -102,10 +102,12 @@ AFRAME.registerComponent("ik-controller", {
     };
 
     this.isInView = true;
-
-    this.el.sceneEl.systems["frame-scheduler"].schedule(this._runScheduledWork, "ik");
+    this.hasConvergedHips = false;
+    this.lastCameraTransform = new THREE.Matrix4();
     this.cameraMirrorSystem = this.el.sceneEl.systems["camera-mirror"];
     this.playerCamera = document.querySelector("#player-camera").getObject3D("camera");
+
+    this.el.sceneEl.systems["frame-scheduler"].schedule(this._runScheduledWork, "ik");
   },
 
   remove() {
@@ -155,9 +157,6 @@ AFRAME.registerComponent("ik-controller", {
       .addVectors(this.chest.position, this.neck.position)
       .add(this.head.position)
       .negate();
-
-    this.lastCameraTransform = new THREE.Matrix4();
-    this.hasConvergedHips = false;
   },
 
   tick(time, dt) {
@@ -293,7 +292,6 @@ AFRAME.registerComponent("ik-controller", {
       const mirrorCamera = this.cameraMirrorSystem.mirrorCamera;
 
       const camera = this.ikRoot.camera.object3D;
-      camera.updateMatrices(true, true);
       camera.getWorldPosition(cameraWorld);
 
       this.isInView =


### PR DESCRIPTION
This PR reduces the work needed to perform IK updates every frame. It has the following optimizations:

- If an avatar is out of view, we only run IK on it via the frame scheduler. We update the `this.isInView` bit for one avatar per frame by doing a frutum check against the player camera and (if available) mirror camera. Note that this means that the in-game camera viewport camera is not included in the set of cameras we care about, which is fine because it has a low frame rate anyway.

- If an avatar's head position has not moved and no further movement on the rest of the avatar is expected, we avoid running an IK step.