### PR TITLE
Fix vertexColors and multi-materials in MobileStandardMaterial

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -1,5 +1,5 @@
 import nextTick from "../utils/next-tick";
-import { forEachMaterial } from "../utils/material-utils";
+import { mapMaterials } from "../utils/material-utils";
 import SketchfabZipWorker from "../workers/sketchfab-zip.worker.js";
 import MobileStandardMaterial from "../materials/MobileStandardMaterial";
 import { getCustomGLTFParserURLResolver } from "../utils/media-utils";
@@ -276,10 +276,12 @@ async function loadGLTF(src, contentType, preferredTechnique, onProgress) {
     // GLTFLoader sets matrixAutoUpdate on animated objects, we want to keep the defaults
     object.matrixAutoUpdate = THREE.Object3D.DefaultMatrixAutoUpdate;
 
-    forEachMaterial(object, material => {
+    object.material = mapMaterials(object, material => {
       if (material.isMeshStandardMaterial && preferredTechnique === "KHR_materials_unlit") {
-        object.material = MobileStandardMaterial.fromStandardMaterial(object.material);
+        return MobileStandardMaterial.fromStandardMaterial(material);
       }
+
+      return material;
     });
   });
 

--- a/src/materials/MobileStandardMaterial.js
+++ b/src/materials/MobileStandardMaterial.js
@@ -95,7 +95,8 @@ export default class MobileStandardMaterial extends THREE.ShaderMaterial {
       opacity: material.opacity,
       transparent: material.transparent,
       skinning: material.skinning,
-      morphTargets: material.morphTargets
+      morphTargets: material.morphTargets,
+      vertexColors: material.vertexColors
     };
 
     const mobileMaterial = new MobileStandardMaterial(parameters);


### PR DESCRIPTION
Google Poly models and any models that used vertex colors or multi-materials were broken on low quality mode. This caused these models to render white.

We now copy the `vertexColors` property in `MobileStandardMaterial.fromStandardMaterial` and use the `mapMaterials` utility method rather than the `forEachMaterial` method when replacing the standard material on low quality.

Fixes #673