### PR TITLE
Fix a few issues with new avatar skinning.

### DIFF
--- a/src/assets/avatars/avatars.js
+++ b/src/assets/avatars/avatars.js
@@ -56,19 +56,14 @@ export function getAvatarType(avatarId) {
   return AVATAR_TYPES.SKINNABLE;
 }
 
-// HACK Skinnable avatars are mutable. If we edit one locally we bump this so the new avatar gltf is fetched
-// TODO come up with a cleaner way to handle this
-let cacheVersion = 0;
-export function bumpCacheVersion() {
-  cacheVersion++;
-}
-
-export function getAvatarSrc(avatarId) {
+export async function getAvatarSrc(avatarId) {
   switch (getAvatarType(avatarId)) {
     case AVATAR_TYPES.LEGACY:
       return `#${avatarId}`;
     case AVATAR_TYPES.SKINNABLE:
-      return getReticulumFetchUrl(`/api/v1/avatars/${avatarId}/avatar.gltf?v=${cacheVersion}`);
+      return fetch(getReticulumFetchUrl(`/api/v1/avatars/${avatarId}`))
+        .then(r => r.json())
+        .then(({ avatars }) => avatars[0].gltf_url);
   }
   return avatarId;
 }

--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -84,6 +84,8 @@ AFRAME.registerComponent("camera-tool", {
 
     this.camera = new THREE.PerspectiveCamera(50, this.renderTarget.width / this.renderTarget.height, 0.1, 30000);
     this.camera.rotation.set(0, Math.PI, 0);
+    this.camera.position.set(0, 0, 0.05);
+    this.camera.matrixNeedsUpdate = true;
     this.el.setObject3D("camera", this.camera);
 
     const material = new THREE.MeshBasicMaterial({

--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -189,6 +189,10 @@ AFRAME.registerComponent("camera-tool", {
     this.localSnapCount = 0; // When camera is moved, reset photo arrangement algorithm
   },
 
+  onAvatarUpdated() {
+    delete this.playerHead;
+  },
+
   tick() {
     const userinput = this.el.sceneEl.systems.userinput;
     const grabber = this.el.components.grabbable.grabbers[0];

--- a/src/components/player-info.js
+++ b/src/components/player-info.js
@@ -33,6 +33,7 @@ AFRAME.registerComponent("player-info", {
     const modelEl = this.el.querySelector(".model");
     if (this.data.avatarSrc && modelEl) {
       modelEl.setAttribute("gltf-model-plus", "src", this.data.avatarSrc);
+      this.el.sceneEl.systems["camera-tools"].avatarUpdated();
     }
 
     const uniforms = injectCustomShaderChunks(this.el.object3D);

--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -7,8 +7,6 @@ import classNames from "classnames";
 import { faTimes } from "@fortawesome/free-solid-svg-icons/faTimes";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
-import { bumpCacheVersion } from "../assets/avatars/avatars";
-
 import styles from "../assets/stylesheets/profile.scss";
 
 const BOT_PARENT_AVATAR =
@@ -137,7 +135,6 @@ export default class AvatarEditor extends Component {
     this.props.onAvatarChanged(avatar.avatar_id);
 
     this.setState({ uploading: false });
-    bumpCacheVersion();
     this.props.saveStateAndFinish();
   };
 

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -147,15 +147,16 @@ export default class SceneEntryManager {
     }
   };
 
-  _updatePlayerRigWithProfile = () => {
+  _updatePlayerRigWithProfile = async () => {
     const { avatarId, displayName } = this.store.state.profile;
-    this.playerRig.setAttribute("player-info", {
-      displayName,
-      avatarSrc: getAvatarSrc(avatarId)
-    });
+
     const hudController = this.playerRig.querySelector("[hud-controller]");
     hudController.setAttribute("hud-controller", { showTip: !this.store.state.activity.hasFoundFreeze });
+    this.playerRig.setAttribute("player-info", { displayName });
     this.scene.emit("username-changed", { username: displayName });
+
+    const avatarSrc = await getAvatarSrc(avatarId);
+    this.playerRig.setAttribute("player-info", { avatarSrc });
   };
 
   _setupKicking = () => {

--- a/src/systems/camera-tools.js
+++ b/src/systems/camera-tools.js
@@ -17,7 +17,7 @@ AFRAME.registerSystem("camera-tools", {
   },
 
   avatarUpdated() {
-    this.cameraEls.forEach(el => delete el.components["camera-tool"].playerHead);
+    this.cameraEls.forEach(el => delete el.components["camera-tool"].onAvatarUpdated());
   },
 
   getMyCamera() {

--- a/src/systems/camera-tools.js
+++ b/src/systems/camera-tools.js
@@ -16,6 +16,10 @@ AFRAME.registerSystem("camera-tools", {
     this.myCamera = null;
   },
 
+  avatarUpdated() {
+    this.cameraEls.forEach(el => delete el.components["camera-tool"].playerHead);
+  },
+
   getMyCamera() {
     if (this.myCamera) return this.myCamera;
     this.myCamera = this.cameraEls.find(NAF.utils.isMine);


### PR DESCRIPTION
- Fix caching issues by requesting the avatar url from the server, which now contains a cache busting timestamp from when the avatar was last updated. Requires https://github.com/mozilla/reticulum/pull/129
- Fix head dispreading in camera tool view when changing avatars (skinned or otherwise)
- Fix an unrelated issue with camera tool spamming GL errors since it was trying to render its own viewfinder.