### PR TITLE
Put interstitial near HUD

### DIFF
--- a/src/components/follow-in-fov.js
+++ b/src/components/follow-in-fov.js
@@ -1,4 +1,4 @@
-AFRAME.registerComponent("follow-in-lower-fov", {
+AFRAME.registerComponent("follow-in-fov", {
   schema: {
     target: { type: "selector" },
     offset: { type: "vec3" },

--- a/src/hub.html
+++ b/src/hub.html
@@ -759,8 +759,8 @@
                 cursorSuperHand: #cursor;"
         ></a-entity>
 
-        <a-entity matrix-auto-update class="vr-notice" follow-in-lower-fov="target: #player-camera; offset: 0 0 -0.8; angle: 39;" visible="false">
-            <a-entity hoverable slice9="width: 0.9; height: 0.2; left: 64; top: 64; right: 66; bottom: 66; opacity: 1.0; src: #action-button" 
+        <a-entity matrix-auto-update class="vr-notice" follow-in-fov="target: #player-camera; offset: 0 0 -0.8; angle: 39;" visible="false">
+            <a-entity hoverable slice9="width: 0.9; height: 0.2; left: 64; top: 64; right: 66; bottom: 66; opacity: 1.0; src: #button"
                 text-button="
                     textHoverColor: #fff;
                     textColor: #fff;

--- a/src/hub.js
+++ b/src/hub.js
@@ -72,7 +72,7 @@ import "./components/emit-state-change";
 import "./components/action-to-event";
 import "./components/emit-scene-event-on-remove";
 import "./components/stop-event-propagation";
-import "./components/follow-in-lower-fov";
+import "./components/follow-in-fov";
 import "./components/matrix-auto-update";
 import "./components/clone-media-button";
 import "./components/open-media-button";

--- a/src/react-components/chat-message.js
+++ b/src/react-components/chat-message.js
@@ -145,7 +145,7 @@ export async function createInWorldLogMessage({ name, type, body }) {
   document.querySelector("a-scene").appendChild(entity);
 
   entity.appendChild(meshEntity);
-  entity.setAttribute("follow-in-lower-fov", {
+  entity.setAttribute("follow-in-fov", {
     target: "#player-camera",
     offset: { x: 0, y: 0.0, z: -0.8 }
   });

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -213,7 +213,7 @@ export default class SceneEntryManager {
     if (this.hubChannel.signedIn) {
       this._pinElement(el);
     } else {
-      this.handleExitTo2DInterstitial();
+      this.handleExitTo2DInterstitial(true);
 
       const wasInVR = this.scene.is("vr-mode");
       const continueTextId = wasInVR ? "entry.return-to-vr" : "dialog.close";
@@ -255,7 +255,7 @@ export default class SceneEntryManager {
     this.hubChannel.unpin(networkId, fileId);
   };
 
-  handleExitTo2DInterstitial = () => {
+  handleExitTo2DInterstitial = isLower => {
     if (!this.scene.is("vr-mode")) return;
 
     this._in2DInterstitial = true;
@@ -265,7 +265,11 @@ export default class SceneEntryManager {
       this.scene.exitVR();
     } else {
       // Non-immersive browser, show notice
-      document.querySelector(".vr-notice").setAttribute("visible", true);
+      const vrNotice = document.querySelector(".vr-notice");
+      vrNotice.setAttribute("visible", true);
+      vrNotice.setAttribute("follow-in-fov", {
+        angle: isLower ? 39 : -15
+      });
     }
   };
 
@@ -321,7 +325,7 @@ export default class SceneEntryManager {
     });
 
     this.scene.addEventListener("action_spawn", () => {
-      this.handleExitTo2DInterstitial();
+      this.handleExitTo2DInterstitial(false);
       window.APP.mediaSearchStore.sourceNavigateToDefaultSource();
     });
 


### PR DESCRIPTION
When clicking the spawn icon the interstitial notice in VR to lift your headset is outside of your FoV. This sets things up to put the notice near the HUD where you are looking. The component which manages this is also now renamed to `follow-in-fov`.