### PR TITLE
Fix up media browser feeling lucky, re-order tabs, fix bug with initi…

### DIFF
--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -239,9 +239,11 @@ class MediaBrowser extends Component {
                     if (e.key === "Enter" && e.ctrlKey) {
                       if (this.state.result && this.state.result.entries.length > 0) {
                         this.handleEntryClicked(e, this.state.result.entries[0]);
-                      } else {
+                      } else if (this.state.query.trim() !== "") {
                         this.handleQueryUpdated(this.state.query, true);
                         this.setState({ selectNextResult: true });
+                      } else {
+                        this.close();
                       }
                     } else if (e.key === "Escape" || e.key === "Enter") {
                       e.target.blur();

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -74,7 +74,7 @@ class MediaBrowser extends Component {
     onMediaSearchResultEntrySelected: PropTypes.func
   };
 
-  state = { query: "", facets: [], showNav: true };
+  state = { query: "", facets: [], showNav: true, selectNextResult: true };
 
   constructor(props) {
     super(props);
@@ -91,7 +91,16 @@ class MediaBrowser extends Component {
   }
 
   storeUpdated = () => {
-    this.setState(this.getStoreAndHistoryState(this.props));
+    const newState = this.getStoreAndHistoryState(this.props);
+    this.setState(newState);
+
+    if (this.state.selectNextResult) {
+      if (newState.result && newState.result.entries.length > 0) {
+        this.selectEntry(newState.result.entries[0]);
+      } else {
+        this.close();
+      }
+    }
   };
 
   sourceChanged = () => {
@@ -119,27 +128,35 @@ class MediaBrowser extends Component {
     return newState;
   };
 
-  handleQueryUpdated = query => {
+  handleQueryUpdated = (query, forceNow) => {
     this.setState({ result: null });
 
     if (this._sendQueryTimeout) {
       clearTimeout(this._sendQueryTimeout);
     }
 
-    // Don't update search on every keystroke, but buffer for some ms.
-    this._sendQueryTimeout = setTimeout(() => {
-      // Drop filter for now, so entering text drops into "search all" mode
+    if (forceNow) {
       this.props.mediaSearchStore.filterQueryNavigate("", query);
-    }, 500);
+    } else {
+      // Don't update search on every keystroke, but buffer for some ms.
+      this._sendQueryTimeout = setTimeout(() => {
+        // Drop filter for now, so entering text drops into "search all" mode
+        this.props.mediaSearchStore.filterQueryNavigate("", query);
+      }, 500);
+    }
 
     this.setState({ query });
   };
 
   handleEntryClicked = (evt, entry) => {
+    evt.preventDefault();
+    this.selectEntry(entry);
+  };
+
+  selectEntry = entry => {
     if (!this.props.onMediaSearchResultEntrySelected) return;
     this.props.onMediaSearchResultEntrySelected(entry);
     this.close();
-    evt.preventDefault();
   };
 
   handleSourceClicked = source => {
@@ -190,6 +207,9 @@ class MediaBrowser extends Component {
     const isVariableWidth = this.state.result && ["bing_images", "tenor"].includes(apiSource);
     const showCustomOption = apiSource !== "scene_listings" || this.props.hubChannel.permissions.update_hub;
 
+    // Don't render anything if we just did a feeling lucky query and are waiting on result.
+    if (this.state.selectNextResult) return <div />;
+
     return (
       <div className={styles.mediaBrowser} ref={browserDiv => (this.browserDiv = browserDiv)}>
         <div className={classNames([styles.box, styles.darkened])}>
@@ -216,9 +236,12 @@ class MediaBrowser extends Component {
                   onFocus={e => handleTextFieldFocus(e.target)}
                   onBlur={() => handleTextFieldBlur()}
                   onKeyDown={e => {
-                    if (e.key === "Enter" && e.shiftKey) {
+                    if (e.key === "Enter" && e.ctrlKey) {
                       if (this.state.result && this.state.result.entries.length > 0) {
                         this.handleEntryClicked(e, this.state.result.entries[0]);
+                      } else {
+                        this.handleQueryUpdated(this.state.query, true);
+                        this.setState({ selectNextResult: true });
                       }
                     } else if (e.key === "Escape" || e.key === "Enter") {
                       e.target.blur();

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1608,6 +1608,7 @@ class UIRoot extends Component {
                       } else if (e.key === "Enter" && e.ctrlKey) {
                         spawnChatMessage(e.target.value);
                         this.setState({ pendingMessage: "" });
+                        e.target.blur();
                       } else if (e.key === "Escape") {
                         e.target.blur();
                       }

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1603,9 +1603,9 @@ class UIRoot extends Component {
                       this.setState({ pendingMessage: e.target.value });
                     }}
                     onKeyDown={e => {
-                      if (e.key === "Enter" && !e.shiftKey) {
+                      if (e.key === "Enter" && !e.ctrlKey && !e.shiftKey) {
                         this.sendMessage(e);
-                      } else if (e.key === "Enter" && e.shiftKey && e.ctrlKey) {
+                      } else if (e.key === "Enter" && e.ctrlKey) {
                         spawnChatMessage(e.target.value);
                         this.setState({ pendingMessage: "" });
                       } else if (e.key === "Escape") {

--- a/src/storage/media-search-store.js
+++ b/src/storage/media-search-store.js
@@ -2,7 +2,7 @@ import { EventTarget } from "event-target-shim";
 import { getReticulumFetchUrl } from "../utils/phoenix-utils";
 import { pushHistoryPath, sluglessPath, withSlug } from "../utils/history";
 
-export const SOURCES = ["videos", "images", "gifs", "scenes", "sketchfab", "poly", "twitch"];
+export const SOURCES = ["videos", "sketchfab", "poly", "scenes", "gifs", "images", "twitch"];
 
 const URL_SOURCE_TO_TO_API_SOURCE = {
   scenes: "scene_listings",
@@ -182,7 +182,7 @@ export default class MediaSearchStore extends EventTarget {
       }
     }
 
-    this._stashedParams = {};
+    this._stashedParams = null;
     this._stashedSource = null;
 
     if (hideNav) {


### PR DESCRIPTION
This fixes issues with the media browser:

- Bug: the initial filters were not being set since the stashed params were being cleared by setting to empty object, not null

- Feature: Ctrl-enter is now the standard "spawn" hotkey in both chat and media browser

- Feature: Ctrl-enter can now be hit in the media browser without waiting for results (great for blind entry)

- Feature: Tabs are re-ordered -- images are shifted to the right, with models to the left.