### PR TITLE
Disable multiview rendering

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -32,7 +32,7 @@
         loading-screen="enabled: false"
         nextframe
         class="grab-cursor"
-        renderer="antialias: true; colorManagement: true; sortObjects: true; physicallyCorrectLights: true; alpha: false; webgl2: true; multiview: true;"
+        renderer="antialias: true; colorManagement: true; sortObjects: true; physicallyCorrectLights: true; alpha: false; webgl2: true; multiview: false;"
         shadow="type: pcfsoft"
         networked-scene="adapter: janus; audio: true; debug: true; connectOnLoad: false;"
         physics="gravity: -9.8; debug: false; driver: ammo; debugDrawMode: 1;"


### PR DESCRIPTION
Disabling multiview "fixes" https://github.com/mozilla/hubs/issues/1082
Obviously we will want to understand the problem and re-enable multiview, but since this is a _bad_ bug on Go and I don't have any ideas for how to solve it, I'd like to disable multiview for now.