### PR TITLE
Don't show the dropdown if you only have one mic.

### DIFF
--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1251,23 +1251,21 @@ class UIRoot extends Component {
               </div>
             </WithHoverSound>
           </div>
-          {this.state.audioTrack && (
+          {this.state.audioTrack && this.state.micDevices.length > 1 ? (
             <div className="audio-setup-panel__device-chooser">
               <WithHoverSound>
-                {
-                  <select
-                    className="audio-setup-panel__device-chooser__dropdown"
-                    value={this.selectedMicDeviceId()}
-                    onChange={this.micDeviceChanged}
-                  >
-                    {this.state.micDevices.map(d => (
-                      <option key={d.deviceId} value={d.deviceId}>
-                        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-                        {d.label}
-                      </option>
-                    ))}
-                  </select>
-                }
+                <select
+                  className="audio-setup-panel__device-chooser__dropdown"
+                  value={this.selectedMicDeviceId()}
+                  onChange={this.micDeviceChanged}
+                >
+                  {this.state.micDevices.map(d => (
+                    <option key={d.deviceId} value={d.deviceId}>
+                      &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                      {d.label}
+                    </option>
+                  ))}
+                </select>
               </WithHoverSound>
               <img
                 className="audio-setup-panel__device-chooser__mic-icon"
@@ -1280,6 +1278,8 @@ class UIRoot extends Component {
                 srcSet="../assets/images/dropdown_arrow@2x.png 2x"
               />
             </div>
+          ) : (
+            <div />
           )}
           {this.shouldShowHmdMicWarning() && (
             <div className="audio-setup-panel__hmd-mic-warning">


### PR DESCRIPTION
I didn't understand the desired intention behind the change in https://github.com/mozilla/hubs/commit/80e7af9a535ac7f1ef6d7e7dbe38d439bc9e8856#diff-706aa9bb80768a301061a401774b665fR1251 which I fixed in https://github.com/mozilla/hubs/pull/960

This does what the original meant to do.