### PR TITLE
Make pen sticky on vive

### DIFF
--- a/src/systems/userinput/bindings/vive-user.js
+++ b/src/systems/userinput/bindings/vive-user.js
@@ -73,8 +73,10 @@ const keyboardBoost = k("boost");
 
 const leftGripPressed1 = v("leftGripPressed1");
 const leftGripPressed2 = v("leftGripPressed2");
+const leftGripPressed3 = v("leftGripPressed2");
 const rightGripPressed1 = v("rightGripPressed1");
 const rightGripPressed2 = v("rightGripPressed2");
+const rightGripPressed3 = v("rightGripPressed2");
 const leftTriggerPressed1 = v("leftTriggerPressed1");
 const leftTriggerPressed2 = v("leftTriggerPressed2");
 const leftTouchpadPressed1 = v("leftTouchpadPressed1");
@@ -741,6 +743,18 @@ export const viveUserBindings = addSetsToBindings({
   [sets.leftHandHoveringOnPen]: [],
   [sets.leftHandHoldingPen]: [
     {
+      src: { value: leftGripPressed3 },
+      dest: { value: paths.actions.leftHand.drop },
+      xform: xforms.rising,
+      priority: 2
+    },
+    {
+      src: { value: leftGripPressed2 },
+      dest: { value: paths.actions.leftHand.drop },
+      xform: xforms.noop,
+      priority: 2
+    },
+    {
       src: { value: leftTouchpadPressed2 },
       dest: { value: leftTouchpadFallingStopTeleport },
       xform: xforms.falling,
@@ -999,7 +1013,8 @@ export const viveUserBindings = addSetsToBindings({
     {
       src: [rHandDrop1],
       dest: { value: paths.actions.rightHand.drop },
-      xform: xforms.any
+      xform: xforms.any,
+      priority: 2
     },
     {
       src: {},
@@ -1010,6 +1025,18 @@ export const viveUserBindings = addSetsToBindings({
   ],
   [sets.rightHandHoveringOnPen]: [],
   [sets.rightHandHoldingPen]: [
+    {
+      src: [rHandDrop1],
+      dest: { value: paths.actions.rightHand.drop },
+      xform: xforms.noop,
+      priority: 1
+    },
+    {
+      src: { value: rightGripPressed3 },
+      dest: { value: paths.actions.rightHand.drop },
+      xform: xforms.rising,
+      priority: 1
+    },
     {
       src: {
         bool: rTouchpadRising,

--- a/src/systems/userinput/bindings/vive-user.js
+++ b/src/systems/userinput/bindings/vive-user.js
@@ -844,7 +844,7 @@ export const viveUserBindings = addSetsToBindings({
         touching: lButton("touchpad").touched
       },
       dest: { value: paths.actions.leftHand.scalePenTip },
-      xform: xforms.touch_axis_scroll(0.1)
+      xform: xforms.touch_axis_scroll(0.05)
     },
     {
       src: { value: lButton("top").pressed },
@@ -1101,7 +1101,7 @@ export const viveUserBindings = addSetsToBindings({
         touching: rButton("touchpad").touched
       },
       dest: { value: paths.actions.rightHand.scalePenTip },
-      xform: xforms.touch_axis_scroll(0.1)
+      xform: xforms.touch_axis_scroll(0.05)
     },
     {
       src: { value: rButton("top").pressed },

--- a/src/systems/userinput/bindings/vive-user.js
+++ b/src/systems/userinput/bindings/vive-user.js
@@ -73,10 +73,8 @@ const keyboardBoost = k("boost");
 
 const leftGripPressed1 = v("leftGripPressed1");
 const leftGripPressed2 = v("leftGripPressed2");
-const leftGripPressed3 = v("leftGripPressed2");
 const rightGripPressed1 = v("rightGripPressed1");
 const rightGripPressed2 = v("rightGripPressed2");
-const rightGripPressed3 = v("rightGripPressed2");
 const leftTriggerPressed1 = v("leftTriggerPressed1");
 const leftTriggerPressed2 = v("leftTriggerPressed2");
 const leftTouchpadPressed1 = v("leftTouchpadPressed1");
@@ -743,7 +741,7 @@ export const viveUserBindings = addSetsToBindings({
   [sets.leftHandHoveringOnPen]: [],
   [sets.leftHandHoldingPen]: [
     {
-      src: { value: leftGripPressed3 },
+      src: { value: leftGripPressed2 },
       dest: { value: paths.actions.leftHand.drop },
       xform: xforms.rising,
       priority: 2
@@ -1032,7 +1030,7 @@ export const viveUserBindings = addSetsToBindings({
       priority: 1
     },
     {
-      src: { value: rightGripPressed3 },
+      src: { value: rightGripPressed2 },
       dest: { value: paths.actions.rightHand.drop },
       xform: xforms.rising,
       priority: 1

--- a/src/systems/userinput/bindings/vive-user.js
+++ b/src/systems/userinput/bindings/vive-user.js
@@ -916,6 +916,24 @@ export const viveUserBindings = addSetsToBindings({
 
   [sets.cursorHoldingPen]: [
     {
+      src: [cursorDrop1],
+      dest: { value: paths.actions.cursor.drop },
+      xform: xforms.noop,
+      priority: 1
+    },
+    {
+      src: [cursorDrop2],
+      dest: { value: paths.actions.cursor.drop },
+      xform: xforms.noop,
+      priority: 1
+    },
+    {
+      src: { value: rightGripPressed2 },
+      dest: { value: paths.actions.cursor.drop },
+      xform: xforms.rising,
+      priority: 1
+    },
+    {
       src: {
         bool: rTouchpadRising,
         value: rDpadCenter


### PR DESCRIPTION
This updates the vive controls to make the pen grip lock by default, so a second grip click is needed to drop it. The reason is that the pen is unique in only actually being usable as a tool when gripped, so this seems like the right tradeoff in comfort vs consistency wrt the grip and trigger working the same as other objects.