### PR TITLE
Fix issue where lobby camera is set up after scene entry

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -617,7 +617,9 @@ document.addEventListener("DOMContentLoaded", async () => {
   const environmentScene = document.querySelector("#environment-scene");
 
   const onFirstEnvironmentLoad = () => {
-    setupLobbyCamera();
+    if (!scene.is("entered")) {
+      setupLobbyCamera();
+    }
 
     // Replace renderer with a noop renderer to reduce bot resource usage.
     if (isBotMode) {


### PR DESCRIPTION
I wasn't able to repro this directly, but there have been reports of the lobby camera behaviors being stuck on the avatar after room entry (the camera panning, etc). The control flow seems to imply that this could be possible if the room is entered before the environment loaded events are handled -- if that is what is causing this issue, this PR should address the problem. 