### PR TITLE
Fix the ray pull gesture to bring objects near properly

### DIFF
--- a/src/components/cursor-controller.js
+++ b/src/components/cursor-controller.js
@@ -103,7 +103,7 @@ AFRAME.registerComponent("cursor-controller", {
     cursor: { type: "selector" },
     camera: { type: "selector" },
     far: { default: 4 },
-    near: { default: 0.06 },
+    near: { default: 0.2 },
     cursorColorHovered: { default: "#2F80ED" },
     cursorColorUnhovered: { default: "#FFFFFF" },
     rayObject: { type: "selector" },


### PR DESCRIPTION
Fixes a regression where pulling an object along the ray to your hand puts it inside your hand again. I am not sure what changed, perhaps the origin of the ray?