### PR TITLE
Verify AFRAME exists in focus handler

### DIFF
--- a/src/utils/focus-utils.js
+++ b/src/utils/focus-utils.js
@@ -8,7 +8,7 @@ let isExitingFullscreenDueToFocus = false;
 // - On non-mobile platforms, selects the value on focus
 // - If full screen, exits/enters full screen because of firefox full screen issues
 export function handleTextFieldFocus(target) {
-  if (!AFRAME) return;
+  if (!window.AFRAME) return;
   const isMobile = AFRAME.utils.device.isMobile();
 
   if (screenfull.isFullscreen && !AFRAME.utils.device.isMobileVR()) {

--- a/src/utils/focus-utils.js
+++ b/src/utils/focus-utils.js
@@ -8,6 +8,7 @@ let isExitingFullscreenDueToFocus = false;
 // - On non-mobile platforms, selects the value on focus
 // - If full screen, exits/enters full screen because of firefox full screen issues
 export function handleTextFieldFocus(target) {
+  if (!AFRAME) return;
   const isMobile = AFRAME.utils.device.isMobile();
 
   if (screenfull.isFullscreen && !AFRAME.utils.device.isMobileVR()) {


### PR DESCRIPTION
fixes a bug that we're getting on the homepage sign in because the focus handler requires AFRAME. this focus handler isn't relevant in this context so instead of refactoring this code to do an alternative mobile check I'm just exiting early if AFRAME isn't on the page.