### PR TITLE
Upgrade AFrame with configurable alpha property on renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3262,9 +3262,9 @@
       }
     },
     "acorn": {
-      "version": "5.7.1",
-      "resolved": "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz",
-      "integrity": "sha1-8JWCkpdwanyXdpWMCvyJMKm52dg="
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
     },
     "acorn-dynamic-import": {
       "version": "4.0.0",
@@ -3279,13 +3279,13 @@
       "dev": true
     },
     "aframe": {
-      "version": "github:mozillareality/aframe#ccbf0a6a5b6ae02bd94dd49578e0995022a03a58",
-      "from": "github:mozillareality/aframe#ccbf0a6a5b6ae02bd94dd49578e0995022a03a58",
+      "version": "github:mozillareality/aframe#78ffa6c68e0cb59a9bb79b321e75f6e878c2d320",
+      "from": "github:mozillareality/aframe#78ffa6c68e0cb59a9bb79b321e75f6e878c2d320",
       "requires": {
         "animejs": "^2.2.0",
         "browserify-css": "^0.8.4",
         "custom-event-polyfill": "^1.0.6",
-        "debug": "github:ngokevin/debug#noTimestamp",
+        "debug": "github:ngokevin/debug#ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a",
         "deep-assign": "^2.0.0",
         "document-register-element": "github:dmarcos/document-register-element#8ccc532b7f3744be954574caf3072a5fd260ca90",
         "envify": "^3.4.1",
@@ -3294,6 +3294,7 @@
         "present": "0.0.6",
         "promise-polyfill": "^3.1.0",
         "style-attr": "^1.0.2",
+        "super-animejs": "^3.0.0",
         "three-bmfont-text": "^2.1.0",
         "webvr-polyfill": "^0.10.10"
       },
@@ -3362,7 +3363,7 @@
       "version": "github:mozillareality/aframe-physics-system#93b1dfe64c00587a9d09e1a8071750e75f340815",
       "from": "github:mozillareality/aframe-physics-system#93b1dfe64c00587a9d09e1a8071750e75f340815",
       "requires": {
-        "cannon": "cannon@github:donmccurdy/cannon.js#022e8ba53fa83abf0ad8a0e4fd08623123838a17",
+        "cannon": "github:donmccurdy/cannon.js#022e8ba53fa83abf0ad8a0e4fd08623123838a17",
         "three-to-cannon": "^1.3.0",
         "webworkify": "^1.4.0"
       }
@@ -5496,16 +5497,6 @@
         "recast": "^0.11.17"
       },
       "dependencies": {
-        "ast-types": {
-          "version": "0.9.6",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
-          "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
-        },
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-        },
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
@@ -5516,17 +5507,6 @@
             "minimatch": "2 || 3",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
-          }
-        },
-        "recast": {
-          "version": "0.11.23",
-          "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-          "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-          "requires": {
-            "ast-types": "0.9.6",
-            "esprima": "~3.1.0",
-            "private": "~0.1.5",
-            "source-map": "~0.5.0"
           }
         }
       }
