### PR TITLE
Fix bug with initial grab

### DIFF
--- a/src/systems/userinput/devices/app-aware-touchscreen.js
+++ b/src/systems/userinput/devices/app-aware-touchscreen.js
@@ -79,9 +79,8 @@ export class AppAwareTouchscreenDevice {
           // If grab was being delayed, we should fire the initial grab and also delay the unassignment
           // to ensure we write at least two frames with the grab down (since the action set will change)
           // and otherwise we'd not see the falling xform.
-          if (assignment.framesUntilGrab >= -1) {
-            assignment.framesUntilGrab = 0;
-            assignment.framesUntilUnassign = 2;
+          if (assignment.framesUntilGrab >= 0) {
+            assignment.framesUntilUnassign = assignment.framesUntilGrab + 2;
           } else {
             unassign(assignment.touch, assignment.job, this.assignments);
           }


### PR DESCRIPTION
this fixes a bug where the initial tap on an object may not delay the grab properly and exhibit the previous "move object on tap" behavior -- this is especially problematic on the first object tapped on in a session. the change also just seems more correct.