### PR TITLE
Do not wait for model loaded

### DIFF
--- a/src/components/avatar-replay.js
+++ b/src/components/avatar-replay.js
@@ -21,9 +21,6 @@ AFRAME.registerComponent("avatar-replay", {
     rightController: { type: "selector" },
     recordingUrl: { type: "string" }
   },
-  init: function() {
-    this.modelLoaded = new Promise(resolve => this.el.addEventListener("model-loaded", resolve));
-  },
 
   update: function() {
     const { camera, leftController, rightController, recordingUrl } = this.data;
@@ -36,7 +33,7 @@ AFRAME.registerComponent("avatar-replay", {
     this._setupController(leftController);
     this._setupController(rightController);
 
-    this.dataLoaded = Promise.all([fetchRecording, this.modelLoaded]).then(([recording]) => {
+    this.dataLoaded = fetchRecording.then(([recording]) => {
       const cameraReplayer = camera.components["motion-capture-replayer"];
       cameraReplayer.startReplaying(recording.camera);
       const leftControllerReplayer = leftController.components["motion-capture-replayer"];


### PR DESCRIPTION
Now that the client sets up the player rig earlier, this model loaded event is fired before the event listener is created.

I'm not 100% sure if the model loading vs the bot being set up is a race condition. I'm going to be investigating a related issue I introduced where the oculus touch controller offset is wrong. (Probably because we check for oculus controllers to determine their offsets before they're ever present.) I suggest we merge this now to fix the bots and I'll look more carefully at this if we notice it being wrong.