### PR TITLE
Do not compileAndUploadMaterials if in bot mode.

### DIFF
--- a/src/components/skybox.js
+++ b/src/components/skybox.js
@@ -1,5 +1,7 @@
 import "three/examples/js/pmrem/PMREMGenerator";
 import "three/examples/js/pmrem/PMREMCubeUVPacker";
+import qsTruthy from "../utils/qs_truthy";
+const isBotMode = qsTruthy("bot");
 
 /**
  * @author zz85 / https://github.com/zz85
@@ -297,7 +299,7 @@ AFRAME.registerComponent("skybox", {
   updateEnvironmentMap() {
     const environmentMapComponent = this.el.sceneEl.components["environment-map"];
 
-    if (environmentMapComponent) {
+    if (environmentMapComponent && !isBotMode) {
       const renderer = this.el.sceneEl.renderer;
       this.skyScene.add(this.sky);
       this.cubeCamera.update(renderer, this.skyScene);

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -335,7 +335,9 @@ class UIRoot extends Component {
 
     if (this.loadingTimeout) window.clearTimeout(this.loadingTimeout);
     this.loadingTimeout = window.setTimeout(() => {
-      AFRAME.scenes[0].renderer.compileAndUploadMaterials(AFRAME.scenes[0].object3D, AFRAME.scenes[0].camera);
+      if (!this.props.isBotMode) {
+        AFRAME.scenes[0].renderer.compileAndUploadMaterials(AFRAME.scenes[0].object3D, AFRAME.scenes[0].camera);
+      }
       this.setState({ hideLoader: true });
     }, 1000);
   };


### PR DESCRIPTION
We replace the scene's `renderer` when we are in bot mode to reduce the load of running it. This fixes the immediate error which causes bots to fail to move.

There are other places where we are manipulating the `renderer` but that I expect will fail if the app is launched in bot mode, but these don't seem to be causing any obvious issues. I did fix one of these by preventing the skybox from updating if in bot mode (for the same reason).