### PR TITLE
Fix bug where pasting doens't work on hub.link

### DIFF
--- a/src/react-components/link-root.js
+++ b/src/react-components/link-root.js
@@ -68,11 +68,11 @@ class LinkRoot extends Component {
     if (this.state.entered.length >= this.maxAllowedChars()) return;
     const newChars = `${this.state.entered}${ch}`;
 
-    if (newChars.length === this.maxAllowedChars()) {
-      this.attemptLookup(newChars);
-    }
-
-    this.setState({ entered: newChars });
+    this.setState({ entered: newChars }, () => {
+      if (this.state.entered.length === this.maxAllowedChars()) {
+        this.attemptLookup(this.state.entered);
+      }
+    });
   };
 
   removeChar = () => {
@@ -175,7 +175,11 @@ class LinkRoot extends Component {
                       this.setState({ isAlphaMode: true });
                     }
 
-                    this.setState({ entered: ev.target.value.toUpperCase() });
+                    this.setState({ entered: ev.target.value.toUpperCase() }, () => {
+                      if (this.state.entered.length === this.maxAllowedChars()) {
+                        this.attemptLookup(this.state.entered);
+                      }
+                    });
                   }}
                 />
               </div>

--- a/src/react-components/link-root.js
+++ b/src/react-components/link-root.js
@@ -31,8 +31,23 @@ class LinkRoot extends Component {
     failedAtLeastOnce: false
   };
 
+  buttonRefs = {};
+
   componentDidMount = () => {
     document.addEventListener("keydown", this.handleKeyDown);
+
+    // https://github.com/facebook/react/issues/9809#issuecomment-413978405
+    if (hasTouchEvents) {
+      for (const [name, ref] of Object.entries(this.buttonRefs)) {
+        if (name === "remove") {
+          ref.ontouchstart = () => this.removeChar();
+        } else if (name === "toggle") {
+          ref.ontouchstart = () => this.toggleMode();
+        } else {
+          ref.ontouchstart = () => this.addToEntry(name);
+        }
+      }
+    }
   };
 
   componentWillUnmount = () => {
@@ -215,7 +230,7 @@ class LinkRoot extends Component {
                     onClick={() => {
                       if (!hasTouchEvents) this.addToEntry(d);
                     }}
-                    onTouchStart={() => this.addToEntry(d)}
+                    ref={r => (this.buttonRefs[d.toString()] = r)}
                   >
                     {d}
                   </button>
@@ -225,7 +240,7 @@ class LinkRoot extends Component {
                 <WithHoverSound>
                   <button
                     className={classNames(styles.keypadButton, styles.keypadToggleMode)}
-                    onTouchStart={() => this.toggleMode()}
+                    ref={r => (this.buttonRefs["toggle"] = r)}
                     onClick={() => {
                       if (!hasTouchEvents) this.toggleMode();
                     }}
@@ -241,7 +256,7 @@ class LinkRoot extends Component {
                   <button
                     disabled={this.state.entered.length === this.maxAllowedChars()}
                     className={classNames(styles.keypadButton, styles.keypadZeroButton)}
-                    onTouchStart={() => this.addToEntry(0)}
+                    ref={r => (this.buttonRefs["0"] = r)}
                     onClick={() => {
                       if (!hasTouchEvents) this.addToEntry(0);
                     }}
@@ -254,7 +269,7 @@ class LinkRoot extends Component {
                 <button
                   disabled={this.state.entered.length === 0 || this.state.entered.length === this.maxAllowedChars()}
                   className={classNames(styles.keypadButton, styles.keypadBackspace)}
-                  onTouchStart={() => this.removeChar()}
+                  ref={r => (this.buttonRefs["remove"] = r)}
                   onClick={() => {
                     if (!hasTouchEvents) this.removeChar();
                   }}


### PR DESCRIPTION
Previously we weren't handling situations where the user pasted into the textbox, now the `onChange` will always check if it's time to redirect.