### PR TITLE
Rename align to recenter and clean up layout

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -253,10 +253,10 @@
                                 <a-entity text="value:clone; width:1.75; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
                             </a-entity>
                             <a-entity scale="0.8 0.8 1" mixin="rounded-text-button" rotate-button rotate-button-selector position="-0.6  0.12 0.01">
-                                <a-entity text="value:rotate; width:1.40; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
+                                <a-entity text="value:rotate; width:1.50; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
                             </a-entity>
                             <a-entity  scale="0.8 0.8 1" mixin="rounded-text-button" rotate-button="mode: align;" position="-0.6 -0.12 0.01">
-                                <a-entity text="value:align; width:1.30; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
+                                <a-entity text="value:re-center; width:1.40; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
                             </a-entity>
                         </a-entity>
                     </a-entity>
@@ -325,11 +325,11 @@
                         <a-entity text=" value:mirror; width:2.5; align:center;" class="mirror-button-label" text-raycast-hack position="0 0.125 0.02"></a-entity>
                         <a-entity mixin="rounded-text-button" remove-networked-object-button position="0 -0.125 0.01"> </a-entity>
                         <a-entity text=" value:remove; width:2.5; align:center;" text-raycast-hack position="0 -0.125 0.02"></a-entity>
-                        <a-entity scale="0.5 0.5 1" mixin="rounded-text-button" rotate-button rotate-button-selector position="-0.6  0.06 0.01">
-                            <a-entity text="value:rotate; width:2.80; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
+                        <a-entity scale="0.8 0.8 1" mixin="rounded-text-button" rotate-button rotate-button-selector position="-0.7 0.06 0.01">
+                            <a-entity text="value:rotate; width:2.40; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
                         </a-entity>
-                        <a-entity  scale="0.5 0.5 1" mixin="rounded-text-button" rotate-button="mode: reset;" position="-0.6 -0.06 0.01">
-                            <a-entity text="value:align; width:2.60; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
+                        <a-entity  scale="0.8 0.8 1" mixin="rounded-text-button" rotate-button="mode: align;" position="-0.7 -0.15 0.01">
+                            <a-entity text="value:re-center; width:2.2; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
                         </a-entity>
                     </a-entity>
                 </a-entity>


### PR DESCRIPTION
This PR renames "align" to "re-center" on the menu and also fixes up the camera rotation/re-center buttons. The re-center button on the camera was also not working because of the mode being wrong (I'm guessing the mode was renamed and this part was not refactored.)