### PR TITLE
Tweak email link copy

### DIFF
--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -5,7 +5,7 @@
     "auth.verified": "Your email has been verified!\nYou can now close this browser tab and return to Hubs.",
     "auth.spoke-verified": "You email has been verified!\nYou can now close this browser tab and return to Spoke.",
     "sign-in.prompt": "Sign in to pin objects in rooms.",
-    "sign-in.auth-started": "Email sent!\nWaiting for you to click on the link in the email...",
+    "sign-in.auth-started": "Email sent!\n\nTo continue, go click on the link in the email using your phone, tablet, or PC.",
     "sign-in.pin": "You'll need to sign in to pin objects.",
     "sign-in.pin-complete": "You are now signed in.",
     "sign-in.as": "Signed in as",


### PR DESCRIPTION
The previous copy left it a bit unclear that you could go on another device to click the link. Might be splitting hairs but this felt better.