### PR TITLE
Add polyfill to fix camera on iOS

### DIFF
--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -18,6 +18,29 @@ const pathsMap = {
   }
 };
 
+const createImageBitmap =
+  window.createImageBitmap ||
+  async function(data) {
+    return new Promise(resolve => {
+      // https://dev.to/nektro/createimagebitmap-polyfill-for-safari-and-edge-228
+      // https://gist.github.com/MonsieurV/fb640c29084c171b4444184858a91bc7
+
+      const canvas = document.createElement("canvas");
+      const ctx = canvas.getContext("2d");
+      canvas.width = data.width;
+      canvas.height = data.height;
+      ctx.putImageData(data, 0, 0);
+      const dataURL = canvas.toDataURL();
+      const img = document.createElement("img");
+
+      img.addEventListener("load", function() {
+        resolve(this);
+      });
+
+      img.src = dataURL;
+    });
+  };
+
 const snapCanvas = document.createElement("canvas");
 async function pixelsToPNG(pixels, width, height) {
   snapCanvas.width = width;


### PR DESCRIPTION
Fixes the camera on iOS by adding a createImageBitmap polyfill.