### PR TITLE
Remove a bunch of little recurring work

### DIFF
--- a/src/components/stats-plus.js
+++ b/src/components/stats-plus.js
@@ -55,6 +55,7 @@ AFRAME.registerComponent("stats-plus", {
     this.lastFpsUpdate = performance.now();
     this.lastFps = 0;
     this.frameCount = 0;
+    this.inVR = scene.is("vr-mode");
 
     if (scene.isMobile) {
       this.statsEl.classList.add("rs-mobile");
@@ -82,7 +83,7 @@ AFRAME.registerComponent("stats-plus", {
       stats("rAF").tick();
       stats("FPS").frame();
       stats().update();
-    } else {
+    } else if (!this.inVR) {
       // Update the fps counter
       const now = performance.now();
       this.frameCount++;
@@ -100,6 +101,7 @@ AFRAME.registerComponent("stats-plus", {
     }
   },
   onEnterVr() {
+    this.inVR = true;
     // Hide all stats elements when entering VR on mobile
     if (this.el.sceneEl.isMobile) {
       this.statsEl.classList.add(HIDDEN_CLASS);
@@ -107,6 +109,7 @@ AFRAME.registerComponent("stats-plus", {
     }
   },
   onExitVr() {
+    this.inVR = false;
     // Revert to previous state whe exiting VR on mobile
     if (this.el.sceneEl.isMobile) {
       if (this.data) {

--- a/src/hub.js
+++ b/src/hub.js
@@ -191,21 +191,6 @@ function getPlatformUnsupportedReason() {
   return null;
 }
 
-function pollForSupportAvailability(callback) {
-  const availabilityUrl = getReticulumFetchUrl("/api/v1/support/availability");
-  let isSupportAvailable = null;
-
-  const updateIfChanged = () =>
-    fetch(availabilityUrl).then(({ ok }) => {
-      if (isSupportAvailable === ok) return;
-      isSupportAvailable = ok;
-      callback(isSupportAvailable);
-    });
-
-  updateIfChanged();
-  setInterval(updateIfChanged, 30000);
-}
-
 function setupLobbyCamera() {
   const camera = document.querySelector("#player-camera");
   const previewCamera = document.querySelector("#environment-scene").object3D.getObjectByName("scene-preview-camera");
@@ -654,8 +639,6 @@ document.addEventListener("DOMContentLoaded", async () => {
   scene.addEventListener("camera_toggled", () => remountUI({}));
 
   scene.addEventListener("camera_removed", () => remountUI({}));
-
-  // pollForSupportAvailability(isSupportAvailable => remountUI({ isSupportAvailable }));
 
   const platformUnsupportedReason = getPlatformUnsupportedReason();
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -658,7 +658,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   scene.addEventListener("camera_removed", () => remountUI({}));
 
-  pollForSupportAvailability(isSupportAvailable => remountUI({ isSupportAvailable }));
+  // pollForSupportAvailability(isSupportAvailable => remountUI({ isSupportAvailable }));
 
   const platformUnsupportedReason = getPlatformUnsupportedReason();
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -167,7 +167,7 @@ import registerTelemetry from "./telemetry";
 import { warmSerializeElement } from "./utils/serialize-element";
 
 import { getAvailableVREntryTypes, VR_DEVICE_AVAILABILITY } from "./utils/vr-caps-detect.js";
-import ConcurrentLoadDetector from "./utils/concurrent-load-detector.js";
+import detectConcurrentLoad from "./utils/concurrent-load-detector.js";
 
 import qsTruthy from "./utils/qs_truthy";
 
@@ -182,9 +182,7 @@ if (!isBotMode && !isTelemetryDisabled) {
 }
 
 disableiOSZoom();
-
-const concurrentLoadDetector = new ConcurrentLoadDetector();
-concurrentLoadDetector.start();
+detectConcurrentLoad();
 
 store.init();
 
@@ -256,7 +254,6 @@ function mountUI(props = {}) {
             {...{
               scene,
               isBotMode,
-              concurrentLoadDetector,
               disableAutoExitOnConcurrentLoad,
               forcedVREntryType,
               store,

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -120,7 +120,6 @@ class UIRoot extends Component {
     enterScene: PropTypes.func,
     exitScene: PropTypes.func,
     onSendMessage: PropTypes.func,
-    concurrentLoadDetector: PropTypes.object,
     disableAutoExitOnConcurrentLoad: PropTypes.bool,
     forcedVREntryType: PropTypes.string,
     isBotMode: PropTypes.bool,
@@ -242,7 +241,7 @@ class UIRoot extends Component {
   }
 
   componentDidMount() {
-    this.props.concurrentLoadDetector.addEventListener("concurrentload", this.onConcurrentLoad);
+    window.addEventListener("concurrentload", this.onConcurrentLoad);
     this.micLevelMovingAverage = MovingAverage(100);
     this.props.scene.addEventListener(
       "didConnectToNetworkedScene",


### PR DESCRIPTION
- Don't update the FPS counter when in VR
- Don't poll for "support" availability. This also stops the error log spam for 404s (which presumably also then later sends another network request to Sentry)
- Don't poll to detect concurrent loads, instead use the `storage` event.