### PR TITLE
fix missing vive controller

### DIFF
--- a/src/systems/userinput/devices/vive-controller.js
+++ b/src/systems/userinput/devices/vive-controller.js
@@ -61,7 +61,6 @@ export class ViveControllerDevice {
     const el = document.querySelector(this.selector);
     if (el.components["tracked-controls"].controller !== this.gamepad) {
       el.components["tracked-controls"].controller = this.gamepad;
-      el.setAttribute("tracked-controls", "controller", this.gamepad.index);
     }
     const rayObject = el.object3D;
     rayObject.updateMatrixWorld();


### PR DESCRIPTION
don't manually set tracked-controls "controller" property as it breaks how controllers are detected in latest aframe. Fixes #922 