### PR TITLE
Upload wasm correctly to S3

### DIFF
--- a/scripts/hab-build-and-push.sh
+++ b/scripts/hab-build-and-push.sh
@@ -36,6 +36,10 @@ mkdir dist/pages
 mv dist/*.html dist/pages
 mv dist/hub.service.js dist/pages
 
-aws s3 sync --acl public-read --cache-control "max-age=31556926" dist/assets "$TARGET_S3_URL/assets"
+# we need to upload wasm blobs with wasm content type explicitly because, unlike all our
+# other assets, AWS's built-in MIME type dictionary doesn't know about that one
+aws s3 sync --acl public-read --cache-control "max-age=31556926" --include "*" --exclude "*.wasm" dist/assets "$TARGET_S3_URL/assets"
+aws s3 sync --acl public-read --cache-control "max-age=31556926" --exclude "*" --include "*.wasm" --content-type "application/wasm" dist/assets "$TARGET_S3_URL/assets"
+
 aws s3 sync --acl public-read --cache-control "no-cache" --delete dist/pages "$TARGET_S3_URL/pages/latest"
 aws s3 sync --acl public-read --cache-control "no-cache" --delete dist/pages "$TARGET_S3_URL/pages/releases/${BUILD_NUMBER}"


### PR DESCRIPTION
If you don't specify a content type, it will get uploaded as binary/octet-stream, and Firefox (at least) will get mad when it tries to download and compile it and refuse to do a streaming compile.

(Perhaps this may also cause CloudFront to gzip it, which is also not working.)