### PR TITLE
Enable webgl2 and multiview (when available)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3279,7 +3279,7 @@
       "dev": true
     },
     "aframe": {
-      "version": "github:mozillareality/aframe#3c6fe4c4a52ba9671f17f3b3d7588fa535b50698",
+      "version": "github:mozillareality/aframe#0663d0e2b5a23e405f11857daf5aacc15fd42808",
       "from": "github:mozillareality/aframe#hubs/master",
       "requires": {
         "animejs": "^2.2.0",
@@ -17742,7 +17742,7 @@
       }
     },
     "three": {
-      "version": "github:mozillareality/three.js#bf46db2d15303dee7d5e9a68a52beacbb2825c75",
+      "version": "github:mozillareality/three.js#25ed09daabc4b924140e8d2858cd3e02ad7a4ac0",
       "from": "github:mozillareality/three.js#hubs/master"
     },
     "three-bmfont-text": {

--- a/src/hub.html
+++ b/src/hub.html
@@ -32,7 +32,7 @@
         loading-screen="enabled: false"
         nextframe
         class="grab-cursor"
-        renderer="antialias: true; colorManagement: true; sortObjects: true; physicallyCorrectLights: true; alpha: false;"
+        renderer="antialias: true; colorManagement: true; sortObjects: true; physicallyCorrectLights: true; alpha: false; webgl2: true; multiview: true;"
         shadow="type: pcfsoft"
         networked-scene="adapter: janus; audio: true; debug: true; connectOnLoad: false;"
         physics="gravity: -9.8; debug: false; driver: ammo; debugDrawMode: 1;"


### PR DESCRIPTION
This enables WebGL2 and Multiview when available. This PR only contains the setting of the new flag, the actual work happens in https://github.com/MozillaReality/aframe/pull/9 and https://github.com/MozillaReality/three.js/pull/19. This will also include a performance improvement from https://github.com/MozillaReality/three.js/pull/18

Todo:
- [x] update hash in package.lock after MozillaReality/three.js#19 and MozillaReality/three.js#18 are merged
- [x] update hash in package.lock after MozillaReality/aframe#9 is merged