### PR TITLE
Bug/grab flicker

### DIFF
--- a/src/systems/userinput/devices/app-aware-touchscreen.js
+++ b/src/systems/userinput/devices/app-aware-touchscreen.js
@@ -170,11 +170,15 @@ export class AppAwareTouchscreenDevice {
       return;
     }
 
-    if (this.assignments.length === 0) {
+    const isFirstTouch = this.assignments.length === 0;
+    const isSecondTouch = this.assignments.length === 1;
+    const isThirdTouch = this.assignments.length === 2;
+
+    if (isFirstTouch || isThirdTouch) {
       let assignment;
 
-      // First touch
-      if (shouldMoveCursor(touch, this.raycaster)) {
+      // First touch or third touch
+      if (isThirdTouch || shouldMoveCursor(touch, this.raycaster)) {
         assignment = assign(touch, MOVE_CURSOR_JOB, this.assignments);
 
         // Grabbing objects is delayed by several frames:
@@ -196,8 +200,8 @@ export class AppAwareTouchscreenDevice {
         (touch.clientX / window.innerWidth) * 2 - 1,
         -(touch.clientY / window.innerHeight) * 2 + 1
       );
-    } else if (this.assignments.length === 1) {
-      // Second touch
+    } else if (isSecondTouch) {
+      // Second touch, begin pinch and convert first touch to pincher
       const previousAssignment = this.assignments[0];
       unassign(previousAssignment.touch, previousAssignment.job, this.assignments);
       const first = assign(previousAssignment.touch, FIRST_PINCHER_JOB, this.assignments);

--- a/src/systems/userinput/devices/app-aware-touchscreen.js
+++ b/src/systems/userinput/devices/app-aware-touchscreen.js
@@ -70,7 +70,7 @@ export class AppAwareTouchscreenDevice {
         case MOVE_CAMERA_JOB:
           // If grab was being delayed, we should fire the initial grab to ensure
           // clicks will work.
-          if (assignment.framesUntilGrab >= 0) {
+          if (assignment.framesUntilGrab > 0) {
             assignment.framesUntilGrab = 0;
             setTimeout(() => this.end(touch));
             return;


### PR DESCRIPTION
This PR addresses a bug that manifests due to the fact that if you quickly tap on an object on touchscreen, we end up transitioning to a new action set, but only write `isTouchingGrabbable` to the frame once, so the `falling` xform does not ever fire, causing the object remained un-dropped. 

This is addressed by adding an additional edge case if the grab was being delayed (due to the pinch detection) -- in that case we now also delay the unassignment of the job by two input frames, which will ensure `true` gets written to the path at least twice: the first time will transition the action set, and the second time will result in the `true/false` falling pair to appear in the stream so the object is dropped.