### PR TITLE
Set rolloff factor to 2 to reduce cross talk

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -158,7 +158,7 @@
 
                         <template data-name="Head">
                             <a-entity
-                                networked-audio-source
+                                networked-audio-source="rolloffFactor: 2.0;"
                                 networked-audio-analyser
                                 personal-space-invader="radius: 0.15; useMaterial: true;"
                                 bone-visibility


### PR DESCRIPTION
Last 2 meetups I've noticed a lot of people talking over each other, making it hard to have breakout conversations. I think this will help.