### PR TITLE
Disable frustum culling on the avatar

### DIFF
--- a/src/components/disable-frustum-culling.js
+++ b/src/components/disable-frustum-culling.js
@@ -1,0 +1,5 @@
+AFRAME.registerComponent("disable-frustum-culling", {
+  init() {
+    this.el.object3D.traverse(o => (o.frustumCulled = false));
+  }
+});

--- a/src/hub.html
+++ b/src/hub.html
@@ -710,6 +710,7 @@
                 <template data-name="AvatarRoot">
                     <a-entity
                         ik-controller="alwaysUpdate: true"
+                        disable-frustum-culling
                         hand-pose__left
                         hand-pose__right
                         hand-pose-controller__left="networkedAvatar:#player-rig;eventSrc:#player-left-controller"

--- a/src/hub.js
+++ b/src/hub.js
@@ -83,6 +83,7 @@ import "./components/open-media-button";
 import "./components/rotate-object-button";
 import "./components/hover-menu";
 import "./components/animation";
+import "./components/disable-frustum-culling";
 
 import ReactDOM from "react-dom";
 import React from "react";


### PR DESCRIPTION
For some still unknown reason it is now easy to accidentally get the avatar body to intersect the near clipping plane of the camera frustum, which results in the entire avatar being clipped out. This PR changes things so that the player's avatar is never subject to frustum culling.