### PR TITLE
Switch to use a lighter-weight zip library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6927,11 +6927,6 @@
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
     },
-    "es6-promise": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
-      "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
-    },
     "es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
@@ -7481,7 +7476,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "expand-braces": {
       "version": "0.1.2",
@@ -8246,7 +8242,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8264,11 +8261,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8281,15 +8280,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8392,7 +8394,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8402,6 +8405,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8414,17 +8418,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -8441,6 +8448,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8513,7 +8521,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8523,6 +8532,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8598,7 +8608,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8628,6 +8639,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8645,6 +8657,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8683,11 +8696,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -9654,7 +9669,8 @@
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+      "dev": true
     },
     "import-fresh": {
       "version": "3.0.0",
@@ -10729,45 +10745,15 @@
       }
     },
     "jszip": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
-      "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.0.tgz",
+      "integrity": "sha512-4WjbsaEtBK/DHeDZOPiPw5nzSGLDEDDreFRDEgnoMwmknPjTqa+23XuYFk6NiGbeiAeZCctiQ/X/z0lQBmDVOQ==",
+      "dev": true,
       "requires": {
-        "core-js": "~2.3.0",
-        "es6-promise": "~3.0.2",
-        "lie": "~3.1.0",
+        "lie": "~3.3.0",
         "pako": "~1.0.2",
-        "readable-stream": "~2.0.6"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
-          "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU="
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          }
-        }
+        "readable-stream": "~2.3.6",
+        "set-immediate-shim": "~1.0.1"
       }
     },
     "jwt-decode": {
@@ -10996,9 +10982,10 @@
       }
     },
     "lie": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
       "requires": {
         "immediate": "~3.0.5"
       }
@@ -19539,6 +19526,14 @@
         "debug": "^2.6.6",
         "load-script": "^1.0.0",
         "sister": "^3.0.0"
+      }
+    },
+    "zip-loader": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/zip-loader/-/zip-loader-1.1.0.tgz",
+      "integrity": "sha512-8XZgg1JFdlHmcKaldLEpjGH6qtxUxwDGfS+cgF1OVWa5dT6QFI6EgzAbMorT1RY6uurlevr6JytawNpUhOJLeQ==",
+      "requires": {
+        "pako": "^1.0.6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "history": "^4.7.2",
     "hls.js": "^0.12.2",
     "jsonschema": "^1.2.2",
-    "jszip": "^3.1.5",
     "jwt-decode": "^2.2.0",
     "markdown-it": "^8.4.2",
     "moving-average": "^1.0.0",
@@ -83,7 +82,8 @@
     "three-pathfinding": "github:mozillareality/three-pathfinding#hubs/master",
     "three-to-cannon": "1.3.0",
     "uuid": "^3.2.1",
-    "webrtc-adapter": "^6.0.2"
+    "webrtc-adapter": "^6.0.2",
+    "zip-loader": "^1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.3.3",

--- a/src/workers/sketchfab-zip.worker.js
+++ b/src/workers/sketchfab-zip.worker.js
@@ -1,25 +1,22 @@
-import JSZip from "jszip";
+import ZipLoader from "zip-loader";
 
 async function fetchZipAndGetBlobs(src) {
-  const zip = await fetch(src)
-    .then(r => r.blob())
-    .then(JSZip.loadAsync);
+  const zip = new ZipLoader(src);
+  return zip.load().then(ev => {
+    // Rewrite any url references in the GLTF to blob urls
+    const fileMap = {};
+    for (const fileName in zip.files) {
+      fileMap[fileName] = zip.extractAsBlobUrl(fileName);
+    }
 
-  // Rewrite any url refferences in the GLTF to blob urls
-  const fileMap = {};
-  const files = Object.values(zip.files);
-  const fileBlobs = await Promise.all(files.map(f => f.async("blob")));
-  for (let i = 0; i < fileBlobs.length; i++) {
-    fileMap[files[i].name] = URL.createObjectURL(fileBlobs[i]);
-  }
+    const gltfJson = JSON.parse(zip.extractAsText("scene.gltf"));
+    gltfJson.buffers && gltfJson.buffers.forEach(b => (b.uri = fileMap[b.uri]));
+    gltfJson.images && gltfJson.images.forEach(i => (i.uri = fileMap[i.uri]));
 
-  const gltfJson = JSON.parse(await zip.file("scene.gltf").async("text"));
-  gltfJson.buffers && gltfJson.buffers.forEach(b => (b.uri = fileMap[b.uri]));
-  gltfJson.images && gltfJson.images.forEach(i => (i.uri = fileMap[i.uri]));
+    fileMap["scene.gtlf"] = URL.createObjectURL(new Blob([JSON.stringify(gltfJson, null, 2)], { type: "text/plain" }));
 
-  fileMap["scene.gtlf"] = URL.createObjectURL(new Blob([JSON.stringify(gltfJson, null, 2)], { type: "text/plain" }));
-
-  return fileMap;
+    return fileMap;
+  });
 }
 
 self.onmessage = async e => {

--- a/src/workers/sketchfab-zip.worker.js
+++ b/src/workers/sketchfab-zip.worker.js
@@ -2,7 +2,7 @@ import ZipLoader from "zip-loader";
 
 async function fetchZipAndGetBlobs(src) {
   const zip = new ZipLoader(src);
-  return zip.load().then(ev => {
+  return zip.load().then(() => {
     // Rewrite any url references in the GLTF to blob urls
     const fileMap = {};
     for (const fileName in zip.files) {
@@ -12,7 +12,6 @@ async function fetchZipAndGetBlobs(src) {
     const gltfJson = JSON.parse(zip.extractAsText("scene.gltf"));
     gltfJson.buffers && gltfJson.buffers.forEach(b => (b.uri = fileMap[b.uri]));
     gltfJson.images && gltfJson.images.forEach(i => (i.uri = fileMap[i.uri]));
-
     fileMap["scene.gtlf"] = URL.createObjectURL(new Blob([JSON.stringify(gltfJson, null, 2)], { type: "text/plain" }));
 
     return fileMap;


### PR DESCRIPTION
Previously, thanks to JSZip, our sketchfab worker Javascript was basically as large as three.js and A-Frame combined. Now it's not.

We should just be doing this work in Farspark, but this can tide us over in the meantime.

Thanks to @yomatsu and @ngokevin for randomly producing [an alternative to JSZip](https://github.com/yomotsu/ZipLoader)!