### PR TITLE
Handle cases where event handlers come in late in VR startup

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -583,7 +583,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   window.APP.scene = scene;
   window.APP.hubChannel = hubChannel;
 
-  scene.addEventListener("enter-vr", () => {
+  const handleEarlyVRMode = () => {
     // If VR headset is activated, refreshing page will fire vrdisplayactivate
     // which puts A-Frame in VR mode, so exit VR mode whenever it is attempted
     // to be entered and we haven't entered the room yet.
@@ -593,6 +593,12 @@ document.addEventListener("DOMContentLoaded", async () => {
       return true;
     }
 
+    return false;
+  };
+
+  scene.addEventListener("enter-vr", () => {
+    if (handleEarlyVRMode()) return true;
+
     document.body.classList.add("vr-mode");
 
     // Don't stretch canvas on cardboard, since that's drawing the actual VR view :)
@@ -601,25 +607,31 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
   });
 
+  handleEarlyVRMode();
+
   // HACK A-Frame 0.9.0 seems to fail to wire up vrdisplaypresentchange early enough
   // to catch presentation state changes and recognize that an HMD is presenting on startup.
-  window.addEventListener(
-    "vrdisplaypresentchange",
-    () => {
-      if (scene.is("vr-entered")) return;
-      if (scene.is("vr-mode")) return;
 
-      const device = AFRAME.utils.device.getVRDisplay();
+  let hasHandledAframeInitBug = false;
+  const handleAframeInitBug = () => {
+    if (hasHandledAframeInitBug) return;
+    if (scene.is("vr-entered")) return;
+    if (scene.is("vr-mode")) return;
 
-      if (device && device.isPresenting) {
-        if (!scene.is("vr-mode")) {
-          console.warn("Hit A-Frame bug where VR display is presenting but A-Frame has not entered VR mode.");
-          scene.enterVR();
-        }
+    const device = AFRAME.utils.device.getVRDisplay();
+
+    if (device && device.isPresenting) {
+      if (!scene.is("vr-mode")) {
+        console.warn("Hit A-Frame bug where VR display is presenting but A-Frame has not entered VR mode.");
+        hasHandledAframeInitBug = true;
+        scene.enterVR();
       }
-    },
-    { once: true }
-  );
+    }
+  };
+
+  window.addEventListener("vrdisplaypresentchange", handleAframeInitBug, { once: true });
+
+  handleAframeInitBug();
 
   scene.addEventListener("exit-vr", () => {
     document.body.classList.remove("vr-mode");


### PR DESCRIPTION
The code currently has two hacks dealing with WebVR startup in A-Frame when a user refreshes the page after a VR session on desktop:

- It's always been the case that A-Frame/WebVR will retain VR mode across refreshes, we have a hack that will exit VR mode on startup if this case is hit

- There was a regression in 0.9.0 that causes A-Frame to miss this condition in certain conditions, resulting in a situation where the display is presenting but A-Frame did not run its relevant "enter VR" routines (to tag the scene metadata, set up cameras, etc.)

The previous hacks handled these cases by subscribing to `enter-vr `and `vrdisplaypresentchange` to get out ahead of these conditions, but in practice it looks like in certain cases these event subscriptions are happening too late, the events have already fired (for both conditions.) This PR updates them to both be handled when these events fire but also pre-emptively run the necessary logic at event subscription time in case the event has already fired.