### PR TITLE
Move text into strings, use local CSS, clean up layout and styling

### DIFF
--- a/src/assets/stylesheets/loader.scss
+++ b/src/assets/stylesheets/loader.scss
@@ -1,8 +1,18 @@
+@import 'shared';
+
 .loader-wrap {
   pointer-events: none;
   position: relative;
   width: 100px;
   height: 90px;
+}
+
+.loader-bottom {
+  position: fixed;
+  bottom: 8px;
+  -webkit-transform: translateX(-50%);
+  transform: translateX(-50%);
+  left: 50%;
 }
 
 .loading-panel {
@@ -23,7 +33,7 @@
 .loading-panel__logo {
   width: 247px;
   height: 57px;
-  margin: 20px 0;
+  margin: 20px 0 10px 0;
 }
 
 .loader-center,
@@ -89,9 +99,10 @@
     top: -0.75em;
   }
 }
-.loadedText {
-  color: green;
-}
-.loadingText {
-  color: gray;
+
+:local(.loading-text) {
+  font-weight: normal;
+  font-size: 0.8em;
+  color: $darker-grey;
+  margin-top: 0;
 }

--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -182,6 +182,10 @@
     "settings.help": "Help",
     "settings.row-profile": "Profile",
     "settings.row-room": "Room",
-    "video_share.notify": "Select again to un-share video."
+    "video_share.notify": "Select again to un-share video.",
+    "loader.joining_lobby": "Joining lobby...",
+    "loader.loading": "Loading ",
+    "loader.object": "object",
+    "loader.objects": "objects"
   }
 }

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -8,6 +8,7 @@ import en from "react-intl/locale-data/en";
 import MovingAverage from "moving-average";
 import screenfull from "screenfull";
 import styles from "../assets/stylesheets/ui-root.scss";
+import loaderStyles from "../assets/stylesheets/loader.scss";
 import entryStyles from "../assets/stylesheets/entry.scss";
 import { ReactAudioContext, WithHoverSound } from "./wrap-with-audio";
 import {
@@ -154,7 +155,6 @@ class UIRoot extends Component {
 
     hideLoader: false,
     didConnectToNetworkedScene: false,
-    loadingText: "Loading objects...",
     loadingNum: 0,
 
     shareScreen: false,
@@ -889,19 +889,26 @@ class UIRoot extends Component {
     return (
       <IntlProvider locale={lang} messages={messages}>
         <div className="loading-panel">
-          <div className="loader-wrap">
+          <img className="loading-panel__logo" src="../assets/images/hub-preview-light-no-shadow.png" />
+
+          <h4 className={loaderStyles.loadingText}>
+            {this.state.loadingNum === 0 ? (
+              <FormattedMessage id="loader.joining_lobby" />
+            ) : (
+              <div>
+                <FormattedMessage id="loader.loading" />
+                {this.state.loadingNum}&nbsp;
+                <FormattedMessage id={`loader.object${this.state.loadingNum > 1 ? "s" : ""}`} />
+                ...
+              </div>
+            )}
+          </h4>
+
+          <div className="loader-wrap loader-bottom">
             <div className="loader">
               <div className="loader-center" />
             </div>
           </div>
-
-          <img className="loading-panel__logo" src="../assets/images/hub-preview-light-no-shadow.png" />
-
-          <h4 className={this.state.loadingNum === 0 ? "loadedText" : "loadingText"}>
-            {this.state.loadingNum === 0
-              ? "Joining lobby..."
-              : `Loading ${this.state.loadingNum} object${this.state.loadingNum > 1 ? "s" : ""}...`}
-          </h4>
         </div>
       </IntlProvider>
     );


### PR DESCRIPTION
Small TLC pass on the loading screen -- also wrote this to show how to move strings into the i18n strings file and use `:local` CSS. (`:local` and nested SASS name expansion are the preferred ways to write CSS classes now, but we haven't refactored all of the existing rules yet.)

![image](https://user-images.githubusercontent.com/220020/53207855-bdd4c200-35e9-11e9-9e67-1fc995406c8a.png)
