### PR TITLE
Disable link page touchscreen fix because it breaks Go

### DIFF
--- a/src/react-components/link-root.js
+++ b/src/react-components/link-root.js
@@ -15,7 +15,7 @@ const MAX_LETTERS = 4;
 
 addLocaleData([...en]);
 disableiOSZoom();
-const hasTouchEvents = "ontouchstart" in document.documentElement;
+const hasTouchEvents = false; //https://github.com/mozilla/hubs/issues/1079 // "ontouchstart" in document.documentElement;
 
 class LinkRoot extends Component {
   static propTypes = {


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/1079

I don't understand the details of how https://github.com/mozilla/hubs/pull/1042 fixed https://github.com/mozilla/hubs/issues/606, but it appears that it regressed the entry flow on Go. Since this is the primary flow for Go users, I am disabling the touchscreen fix which can be solved later.