### PR TITLE
Deal with default camera issue

### DIFF
--- a/src/components/set-active-camera.js
+++ b/src/components/set-active-camera.js
@@ -5,7 +5,7 @@ AFRAME.registerComponent("set-active-camera", {
     const cameraSystem = this.el.sceneEl.systems.camera;
     const currentActiveCamera = cameraSystem.activeCameraEl;
 
-    if (currentActiveCamera && currentActiveCamera !== this.el) {
+    if (currentActiveCamera !== this.el) {
       cameraSystem.setActiveCamera(this.el);
 
       // Also A-Frame fails to delete the default camera :P

--- a/src/components/set-active-camera.js
+++ b/src/components/set-active-camera.js
@@ -1,0 +1,18 @@
+AFRAME.registerComponent("set-active-camera", {
+  init() {
+    // This is a hack needed to set the active camera because sometimes A-Frame will create the default camera and set it to the active camera on startup because the query selector to find an existing camera in the scene fails.
+
+    const cameraSystem = this.el.sceneEl.systems.camera;
+    const currentActiveCamera = cameraSystem.activeCameraEl;
+
+    if (currentActiveCamera && currentActiveCamera !== this.el) {
+      cameraSystem.setActiveCamera(this.el);
+
+      // Also A-Frame fails to delete the default camera :P
+      currentActiveCamera.parentNode.removeChild(currentActiveCamera);
+
+      // Look controls leaves behind this CSS class.
+      this.el.sceneEl.canvas.classList.remove("a-grab-cursor");
+    }
+  }
+});

--- a/src/hub.html
+++ b/src/hub.html
@@ -620,6 +620,7 @@
                 pitch-yaw-rotator
                 set-yxz-order
                 matrix-auto-update
+                set-active-camera
                 sound__teleport_start="positional: false; src: #sound_asset-teleport_start; on: nothing; poolSize: 2; loop: true;"
                 scene-sound__teleport_start="on: right-teleport_down; off: right-teleport_up;"
                 sound__teleport_start2="positional: false; src: #sound_asset-teleport_start; on: nothing; poolSize: 2; loop: true;"

--- a/src/hub.js
+++ b/src/hub.js
@@ -84,6 +84,7 @@ import "./components/rotate-object-button";
 import "./components/hover-menu";
 import "./components/animation";
 import "./components/disable-frustum-culling";
+import "./components/set-active-camera";
 
 import ReactDOM from "react-dom";
 import React from "react";


### PR DESCRIPTION
This PR deals with a long standing issue where there is a race condition on the A-Frame `camera` system running a `querySelector` for `[camera]` tags in the scene DOM. If there is no such tag, it assumes there is no camera, and so creates its default camera + look controls. In practice, it seems like this query selector can fail in Hubs perhaps due to the complex hierarchy surrounding the `#player-camera` in the DOM, but I'm not sure.

In any case, there doesn't seem to be a way to flip this behavior off or set things up to prevent the default camera from getting injected when it does trigger. So, this PR introduces a component which will properly clean up the default camera if it was injected.