### PR TITLE
Set service worker timeout

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -504,6 +504,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     } catch (e) {
       subscriptions.setRegistrationFailed();
     }
+  } else {
+    subscriptions.setRegistrationFailed();
   }
 
   const scene = document.querySelector("a-scene");

--- a/src/subscriptions.js
+++ b/src/subscriptions.js
@@ -1,4 +1,5 @@
 import nextTick from "./utils/next-tick.js";
+const INIT_TIMEOUT_MS = 5000;
 
 // Manages web push subscriptions
 //
@@ -46,9 +47,10 @@ export default class Subscriptions {
 
   getCurrentEndpoint = async () => {
     if (!navigator.serviceWorker) return null;
+    const startedAt = performance.now();
 
     // registration becomes null if failed, non null if registered
-    while (this.registration === undefined) await nextTick();
+    while (this.registration === undefined && performance.now() - startedAt < INIT_TIMEOUT_MS) await nextTick();
     if (!this.registration || !this.registration.pushManager) return null;
 
     while (this.vapidPublicKey === undefined) await nextTick();

--- a/src/subscriptions.js
+++ b/src/subscriptions.js
@@ -51,6 +51,7 @@ export default class Subscriptions {
 
     // registration becomes null if failed, non null if registered
     while (this.registration === undefined && performance.now() - startedAt < INIT_TIMEOUT_MS) await nextTick();
+    if (performance.now() - startedAt >= INIT_TIMEOUT_MS) console.warn("Service worker registration timed out.");
     if (!this.registration || !this.registration.pushManager) return null;
 
     while (this.vapidPublicKey === undefined) await nextTick();


### PR DESCRIPTION
This adds a 5s timeout to the registration of the service worker completing. I thought I had all the relevant error handling in place, but it seems that in some cases the browser is not completing the promise for the registration, at all, when testing on a mobile device on a LAN. I am not positive what is going on, it seems related to the service worker loading over a slow LAN, but this timeout seems sane anyway (and the result is that the checkbox will just be hidden for notifications.)