### PR TITLE
Feature/content search tile links

### DIFF
--- a/src/assets/stylesheets/media-browser.scss
+++ b/src/assets/stylesheets/media-browser.scss
@@ -270,6 +270,9 @@
             text-overflow: ellipsis;
             overflow: hidden;
             white-space: nowrap;
+            color: black;
+            text-decoration: none;
+            display: block;
           }
 
           :local(.attribution) {

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -138,6 +138,7 @@ class MediaBrowser extends Component {
     if (!this.props.onMediaSearchResultEntrySelected) return;
     this.props.onMediaSearchResultEntrySelected(entry);
     this.close();
+    return false;
   };
 
   handleSourceClicked = source => {
@@ -342,18 +343,27 @@ class MediaBrowser extends Component {
 
     return (
       <div style={{ width: `${imageWidth}px` }} className={styles.tile} key={`${entry.id}_${idx}`}>
-        <div
+        <a
+          href={entry.url}
+          target="_blank"
+          rel="noreferrer noopener"
           onClick={() => this.handleEntryClicked(entry)}
           className={styles.image}
           style={{ width: `${imageWidth}px`, height: `${imageHeight}px` }}
         >
           <img src={scaledThumbnailUrlFor(imageSrc, imageWidth, imageHeight)} />
-        </div>
+        </a>
         {!entry.type.endsWith("_image") && (
           <div className={styles.info}>
-            <div className={styles.name} onClick={() => this.handleEntryClicked(entry)}>
+            <a
+              href={entry.url}
+              target="_blank"
+              rel="noreferrer noopener"
+              className={styles.name}
+              onClick={() => this.handleEntryClicked(entry)}
+            >
               {entry.name}
-            </div>
+            </a>
             <div className={styles.attribution}>
               <div className={styles.creator}>
                 {creator && !creator.name && <span>{creator}</span>}

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -134,11 +134,11 @@ class MediaBrowser extends Component {
     this.setState({ query });
   };
 
-  handleEntryClicked = entry => {
+  handleEntryClicked = (evt, entry) => {
     if (!this.props.onMediaSearchResultEntrySelected) return;
     this.props.onMediaSearchResultEntrySelected(entry);
     this.close();
-    return false;
+    evt.preventDefault();
   };
 
   handleSourceClicked = source => {
@@ -216,7 +216,7 @@ class MediaBrowser extends Component {
                   onKeyDown={e => {
                     if (e.key === "Enter" && e.shiftKey) {
                       if (this.state.result && this.state.result.entries.length > 0) {
-                        this.handleEntryClicked(this.state.result.entries[0]);
+                        this.handleEntryClicked(e, this.state.result.entries[0]);
                       }
                     } else if (e.key === "Escape" || e.key === "Enter") {
                       e.target.blur();
@@ -347,7 +347,7 @@ class MediaBrowser extends Component {
           href={entry.url}
           target="_blank"
           rel="noreferrer noopener"
-          onClick={() => this.handleEntryClicked(entry)}
+          onClick={e => this.handleEntryClicked(e, entry)}
           className={styles.image}
           style={{ width: `${imageWidth}px`, height: `${imageHeight}px` }}
         >
@@ -360,7 +360,7 @@ class MediaBrowser extends Component {
               target="_blank"
               rel="noreferrer noopener"
               className={styles.name}
-              onClick={() => this.handleEntryClicked(entry)}
+              onClick={e => this.handleEntryClicked(e, entry)}
             >
               {entry.name}
             </a>

--- a/src/systems/userinput/devices/mouse.js
+++ b/src/systems/userinput/devices/mouse.js
@@ -7,6 +7,18 @@ const modeMod = {
   [WheelEvent.DOM_DELTA_PAGE]: 2
 };
 
+const isInModal = (() => {
+  let uiRoot = null;
+
+  return function() {
+    if (!uiRoot) {
+      uiRoot = document.querySelector(".ui-root");
+    }
+
+    return uiRoot && uiRoot.classList.contains("in-modal-or-overlay");
+  };
+})();
+
 export class MouseDevice {
   constructor() {
     this.events = [];
@@ -21,15 +33,9 @@ export class MouseDevice {
     ["mousedown", "wheel"].map(x => canvas.addEventListener(x, queueEvent));
     ["mousemove", "mouseup"].map(x => window.addEventListener(x, queueEvent));
 
-    let uiRoot = null;
-
     document.addEventListener("wheel", e => {
-      if (!uiRoot) {
-        uiRoot = document.querySelector(".ui-root");
-      }
-
       // Do not capture wheel events if they are being sent to an modal/overlay
-      if (uiRoot && !uiRoot.classList.contains("in-modal-or-overlay")) {
+      if (!isInModal()) {
         e.preventDefault();
       }
     });
@@ -77,6 +83,8 @@ export class MouseDevice {
   }
 }
 
-window.oncontextmenu = e => {
-  e.preventDefault();
+window.oncontextmenu = () => {
+  if (!isInModal()) {
+    e.preventDefault();
+  }
 };

--- a/src/systems/userinput/devices/mouse.js
+++ b/src/systems/userinput/devices/mouse.js
@@ -83,7 +83,7 @@ export class MouseDevice {
   }
 }
 
-window.oncontextmenu = (e) => {
+window.oncontextmenu = e => {
   if (!isInModal()) {
     e.preventDefault();
   }

--- a/src/systems/userinput/devices/mouse.js
+++ b/src/systems/userinput/devices/mouse.js
@@ -83,7 +83,7 @@ export class MouseDevice {
   }
 }
 
-window.oncontextmenu = () => {
+window.oncontextmenu = (e) => {
   if (!isInModal()) {
     e.preventDefault();
   }


### PR DESCRIPTION
This PR updates the media browser to use actual links in the tiles, so you can right click and get the underlying URL or open it in a new tab to preview it.