### PR TITLE
Fix showing of player hud when camera active

### DIFF
--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -195,7 +195,10 @@ AFRAME.registerComponent("camera-tool", {
           this.playerHead.updateMatrixWorld(true, true);
         }
 
+        let playerHudWasVisible = false;
+
         if (this.playerHud) {
+          playerHudWasVisible = this.playerHud.visible;
           this.playerHud.visible = false;
         }
 
@@ -214,7 +217,7 @@ AFRAME.registerComponent("camera-tool", {
           this.playerHead.updateMatrixWorld(true, true);
         }
         if (this.playerHud) {
-          this.playerHud.visible = true;
+          this.playerHud.visible = playerHudWasVisible;
         }
         this.lastUpdate = now;
         this.updateRenderTargetNextTick = false;

--- a/src/systems/camera-mirror.js
+++ b/src/systems/camera-mirror.js
@@ -85,7 +85,10 @@ AFRAME.registerSystem("camera-mirror", {
         playerHead.updateMatrixWorld(true, true);
       }
 
+      let playerHudWasVisible;
+
       if (playerHud) {
+        playerHudWasVisible = playerHud.visible;
         playerHud.visible = false;
       }
       renderer.vr.enabled = false;
@@ -100,7 +103,7 @@ AFRAME.registerSystem("camera-mirror", {
         playerHead.updateMatrixWorld(true);
       }
       if (playerHud) {
-        playerHud.visible = true;
+        playerHud.visible = playerHudWasVisible;
       }
     };
   }


### PR DESCRIPTION
In 2D mode turning on the camera or mirror mode would inadvertently show the in-world HUD even if it was previously not visible.