### PR TITLE
Make media button components more robust

### DIFF
--- a/src/components/clone-media-button.js
+++ b/src/components/clone-media-button.js
@@ -4,18 +4,22 @@ import { guessContentType } from "../utils/media-utils";
 
 AFRAME.registerComponent("clone-media-button", {
   init() {
+
+    this.updateSrc = () => {
+      const src = this.src = this.targetEl.components["media-loader"].data.src;
+      const visible = src && (guessContentType(src) !== "video/vnd.hubs-webrtc");
+      this.el.object3D.visible = !!visible;
+    };
+
     NAF.utils.getNetworkedEntity(this.el).then(networkedEl => {
       this.targetEl = networkedEl;
-
-      const { src } = this.targetEl.components["media-loader"].data;
-
-      if (guessContentType(src) === "video/vnd.hubs-webrtc") {
-        this.el.object3D.visible = false;
-      }
+      this.targetEl.addEventListener("media_resolved", this.updateSrc, { once: true });
+      this.updateSrc();
     });
 
     this.onClick = () => {
-      const { src, resize } = this.targetEl.components["media-loader"].data;
+      const src = this.src;
+      const { resize } = this.targetEl.components["media-loader"].data;
       const { entity } = addMedia(src, "#interactable-media", ObjectContentOrigins.URL, true, resize);
 
       entity.object3D.matrixNeedsUpdate = true;

--- a/src/components/clone-media-button.js
+++ b/src/components/clone-media-button.js
@@ -4,10 +4,9 @@ import { guessContentType } from "../utils/media-utils";
 
 AFRAME.registerComponent("clone-media-button", {
   init() {
-
     this.updateSrc = () => {
-      const src = this.src = this.targetEl.components["media-loader"].data.src;
-      const visible = src && (guessContentType(src) !== "video/vnd.hubs-webrtc");
+      const src = (this.src = this.targetEl.components["media-loader"].data.src);
+      const visible = src && guessContentType(src) !== "video/vnd.hubs-webrtc";
       this.el.object3D.visible = !!visible;
     };
 

--- a/src/components/open-media-button.js
+++ b/src/components/open-media-button.js
@@ -6,8 +6,8 @@ AFRAME.registerComponent("open-media-button", {
     this.label = this.el.querySelector("[text]");
 
     this.updateSrc = () => {
-      const src = this.src = this.targetEl.components["media-loader"].data.src;
-      const visible = src && (guessContentType(src) !== "video/vnd.hubs-webrtc");
+      const src = (this.src = this.targetEl.components["media-loader"].data.src);
+      const visible = src && guessContentType(src) !== "video/vnd.hubs-webrtc";
       this.el.object3D.visible = !!visible;
 
       if (visible) {

--- a/src/components/open-media-button.js
+++ b/src/components/open-media-button.js
@@ -6,21 +6,19 @@ AFRAME.registerComponent("open-media-button", {
     this.label = this.el.querySelector("[text]");
 
     this.updateSrc = () => {
-      this.src = this.targetEl.components["media-loader"].data.src;
+      const src = this.src = this.targetEl.components["media-loader"].data.src;
+      const visible = src && (guessContentType(src) !== "video/vnd.hubs-webrtc");
+      this.el.object3D.visible = !!visible;
 
-      if (guessContentType(this.src) === "video/vnd.hubs-webrtc") {
-        this.el.object3D.visible = false;
+      if (visible) {
+        let label = "open link";
+        if (isHubsSceneUrl(src)) {
+          label = "use scene";
+        } else if (isHubsRoomUrl(src)) {
+          label = "visit room";
+        }
+        this.label.setAttribute("text", "value", label);
       }
-
-      let label = "open link";
-
-      if (isHubsSceneUrl(this.src)) {
-        label = "use scene";
-      } else if (isHubsRoomUrl(this.src)) {
-        label = "visit room";
-      }
-
-      this.label.setAttribute("text", "value", label);
     };
 
     this.onClick = () => {


### PR DESCRIPTION
These components need to handle the case where `src` is empty, because that's the case they are going to get when they is spawned from the `#interactable-media` template. Previously, race conditions caused them to sometimes spew errors and/or not quite work right due to poor handling of that case.

IMO these components should stop having this odd logic in them and instead have a `src` attribute supplied by `addMedia`, but that change can take a back seat to correctness.