@@ -6165,7 +6145,7 @@
     },
     "decompress-response": {
       "version": "3.3.0",
-      "resolved": "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
         "mimic-response": "^1.0.0"
@@ -6242,7 +6222,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true,
       "requires": {
         "foreach": "^2.0.5",
         "object-keys": "^1.0.8"
@@ -6928,7 +6907,6 @@
       "version": "1.12.0",
       "resolved": "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz",
       "integrity": "sha1-nbvdJ8aFbwABQhyhh4LXhr+KYWU=",
-      "dev": true,
       "requires": {
         "es-to-primitive": "^1.1.1",
         "function-bind": "^1.1.1",
@@ -6941,7 +6919,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.1",
         "is-date-object": "^1.0.1",
@@ -7508,8 +7485,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "expand-braces": {
       "version": "0.1.2",
@@ -8180,8 +8156,7 @@
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -8275,8 +8250,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8294,13 +8268,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8313,18 +8285,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8427,8 +8396,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8438,7 +8406,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8451,20 +8418,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -8481,7 +8445,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8554,8 +8517,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8565,7 +8527,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8641,8 +8602,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8672,7 +8632,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8690,7 +8649,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8729,13 +8687,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -8784,8 +8740,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
-      "dev": true
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -9157,7 +9112,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz",
       "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -10108,8 +10062,7 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-decimal": {
       "version": "1.0.2",
@@ -10323,7 +10276,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -10354,8 +10306,7 @@
     "is-symbol": {
       "version": "1.0.1",
       "resolved": "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-      "dev": true
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -11707,8 +11658,8 @@
     },
     "mimic-response": {
       "version": "1.0.1",
-      "resolved": "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs="
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "min-document": {
       "version": "2.19.0",
@@ -12421,8 +12372,7 @@
     "object-keys": {
       "version": "1.0.12",
       "resolved": "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz",
-      "integrity": "sha1-CcU4VTd1dTEMymL1W7M0q/97PtI=",
-      "dev": true
+      "integrity": "sha1-CcU4VTd1dTEMymL1W7M0q/97PtI="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -12972,12 +12922,12 @@
       }
     },
     "parse-headers": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
-      "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.2.tgz",
+      "integrity": "sha512-/LypJhzFmyBIDYP9aDVgeyEb5sQfbfY5mnDq4hVhlQ69js87wXfmEI5V3xI6vvXasqebp0oCytYFLxsBVfCzSg==",
       "requires": {
-        "for-each": "^0.3.2",
-        "trim": "0.0.1"
+        "for-each": "^0.3.3",
+        "string.prototype.trim": "^1.1.2"
       }
     },
     "parse-json": {
@@ -14609,6 +14559,29 @@
         "minimatch": "^3.0.2",
         "readable-stream": "^2.0.2",
         "set-immediate-shim": "^1.0.1"
+      }
+    },
+    "recast": {
+      "version": "0.11.23",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+      "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+      "requires": {
+        "ast-types": "0.9.6",
+        "esprima": "~3.1.0",
+        "private": "~0.1.5",
+        "source-map": "~0.5.0"
+      },
+      "dependencies": {
+        "ast-types": {
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+          "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
+        },
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+        }
       }
     },
     "rechoir": {
@@ -16742,7 +16715,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.5.0",
@@ -17330,6 +17302,11 @@
           }
         }
       }
+    },
+    "super-animejs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/super-animejs/-/super-animejs-3.0.0.tgz",
+      "integrity": "sha512-sU+zS5zBFIfiZLswckLAiTV1wuWAm3O34sC1SfwFiHv8zVkpzGmntjwjwq6JUd34x/6vSset7gWZRmBiWkrLUA=="
     },
     "super-hands": {
       "version": "github:mozillareality/aframe-super-hands-component#68d022fd24c6c986ec3af09a3e88b75323e9803f",
@@ -17991,7 +17968,8 @@
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "dev": true
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -19164,9 +19142,9 @@
       }
     },
     "webvr-polyfill-dpdb": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/webvr-polyfill-dpdb/-/webvr-polyfill-dpdb-1.0.14.tgz",
-      "integrity": "sha512-/B26Cn0DNvJm6VsqBuanASWCp/aYpLpmQUy+x/5BAEEpBWWCZfjfbXAba4d8CYqeIlRGFXUIuRDycGcf5HR1Tg=="
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/webvr-polyfill-dpdb/-/webvr-polyfill-dpdb-1.0.15.tgz",
+      "integrity": "sha512-EfjKbmt9n0WCSrTZgvL76IEjMl5yaZ8kZIlgWZnRJzmuKSMB0lrzZzlCJC5AtDizGnpWXlVn9UtAEgVd2nAIjA=="
     },
     "webworkify": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.2",
     "@fortawesome/free-solid-svg-icons": "^5.2.0",
     "@fortawesome/react-fontawesome": "^0.1.0",
-    "aframe": "github:mozillareality/aframe#ccbf0a6a5b6ae02bd94dd49578e0995022a03a58",
+    "aframe": "github:mozillareality/aframe#78ffa6c68e0cb59a9bb79b321e75f6e878c2d320",
     "aframe-billboard-component": "^2.0.0",
     "aframe-inspector": "^0.8.3",
     "aframe-motion-capture-components": "github:mozillareality/aframe-motion-capture-components#aframe090",

