### PR TITLE
Take slug off of basename, add helper functions to deal with slug

### DIFF
--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -4,7 +4,7 @@ import { injectIntl, FormattedMessage } from "react-intl";
 import styles from "../assets/stylesheets/media-browser.scss";
 import classNames from "classnames";
 import { scaledThumbnailUrlFor } from "../utils/media-utils";
-import { pushHistoryPath, pushHistoryState } from "../utils/history";
+import { pushHistoryPath, pushHistoryState, sluglessPath, withSlug } from "../utils/history";
 import { faAngleLeft } from "@fortawesome/free-solid-svg-icons/faAngleLeft";
 import { faAngleRight } from "@fortawesome/free-solid-svg-icons/faAngleRight";
 import { faSearch } from "@fortawesome/free-solid-svg-icons/faSearch";
@@ -99,7 +99,7 @@ class MediaBrowser extends Component {
     const result = props.mediaSearchStore.result;
 
     const newState = { result, query: searchParams.get("q") || "" };
-    const urlSource = searchParams.get("media_source") || this.props.history.location.pathname.substring(7);
+    const urlSource = searchParams.get("media_source") || sluglessPath(this.props.history.location).substring(7);
     newState.showNav = !!(searchParams.get("media_nav") !== "false");
 
     if (result && result.suggestions && result.suggestions.length > 0) {
@@ -178,8 +178,12 @@ class MediaBrowser extends Component {
 
   pushExitMediaBrowserHistory = () => {
     const { pathname } = this.props.history.location;
-    const hasMediaPath = pathname.startsWith("/media");
-    pushHistoryPath(this.props.history, hasMediaPath ? "/" : pathname, this.getSearchClearedSearchParams().toString());
+    const hasMediaPath = sluglessPath(this.props.history.location).startsWith("/media");
+    pushHistoryPath(
+      this.props.history,
+      hasMediaPath ? withSlug(this.props.history.location, "/") : pathname,
+      this.getSearchClearedSearchParams().toString()
+    );
   };
 
   showCreateObject = () => {
@@ -202,7 +206,7 @@ class MediaBrowser extends Component {
     const hasNext = this.state.result && !!this.state.result.meta.next_cursor;
     const searchParams = new URLSearchParams(this.props.history.location.search);
     const hasPrevious = searchParams.get("cursor");
-    const urlSource = searchParams.get("media_source") || this.props.history.location.pathname.substring(7);
+    const urlSource = searchParams.get("media_source") || sluglessPath(this.props.history.location).substring(7);
     const apiSource = this.state.result && this.state.result.meta.source;
     const isVariableWidth = this.state.result && ["bing_images", "tenor"].includes(apiSource);
 

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -10,7 +10,13 @@ import screenfull from "screenfull";
 import styles from "../assets/stylesheets/ui-root.scss";
 import entryStyles from "../assets/stylesheets/entry.scss";
 import { ReactAudioContext, WithHoverSound } from "./wrap-with-audio";
-import { pushHistoryState, clearHistoryState, popToBeginningOfHubHistory, navigateToPriorPage } from "../utils/history";
+import {
+  pushHistoryState,
+  clearHistoryState,
+  popToBeginningOfHubHistory,
+  navigateToPriorPage,
+  sluglessPath
+} from "../utils/history";
 import StateLink from "./state-link.js";
 import StateRoute from "./state-route.js";
 
@@ -137,7 +143,6 @@ class UIRoot extends Component {
   state = {
     enterInVR: false,
     entered: false,
-    lastEntryStepPath: null,
     dialog: null,
     showInviteDialog: false,
     showPresenceList: false,
@@ -226,7 +231,7 @@ class UIRoot extends Component {
     //
     // We don't do this for the media browser case, since we want to be able to share
     // links to the browser pages
-    if (this.props.history.location.state && !this.props.history.location.pathname.startsWith("/media")) {
+    if (this.props.history.location.state && !sluglessPath(this.props.history.location).startsWith("/media")) {
       popToBeginningOfHubHistory(this.props.history);
     }
 
@@ -648,7 +653,7 @@ class UIRoot extends Component {
       clearInterval(this.state.micUpdateInterval);
     }
 
-    this.setState({ entered: true, lastEntryStepPath: this.props.history.location.pathname, showInviteDialog: false });
+    this.setState({ entered: true, showInviteDialog: false });
     clearHistoryState(this.props.history);
   };
 
@@ -1184,7 +1189,7 @@ class UIRoot extends Component {
   isInModalOrOverlay = () => {
     if (
       this.state.entered &&
-      (IN_ROOM_MODAL_ROUTER_PATHS.find(x => this.props.history.location.pathname.startsWith(x)) ||
+      (IN_ROOM_MODAL_ROUTER_PATHS.find(x => sluglessPath(this.props.history.location).startsWith(x)) ||
         IN_ROOM_MODAL_QUERY_VARS.find(x => new URLSearchParams(this.props.history.location.search).get(x)))
     ) {
       return true;

--- a/src/storage/media-search-store.js
+++ b/src/storage/media-search-store.js
@@ -1,6 +1,6 @@
 import { EventTarget } from "event-target-shim";
 import { getReticulumFetchUrl } from "../utils/phoenix-utils";
-import { pushHistoryPath } from "../utils/history";
+import { pushHistoryPath, sluglessPath, withSlug } from "../utils/history";
 
 const URL_SOURCE_TO_TO_API_SOURCE = {
   scenes: "scene_listings",
@@ -123,13 +123,14 @@ export default class MediaSearchStore extends EventTarget {
       searchParams.set("media_source", source);
       pushHistoryPath(this.history, this.history.location.pathname, searchParams.toString());
     } else {
-      pushHistoryPath(this.history, `/media/${source}`, searchParams.toString());
+      pushHistoryPath(this.history, withSlug(this.history.location, `/media/${source}`), searchParams.toString());
     }
   };
 
   getUrlMediaSource = location => {
-    const { pathname, search } = location;
+    const { search } = location;
     const urlParams = new URLSearchParams(search);
+    const pathname = sluglessPath(location);
 
     if (!pathname.startsWith("/media") && !urlParams.get("media_source")) return null;
     return urlParams.get("media_source") || pathname.substring(7);

--- a/src/utils/history.js
+++ b/src/utils/history.js
@@ -2,6 +2,11 @@
 // need to be used to manipulate history state so we can deal with edge cases around
 // entry back button and refreshes once entered.
 //
+// These functions also transparently deal with the room slug, so incoming calls can ignore
+// dealing with it, and provides APIs for getting the non-slug part of the path.
+//
+// The slug cannot be part of the basename for history, because the slug changes intra-session
+// if the room is renamed.
 
 // This pushes/replaces a new k, v pair into the history, while maintaining all the other
 // keys, or clears state if k if null.
@@ -34,10 +39,6 @@ function pushOrUpdateHistory(history, replace, k, v, newPathname, newSearch) {
   state.__historyLength = newLength;
 
   method({ pathname, search, state });
-}
-
-export function replaceHistoryState(history, k, v) {
-  pushOrUpdateHistory(history, true, k, v);
 }
 
 export function pushHistoryState(history, k, v) {
@@ -80,4 +81,17 @@ export function popToBeginningOfHubHistory(history, navigateToPriorPage) {
 // This will pop the browser history to the entry before the first entry for this hubs room.
 export function navigateToPriorPage(history) {
   popToBeginningOfHubHistory(history, true);
+}
+
+// Returns the part of the pathname that does not include the slug
+export function sluglessPath(location) {
+  const parts = location.pathname.split("/");
+  return `/${parts.slice(2).join("/")}`;
+}
+
+// Returns a new path that includes the current slug as a prefix to the
+// provided path.
+export function withSlug(location, path) {
+  const parts = location.pathname.split("/");
+  return `/${parts[1]}${path}`;
 }


### PR DESCRIPTION
The room rename functionality had bugs because the underlying history object we are using does not allow modification of the `basename`, and the `basename` previously included the slug, which changes when we rename the room. This PR drops the slug out of the `basename` (so its just `/<hub sid>`) and then the slug management happens in the application code. The two category of changes are:

- Places where we were just checking `pathname` now have to filter out the slug via `sluglessPath()`
- Places where we were pushing paths into the history without the slug now need to add the slug with `withSlug()`

The actual history replace when a room rename occurs now happens via the history module, and no longer directly uses the history API of the browser. This fixes additional issues and is overall just cleaner.