### PR TITLE
Add deadzone and increase sensitivty on pen resize

### DIFF
--- a/src/systems/userinput/bindings/oculus-touch-user.js
+++ b/src/systems/userinput/bindings/oculus-touch-user.js
@@ -31,13 +31,13 @@ const rightDpadCenter = `${name}rightDpad/center`;
 const rightJoy = `${name}right/joy`;
 const rightJoyY1 = `${name}right/joyY1`;
 const rightJoyY2 = `${name}right/joyY2`;
+const rightJoyYDeadzoned = `${name}left/joy/y/deadzoned`;
 const leftDpadNorth = `${name}leftDpad/north`;
 const leftDpadSouth = `${name}leftDpad/south`;
 const leftDpadEast = `${name}leftDpad/east`;
 const leftDpadWest = `${name}leftDpad/west`;
 const leftDpadCenter = `${name}leftDpad/center`;
 const leftJoy = `${name}left/joy`;
-const leftJoyY = `${name}left/joyY`;
 const oculusTouchCharacterAcceleration = `${name}characterAcceleration`;
 const keyboardCharacterAcceleration = "/var/keyboard/characterAcceleration";
 const characterAcceleration = "/var/oculus-touch/nonNormalizedCharacterAcceleration";
@@ -733,14 +733,7 @@ export const oculusTouchUserBindings = addSetsToBindings({
       priority: 2
     },
     {
-      src: {
-        value: leftAxis("joyY")
-      },
-      dest: { value: leftJoyY },
-      xform: xforms.copy
-    },
-    {
-      src: { value: leftJoyY },
+      src: { value: leftJoyYDeadzoned },
       dest: { value: paths.actions.leftHand.scalePenTip },
       xform: xforms.scale(-0.005),
       priority: 1
@@ -910,9 +903,18 @@ export const oculusTouchUserBindings = addSetsToBindings({
       priority: 2
     },
     {
-      src: { value: rightJoyY2 },
+      src: {
+        value: rightAxis("joyY")
+      },
+      dest: {
+        value: rightJoyYDeadzoned
+      },
+      xform: xforms.deadzone(0.1)
+    },
+    {
+      src: { value: rightJoyYDeadzoned },
       dest: { value: paths.actions.rightHand.scalePenTip },
-      xform: xforms.scale(-0.005),
+      xform: xforms.scale(-0.005, 5),
       priority: 2
     },
     {

--- a/src/systems/userinput/bindings/oculus-touch-user.js
+++ b/src/systems/userinput/bindings/oculus-touch-user.js
@@ -735,7 +735,7 @@ export const oculusTouchUserBindings = addSetsToBindings({
     {
       src: { value: leftJoyYDeadzoned },
       dest: { value: paths.actions.leftHand.scalePenTip },
-      xform: xforms.scale(-0.005),
+      xform: xforms.scaleExp(-0.005, 5),
       priority: 1
     },
     {
@@ -914,7 +914,7 @@ export const oculusTouchUserBindings = addSetsToBindings({
     {
       src: { value: rightJoyYDeadzoned },
       dest: { value: paths.actions.rightHand.scalePenTip },
-      xform: xforms.scale(-0.005, 5),
+      xform: xforms.scaleExp(-0.005, 5),
       priority: 2
     },
     {

--- a/src/systems/userinput/bindings/xforms.js
+++ b/src/systems/userinput/bindings/xforms.js
@@ -7,10 +7,14 @@ export const xforms = {
   copy: function(frame, src, dest) {
     frame[dest.value] = frame[src.value];
   },
-  scale: function(scalar) {
+  scale: function(scalar, exp = 1) {
     return function scale(frame, src, dest) {
       if (frame[src.value] !== undefined) {
-        frame[dest.value] = frame[src.value] * scalar;
+        if (exp === 1) {
+          frame[dest.value] = frame[src.value] * scalar;
+        } else {
+          frame[dest.value] = Math.pow(frame[src.value], exp) * scalar;
+        }
       }
     };
   },

--- a/src/systems/userinput/bindings/xforms.js
+++ b/src/systems/userinput/bindings/xforms.js
@@ -7,7 +7,14 @@ export const xforms = {
   copy: function(frame, src, dest) {
     frame[dest.value] = frame[src.value];
   },
-  scale: function(scalar, exp = 1) {
+  scale: function(scalar) {
+    return function scale(frame, src, dest) {
+      if (frame[src.value] !== undefined) {
+        frame[dest.value] = frame[src.value] * scalar;
+      }
+    };
+  },
+  scaleExp: function(scalar, exp = 1) {
     return function scale(frame, src, dest) {
       if (frame[src.value] !== undefined) {
         if (exp === 1) {


### PR DESCRIPTION
This fixes up the oculus touch UX for changing the pen settings -- pen resizing now has nicer sensitivity for finer brush scaling, and color changing is now subject to a deadzone so you won't resize the tip while you swap colors.