### PR TITLE
Fix modal detection in lobby

### DIFF
--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -90,6 +90,10 @@ const HMD_MIC_REGEXES = [/\Wvive\W/i, /\Wrift\W/i];
 const IN_ROOM_MODAL_ROUTER_PATHS = ["/media"];
 const IN_ROOM_MODAL_QUERY_VARS = ["media_source"];
 
+const LOBBY_MODAL_ROUTER_PATHS = ["/media/scenes"];
+const LOBBY_MODAL_QUERY_VARS = ["media_source"];
+const LOBBY_MODAL_QUERY_VALUES = ["scenes"];
+
 async function grantedMicLabels() {
   const mediaDevices = await navigator.mediaDevices.enumerateDevices();
   return mediaDevices.filter(d => d.label && d.kind === "audioinput").map(d => d.label);
@@ -1336,6 +1340,16 @@ class UIRoot extends Component {
       this.state.entered &&
       (IN_ROOM_MODAL_ROUTER_PATHS.find(x => sluglessPath(this.props.history.location).startsWith(x)) ||
         IN_ROOM_MODAL_QUERY_VARS.find(x => new URLSearchParams(this.props.history.location.search).get(x)))
+    ) {
+      return true;
+    }
+
+    if (
+      !this.state.entered &&
+      (LOBBY_MODAL_ROUTER_PATHS.find(x => sluglessPath(this.props.history.location).startsWith(x)) ||
+        LOBBY_MODAL_QUERY_VARS.find(
+          (x, i) => new URLSearchParams(this.props.history.location.search).get(x) === LOBBY_MODAL_QUERY_VALUES[i]
+        ))
     ) {
       return true;
     }


### PR DESCRIPTION
Fixes a bug where the `is-in-modal-or-overlay` css class was not being set on the root when in the lobby and opening the scene picker, which broke scrolling and right clicking context menus when selecting a scene from within the lobby. This PR updates the modal detection to special case the scene picker, which is the only media browser UI that can be seen from within the lobby. (Eventually this will include the avatar picker.)

The reason for the special casing here is because we also support sharing room URLs that have media browser paths, but the modal display is delayed until room entry, so we do not want to apply the css class in those scenarios. (Otherwise, for example, you could right click to get a context menu on the canvas, which is undesirable.) But this is only the behavior for media sources other than scenes (sketchfab, etc) so we need to special case it.