### PR TITLE
Fix environment map / lighting in avatar picker

### DIFF
--- a/src/avatar-selector.js
+++ b/src/avatar-selector.js
@@ -12,6 +12,7 @@ patchWebGLRenderingContext();
 import "./assets/stylesheets/avatar-selector.scss";
 import "three/examples/js/loaders/GLTFLoader";
 
+import "./components/skybox";
 import "./components/animation";
 import "./components/animation-mixer";
 import "./components/audio-feedback";

--- a/src/components/environment-map.js
+++ b/src/components/environment-map.js
@@ -8,7 +8,9 @@ import cubeMapNegZ from "../assets/images/cubemap/negz.jpg";
 
 async function createDefaultEnvironmentMap() {
   const urls = [cubeMapPosX, cubeMapNegX, cubeMapPosY, cubeMapNegY, cubeMapPosZ, cubeMapNegZ];
-  const texture = await new THREE.CubeTextureLoader().load(urls);
+  const texture = await new Promise((resolve, reject) =>
+    new THREE.CubeTextureLoader().load(urls, resolve, undefined, reject)
+  );
   texture.format = THREE.RGBFormat;
   return texture;
 }

--- a/src/components/skybox.js
+++ b/src/components/skybox.js
@@ -229,7 +229,7 @@ AFRAME.registerComponent("skybox", {
     mieCoefficient: { type: "number", default: 0.005 },
     mieDirectionalG: { type: "number", default: 0.8 },
     inclination: { type: "number", default: 0 },
-    azimuth: { type: "number", default: 0 },
+    azimuth: { type: "number", default: 0.15 },
     distance: { type: "number", default: 8000 }
   },
 
@@ -242,7 +242,7 @@ AFRAME.registerComponent("skybox", {
 
     // HACK: Render environment map on next frame to avoid bug where the render target texture is black.
     this.updateEnvironmentMap = this.updateEnvironmentMap.bind(this);
-    requestAnimationFrame(this.updateEnvironmentMap);
+    requestAnimationFrame(() => setTimeout(this.updateEnvironmentMap), 0);
   },
 
   update(oldData) {

--- a/src/components/skybox.js
+++ b/src/components/skybox.js
@@ -240,9 +240,11 @@ AFRAME.registerComponent("skybox", {
     this.cubeCamera = new THREE.CubeCamera(1, 100000, 512);
     this.skyScene.add(this.cubeCamera);
 
-    // HACK: Render environment map on next frame to avoid bug where the render target texture is black.
     this.updateEnvironmentMap = this.updateEnvironmentMap.bind(this);
-    requestAnimationFrame(() => setTimeout(this.updateEnvironmentMap), 0);
+    // HACK: Render environment map on next frame to avoid bug where the render target texture is black.
+    // EXTRA HACK: Added timeout due to additional case where texture is black in avatar-selector in Firefox.
+    // This is likely due to the custom elements attached callback being synchronous on Chrome but not Firefox.
+    requestAnimationFrame(() => setTimeout(this.updateEnvironmentMap));
   },
 
   update(oldData) {

--- a/src/react-components/avatar-selector.js
+++ b/src/react-components/avatar-selector.js
@@ -98,6 +98,16 @@ class AvatarSelector extends Component {
     });
   }
 
+  componentDidMount() {
+    // <a-scene> component not initialized until scene element mounted and loaded.
+    this.scene.addEventListener("loaded", () => {
+      this.scene.setAttribute("light", {
+        defaultLightsEnabled: false
+      });
+      this.scene.setAttribute("shadow", { type: "pcfsoft", enabled: window.APP.quality !== "low" });
+    });
+  }
+
   componentDidUpdate(prevProps) {
     if (this.props.avatarId !== prevProps.avatarId) {
       // HACK - animation ought to restart the animation when the `to` attribute changes, but it doesn't
@@ -145,7 +155,6 @@ class AvatarSelector extends Component {
       <div className="avatar-selector">
         <a-scene
           vr-mode-ui="enabled: false"
-          light="defaultLightsEnabled: false"
           ref={sce => (this.scene = sce)}
           background="color: #aaa"
           environment-map=""
@@ -153,17 +162,7 @@ class AvatarSelector extends Component {
         >
           <a-assets>{avatarAssets}</a-assets>
 
-          <a-entity
-            skybox="
-            turbidity: 20;
-            rayleigh: 0.03;
-            luminance: 0.175;
-            mieCoefficient: 0.004;
-            mieDirectionalG: 0.098;
-            azimuth: 0.37;
-            inclination: 0.14;
-          "
-          />
+          <a-entity skybox="turbidity: 20; rayleigh: 0.03; luminance: 0.175; mieCoefficient: 0.004; mieDirectionalG: 0.098; azimuth: 0.37; inclination: 0.14;" />
 
           <a-entity
             ref={anm => (this.animation = anm)}

--- a/src/react-components/avatar-selector.js
+++ b/src/react-components/avatar-selector.js
@@ -120,20 +120,6 @@ class AvatarSelector extends Component {
     }
   }
 
-  componentDidMount() {
-    // <a-scene> component not initialized until scene element mounted and loaded.
-    this.scene.addEventListener("loaded", () => {
-      this.scene.setAttribute("renderer", {
-        gammaOutput: true,
-        sortObjects: true,
-        physicallyCorrectLights: true,
-        colorManagement: true
-      });
-      this.scene.setAttribute("shadow", { type: "pcfsoft", enabled: window.APP.quality !== "low" });
-      this.scene.setAttribute("environment-map", "");
-    });
-  }
-
   render() {
     const avatarAssets = this.props.avatars.map(avatar => (
       <a-asset-item id={avatar.id} key={avatar.id} response-type="arraybuffer" src={`${avatar.model}`} />
@@ -157,8 +143,27 @@ class AvatarSelector extends Component {
 
     return (
       <div className="avatar-selector">
-        <a-scene vr-mode-ui="enabled: false" ref={sce => (this.scene = sce)}>
+        <a-scene
+          vr-mode-ui="enabled: false"
+          light="defaultLightsEnabled: false"
+          ref={sce => (this.scene = sce)}
+          background="color: #aaa"
+          environment-map=""
+          renderer="antialias: true; colorManagement: true; sortObjects: true; physicallyCorrectLights: true; alpha: false; gammaOutput: true;"
+        >
           <a-assets>{avatarAssets}</a-assets>
+
+          <a-entity
+            skybox="
+            turbidity: 20;
+            rayleigh: 0.03;
+            luminance: 0.175;
+            mieCoefficient: 0.004;
+            mieDirectionalG: 0.098;
+            azimuth: 0.37;
+            inclination: 0.14;
+          "
+          />
 
           <a-entity
             ref={anm => (this.animation = anm)}
@@ -169,15 +174,19 @@ class AvatarSelector extends Component {
           </a-entity>
 
           <a-entity position="0 1.5 -5.6" rotation="-10 180 0">
-            <a-entity camera="far: 1;" />
+            <a-entity camera="far: 1.5;" />
           </a-entity>
 
           <a-entity
             hide-when-quality="low"
-            light="type: directional; color: #F9FFCE; intensity: 0.6"
-            position="0 5 -15"
+            light="type: directional; color: #fdf5c2; intensity: 12"
+            position="0 10 -15"
           />
-          <a-entity hide-when-quality="low" light="type: ambient; color: #FFF" />
+
+          <a-entity
+            hide-when-quality="low"
+            light="type: hemisphere; color: #b1e3ff; groundColor: #b1e3ff; intensity: 1.5;"
+          />
         </a-scene>
         <WithHoverSound>
           <button className="avatar-selector__previous-button" onClick={this.emitChangeToPrevious}>


### PR DESCRIPTION
This PR fixes up the environment map and lighting in the avatar picker. There was a race condition that prevented the environment map from being applied to the avatars in the scene. Also, the renderer properties were being assigned to the scene after the renderer had already been initialized. As such the gamma correction and physical lights properties were not actually applied.

Fixes #944 

This may also fix the environment map when changing scenes. I believe the additional `setTimeout` in `skybox` will fix any race condition that occurs there.