### PR TITLE
Feature/content search last search restore

### DIFF
--- a/src/assets/stylesheets/media-browser.scss
+++ b/src/assets/stylesheets/media-browser.scss
@@ -323,6 +323,7 @@
           width: 100%;
 
           img {
+            background-color: $light-grey;
             border-radius: 12px;
             width: 100%;
             height: 100%;

--- a/src/assets/stylesheets/media-browser.scss
+++ b/src/assets/stylesheets/media-browser.scss
@@ -122,6 +122,7 @@
     display: flex;
     align-items: flex-start;
     width: 100vw;
+    max-width: 1720px;
     margin: 32px;
     margin-bottom: 24px;
     height: 77px;
@@ -129,6 +130,7 @@
 
   :local(.nav) {
     width: 100vw;
+    max-width: 1720px;
     display: flex;
     position: relative;
     min-height: 38px;
@@ -181,6 +183,7 @@
 
   :local(.facets) {
     width: 100vw;
+    max-width: 1720px;
     display: flex;
     position: relative;
     height: 44px;
@@ -240,6 +243,7 @@
 
   :local(.body) {
     width: 100vw;
+    max-width: 1720px;
 
     :local(.tiles) {
       margin: 8px 8px 24px 8px;

--- a/src/message-dispatch.js
+++ b/src/message-dispatch.js
@@ -81,7 +81,7 @@ export default class MessageDispatch {
             this.addToPresenceLog({ type: "log", body: "You do not have permission to change the scene." });
           }
         } else {
-          this.mediaSearchStore.sourceNavigate("scenes");
+          this.mediaSearchStore.sourceNavigateWithNoNav("scenes");
         }
 
         break;

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -125,12 +125,8 @@ class MediaBrowser extends Component {
       clearTimeout(this._sendQueryTimeout);
     }
 
-    const lastQuery = query;
-
     // Don't update search on every keystroke, but buffer for some ms.
     this._sendQueryTimeout = setTimeout(() => {
-      if (query !== lastQuery) return;
-
       // Drop filter for now, so entering text drops into "search all" mode
       this.props.mediaSearchStore.filterQueryNavigate("", query);
     }, 500);

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -125,8 +125,12 @@ class MediaBrowser extends Component {
       clearTimeout(this._sendQueryTimeout);
     }
 
+    const lastQuery = query;
+
     // Don't update search on every keystroke, but buffer for some ms.
     this._sendQueryTimeout = setTimeout(() => {
+      if (query !== lastQuery) return;
+
       // Drop filter for now, so entering text drops into "search all" mode
       this.props.mediaSearchStore.filterQueryNavigate("", query);
     }, 500);
@@ -145,7 +149,7 @@ class MediaBrowser extends Component {
   };
 
   handleFacetClicked = facet => {
-    const searchParams = this.getSearchClearedSearchParams();
+    const searchParams = this.getSearchClearedSearchParams(true);
 
     for (const [k, v] of Object.entries(facet.params)) {
       searchParams.set(k, v);
@@ -154,8 +158,8 @@ class MediaBrowser extends Component {
     pushHistoryPath(this.props.history, this.props.history.location.pathname, searchParams.toString());
   };
 
-  getSearchClearedSearchParams = () => {
-    return this.props.mediaSearchStore.getSearchClearedSearchParams(this.props.history.location);
+  getSearchClearedSearchParams = keepSource => {
+    return this.props.mediaSearchStore.getSearchClearedSearchParams(this.props.history.location, keepSource);
   };
 
   pushExitMediaBrowserHistory = () => {

--- a/src/react-components/settings-menu.js
+++ b/src/react-components/settings-menu.js
@@ -60,7 +60,7 @@ export default class SettingsMenu extends Component {
                 <div className={styles.listItem}>
                   <div
                     className={styles.listItemLink}
-                    onClick={() => this.props.mediaSearchStore.sourceNavigate("scenes", true)}
+                    onClick={() => this.props.mediaSearchStore.sourceNavigateWithNoNav("scenes")}
                   >
                     <FormattedMessage id="settings.change-scene" />
                   </div>

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -984,7 +984,7 @@ class UIRoot extends Component {
             <WithHoverSound>
               <div
                 className={entryStyles.chooseScene}
-                onClick={() => this.props.mediaSearchStore.sourceNavigate("scenes", true)}
+                onClick={() => this.props.mediaSearchStore.sourceNavigateWithNoNav("scenes")}
               >
                 <i>
                   <FontAwesomeIcon icon={faImage} />

--- a/src/storage/media-search-store.js
+++ b/src/storage/media-search-store.js
@@ -136,7 +136,6 @@ export default class MediaSearchStore extends EventTarget {
     this._stashedParams = {};
     this._stashedSource = this.getUrlMediaSource(location);
 
-    // Strip browsing query params
     for (const param of SEARCH_CONTEXT_PARAMS) {
       const value = searchParams.get(param);
 
@@ -147,11 +146,7 @@ export default class MediaSearchStore extends EventTarget {
   };
 
   sourceNavigateToDefaultSource = () => {
-    this.sourceNavigate(
-      this._stashedSource ? this._stashedSource : SOURCES[0],
-      false,
-      true
-    );
+    this.sourceNavigate(this._stashedSource ? this._stashedSource : SOURCES[0], false, true);
   };
 
   sourceNavigate = (source, hideNav, useLastStashedParams) => {

--- a/src/storage/media-search-store.js
+++ b/src/storage/media-search-store.js
@@ -131,7 +131,7 @@ export default class MediaSearchStore extends EventTarget {
     return searchParams;
   };
 
-  stashLastSearchParams = location => {
+  _stashLastSearchParams = location => {
     const searchParams = new URLSearchParams(location.search);
     this._stashedParams = {};
     this._stashedSource = this.getUrlMediaSource(location);
@@ -145,11 +145,19 @@ export default class MediaSearchStore extends EventTarget {
     }
   };
 
-  sourceNavigateToDefaultSource = () => {
-    this.sourceNavigate(this._stashedSource ? this._stashedSource : SOURCES[0], false, true);
+  sourceNavigate = source => {
+    this._sourceNavigate(source, false, true);
   };
 
-  sourceNavigate = (source, hideNav, useLastStashedParams) => {
+  sourceNavigateToDefaultSource = () => {
+    this._sourceNavigate(this._stashedSource ? this._stashedSource : SOURCES[0], false, true);
+  };
+
+  sourceNavigateWithNoNav = source => {
+    this._sourceNavigate(source, true, false);
+  };
+
+  _sourceNavigate = (source, hideNav, useLastStashedParams) => {
     const currentQuery = new URLSearchParams(this.history.location.search).get("q");
     const searchParams = this.getSearchClearedSearchParams(this.history.location);
 
@@ -201,7 +209,7 @@ export default class MediaSearchStore extends EventTarget {
   pushExitMediaBrowserHistory = history => {
     if (!history) history = this.history;
 
-    this.stashLastSearchParams(history.location);
+    this._stashLastSearchParams(history.location);
 
     const { pathname } = history.location;
     const hasMediaPath = sluglessPath(history.location).startsWith("/media");

--- a/src/storage/media-search-store.js
+++ b/src/storage/media-search-store.js
@@ -20,6 +20,8 @@ export const MEDIA_SOURCE_DEFAULT_FILTERS = {
   scenes: "featured"
 };
 
+const SEARCH_CONTEXT_PARAMS = ["q", "filter", "cursor"];
+
 // This class is responsible for fetching and storing media search results and provides a
 // convenience API for performing history updates relevant to search navigation.
 export default class MediaSearchStore extends EventTarget {
@@ -57,7 +59,7 @@ export default class MediaSearchStore extends EventTarget {
     const currentRequestIndex = this.requestIndex;
     const searchParams = new URLSearchParams();
 
-    for (const param of ["q", "filter", "cursor"]) {
+    for (const param of SEARCH_CONTEXT_PARAMS) {
       if (!urlParams.get(param)) continue;
       searchParams.set(param, urlParams.get(param));
     }
@@ -113,32 +115,72 @@ export default class MediaSearchStore extends EventTarget {
     pushHistoryPath(this.history, location.pathname, searchParams.toString());
   };
 
-  getSearchClearedSearchParams = location => {
+  getSearchClearedSearchParams = (location, keepSource) => {
     const searchParams = new URLSearchParams(location.search);
 
     // Strip browsing query params
     searchParams.delete("q");
     searchParams.delete("filter");
     searchParams.delete("cursor");
-    searchParams.delete("media_source");
     searchParams.delete("media_nav");
+
+    if (!keepSource) {
+      searchParams.delete("media_source");
+    }
 
     return searchParams;
   };
 
-  sourceNavigateToDefaultSource = () => {
-    this.sourceNavigate(SOURCES[0]);
+  stashLastSearchParams = location => {
+    const searchParams = new URLSearchParams(location.search);
+    this._stashedParams = {};
+    this._stashedSource = this.getUrlMediaSource(location);
+
+    // Strip browsing query params
+    for (const param of SEARCH_CONTEXT_PARAMS) {
+      const value = searchParams.get(param);
+
+      if (value) {
+        this._stashedParams[param] = value;
+      }
+    }
   };
 
-  sourceNavigate = (source, hideNav) => {
+  sourceNavigateToDefaultSource = () => {
+    this.sourceNavigate(
+      this._stashedSource ? this._stashedSource : SOURCES[0],
+      false,
+      true
+    );
+  };
+
+  sourceNavigate = (source, hideNav, useLastStashedParams) => {
     const currentQuery = new URLSearchParams(this.history.location.search).get("q");
     const searchParams = this.getSearchClearedSearchParams(this.history.location);
 
     if (currentQuery) {
       searchParams.set("q", currentQuery);
-    } else if (MEDIA_SOURCE_DEFAULT_FILTERS[source]) {
-      searchParams.set("filter", MEDIA_SOURCE_DEFAULT_FILTERS[source]);
+    } else {
+      if (useLastStashedParams && this._stashedParams) {
+        for (const param of SEARCH_CONTEXT_PARAMS) {
+          const value = this._stashedParams[param];
+
+          // Only q param is compatible across sources, so keep it if is stashed.
+          const useValue = param === "q" || this._stashedSource === source;
+
+          if (value && useValue) {
+            searchParams.set(param, value);
+          }
+        }
+      } else {
+        if (MEDIA_SOURCE_DEFAULT_FILTERS[source]) {
+          searchParams.set("filter", MEDIA_SOURCE_DEFAULT_FILTERS[source]);
+        }
+      }
     }
+
+    this._stashedParams = {};
+    this._stashedSource = null;
 
     if (hideNav) {
       searchParams.set("media_nav", "false");
@@ -163,6 +205,8 @@ export default class MediaSearchStore extends EventTarget {
 
   pushExitMediaBrowserHistory = history => {
     if (!history) history = this.history;
+
+    this.stashLastSearchParams(history.location);
 
     const { pathname } = history.location;
     const hasMediaPath = sluglessPath(history.location).startsWith("/media");

--- a/src/systems/ui-hotkeys.js
+++ b/src/systems/ui-hotkeys.js
@@ -26,7 +26,7 @@ AFRAME.registerSystem("ui-hotkeys", {
 
     for (let i = 1; i <= 7; i++) {
       if (this.userinput.get(`/actions/mediaSearch${i}`)) {
-        this.mediaSearchStore.sourceNavigate(SOURCES[i - 1], false, true);
+        this.mediaSearchStore.sourceNavigate(SOURCES[i - 1]);
       }
     }
   },

--- a/src/systems/ui-hotkeys.js
+++ b/src/systems/ui-hotkeys.js
@@ -26,7 +26,7 @@ AFRAME.registerSystem("ui-hotkeys", {
 
     for (let i = 1; i <= 7; i++) {
       if (this.userinput.get(`/actions/mediaSearch${i}`)) {
-        this.mediaSearchStore.sourceNavigate(SOURCES[i - 1]);
+        this.mediaSearchStore.sourceNavigate(SOURCES[i - 1], false, true);
       }
     }
   },


### PR DESCRIPTION
This PR introduces a "stash" of the previous query/page/filter from the media browser, so if you re-open it, it picks up where you last left off. (And if you switch to another tab using the hotkeys, it retains the query.)