### PR TITLE
Only finish local tip for pinning and invite

### DIFF
--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1526,7 +1526,10 @@ class UIRoot extends Component {
             {entered &&
               this.props.activeTips.bottom && (
                 <div className={styles.bottomTip}>
-                  <button className={styles.tipCancel} onClick={() => handleTipClose(this.props.activeTips.bottom)}>
+                  <button
+                    className={styles.tipCancel}
+                    onClick={() => handleTipClose(this.props.activeTips.bottom, "bottom")}
+                  >
                     <i>
                       <FontAwesomeIcon icon={faTimes} />
                     </i>

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -55,7 +55,7 @@ import ChatCommandHelp from "./chat-command-help";
 import { spawnChatMessage } from "./chat-message";
 import { showFullScreenIfAvailable, showFullScreenIfWasFullScreen } from "../utils/fullscreen";
 import { handleTextFieldFocus, handleTextFieldBlur } from "../utils/focus-utils";
-import { markTipScopeFinished } from "../systems/tips.js";
+import { handleTipClose } from "../systems/tips.js";
 import { faUsers } from "@fortawesome/free-solid-svg-icons/faUsers";
 import { faImage } from "@fortawesome/free-solid-svg-icons/faImage";
 import { faBars } from "@fortawesome/free-solid-svg-icons/faBars";
@@ -1526,7 +1526,10 @@ class UIRoot extends Component {
             {entered &&
               this.props.activeTips.bottom && (
                 <div className={styles.bottomTip}>
-                  <button className={styles.tipCancel} onClick={() => markTipScopeFinished("bottom")}>
+                  <button
+                    className={styles.tipCancel}
+                    onClick={() => handleTipClose(this.props.activeTips.bottom)}
+                  >
                     <i>
                       <FontAwesomeIcon icon={faTimes} />
                     </i>

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1526,10 +1526,7 @@ class UIRoot extends Component {
             {entered &&
               this.props.activeTips.bottom && (
                 <div className={styles.bottomTip}>
-                  <button
-                    className={styles.tipCancel}
-                    onClick={() => handleTipClose(this.props.activeTips.bottom)}
-                  >
+                  <button className={styles.tipCancel} onClick={() => handleTipClose(this.props.activeTips.bottom)}>
                     <i>
                       <FontAwesomeIcon icon={faTimes} />
                     </i>

--- a/src/systems/tips.js
+++ b/src/systems/tips.js
@@ -92,8 +92,8 @@ export const markTipFinished = tip => {
   localStorageCache = null;
 };
 
-export const handleTipClose = fullTip => {
-  const [scope, tip] = fullTip.split(".");
+export const handleTipClose = (fullTip, scope) => {
+  const [platform, tip] = fullTip.split(".");
 
   // Invite and pinning tips should be locally cleared, others should clear all remaining tips.
   const tips = LOCAL_CLOSE_TIPS.includes(tip) ? [tip] : platformTips[scope];

--- a/src/systems/tips.js
+++ b/src/systems/tips.js
@@ -62,6 +62,9 @@ const TIPS = {
   standalone: { top: [], bottom: [] }
 };
 
+// These tips, if closed, will only clear themselves, not all tips.
+const LOCAL_CLOSE_TIPS = ["invite", "object_pin"];
+
 let localStorageCache = null;
 let finishedScopes = {}; // Optimization, lets system skip scopes altogether once finished.
 
@@ -89,8 +92,11 @@ export const markTipFinished = tip => {
   localStorageCache = null;
 };
 
-export const markTipScopeFinished = scope => {
-  const tips = platformTips[scope];
+export const handleTipClose = fullTip => {
+  const [scope, tip] = fullTip.split(".");
+
+  // Invite and pinning tips should be locally cleared, others should clear all remaining tips.
+  const tips = LOCAL_CLOSE_TIPS.includes(tip) ? [tip] : platformTips[scope];
 
   for (let i = 0; i < tips.length; i++) {
     const tip = tips[i];

--- a/src/systems/tips.js
+++ b/src/systems/tips.js
@@ -93,7 +93,7 @@ export const markTipFinished = tip => {
 };
 
 export const handleTipClose = (fullTip, scope) => {
-  const [platform, tip] = fullTip.split(".");
+  const tip = fullTip.split(".")[1];
 
   // Invite and pinning tips should be locally cleared, others should clear all remaining tips.
   const tips = LOCAL_CLOSE_TIPS.includes(tip) ? [tip] : platformTips[scope];


### PR DESCRIPTION
This makes it so if you X out the invite tip or the pinning tip (both of which are terminal tips in the happy path) it won't clear out all tips, just that one. The main effect before this was if you say cancelled the Invite tip you'd never be taught about how to use the pen.