### PR TITLE
Fix GearVR controllers

### DIFF
--- a/src/systems/userinput/devices/gear-vr-controller.js
+++ b/src/systems/userinput/devices/gear-vr-controller.js
@@ -28,6 +28,8 @@ export class GearVRControllerDevice {
 
   write(frame) {
     if (this.gamepad.connected) {
+      // Oculus Browser on Gear VR seems to require a call to getGamepads() for the gamepad state to update.
+      navigator.getGamepads();
       const touchpad = this.gamepad.buttons[0];
       frame.setValueType(TOUCHPAD.pressed, !!touchpad.pressed);
       frame.setValueType(TOUCHPAD.touched, !!touchpad.touched);

--- a/src/systems/userinput/devices/gear-vr-controller.js
+++ b/src/systems/userinput/devices/gear-vr-controller.js
@@ -27,9 +27,9 @@ export class GearVRControllerDevice {
   }
 
   write(frame) {
+    // Chrome requires a call to getGamepads() for the gamepad state to update.
+    navigator.getGamepads();
     if (this.gamepad.connected) {
-      // Oculus Browser on Gear VR seems to require a call to getGamepads() for the gamepad state to update.
-      navigator.getGamepads();
       const touchpad = this.gamepad.buttons[0];
       frame.setValueType(TOUCHPAD.pressed, !!touchpad.pressed);
       frame.setValueType(TOUCHPAD.touched, !!touchpad.touched);


### PR DESCRIPTION
Apparently gamepad state does not update on GearVR unless you call getGamepads every tick