### PR TITLE
Fix up a bunch of layout and full screen issues on mobile

### DIFF
--- a/src/assets/stylesheets/audio.scss
+++ b/src/assets/stylesheets/audio.scss
@@ -150,6 +150,8 @@
     background: none;
     border: none;
     cursor: pointer;
+    width: 111px;
+    height: 111px;
   }
 
   &__next-container {

--- a/src/assets/stylesheets/media-browser.scss
+++ b/src/assets/stylesheets/media-browser.scss
@@ -121,17 +121,17 @@
   :local(.header) {
     display: flex;
     align-items: flex-start;
-    width: 100%;
+    width: 100vw;
     margin: 32px;
     margin-bottom: 24px;
-    min-height: fit-content;
+    height: 77px;
   }
 
   :local(.nav) {
-    width: 100%;
+    width: 100vw;
     display: flex;
     position: relative;
-    min-height: fit-content;
+    min-height: 38px;
     border-bottom: 1px solid $light-grey;
     white-space: nowrap;
     padding-left: 12px;
@@ -180,7 +180,7 @@
   }
 
   :local(.facets) {
-    width: 100%;
+    width: 100vw;
     display: flex;
     position: relative;
     height: 44px;
@@ -207,7 +207,7 @@
       margin: 0 8px;
       text-align: center;
       min-width: auto;
-      min-height: fit-content;
+      min-height: 44px;
       white-space: nowrap;
 
       @media(max-width: 768px) {
@@ -239,7 +239,7 @@
 
 
   :local(.body) {
-    width: 100%;
+    width: 100vw;
 
     :local(.tiles) {
       margin: 8px 8px 24px 8px;

--- a/src/assets/stylesheets/ui-root.scss
+++ b/src/assets/stylesheets/ui-root.scss
@@ -322,7 +322,8 @@ body.vr-mode {
 
 :local(.message-entry-on-mobile) {
   // Hide chatbox for joysticks
-  @media (orientation: landscape) {
+  // Orientation selector fails here when keyboard pops up on shorter screens
+  @media (min-aspect-ratio: 4/3) {
     display: none;
   }
 }

--- a/src/components/virtual-gamepad-controls.css
+++ b/src/components/virtual-gamepad-controls.css
@@ -1,10 +1,11 @@
 :local(.touchZone) {
   position: absolute;
-  height: 30vh;
+  height: 20vh;
   bottom: 0;
 
-  @media(orientation: portrait) {
-    height: 20vh;
+  /* Orientation selector fails here when keyboard pops up on shorter screens */
+  @media(min-aspect-ratio: 4/3) {
+    height: 30vh;
   }
 }
 
@@ -24,12 +25,13 @@
   left: 0;
   right: 0;
   bottom: 15vh;
-  display: flex;
   align-items: center;
   justify-content: space-around;
+  display: none;
 
-  @media (orientation: portrait) {
-    display: none;
+  /* Orientation selector fails here when keyboard pops up on shorter screens */
+  @media (min-aspect-ratio: 4/3) {
+    display: flex;
   }
 }
 

--- a/src/react-components/create-object-dialog.js
+++ b/src/react-components/create-object-dialog.js
@@ -7,6 +7,7 @@ import { faTimes } from "@fortawesome/free-solid-svg-icons/faTimes";
 import styles from "../assets/stylesheets/create-object-dialog.scss";
 import cx from "classnames";
 import DialogContainer from "./dialog-container.js";
+import { handleTextFieldFocus, handleTextFieldBlur } from "../utils/focus-utils";
 import { WithHoverSound } from "./wrap-with-audio";
 
 const attributionHostnames = {
@@ -127,6 +128,8 @@ export default class CreateObjectDialog extends Component {
       <input
         className={cx(styles.leftSideOfInput)}
         placeholder="Image/Video/glTF URL"
+        onFocus={e => handleTextFieldFocus(e.target)}
+        onBlur={() => handleTextFieldBlur()}
         onChange={this.onUrlChange}
         type="url"
         value={this.state.url}

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -13,11 +13,10 @@ import { faTimes } from "@fortawesome/free-solid-svg-icons/faTimes";
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons/faExternalLinkAlt";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { SOURCES } from "../storage/media-search-store";
+import { handleTextFieldFocus, handleTextFieldBlur } from "../utils/focus-utils";
 import { showFullScreenIfWasFullScreen } from "../utils/fullscreen";
-import screenfull from "screenfull";
 import qsTruthy from "../utils/qs_truthy";
 
-const isMobile = AFRAME.utils.device.isMobile();
 const allowContentSearch = qsTruthy("content_search");
 
 const PUBLISHER_FOR_ENTRY_TYPE = {
@@ -220,17 +219,8 @@ class MediaBrowser extends Component {
                   placeholder={formatMessage({
                     id: `media-browser.search-placeholder.${urlSource}`
                   })}
-                  onFocus={e => {
-                    if (screenfull.isFullscreen) {
-                      // If a text field is focused outside of full screen mode,
-                      // Firefox mobile can end up getting into a weird half-fullscreen
-                      // mode that results in further requests to go full screen
-                      // to fail.
-                      screenfull.exit();
-                    }
-
-                    if (!isMobile) e.target.select();
-                  }}
+                  onFocus={e => handleTextFieldFocus(e.target)}
+                  onBlur={() => handleTextFieldBlur()}
                   onKeyDown={e => {
                     if (e.key === "Enter" && e.shiftKey) {
                       if (this.state.result && this.state.result.entries.length > 0) {

--- a/src/react-components/profile-entry-panel.js
+++ b/src/react-components/profile-entry-panel.js
@@ -7,6 +7,9 @@ import classNames from "classnames";
 import hubLogo from "../assets/images/hub-preview-white.png";
 import { WithHoverSound } from "./wrap-with-audio";
 import { avatars } from "../assets/avatars/avatars";
+import screenfull from "screenfull";
+
+const isMobile = AFRAME.utils.device.isMobile();
 
 class ProfileEntryPanel extends Component {
   static propTypes = {
@@ -95,7 +98,17 @@ class ProfileEntryPanel extends Component {
               id="profile-entry-display-name"
               className={styles.formFieldText}
               value={this.state.displayName}
-              onFocus={e => e.target.select()}
+              onFocus={e => {
+                if (screenfull.isFullscreen) {
+                  // If a text field is focused outside of full screen mode,
+                  // Firefox mobile can end up getting into a weird half-fullscreen
+                  // mode that results in further requests to go full screen
+                  // to fail.
+                  screenfull.exit();
+                }
+
+                if (!isMobile) e.target.select();
+              }}
               onChange={e => this.setState({ displayName: e.target.value })}
               required
               spellCheck="false"

--- a/src/react-components/profile-entry-panel.js
+++ b/src/react-components/profile-entry-panel.js
@@ -7,9 +7,7 @@ import classNames from "classnames";
 import hubLogo from "../assets/images/hub-preview-white.png";
 import { WithHoverSound } from "./wrap-with-audio";
 import { avatars } from "../assets/avatars/avatars";
-import screenfull from "screenfull";
-
-const isMobile = AFRAME.utils.device.isMobile();
+import { handleTextFieldFocus, handleTextFieldBlur } from "../utils/focus-utils";
 
 class ProfileEntryPanel extends Component {
   static propTypes = {
@@ -98,17 +96,8 @@ class ProfileEntryPanel extends Component {
               id="profile-entry-display-name"
               className={styles.formFieldText}
               value={this.state.displayName}
-              onFocus={e => {
-                if (screenfull.isFullscreen) {
-                  // If a text field is focused outside of full screen mode,
-                  // Firefox mobile can end up getting into a weird half-fullscreen
-                  // mode that results in further requests to go full screen
-                  // to fail.
-                  screenfull.exit();
-                }
-
-                if (!isMobile) e.target.select();
-              }}
+              onFocus={e => handleTextFieldFocus(e.target)}
+              onBlur={() => handleTextFieldBlur()}
               onChange={e => this.setState({ displayName: e.target.value })}
               required
               spellCheck="false"

--- a/src/react-components/rename-room-dialog.js
+++ b/src/react-components/rename-room-dialog.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { FormattedMessage } from "react-intl";
+import { handleTextFieldFocus, handleTextFieldBlur } from "../utils/focus-utils";
 
 import styles from "../assets/stylesheets/rename-room-dialog.scss";
 import DialogContainer from "./dialog-container";
@@ -38,6 +39,8 @@ export default class RenameRoomDialog extends Component {
             minLength={5}
             placeholder="Room name"
             value={this.state.name}
+            onFocus={e => handleTextFieldFocus(e.target)}
+            onBlur={() => handleTextFieldBlur()}
             onChange={e => this.setState({ name: e.target.value })}
             className={styles.nameField}
           />

--- a/src/react-components/sign-in-dialog.js
+++ b/src/react-components/sign-in-dialog.js
@@ -4,6 +4,7 @@ import { FormattedMessage } from "react-intl";
 
 import styles from "../assets/stylesheets/sign-in-dialog.scss";
 import DialogContainer from "./dialog-container";
+import { handleTextFieldFocus, handleTextFieldBlur } from "../utils/focus-utils";
 
 export default class SignInDialog extends Component {
   static propTypes = {
@@ -52,6 +53,8 @@ export default class SignInDialog extends Component {
             required
             placeholder="Your email address"
             value={this.state.email}
+            onFocus={e => handleTextFieldFocus(e.target)}
+            onBlur={() => handleTextFieldBlur()}
             onChange={e => this.setState({ email: e.target.value })}
             className={styles.emailField}
           />

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -52,6 +52,7 @@ import TwoDHUD from "./2d-hud";
 import ChatCommandHelp from "./chat-command-help";
 import { spawnChatMessage } from "./chat-message";
 import { showFullScreenIfAvailable, showFullScreenIfWasFullScreen } from "../utils/fullscreen";
+import { handleTextFieldFocus, handleTextFieldBlur } from "../utils/focus-utils";
 import { faUsers } from "@fortawesome/free-solid-svg-icons/faUsers";
 import { faImage } from "@fortawesome/free-solid-svg-icons/faImage";
 import { faBars } from "@fortawesome/free-solid-svg-icons/faBars";
@@ -968,9 +969,8 @@ class UIRoot extends Component {
                 value={this.state.pendingMessage}
                 rows={textRows}
                 style={{ height: pendingMessageTextareaHeight }}
-                onFocus={e => {
-                  if (!isMobile) e.target.select();
-                }}
+                onFocus={e => handleTextFieldFocus(e.target)}
+                onBlur={() => handleTextFieldBlur()}
                 onChange={e => this.setState({ pendingMessage: e.target.value })}
                 onKeyDown={e => {
                   if (e.key === "Enter" && !e.shiftKey) {
@@ -1493,31 +1493,12 @@ class UIRoot extends Component {
                     value={this.state.pendingMessage}
                     rows={textRows}
                     onFocus={e => {
+                      handleTextFieldFocus(e.target);
                       this.setState({ messageEntryOnTop: isMobile });
-
-                      if (screenfull.isFullscreen) {
-                        // This will prevent focus, but its the only way to avoid getting into a
-                        // weird "firefox reports full screen but actually not". You end up having to tap
-                        // twice to ultimately get the focus.
-                        //
-                        // We need to keep track of a bit here so that we don't re-full screen when
-                        // the text box is blurred by the browser.
-
-                        this.isExitingFullscreenDueToFocus = true;
-                        screenfull.exit();
-                      }
-
-                      if (!isMobile) e.target.select();
                     }}
                     onBlur={() => {
-                      // This is the incidental blur event when exiting fullscreen mode on mobile
-                      if (this.isExitingFullscreenDueToFocus) {
-                        this.isExitingFullscreenDueToFocus = false;
-                        return;
-                      }
-
+                      handleTextFieldBlur();
                       this.setState({ messageEntryOnTop: false });
-                      showFullScreenIfWasFullScreen();
                     }}
                     onChange={e => {
                       e.stopPropagation();

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -51,6 +51,7 @@ import SettingsMenu from "./settings-menu.js";
 import TwoDHUD from "./2d-hud";
 import ChatCommandHelp from "./chat-command-help";
 import { spawnChatMessage } from "./chat-message";
+import { showFullScreenIfAvailable, showFullScreenIfWasFullScreen } from "../utils/fullscreen";
 import { faUsers } from "@fortawesome/free-solid-svg-icons/faUsers";
 import { faImage } from "@fortawesome/free-solid-svg-icons/faImage";
 import { faBars } from "@fortawesome/free-solid-svg-icons/faBars";
@@ -288,6 +289,7 @@ class UIRoot extends Component {
 
     const closeAndContinue = () => {
       this.closeDialog();
+      showFullScreenIfWasFullScreen();
       onContinueAfterSignIn();
     };
 
@@ -674,14 +676,11 @@ class UIRoot extends Component {
     );
   };
 
-  showFullScreenIfAvailable = () => {
-    if (this.shouldShowFullScreen()) {
-      screenfull.request();
-    }
-  };
-
   onAudioReadyButton = () => {
-    this.showFullScreenIfAvailable();
+    if (!this.state.enterVR) {
+      showFullScreenIfAvailable();
+    }
+
     this.props.enterScene(this.state.mediaStream, this.state.enterInVR, this.props.hubId);
 
     const mediaStream = this.state.mediaStream;
@@ -728,6 +727,8 @@ class UIRoot extends Component {
   };
 
   closeDialog = () => {
+    showFullScreenIfWasFullScreen();
+
     if (this.state.dialog) {
       this.setState({ dialog: null });
     } else {
@@ -966,7 +967,9 @@ class UIRoot extends Component {
                 value={this.state.pendingMessage}
                 rows={textRows}
                 style={{ height: pendingMessageTextareaHeight }}
-                onFocus={e => e.target.select()}
+                onFocus={e => {
+                  if (!isMobile) e.target.select();
+                }}
                 onChange={e => this.setState({ pendingMessage: e.target.value })}
                 onKeyDown={e => {
                   if (e.key === "Enter" && !e.shiftKey) {
@@ -1504,7 +1507,7 @@ class UIRoot extends Component {
                         screenfull.exit();
                       }
 
-                      e.target.select();
+                      if (!isMobile) e.target.select();
                     }}
                     onBlur={() => {
                       // This is the incidental blur event when exiting fullscreen mode on mobile
@@ -1514,7 +1517,7 @@ class UIRoot extends Component {
                       }
 
                       this.setState({ messageEntryOnTop: false });
-                      this.showFullScreenIfAvailable();
+                      showFullScreenIfWasFullScreen();
                     }}
                     onChange={e => {
                       e.stopPropagation();

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -84,6 +84,7 @@ async function grantedMicLabels() {
   return mediaDevices.filter(d => d.label && d.kind === "audioinput").map(d => d.label);
 }
 
+const isMobile = AFRAME.utils.device.isMobile();
 const AUTO_EXIT_TIMER_SECONDS = 10;
 
 import webmTone from "../assets/sfx/tone.webm";
@@ -639,7 +640,7 @@ class UIRoot extends Component {
   };
 
   shouldShowHmdMicWarning = () => {
-    if (AFRAME.utils.device.isMobile() || AFRAME.utils.device.isOculusGo()) return false;
+    if ( || AFRAME.utils.device.isOculusGo()) return false;
     if (!this.state.enterInVR) return false;
     if (!this.hasHmdMicrophone()) return false;
 
@@ -669,7 +670,7 @@ class UIRoot extends Component {
   shouldShowFullScreen = () => {
     // Disable full screen on iOS, since Safari's fullscreen mode does not let you prevent native pinch-to-zoom gestures.
     return (
-      (AFRAME.utils.device.isMobile() || AFRAME.utils.device.isOculusGo()) &&
+      (isMobile || AFRAME.utils.device.isOculusGo()) &&
       !AFRAME.utils.device.isIOS() &&
       !this.state.enterInVR &&
       screenfull.enabled
@@ -1137,9 +1138,9 @@ class UIRoot extends Component {
     const micClip = {
       clip: `rect(${maxLevelHeight - Math.floor(this.state.micLevel * maxLevelHeight)}px, 111px, 111px, 0px)`
     };
-    const isMobile = AFRAME.utils.device.isMobile() || AFRAME.utils.device.isOculusGo();
+    const isMobileOrGo = isMobile || AFRAME.utils.device.isOculusGo();
     const speakerClip = { clip: `rect(${this.state.tonePlaying ? 0 : maxLevelHeight}px, 111px, 111px, 0px)` };
-    const subtitleId = isMobile ? "audio.subtitle-mobile" : "audio.subtitle-desktop";
+    const subtitleId = isMobileOrGo ? "audio.subtitle-mobile" : "audio.subtitle-desktop";
     return (
       <div className="audio-setup-panel">
         <div onClick={() => this.props.history.goBack()} className={entryStyles.back}>
@@ -1154,7 +1155,7 @@ class UIRoot extends Component {
             <FormattedMessage id="audio.title" />
           </div>
           <div className="audio-setup-panel__subtitle">
-            {(isMobile || this.state.enterInVR) && <FormattedMessage id={subtitleId} />}
+            {(isMobileOrGo || this.state.enterInVR) && <FormattedMessage id={subtitleId} />}
           </div>
           <div className="audio-setup-panel__levels">
             <div className="audio-setup-panel__levels__icon">
@@ -1325,7 +1326,6 @@ class UIRoot extends Component {
       [styles.messageEntryOnTop]: this.state.messageEntryOnTop
     };
 
-    const isMobile = AFRAME.utils.device.isMobile();
     const presenceLogEntries = this.props.presenceLogEntries || [];
 
     const mediaSource = this.props.mediaSearchStore.getUrlMediaSource(this.props.history.location);

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -640,7 +640,7 @@ class UIRoot extends Component {
   };
 
   shouldShowHmdMicWarning = () => {
-    if ( || AFRAME.utils.device.isOculusGo()) return false;
+    if (isMobile || AFRAME.utils.device.isOculusGo()) return false;
     if (!this.state.enterInVR) return false;
     if (!this.hasHmdMicrophone()) return false;
 

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -1,5 +1,4 @@
 import qsTruthy from "./utils/qs_truthy";
-import screenfull from "screenfull";
 import nextTick from "./utils/next-tick";
 import pinnedEntityToGltf from "./utils/pinned-entity-to-gltf";
 

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -13,10 +13,6 @@ const aframeInspectorUrl = require("file-loader?name=assets/js/[name]-[hash].[ex
 import { addMedia, proxiedUrlFor, getPromotionTokenForFile } from "./utils/media-utils";
 import { ObjectContentOrigins } from "./object-types";
 
-function requestFullscreen() {
-  if (screenfull.enabled && !screenfull.isFullscreen) screenfull.request();
-}
-
 export default class SceneEntryManager {
   constructor(hubChannel, authChannel) {
     this.hubChannel = hubChannel;
@@ -145,7 +141,6 @@ export default class SceneEntryManager {
       this.scene.renderer.setAnimationLoop(null); // Stop animation loop, TODO A-Frame should do this
     }
     document.body.removeChild(this.scene);
-    document.body.removeEventListener("touchend", requestFullscreen);
   };
 
   _setupPlayerRig = () => {

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -67,12 +67,6 @@ export default class SceneEntryManager {
           .indexOf("cardboard") >= 0;
 
       this.scene.enterVR();
-    } else if (AFRAME.utils.device.isMobile() && !AFRAME.utils.device.isIOS()) {
-      document.body.addEventListener("touchend", () => {
-        if (!document.activeElement && !["INPUT", "TEXTAREA"].includes(document.activeElement.nodeName)) {
-          requestFullscreen();
-        }
-      });
     }
 
     if (!isCardboard) {

--- a/src/utils/focus-utils.js
+++ b/src/utils/focus-utils.js
@@ -1,0 +1,36 @@
+import screenfull from "screenfull";
+const isMobile = AFRAME.utils.device.isMobile();
+import { showFullScreenIfWasFullScreen } from "./fullscreen";
+
+let isExitingFullscreenDueToFocus = false;
+
+// Utility function that handles a bunch of incidental stuff related to text fields:
+//
+// - On non-mobile platforms, selects the value on focus
+// - If full screen, exits/enters full screen because of firefox full screen issues
+export function handleTextFieldFocus(target) {
+  if (screenfull.isFullscreen) {
+    // This will prevent focus, but its the only way to avoid getting into a
+    // weird "firefox reports full screen but actually not". You end up having to tap
+    // twice to ultimately get the focus.
+    //
+    // We need to keep track of a bit here so that we don't re-full screen when
+    // the text box is blurred by the browser.
+
+    isExitingFullscreenDueToFocus = true;
+    screenfull.exit();
+    setTimeout(() => target.focus(), 200);
+  }
+
+  if (!isMobile) target.select();
+}
+
+export function handleTextFieldBlur() {
+  // This is the incidental blur event when exiting fullscreen mode on mobile
+  if (isExitingFullscreenDueToFocus) {
+    isExitingFullscreenDueToFocus = false;
+    return;
+  }
+
+  showFullScreenIfWasFullScreen();
+}

--- a/src/utils/fullscreen.js
+++ b/src/utils/fullscreen.js
@@ -1,0 +1,25 @@
+import screenfull from "screenfull";
+
+let hasEnteredFullScreenThisSession = false;
+
+function shouldShowFullScreen() {
+  // Disable full screen on iOS, since Safari's fullscreen mode does not let you prevent native pinch-to-zoom gestures.
+  return (
+    (AFRAME.utils.device.isMobile() || AFRAME.utils.device.isOculusGo()) &&
+    !AFRAME.utils.device.isIOS() &&
+    screenfull.enabled
+  );
+}
+
+export function showFullScreenIfAvailable() {
+  if (shouldShowFullScreen()) {
+    screenfull.request();
+    hasEnteredFullScreenThisSession = true;
+  }
+}
+
+export function showFullScreenIfWasFullScreen() {
+  if (hasEnteredFullScreenThisSession && !screenfull.isFullscreen) {
+    screenfull.request();
+  }
+}


### PR DESCRIPTION
This PR deals with a number of ugly issues discovered around UX on firefox mobile:

- A bunch of flexbox constraints were wrong, using `fit-content` and also `width: 100%` -- the former is just straight up unsupported and the latter seemed to be computing the wrong min width. I worked around these by using `100vw` and setting `min-heights` and explicit `heights`. (I feel like this isn't really right, but it seems to result in the right layout.)

- Fixes a bunch of full screen transition issues. The main thing that I've encountered is that Firefox Android, when dealing with focused input fields, can in certain cases (like when we auto focus I think, or when the user uses the copy/paste functionality) exit full screen but no longer be able to re-enter it even if we request it. The result is that we need to exit full screen explicitly when interacting with text boxes, and re-enter it when that interaction has concluded.

- Auto-select on focus is kind of weird on mobile because it pops up the copy/paste options, so I stopped doing it.