### PR TITLE
Fix for stretching of canvas when preemptively exiting VR

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -538,7 +538,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   window.APP.scene = scene;
   window.APP.hubChannel = hubChannel;
 
-  const preEmptVRMode = () => {
+  const preemptVRMode = () => {
     // If VR headset is activated, refreshing page will fire vrdisplayactivate
     // which puts A-Frame in VR mode, so exit VR mode whenever it is attempted
     // to be entered and we haven't entered the room yet.
@@ -551,7 +551,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   };
 
   scene.addEventListener("enter-vr", () => {
-    if (preEmptVRMode()) return;
+    if (preemptVRMode()) return;
     document.body.classList.add("vr-mode");
 
     // Don't stretch canvas on cardboard, since that's drawing the actual VR view :)
@@ -560,7 +560,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
   });
 
-  preEmptVRMode();
+  preemptVRMode();
 
   scene.addEventListener("exit-vr", () => {
     document.body.classList.remove("vr-mode");

--- a/src/hub.js
+++ b/src/hub.js
@@ -539,7 +539,6 @@ document.addEventListener("DOMContentLoaded", async () => {
   window.APP.hubChannel = hubChannel;
 
   scene.addEventListener("enter-vr", () => {
-    console.log("after");
     document.body.classList.add("vr-mode");
 
     if (!scene.is("entered")) {

--- a/src/hub.js
+++ b/src/hub.js
@@ -539,12 +539,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   window.APP.hubChannel = hubChannel;
 
   scene.addEventListener("enter-vr", () => {
+    console.log("after");
     document.body.classList.add("vr-mode");
-
-    // Don't stretch canvas on cardboard, since that's drawing the actual VR view :)
-    if (!isMobile || availableVREntryTypes.cardboard !== VR_DEVICE_AVAILABILITY.yes) {
-      document.body.classList.add("vr-mode-stretch");
-    }
 
     if (!scene.is("entered")) {
       // If VR headset is activated, refreshing page will fire vrdisplayactivate
@@ -552,6 +548,11 @@ document.addEventListener("DOMContentLoaded", async () => {
       // to be entered and we haven't entered the room yet.
       console.log("Pre-emptively exiting VR mode.");
       scene.exitVR();
+    } else {
+      // Don't stretch canvas on cardboard, since that's drawing the actual VR view :)
+      if (!isMobile || availableVREntryTypes.cardboard !== VR_DEVICE_AVAILABILITY.yes) {
+        document.body.classList.add("vr-mode-stretch");
+      }
     }
   });
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -538,22 +538,29 @@ document.addEventListener("DOMContentLoaded", async () => {
   window.APP.scene = scene;
   window.APP.hubChannel = hubChannel;
 
+  const preEmptVRMode = () => {
+    // If VR headset is activated, refreshing page will fire vrdisplayactivate
+    // which puts A-Frame in VR mode, so exit VR mode whenever it is attempted
+    // to be entered and we haven't entered the room yet.
+    console.log("Pre-emptively exiting VR mode.");
+
+    if (scene.is("vr-mode") && !scene.is("entered")) {
+      scene.exitVR();
+      return true;
+    }
+  };
+
   scene.addEventListener("enter-vr", () => {
+    if (preEmptVRMode()) return;
     document.body.classList.add("vr-mode");
 
-    if (!scene.is("entered")) {
-      // If VR headset is activated, refreshing page will fire vrdisplayactivate
-      // which puts A-Frame in VR mode, so exit VR mode whenever it is attempted
-      // to be entered and we haven't entered the room yet.
-      console.log("Pre-emptively exiting VR mode.");
-      scene.exitVR();
-    } else {
-      // Don't stretch canvas on cardboard, since that's drawing the actual VR view :)
-      if (!isMobile || availableVREntryTypes.cardboard !== VR_DEVICE_AVAILABILITY.yes) {
-        document.body.classList.add("vr-mode-stretch");
-      }
+    // Don't stretch canvas on cardboard, since that's drawing the actual VR view :)
+    if (!isMobile || availableVREntryTypes.cardboard !== VR_DEVICE_AVAILABILITY.yes) {
+      document.body.classList.add("vr-mode-stretch");
     }
   });
+
+  preEmptVRMode();
 
   scene.addEventListener("exit-vr", () => {
     document.body.classList.remove("vr-mode");

--- a/src/hub.js
+++ b/src/hub.js
@@ -555,7 +555,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
   });
 
-  scene.addEventListener("exit-vr", () => document.body.classList.remove("vr-mode"));
+  scene.addEventListener("exit-vr", () => {
+    document.body.classList.remove("vr-mode");
+    document.body.classList.remove("vr-mode-stretch");
+  });
 
   registerNetworkSchemas();
 


### PR DESCRIPTION
We have some logic to exit VR if VR mode is erroneously retained across refreshes, but the logic doesn't properly avoid setting the CSS class that stretches the canvas if that condition is hit.