### PR TITLE
Hide mirror and clone buttons on objects where they are not valid

### DIFF
--- a/src/components/clone-media-button.js
+++ b/src/components/clone-media-button.js
@@ -1,10 +1,17 @@
 import { addMedia } from "../utils/media-utils";
 import { ObjectContentOrigins } from "../object-types";
+import { guessContentType } from "../utils/media-utils";
 
 AFRAME.registerComponent("clone-media-button", {
   init() {
     NAF.utils.getNetworkedEntity(this.el).then(networkedEl => {
       this.targetEl = networkedEl;
+
+      const { src } = this.targetEl.components["media-loader"].data;
+
+      if (guessContentType(src) === "video/vnd.hubs-webrtc") {
+        this.el.object3D.visible = false;
+      }
     });
 
     this.onClick = () => {

--- a/src/components/mirror-camera-button.js
+++ b/src/components/mirror-camera-button.js
@@ -23,6 +23,10 @@ AFRAME.registerComponent("mirror-camera-button", {
       this.targetEl.addEventListener("unmirrored", this._updateUI);
       this._updateUI();
     });
+
+    if (AFRAME.utils.device.isMobile() || AFRAME.utils.device.isMobileVR()) {
+      this.el.object3D.visible = false;
+    }
   },
 
   play() {

--- a/src/components/open-media-button.js
+++ b/src/components/open-media-button.js
@@ -1,4 +1,5 @@
 import { isHubsSceneUrl, isHubsRoomUrl } from "../utils/media-utils";
+import { guessContentType } from "../utils/media-utils";
 
 AFRAME.registerComponent("open-media-button", {
   init() {
@@ -6,6 +7,10 @@ AFRAME.registerComponent("open-media-button", {
 
     this.updateSrc = () => {
       this.src = this.targetEl.components["media-loader"].data.src;
+
+      if (guessContentType(this.src) === "video/vnd.hubs-webrtc") {
+        this.el.object3D.visible = false;
+      }
 
       let label = "open link";
 

--- a/src/hub.html
+++ b/src/hub.html
@@ -333,8 +333,9 @@
                     auto-scale-cannon-physics-body
                 >
                     <a-entity class="ui interactable-ui camera-menu" visibility-while-frozen="withinDistance: 10;" mixin="button-container" >
-                        <a-entity mixin="rounded-text-action-button" mirror-camera-button="labelSelector:.mirror-button-label;" position="0 0.125 0.01"> </a-entity>
-                        <a-entity text=" value:mirror; width:2.5; align:center;" class="mirror-button-label" text-raycast-hack position="0 0.125 0.02"></a-entity>
+                        <a-entity mixin="rounded-text-action-button" mirror-camera-button="labelSelector:.mirror-button-label;" position="0 0.125 0.01">
+                            <a-entity text=" value:mirror; width:2.5; align:center;" class="mirror-button-label" text-raycast-hack position="0 0.125 0.02"></a-entity>
+                        </a-entity>
                         <a-entity mixin="rounded-text-button" remove-networked-object-button position="0 -0.125 0.01"> </a-entity>
                         <a-entity text=" value:remove; width:2.5; align:center;" text-raycast-hack position="0 -0.125 0.02"></a-entity>
                         <a-entity scale="0.8 0.8 1" mixin="rounded-text-button" rotate-button rotate-button-selector position="-0.7 0.06 0.01">


### PR DESCRIPTION
The "mirror" button and "clone" buttons are not always valid, so hide them when they are not.