### PR TITLE
Do not handle freeze mode toggles when not entered

### DIFF
--- a/src/components/freeze-controller.js
+++ b/src/components/freeze-controller.js
@@ -23,7 +23,10 @@ AFRAME.registerComponent("freeze-controller", {
   },
 
   tick: function() {
-    const userinput = AFRAME.scenes[0].systems.userinput;
+    const scene = this.el.sceneEl;
+    if (!scene.is("entered")) return;
+
+    const userinput = scene.systems.userinput;
     const ensureFrozen = userinput.get(paths.actions.ensureFrozen);
     const thaw = userinput.get(paths.actions.thaw);
     const toggleFreeze = userinput.get(paths.actions.toggleFreeze);


### PR DESCRIPTION
Fixes bug where user can enter freeze mode in the lobby by using the keyboard.