### PR TITLE
Refactor everything to use AFRAME's isMobileVR

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -130,10 +130,11 @@ const store = window.APP.store;
 const mediaSearchStore = window.APP.mediaSearchStore;
 
 const qs = new URLSearchParams(location.search);
-const isMobile = AFRAME.utils.device.isMobile() || AFRAME.utils.device.isMobileVR();
+const isMobile = AFRAME.utils.device.isMobile();
+const isMobileVR = AFRAME.utils.device.isMobileVR();
 
 THREE.Object3D.DefaultMatrixAutoUpdate = false;
-window.APP.quality = qs.get("quality") || isMobile ? "low" : "high";
+window.APP.quality = qs.get("quality") || (isMobile || isMobileVR) ? "low" : "high";
 
 const SHAPES = require("aframe-physics-system/src/constants").SHAPES;
 const Ammo = require("ammo.js/builds/ammo.wasm.js");
@@ -575,7 +576,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     document.body.classList.add("vr-mode");
 
     // Don't stretch canvas on cardboard, since that's drawing the actual VR view :)
-    if (!isMobile || availableVREntryTypes.cardboard !== VR_DEVICE_AVAILABILITY.yes) {
+    if ((!isMobile && !isMobileVR) || availableVREntryTypes.cardboard !== VR_DEVICE_AVAILABILITY.yes) {
       document.body.classList.add("vr-mode-stretch");
     }
   });
@@ -656,7 +657,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
   }
 
