### PR TITLE
Poll for video dimensions on iOS because of canplay issue

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -163,7 +163,28 @@ function createVideoTexture(url, contentType) {
       videoEl.onerror = reject;
     }
 
-    videoEl.addEventListener("canplay", () => resolve(texture), { once: true });
+    let hasResolved = false;
+
+    const resolveOnce = () => {
+      if (hasResolved) return;
+      hasResolved = true;
+      resolve(texture);
+    };
+
+    videoEl.addEventListener("canplay", resolveOnce, { once: true });
+
+    // HACK: Sometimes iOS fails to fire the canplay event, so we poll for the video dimensions to appear instead.
+    if (isIOS) {
+      const poll = () => {
+        if ((texture.image.videoHeight || texture.image.height) && (texture.image.videoWidth || texture.image.width)) {
+          resolveOnce();
+        } else {
+          setTimeout(poll, 500);
+        }
+      };
+
+      poll();
+    }
   });
 }
 

--- a/src/hub.html
+++ b/src/hub.html
@@ -426,7 +426,7 @@
                 >
                     <a-entity class="unmute-button">
                         <a-entity mixin="rounded-text-button" slice9="width: 0.4" unmute-video-button> </a-entity>
-                        <a-entity text=" value:un-mute; width:2; align:center;" text-raycast-hack position="0 0 0.01"></a-entity>
+                        <a-entity text=" value:un-mute; width:2; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
                     </a-entity>
                 </a-entity>
             </template>


### PR DESCRIPTION
On iOS Safari, it seems that the `canplay` event can sometimes not fire when pasting in videos. This adds a hacky fallback mechanism to detect when it's OK to forward the texture and set up the mesh by determining when the w/h of the video becomes available.