--- a/src/avatar-selector.js
+++ b/src/avatar-selector.js
@@ -34,7 +34,7 @@ function getHashArg(arg) {
 
 window.APP = new App();
 window.APP.quality =
-  getHashArg("quality") || (AFRAME.utils.device.isMobile() || AFRAME.utils.device.isOculusGo()) ? "low" : "high";
+  getHashArg("quality") || (AFRAME.utils.device.isMobile() || AFRAME.utils.device.isMobileVR()) ? "low" : "high";
 
 function postAvatarIdToParent(newAvatarId) {
   window.parent.postMessage({ avatarId: newAvatarId }, location.origin);

--- a/src/components/water.js
+++ b/src/components/water.js
@@ -172,7 +172,7 @@ AFRAME.registerComponent("water", {
       fog: false
     };
 
-    if (AFRAME.utils.device.isMobile() || AFRAME.utils.device.isOculusGo() || this.data.forceMobile) {
+    if (AFRAME.utils.device.isMobile() || AFRAME.utils.device.isMobileVR() || this.data.forceMobile) {
       this.water = new MobileWater(waterGeometry, waterConfig);
     } else {
       this.water = new THREE.Water(waterGeometry, waterConfig);

--- a/src/hub.html
+++ b/src/hub.html
@@ -31,7 +31,7 @@
     <a-scene
         nextframe
         class="grab-cursor"
-        renderer="antialias: true; colorManagement: true; sortObjects: true; physicallyCorrectLights: true; alpha: true;"
+        renderer="antialias: true; colorManagement: true; sortObjects: true; physicallyCorrectLights: true; alpha: false;"
         shadow="type: pcfsoft"
         networked-scene="adapter: janus; audio: true; debug: true; connectOnLoad: false;"
         physics="gravity: -6; debug: false;"

--- a/src/hub.html
+++ b/src/hub.html
@@ -31,7 +31,7 @@
     <a-scene
         nextframe
         class="grab-cursor"
-        renderer="antialias: true; colorManagement: true; sortObjects: true; physicallyCorrectLights: true;"
+        renderer="antialias: true; colorManagement: true; sortObjects: true; physicallyCorrectLights: true; alpha: true;"
         shadow="type: pcfsoft"
         networked-scene="adapter: janus; audio: true; debug: true; connectOnLoad: false;"
         physics="gravity: -6; debug: false;"

--- a/src/hub.js
+++ b/src/hub.js
@@ -127,7 +127,7 @@ const store = window.APP.store;
 const mediaSearchStore = window.APP.mediaSearchStore;
 
 const qs = new URLSearchParams(location.search);
-const isMobile = AFRAME.utils.device.isMobile() || AFRAME.utils.device.isOculusGo();
+const isMobile = AFRAME.utils.device.isMobile() || AFRAME.utils.device.isMobileVR();
 
 THREE.Object3D.DefaultMatrixAutoUpdate = false;
 window.APP.quality = qs.get("quality") || isMobile ? "low" : "high";

--- a/src/react-components/2d-hud.js
+++ b/src/react-components/2d-hud.js
@@ -50,7 +50,7 @@ class TopHUD extends Component {
   };
 
   buildVideoSharingButtons = () => {
-    const isMobile = AFRAME.utils.device.isMobile() || AFRAME.utils.device.isOculusGo();
+    const isMobile = AFRAME.utils.device.isMobile() || AFRAME.utils.device.isMobileVR();
 
     const videoShareExtraOptionTypes = [];
     const primaryVideoShareType =

--- a/src/react-components/chat-message.js
+++ b/src/react-components/chat-message.js
@@ -137,7 +137,7 @@ function renderChatMessage(body, from, allowEmojiRender, lowResolution) {
 export async function createInWorldLogMessage({ name, type, body }) {
   if (type !== "chat") return;
 
-  const lowResolution = AFRAME.utils.device.isMobile() || AFRAME.utils.device.isOculusGo();
+  const lowResolution = AFRAME.utils.device.isMobile() || AFRAME.utils.device.isMobileVR();
   const blob = await renderChatMessage(body, name, false, lowResolution);
   const entity = document.createElement("a-entity");
   const meshEntity = document.createElement("a-entity");

--- a/src/react-components/create-object-dialog.js
+++ b/src/react-components/create-object-dialog.js
@@ -16,7 +16,7 @@ const attributionHostnames = {
 };
 
 const DEFAULT_OBJECT_URL = "https://asset-bundles-prod.reticulum.io/interactables/Ducky/DuckyMesh-438ff8e022.gltf";
-const isMobile = AFRAME.utils.device.isMobile() || AFRAME.utils.device.isOculusGo();
+const isMobile = AFRAME.utils.device.isMobile() || AFRAME.utils.device.isMobileVR();
 const instructions = "Paste a URL to an image, video, model, scene, or upload.";
 const desktopTips = "Tip: You can paste media directly into Hubs with Ctrl+V";
 const references = (

--- a/src/react-components/entry-buttons.js
+++ b/src/react-components/entry-buttons.js
@@ -50,7 +50,7 @@ EntryButton.propTypes = {
   isInHMD: PropTypes.bool
 };
 
-const isMobile = AFRAME.utils.device.isMobile() || AFRAME.utils.device.isOculusGo();
+const isMobile = AFRAME.utils.device.isMobile() || AFRAME.utils.device.isMobileVR();
 
 export const TwoDEntryButton = props => {
   const entryButtonProps = {

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -664,7 +664,7 @@ class UIRoot extends Component {
   };
 
   shouldShowHmdMicWarning = () => {
-    if (isMobile || AFRAME.utils.device.isOculusGo()) return false;
+    if (isMobile || AFRAME.utils.device.isMobileVR()) return false;
     if (!this.state.enterInVR) return false;
     if (!this.hasHmdMicrophone()) return false;
 
@@ -694,7 +694,7 @@ class UIRoot extends Component {
   shouldShowFullScreen = () => {
     // Disable full screen on iOS, since Safari's fullscreen mode does not let you prevent native pinch-to-zoom gestures.
     return (
-      (isMobile || AFRAME.utils.device.isOculusGo()) &&
+      (isMobile || AFRAME.utils.device.isMobileVR()) &&
       !AFRAME.utils.device.isIOS() &&
       !this.state.enterInVR &&
       screenfull.enabled
@@ -1170,7 +1170,7 @@ class UIRoot extends Component {
     const micClip = {
       clip: `rect(${maxLevelHeight - Math.floor(this.state.micLevel * maxLevelHeight)}px, 111px, 111px, 0px)`
     };
-    const isMobileOrGo = isMobile || AFRAME.utils.device.isOculusGo();
+    const isMobileOrGo = isMobile || AFRAME.utils.device.isMobileVR();
     const speakerClip = { clip: `rect(${this.state.tonePlaying ? 0 : maxLevelHeight}px, 111px, 111px, 0px)` };
     const subtitleId = isMobileOrGo ? "audio.subtitle-mobile" : "audio.subtitle-desktop";
     return (

--- a/src/scene.js
+++ b/src/scene.js
@@ -28,7 +28,7 @@ import { App } from "./App";
 window.APP = new App();
 
 const qs = new URLSearchParams(location.search);
-const isMobile = AFRAME.utils.device.isMobile() || AFRAME.utils.device.isOculusGo();
+const isMobile = AFRAME.utils.device.isMobile() || AFRAME.utils.device.isMobileVR();
 
 window.APP.quality = qs.get("quality") || isMobile ? "low" : "high";
 

--- a/src/systems/camera-mirror.js
+++ b/src/systems/camera-mirror.js
@@ -17,7 +17,7 @@ AFRAME.registerSystem("camera-mirror", {
   // Adds a camera under el, and starts mirroring
   mirrorCameraAtEl(el) {
     // TODO probably should explicitly check for immersive mode here.
-    if (AFRAME.utils.device.isMobile() || AFRAME.utils.device.isOculusGo()) return;
+    if (AFRAME.utils.device.isMobile() || AFRAME.utils.device.isMobileVR()) return;
     if (this.mirrorEl && this.mirrorEl !== el) this.unmirrorCameraAtEl(this.mirrorEl);
 
     this.mirrorEl = el;

--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -172,7 +172,7 @@ AFRAME.registerSystem("userinput", {
     this.xformStates = new Map();
     this.activeDevices = new Set([new HudDevice()]);
 
-    if (!(AFRAME.utils.device.isMobile() || AFRAME.utils.device.isOculusGo())) {
+    if (!(AFRAME.utils.device.isMobile() || AFRAME.utils.device.isMobileVR())) {
       this.activeDevices.add(new MouseDevice());
       this.activeDevices.add(new AppAwareMouseDevice());
       this.activeDevices.add(new KeyboardDevice());

--- a/src/utils/fullscreen.js
+++ b/src/utils/fullscreen.js
@@ -5,7 +5,7 @@ let hasEnteredFullScreenThisSession = false;
 function shouldShowFullScreen() {
   // Disable full screen on iOS, since Safari's fullscreen mode does not let you prevent native pinch-to-zoom gestures.
   return (
-    (AFRAME.utils.device.isMobile() || AFRAME.utils.device.isOculusGo()) &&
+    (AFRAME.utils.device.isMobile() || AFRAME.utils.device.isMobileVR()) &&
     !AFRAME.utils.device.isIOS() &&
     screenfull.enabled
   );


### PR DESCRIPTION
This PR fixes the transparent "vampire cat" bug we saw by allowing the alpha flag to be disabled on the WebGLRendering context and making the backbuffer opaque. Thanks to @daoshengmu and @netpro2k for all the help!

This change is explained in more detail here: https://github.com/aframevr/aframe/pull/4041

Fixes https://github.com/mozilla/hubs/issues/733