### PR TITLE
Bump three-mesh-bvh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17768,8 +17768,9 @@
       }
     },
     "three-mesh-bvh": {
-      "version": "github:mquander/three-mesh-bvh#5dfd31ecf7a68003a68933036875ba802fd7b9b6",
-      "from": "github:mquander/three-mesh-bvh#global-three"
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.1.0.tgz",
+      "integrity": "sha512-CYcODvb9jgXQdTt99Uj6Ec6+CiYc3S1NE7jp1iUud9+7ACWe358qpERF7qxJjJa3+XLQxz2pDCigwZHGc9LLjQ=="
     },
     "three-pathfinding": {
       "version": "github:mozillareality/three-pathfinding#a52f437eaaf1b608c5f7fed046846bdbd79c75e7",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "screenfull": "^3.3.2",
     "super-hands": "github:mozillareality/aframe-super-hands-component#hubs/master",
     "three": "github:mozillareality/three.js#hubs/master",
-    "three-mesh-bvh": "github:mquander/three-mesh-bvh#global-three",
+    "three-mesh-bvh": "^0.1.0",
     "three-pathfinding": "github:mozillareality/three-pathfinding#hubs/master",
     "three-to-cannon": "1.3.0",
     "uuid": "^3.2.1",

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -341,20 +341,14 @@ export function generateMeshBVH(object3D) {
     const hasBufferGeometry = obj.isMesh && obj.geometry.isBufferGeometry;
     const hasBoundsTree = hasBufferGeometry && obj.geometry.boundsTree;
     if (hasBufferGeometry && !hasBoundsTree) {
-      // we can't currently build a BVH for geometries with groups, because the groups rely on the
-      // existing ordering of the index, which we kill as a result of building the tree
-      if (obj.geometry.groups && obj.geometry.groups.length) {
-        console.warn("BVH construction not supported for geometry with groups; raycasting may suffer.");
-      } else {
-        const geo = obj.geometry;
-        const triCount = geo.index ? geo.index.count / 3 : geo.attributes.position.count / 3;
-        // only bother using memory and time making a BVH if there are a reasonable number of tris,
-        // and if there are too many it's too painful and large to tolerate doing it (at least until
-        // we put this in a web worker)
-        if (triCount > 1000 && triCount < 1000000) {
-          geo.boundsTree = new MeshBVH(obj.geometry, { strategy: 0, maxDepth: 30 });
-          geo.setIndex(geo.boundsTree.index);
-        }
+      const geo = obj.geometry;
+      const triCount = geo.index ? geo.index.count / 3 : geo.attributes.position.count / 3;
+      // only bother using memory and time making a BVH if there are a reasonable number of tris,
+      // and if there are too many it's too painful and large to tolerate doing it (at least until
+      // we put this in a web worker)
+      if (triCount > 1000 && triCount < 1000000) {
+        // note that bounds tree construction creates an index as a side effect if one doesn't already exist
+        geo.boundsTree = new MeshBVH(obj.geometry, { strategy: 0, maxDepth: 30 });
       }
     }
   });


### PR DESCRIPTION
Now that the A-Frame/three build process is less weird, we don't have to use a fork of three-mesh-bvh anymore.

In addition, three-mesh-bvh now supports [geometries with groups](https://github.com/gkjohnson/three-mesh-bvh/pull/70), so we can have fast raycasting for them also now.