### PR TITLE
Use a loading space with no skybox

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -164,7 +164,7 @@ const isBotMode = qsTruthy("bot");
 const isTelemetryDisabled = qsTruthy("disable_telemetry");
 const isDebug = qsTruthy("debug");
 const loadingEnvironmentURL =
-  "https://hubs-proxy.com/https://uploads-prod.reticulum.io/files/58c034aa-ff17-4d3c-a6cc-c9095bb4822c.glb";
+  "https://hubs-proxy.com/https://uploads-prod.reticulum.io/files/61d77151-7a74-40a6-b427-0c5a350c4502.glb";
 
 if (!isBotMode && !isTelemetryDisabled) {
   registerTelemetry("/hub", "Room Landing Page");


### PR DESCRIPTION
To potentially fix the issue where after a scene transition the environment map is dark, this switches the loading scene to use during the transition to be one with no skybox, so the environment map should not change.