### PR TITLE
Fix up userinput-debug, add rudimentary debug flag

### DIFF
--- a/src/systems/userinput/userinput-debug.js
+++ b/src/systems/userinput/userinput-debug.js
@@ -18,8 +18,8 @@ AFRAME.registerSystem("userinput-debug", {
       };
       const pathsOutput = [];
       const { frame } = userinput;
-      for (const key in frame) {
-        if (!frame.hasOwnProperty(key)) continue;
+      for (const key in frame.values) {
+        if (!frame.get(key)) continue;
         if (!["/actions/"].some(x => key.startsWith(x))) continue;
         let val = JSON.stringify(frame.get(key), replacer);
         if (val) val = val.replace(/{"(\w{3,})":/g, '{\n  "$1":').replace(/,"(\w{3,})":/g, ',\n  "$1":');

--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -382,8 +382,25 @@ AFRAME.registerSystem("userinput", {
         this.xformStates.delete(binding);
       }
 
-      const { src, dest, xform } = binding;
+      const { src, dest, xform, debug } = binding;
+
+      let oldValue;
+
+      if (debug) {
+        oldValue = this.frame.get(dest.value);
+      }
+
       const newState = xform(this.frame, src, dest, this.xformStates.get(binding));
+
+      if (debug) {
+        // Note for now this only works with bindings that have { value: } sources and dests
+        console.log(
+          `${JSON.stringify(src.value)} (${src.value && JSON.stringify(this.frame.get(src.value))}) to ${JSON.stringify(
+            dest
+          )}: ${oldValue} -> ${this.frame.get(dest.value)}`
+        );
+      }
+
       if (newState !== undefined) {
         this.xformStates.set(binding, newState);
       }


### PR DESCRIPTION
Fixes up the userinput-debug system and also adds a handy debug: true flag that can be set on a binding to spit out the state before and after its xform every tick. For now only supports the `{ value: }` style src and dests.

Fixes #1061