### PR TITLE
Bug/ios video audio corruption

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -330,6 +330,7 @@ AFRAME.registerComponent("media-video", {
     this.togglePlaying = this.togglePlaying.bind(this);
 
     this.lastUpdate = 0;
+    this.videoMutedAt = 0;
 
     this.el.setAttribute("hover-menu__video", { template: "#video-hover-menu", dirs: ["forward", "back"] });
     this.el.components["hover-menu__video"].getHoverMenu().then(menu => {
@@ -556,6 +557,10 @@ AFRAME.registerComponent("media-video", {
     }
 
     this.updatePlaybackState(true);
+
+    if (this.video.muted) {
+      this.videoMutedAt = performance.now();
+    }
 
     this.el.emit("video-loaded");
   },

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -622,11 +622,12 @@ AFRAME.registerComponent("media-video", {
   remove() {
     this.cleanUp();
 
-    const sound = this.el.getObject3D("sound");
-
-    if (sound) {
-      sound.disconnect();
+    if (this.audio) {
+      this.el.removeObject3D("sound");
+      this.audio.disconnect();
+      delete this.audio;
     }
+
     if (this.video) {
       this.video.removeEventListener("pause", this.onPauseStateChange);
       this.video.removeEventListener("play", this.onPauseStateChange);

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -622,6 +622,11 @@ AFRAME.registerComponent("media-video", {
   remove() {
     this.cleanUp();
 
+    const sound = this.el.getObject3D("sound");
+
+    if (sound) {
+      sound.disconnect();
+    }
     if (this.video) {
       this.video.removeEventListener("pause", this.onPauseStateChange);
       this.video.removeEventListener("play", this.onPauseStateChange);

--- a/src/components/unmute-video-button.js
+++ b/src/components/unmute-video-button.js
@@ -5,9 +5,19 @@ AFRAME.registerComponent("unmute-video-button", {
     this.onClick = () => {
       const videoEl = findAncestorWithComponent(this.el, "media-video");
       const mediaVideo = videoEl.components["media-video"];
-      if (!mediaVideo || !mediaVideo.video) return;
-      mediaVideo.video.muted = false;
-      this.el.setAttribute("visible", false);
+      if (!mediaVideo || !mediaVideo.video || !mediaVideo.videoMutedAt) return;
+
+      // iOS initially plays the sound and *then* mutes it, and sometimes a second video playing
+      // can break all sound in the app. (Likely a Safari bug.) Adding a delay before the unmute
+      // occurs seems to help with reducing this.
+      if (performance.now() - mediaVideo.videoMutedAt < 3000) {
+        return;
+      }
+
+      if (mediaVideo.video.muted) {
+        mediaVideo.video.muted = false;
+        this.el.setAttribute("visible", false);
+      }
     };
   },
 


### PR DESCRIPTION
This adds two changes that seem to mitigate a large part of the scenarios where Safari on iOS has audio die or videos can misbehave:

- We weren't clearing out audio sources on removal, oops
- Prevent the user from unmuting for a few seconds.  