### PR TITLE
Fix up touch controls

### DIFF
--- a/src/assets/stylesheets/presence-log.scss
+++ b/src/assets/stylesheets/presence-log.scss
@@ -150,6 +150,8 @@
     color: $light-text;
     min-height: 18px;
 
+    // If this is selectable, tap holding on mobile anywhere on the screen will result
+    // in a selection.
     user-select: none;
     -moz-user-select: none;
     -webkit-user-select: none;

--- a/src/assets/stylesheets/ui-root.scss
+++ b/src/assets/stylesheets/ui-root.scss
@@ -2,6 +2,7 @@
 
 :local(.ui) {
   @extend %default-font;
+  @extend %unselectable;
 
   width: 100%;
   height: 100%;

--- a/src/systems/userinput/bindings/touchscreen-user.js
+++ b/src/systems/userinput/bindings/touchscreen-user.js
@@ -87,7 +87,7 @@ export const touchscreenUserBindings = addSetsToBindings({
     {
       src: { value: paths.device.touchscreen.isTouchingGrabbable },
       dest: { value: paths.actions.cursor.grab },
-      xform: xforms.copy
+      xform: xforms.rising
     },
     {
       src: { value: paths.device.hud.penButton },

--- a/src/systems/userinput/devices/app-aware-touchscreen.js
+++ b/src/systems/userinput/devices/app-aware-touchscreen.js
@@ -13,6 +13,18 @@ function distance(x1, y1, x2, y2) {
   return Math.sqrt(dx * dx + dy * dy);
 }
 
+const getPlayerCamera = (() => {
+  let playerCamera;
+
+  return function() {
+    if (!playerCamera) {
+      playerCamera = document.querySelector("#player-camera").components.camera.camera;
+    }
+
+    return playerCamera;
+  };
+})();
+
 function shouldMoveCursor(touch, raycaster) {
   const cursorController = document.querySelector("[cursor-controller]").components["cursor-controller"];
   const isCursorGrabbing = cursorController.data.cursor.components["super-hands"].state.has("grab-start");
@@ -25,7 +37,7 @@ function shouldMoveCursor(touch, raycaster) {
       x: (touch.clientX / window.innerWidth) * 2 - 1,
       y: -(touch.clientY / window.innerHeight) * 2 + 1
     },
-    document.querySelector("#player-camera").components.camera.camera
+    getPlayerCamera()
   );
   raycaster.intersectObjects(cursorController.targets, true, rawIntersections);
   const intersection = rawIntersections.find(x => x.object.el);
@@ -117,7 +129,7 @@ export class AppAwareTouchscreenDevice {
     switch (assignment.job) {
       case MOVE_CURSOR_JOB:
         assignment.cursorPose.fromCameraProjection(
-          document.querySelector("#player-camera").components.camera.camera,
+          getPlayerCamera(),
           (touch.clientX / window.innerWidth) * 2 - 1,
           -(touch.clientY / window.innerHeight) * 2 + 1
         );
@@ -149,44 +161,51 @@ export class AppAwareTouchscreenDevice {
       return;
     }
 
-    if (!jobIsAssigned(MOVE_CURSOR_JOB, this.assignments) && shouldMoveCursor(touch, this.raycaster)) {
-      const assignment = assign(touch, MOVE_CURSOR_JOB, this.assignments);
+    if (this.assignments.length === 0) {
+      let assignment;
+
+      // First touch
+      if (shouldMoveCursor(touch, this.raycaster)) {
+        assignment = assign(touch, MOVE_CURSOR_JOB, this.assignments);
+
+        // Grabbing objects is delayed by several frames:
+        // - We don't want the physics constraint to be applied to early, which results in crazy velocities
+        // - We don't want to mis-trigger grabs if the user is about to put down a second finger.
+        assignment.framesUntilGrab = 2;
+      } else {
+        assignment = assign(touch, MOVE_CAMERA_JOB, this.assignments);
+        assignment.delta = [0, 0];
+      }
+
+      assignment.clientX = touch.clientX;
+      assignment.clientY = touch.clientY;
+
+      // On touch down, we always move the cursor on the first frame, but the MOVE_CURSOR_JOB indicates
+      // the touch will then track the cursor (instead of the camera)
       assignment.cursorPose = new Pose().fromCameraProjection(
-        document.querySelector("#player-camera").components.camera.camera,
+        getPlayerCamera(),
         (touch.clientX / window.innerWidth) * 2 - 1,
         -(touch.clientY / window.innerHeight) * 2 + 1
       );
-      assignment.isFirstFrame = true;
-    } else if (!jobIsAssigned(MOVE_CAMERA_JOB, this.assignments)) {
-      const assignment = assign(touch, MOVE_CAMERA_JOB, this.assignments);
-      assignment.clientX = touch.clientX;
-      assignment.clientY = touch.clientY;
-      assignment.delta = [0, 0];
-    } else if (!jobIsAssigned(SECOND_PINCHER_JOB, this.assignments)) {
-      let first;
-      if (jobIsAssigned(FIRST_PINCHER_JOB, this.assignments)) {
-        first = findByJob(FIRST_PINCHER_JOB, this.assignments);
-      } else {
-        const cameraMover = findByJob(MOVE_CAMERA_JOB, this.assignments);
-        unassign(cameraMover.touch, cameraMover.job, this.assignments);
-
-        first = assign(cameraMover.touch, FIRST_PINCHER_JOB, this.assignments);
-        first.clientX = cameraMover.clientX;
-        first.clientY = cameraMover.clientY;
-      }
+    } else if (this.assignments.length === 1) {
+      // Second touch
+      const previousAssignment = this.assignments[0];
+      unassign(previousAssignment.touch, previousAssignment.job, this.assignments);
+      const first = assign(previousAssignment.touch, FIRST_PINCHER_JOB, this.assignments);
+      first.clientX = previousAssignment.clientX;
+      first.clientY = previousAssignment.clientY;
 
       const second = assign(touch, SECOND_PINCHER_JOB, this.assignments);
       second.clientX = touch.clientX;
       second.clientY = touch.clientY;
 
       const initialDistance = distance(first.clientX, first.clientY, second.clientX, second.clientY);
+
       this.pinch = {
         initialDistance,
         currentDistance: initialDistance,
         delta: 0
       };
-    } else {
-      console.warn("no job suitable for touch", touch);
     }
 
     if (this.pendingTap.maxTouchCount === 0 && this.assignments.length > 0) {
@@ -241,15 +260,17 @@ export class AppAwareTouchscreenDevice {
 
     if (hasCursorJob || hasCameraJob) {
       frame[path.isTouching] = true;
+
+      const assignment = findByJob(MOVE_CURSOR_JOB, this.assignments) || findByJob(MOVE_CAMERA_JOB, this.assignments);
+      frame[path.cursorPose] = assignment.cursorPose;
     }
+
+    frame[path.isTouchingGrabbable] = false;
 
     if (hasCursorJob) {
       const assignment = findByJob(MOVE_CURSOR_JOB, this.assignments);
-      frame[path.cursorPose] = assignment.cursorPose;
-      // If you touch a grabbable, we want to wait 1 frame before admitting it to anyone else, because we
-      // want to hover on the first frame and grab on the next.
-      frame[path.isTouchingGrabbable] = !assignment.isFirstFrame;
-      assignment.isFirstFrame = false;
+      frame[path.isTouchingGrabbable] = assignment.framesUntilGrab <= 0;
+      assignment.framesUntilGrab--;
     }
 
     if (hasCameraJob) {

--- a/src/systems/userinput/devices/app-aware-touchscreen.js
+++ b/src/systems/userinput/devices/app-aware-touchscreen.js
@@ -169,7 +169,7 @@ export class AppAwareTouchscreenDevice {
         assignment = assign(touch, MOVE_CURSOR_JOB, this.assignments);
 
         // Grabbing objects is delayed by several frames:
-        // - We don't want the physics constraint to be applied to early, which results in crazy velocities
+        // - We don't want the physics constraint to be applied too early, which results in crazy velocities
         // - We don't want to mis-trigger grabs if the user is about to put down a second finger.
         assignment.framesUntilGrab = 2;
       } else {


### PR DESCRIPTION
This fixes up a bunch of things with the touch controls:

- Tapping and holding on the screen (on android) no longer makes a fake selection
- Fix for the user input bindings that was resulting in holding your finger doing a grab/ungrab every frame :)
- Fixes a bunch of behaviors with the touch handling:
  - If you put two fingers down quickly to pinch or freeze, you will not accidentally grab the object on the first finger
  - We delay the grab an extra input frame to eliminate the weird physics side effect
  - You can now tap off of objects to de-hover/select them. This is done by always moving the cursor on touch start.

We also now don't do the query selector for the player camera every tick