### PR TITLE
Bump detect-browser to 3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6391,9 +6391,9 @@
       "dev": true
     },
     "detect-browser": {
-      "version": "2.5.1",
-      "resolved": "https://registry.yarnpkg.com/detect-browser/-/detect-browser-2.5.1.tgz",
-      "integrity": "sha1-FB0VgPuQEVZXagqZKsMZxLIUj4s="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-3.0.1.tgz",
+      "integrity": "sha512-L6b76EfUxnoxGHM5Vz7nrshQPIbOHtitDWpGufrp5srQdJrEYi1xpUVZeFbfssWAJvUWo/iDIVlz8hOP4Z8OCw=="
     },
     "detect-file": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "classnames": "^2.2.5",
     "copy-to-clipboard": "^3.0.8",
     "deepmerge": "^2.1.1",
-    "detect-browser": "^2.1.0",
+    "detect-browser": "^3.0.1",
     "event-target-shim": "^3.0.1",
     "form-urlencoded": "^2.0.4",
     "history": "^4.7.2",


### PR DESCRIPTION
This has no functionality change that we care about, but it's nice to do because [a fix in detect-browser](https://github.com/DamonOehlman/detect-browser/pull/65) means that Webpack will no longer ship a useless shim for the Node `os` module in our build.