### PR TITLE
Remove proxying for the 'loading' scene

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -175,7 +175,7 @@ const isBotMode = qsTruthy("bot");
 const isTelemetryDisabled = qsTruthy("disable_telemetry");
 const isDebug = qsTruthy("debug");
 const loadingEnvironmentURL =
-  "https://hubs-proxy.com/https://uploads-prod.reticulum.io/files/61d77151-7a74-40a6-b427-0c5a350c4502.glb";
+      proxiedUrlFor("https://uploads-prod.reticulum.io/files/61d77151-7a74-40a6-b427-0c5a350c4502.glb");
 
 if (!isBotMode && !isTelemetryDisabled) {
   registerTelemetry("/hub", "Room Landing Page");


### PR DESCRIPTION
There's no reason to CORS proxy this, and the code as written would be incorrect with `HUBS_PROXY` set to anything else.