### PR TITLE
Switch browser UI to full screen mode on mobile VR

### DIFF
--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -1,6 +1,7 @@
 import qsTruthy from "./utils/qs_truthy";
 import nextTick from "./utils/next-tick";
 import pinnedEntityToGltf from "./utils/pinned-entity-to-gltf";
+import { showFullScreenIfAvailable } from "./utils/fullscreen";
 
 const playerHeight = 1.6;
 const isBotMode = qsTruthy("bot");
@@ -278,6 +279,7 @@ export default class SceneEntryManager {
     if (this.availableVREntryTypes.isInHMD) {
       // Immersive browser, exit VR.
       this.scene.exitVR();
+      showFullScreenIfAvailable();
     } else {
       // Non-immersive browser, show notice
       const vrNotice = document.querySelector(".vr-notice");

--- a/src/utils/focus-utils.js
+++ b/src/utils/focus-utils.js
@@ -8,10 +8,9 @@ let isExitingFullscreenDueToFocus = false;
 // - On non-mobile platforms, selects the value on focus
 // - If full screen, exits/enters full screen because of firefox full screen issues
 export function handleTextFieldFocus(target) {
-  if (AFRAME.utils.device.isMobileVR()) return;
   const isMobile = AFRAME.utils.device.isMobile();
 
-  if (screenfull.isFullscreen) {
+  if (screenfull.isFullscreen && !AFRAME.utils.device.isMobileVR()) {
     // This will prevent focus, but its the only way to avoid getting into a
     // weird "firefox reports full screen but actually not". You end up having to tap
     // twice to ultimately get the focus.

--- a/src/utils/focus-utils.js
+++ b/src/utils/focus-utils.js
@@ -8,6 +8,7 @@ let isExitingFullscreenDueToFocus = false;
 // - On non-mobile platforms, selects the value on focus
 // - If full screen, exits/enters full screen because of firefox full screen issues
 export function handleTextFieldFocus(target) {
+  if (AFRAME.utils.device.isMobileVR()) return;
   const isMobile = AFRAME.utils.device.isMobile();
 
   if (screenfull.isFullscreen) {


### PR DESCRIPTION
I wasn't able to test this locally since I think full screen mode is disabled over non SSL domains, but this theoretically should flip us into full screen mode on standalones when existing immersive mode for UI stuff, which is cool.