### PR TITLE
Do not save events with no key.

### DIFF
--- a/src/systems/userinput/devices/keyboard.js
+++ b/src/systems/userinput/devices/keyboard.js
@@ -6,6 +6,7 @@ export class KeyboardDevice {
 
     ["keydown", "keyup"].map(x =>
       document.addEventListener(x, e => {
+        if (!e.key) return;
         this.events.push(e);
 
         // Block browser hotkeys for chat command and media browser


### PR DESCRIPTION
I encounter this error when selecting one of the browser's autofill options in chrome with my mouse when entering in my email to log in. We can ignore `keydown` and `keyup` events that don't have a `key`