### PR TITLE
Fix cursor color issue with env map

### DIFF
--- a/src/components/cursor-controller.js
+++ b/src/components/cursor-controller.js
@@ -241,8 +241,14 @@ AFRAME.registerComponent("cursor-controller", {
           ? cursorColorHovered
           : cursorColorUnhovered;
 
-      if (this.data.cursor.components.material.data.color !== cursorColor) {
+      const cursorAframeMaterial = this.data.cursor.components.material;
+
+      if (cursorAframeMaterial.data.color !== cursorColor) {
+        // A-Frame resets envmap on the three material when setting any attributes on the material,
+        // since we don't update the envmap on A-Frame materials when we rewrite the environment map.
+        const envMap = cursorAframeMaterial.material.envMap;
         this.data.cursor.setAttribute("material", "color", cursorColor);
+        cursorAframeMaterial.material.envMap = envMap;
       }
 
       if (this.line.material.visible) {


### PR DESCRIPTION
This works around an issue where if you set `material` A-Frame component attributes, the environment map on the underlying material is wiped out. We do this in two places, the teleporter and the cursor when updating the color. I've left the teleporter out for now since it probably isn't that big of a deal, but the cursor should probably always reflect the actual environment map.