### PR TITLE
Disable aframe's loading screen

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -29,6 +29,7 @@
 
 <body>
     <a-scene
+        loading-screen="enabled: false"
         nextframe
         class="grab-cursor"
         renderer="antialias: true; colorManagement: true; sortObjects: true; physicallyCorrectLights: true; alpha: false;"

--- a/src/react-components/avatar-selector.js
+++ b/src/react-components/avatar-selector.js
@@ -158,6 +158,7 @@ class AvatarSelector extends Component {
           ref={sce => (this.scene = sce)}
           background="color: #aaa"
           environment-map=""
+          loading-screen="enabled: false"
           renderer="antialias: true; colorManagement: true; sortObjects: true; physicallyCorrectLights: true; alpha: false; gammaOutput: true;"
         >
           <a-assets>{avatarAssets}</a-assets>

--- a/src/scene.html
+++ b/src/scene.html
@@ -29,7 +29,8 @@
 
 <body>
     <a-scene
-        renderer="antialias: true; gammaOutput: true; sortObjects: true; physicallyCorrectLights: true; colorManagement: true"
+        loading-screen="enabled: false"
+        renderer="antialias: true; gammaOutput: true; sortObjects: true; physicallyCorrectLights: true; colorManagement: true; alpha: false;"
         shadow="type: pcfsoft"
         vr-mode-ui="enabled: false"
         environment-map="loadDefault: false"


### PR DESCRIPTION
This disables the blue loading screen you see for a second or two when loading a scene.

Also I forgot to disable the alpha backbuffer on scene page so I added that flag.