### PR TITLE
Deal with touchscreen sitting on tabletop

### DIFF
--- a/src/systems/userinput/devices/gyro.js
+++ b/src/systems/userinput/devices/gyro.js
@@ -68,6 +68,9 @@ export class GyroDevice {
       hmdEuler.setFromQuaternion(this.hmdQuaternion, "YXZ");
     }
 
+    // Don't use gyro values when device is lying flat
+    if (hmdEuler.x < -Math.PI * 0.475) return;
+
     const dX = THREE.Math.RAD2DEG * difference(hmdEuler.x, this.prevX);
     const dY = THREE.Math.RAD2DEG * difference(hmdEuler.y, this.prevY);
 


### PR DESCRIPTION
Currently if you try to use hubs with your phone sitting flat, the camera oscillates around like crazy, this masks out extreme angles from the gyro.