-  if (availableVREntryTypes.isInHMD) {
+  if (isMobileVR) {
     remountUI({ availableVREntryTypes, forcedVREntryType: "vr" });
 
     if (/Oculus/.test(navigator.userAgent)) {
@@ -714,7 +715,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // Hub local channel
   const context = {
-    mobile: isMobile,
+    mobile: isMobile || isMobileVR,
     hmd: availableVREntryTypes.isInHMD
   };
 

--- a/src/link.js
+++ b/src/link.js
@@ -1,4 +1,5 @@
 import "./assets/stylesheets/link.scss";
+import "aframe";
 import React from "react";
 import ReactDOM from "react-dom";
 import registerTelemetry from "./telemetry";

--- a/src/link.js
+++ b/src/link.js
@@ -6,9 +6,9 @@ import LinkRoot from "./react-components/link-root";
 import LinkChannel from "./utils/link-channel";
 import { connectToReticulum } from "./utils/phoenix-utils";
 import Store from "./storage/store";
-import { detectInHMD } from "./utils/vr-caps-detect.js";
 
 registerTelemetry("/link", "Hubs Device Link");
+const isMobileVR = AFRAME.utils.device.isMobileVR();
 
 const socket = connectToReticulum();
 const store = new Store();
@@ -19,6 +19,6 @@ const linkChannel = new LinkChannel(store);
 linkChannel.setSocket(socket);
 
 ReactDOM.render(
-  <LinkRoot store={store} linkChannel={linkChannel} showHeadsetLinkOption={detectInHMD()} />,
+  <LinkRoot store={store} linkChannel={linkChannel} showHeadsetLinkOption={isMobileVR} />,
   document.getElementById("link-root")
 );

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1393,7 +1393,7 @@ class UIRoot extends Component {
       [styles.backgrounded]: this.isInModalOrOverlay()
     });
 
-    const showVREntryButton = entered && isMobilePhoneOrVR;
+    const showVREntryButton = entered && isMobileVR;
 
     const textRows = this.state.pendingMessage.split("\n").length;
     const pendingMessageTextareaHeight = textRows * 28 + "px";

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -96,6 +96,8 @@ async function grantedMicLabels() {
 }
 
 const isMobile = AFRAME.utils.device.isMobile();
+const isMobileVR = AFRAME.utils.device.isMobileVR();
+
 const AUTO_EXIT_TIMER_SECONDS = 10;
 
 import webmTone from "../assets/sfx/tone.webm";
@@ -1126,7 +1128,7 @@ class UIRoot extends Component {
           <DeviceEntryButton
             secondary={true}
             onClick={() => this.attemptLink()}
-            isInHMD={this.props.availableVREntryTypes.isInHMD}
+            isInHMD={isMobileVR}
           />
           {this.props.availableVREntryTypes.safari === VR_DEVICE_AVAILABILITY.maybe && (
             <StateLink stateKey="modal" stateValue="safari" history={this.props.history}>
@@ -1204,9 +1206,9 @@ class UIRoot extends Component {
     const micClip = {
       clip: `rect(${maxLevelHeight - Math.floor(this.state.micLevel * maxLevelHeight)}px, 111px, 111px, 0px)`
     };
-    const isMobileOrGo = isMobile || AFRAME.utils.device.isMobileVR();
+    const isMobilePhoneOrVR = isMobile || isMobileVR;
     const speakerClip = { clip: `rect(${this.state.tonePlaying ? 0 : maxLevelHeight}px, 111px, 111px, 0px)` };
-    const subtitleId = isMobileOrGo ? "audio.subtitle-mobile" : "audio.subtitle-desktop";
+    const subtitleId = isMobilePhoneOrVR ? "audio.subtitle-mobile" : "audio.subtitle-desktop";
     return (
       <div className="audio-setup-panel">
         <div onClick={() => this.props.history.goBack()} className={entryStyles.back}>
@@ -1221,7 +1223,7 @@ class UIRoot extends Component {
             <FormattedMessage id="audio.title" />
           </div>
           <div className="audio-setup-panel__subtitle">
-            {(isMobileOrGo || this.state.enterInVR) && <FormattedMessage id={subtitleId} />}
+            {(isMobilePhoneOrVR || this.state.enterInVR) && <FormattedMessage id={subtitleId} />}
           </div>
           <div className="audio-setup-panel__levels">
             <div className="audio-setup-panel__levels__icon">
@@ -1395,7 +1397,7 @@ class UIRoot extends Component {
       [styles.backgrounded]: this.isInModalOrOverlay()
     });
 
-    const showVREntryButton = entered && this.props.availableVREntryTypes.isInHMD;
+    const showVREntryButton = entered && isMobilePhoneOrVR;
 
     const textRows = this.state.pendingMessage.split("\n").length;
     const pendingMessageTextareaHeight = textRows * 28 + "px";
@@ -1709,7 +1711,7 @@ class UIRoot extends Component {
                 )}
                 {this.state.showInviteDialog && (
                   <InviteDialog
-                    allowShare={!this.props.availableVREntryTypes.isInHMD}
+                    allowShare={!isMobileVR}
                     entryCode={this.props.hubEntryCode}
                     hubId={this.props.hubId}
                     onClose={() => this.setState({ showInviteDialog: false })}

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -97,6 +97,7 @@ async function grantedMicLabels() {
 
 const isMobile = AFRAME.utils.device.isMobile();
 const isMobileVR = AFRAME.utils.device.isMobileVR();
+const isMobilePhoneOrVR = isMobile || isMobileVR;
 
 const AUTO_EXIT_TIMER_SECONDS = 10;
 
@@ -1125,11 +1126,7 @@ class UIRoot extends Component {
           {this.props.availableVREntryTypes.daydream === VR_DEVICE_AVAILABILITY.yes && (
             <DaydreamEntryButton secondary={true} onClick={this.enterDaydream} subtitle={null} />
           )}
-          <DeviceEntryButton
-            secondary={true}
-            onClick={() => this.attemptLink()}
-            isInHMD={isMobileVR}
-          />
+          <DeviceEntryButton secondary={true} onClick={() => this.attemptLink()} isInHMD={isMobileVR} />
           {this.props.availableVREntryTypes.safari === VR_DEVICE_AVAILABILITY.maybe && (
             <StateLink stateKey="modal" stateValue="safari" history={this.props.history}>
               <SafariEntryButton onClick={this.showSafariDialog} />
@@ -1206,7 +1203,6 @@ class UIRoot extends Component {
     const micClip = {
       clip: `rect(${maxLevelHeight - Math.floor(this.state.micLevel * maxLevelHeight)}px, 111px, 111px, 0px)`
     };
-    const isMobilePhoneOrVR = isMobile || isMobileVR;
     const speakerClip = { clip: `rect(${this.state.tonePlaying ? 0 : maxLevelHeight}px, 111px, 111px, 0px)` };
     const subtitleId = isMobilePhoneOrVR ? "audio.subtitle-mobile" : "audio.subtitle-desktop";
     return (

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -16,6 +16,7 @@ import { getAvatarSrc } from "./assets/avatars/avatars";
 import { pushHistoryState } from "./utils/history";
 
 const isIOS = AFRAME.utils.device.isIOS();
+const isMobileVR = AFRAME.utils.device.isMobileVR();
 
 export default class SceneEntryManager {
   constructor(hubChannel, authChannel, availableVREntryTypes, history) {
@@ -451,7 +452,7 @@ export default class SceneEntryManager {
       if (entry.type === "scene_listing" && this.hubChannel.permissions.update_hub) return;
 
       // If user has HMD lifted up, delay spawning for now. eventually show a modal
-      const delaySpawn = this._in2DInterstitial && !this.availableVREntryTypes.isInHMD;
+      const delaySpawn = this._in2DInterstitial && !isMobileVR;
       setTimeout(() => {
         spawnMediaInfrontOfPlayer(entry.url, ObjectContentOrigins.URL);
       }, delaySpawn ? 3000 : 0);

--- a/src/systems/tips.js
+++ b/src/systems/tips.js
@@ -1,6 +1,5 @@
 import { sets } from "./userinput/sets";
 import { paths } from "./userinput/paths";
-import { detectInHMD } from "../utils/vr-caps-detect";
 
 // The output of this system is activeTips which shows, if any, the tips to show at the top
 // and bottom of the screen. There are named tips (eg locomotion) that each have validators.
@@ -69,9 +68,10 @@ let localStorageCache = null;
 let finishedScopes = {}; // Optimization, lets system skip scopes altogether once finished.
 
 const isMobile = AFRAME.utils.device.isMobile();
+const isMobileVR = AFRAME.utils.device.isMobileVR();
 
 const tipPlatform = () => {
-  if (detectInHMD()) return "standalone";
+  if (isMobileVR) return "standalone";
   return isMobile ? "mobile" : "desktop";
 };
 

--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -33,7 +33,7 @@ const gearVRControllerUserBindings = generate3DOFTriggerBindings(paths.device.ge
 import { resolveActionSets } from "./resolve-action-sets";
 import { GamepadDevice } from "./devices/gamepad";
 import { gamepadBindings } from "./bindings/generic-gamepad";
-import { detectInHMD, getAvailableVREntryTypes, VR_DEVICE_AVAILABILITY } from "../../utils/vr-caps-detect";
+import { getAvailableVREntryTypes, VR_DEVICE_AVAILABILITY } from "../../utils/vr-caps-detect";
 import { ArrayBackedSet } from "./array-backed-set";
 
 function intersection(setA, setB) {
@@ -204,11 +204,14 @@ AFRAME.registerSystem("userinput", {
     this.xformStates = new Map();
     this.activeDevices = new ArrayBackedSet([new HudDevice()]);
 
-    if (!(AFRAME.utils.device.isMobile() || AFRAME.utils.device.isMobileVR())) {
+    const isMobile = AFRAME.utils.device.isMobile();
+    const isMobileVR = AFRAME.utils.device.isMobileVR();
+
+    if (!(isMobile || isMobileVR)) {
       this.activeDevices.add(new MouseDevice());
       this.activeDevices.add(new AppAwareMouseDevice());
       this.activeDevices.add(new KeyboardDevice());
-    } else if (!detectInHMD()) {
+    } else if (!isMobileVR) {
       this.activeDevices.add(new AppAwareTouchscreenDevice());
       this.activeDevices.add(new KeyboardDevice());
       this.activeDevices.add(new GyroDevice());

--- a/src/utils/vr-interstitial.js
+++ b/src/utils/vr-interstitial.js
@@ -1,7 +1,7 @@
-import { detectInHMD } from "./vr-caps-detect";
 import { showFullScreenIfAvailable } from "./fullscreen";
 
 let isIn2DInterstitial = false;
+const isMobileVR = AFRAME.utils.device.isMobileVR();
 
 export function handleExitTo2DInterstitial(isLower) {
   const scene = document.querySelector("a-scene");
@@ -9,7 +9,7 @@ export function handleExitTo2DInterstitial(isLower) {
 
   isIn2DInterstitial = true;
 
-  if (detectInHMD()) {
+  if (isMobileVR) {
     // Immersive browser, exit VR.
     scene.exitVR();
     showFullScreenIfAvailable();
@@ -29,7 +29,7 @@ export function handleReEntryToVRFrom2DInterstitial() {
 
   document.querySelector(".vr-notice").object3D.visible = false;
 
-  if (detectInHMD()) {
+  if (isMobileVR) {
     const scene = document.querySelector("a-scene");
     scene.enterVR();
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -267,7 +267,7 @@ module.exports = (env, argv) => ({
     new HTMLWebpackPlugin({
       filename: "link.html",
       template: path.join(__dirname, "src", "link.html"),
-      chunks: ["vendor", "link"]
+      chunks: ["vendor", "engine", "link"]
     }),
     new HTMLWebpackPlugin({
       filename: "spoke.html",


### PR DESCRIPTION
This abandons our own detection ("`isInHMD`") if the user is using an immersive browser and falls back to using A-Frame's new `isMobileVR` detection routine.