### PR TITLE
Fix hand rotations for new skinned avatar skeleton

### DIFF
--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -12,7 +12,7 @@ const aframeInspectorUrl = require("file-loader?name=assets/js/[name]-[hash].[ex
 import { addMedia, getPromotionTokenForFile } from "./utils/media-utils";
 import { handleExitTo2DInterstitial, handleReEntryToVRFrom2DInterstitial } from "./utils/vr-interstitial";
 import { ObjectContentOrigins } from "./object-types";
-import { getAvatarSrc } from "./assets/avatars/avatars";
+import { getAvatarSrc, getAvatarType } from "./assets/avatars/avatars";
 import { pushHistoryState } from "./utils/history";
 
 const isIOS = AFRAME.utils.device.isIOS();
@@ -157,6 +157,7 @@ export default class SceneEntryManager {
 
     const avatarSrc = await getAvatarSrc(avatarId);
     this.playerRig.setAttribute("player-info", { avatarSrc });
+    this.playerRig.setAttribute("ik-root", "avatarType", getAvatarType(avatarId));
   };
 
   _setupKicking = () => {

--- a/src/systems/userinput/bindings/keyboard-mouse-user.js
+++ b/src/systems/userinput/bindings/keyboard-mouse-user.js
@@ -3,6 +3,8 @@ import { sets } from "../sets";
 import { xforms } from "./xforms";
 import { addSetsToBindings } from "./utils";
 
+// import { Pose } from "../pose";
+
 const wasd_vec2 = "/var/mouse-and-keyboard/wasd_vec2";
 const keyboardCharacterAcceleration = "/var/mouse-and-keyboard/keyboardCharacterAcceleration";
 const arrows_vec2 = "/var/mouse-and-keyboard/arrows_vec2";
@@ -301,6 +303,30 @@ export const keyboardMouseUserBindings = addSetsToBindings({
       xform: xforms.falling,
       priority: 100
     }
+
+    // Helpful bindings for debugging hands in 2D
+    // {
+    //   src: {},
+    //   dest: { value: paths.actions.rightHand.matrix },
+    //   xform: xforms.always(
+    //     new THREE.Matrix4().compose(
+    //       new THREE.Vector3(0.2, 1.3, -0.8),
+    //       new THREE.Quaternion(0, 0, 0, 0),
+    //       new THREE.Vector3(1, 1, 1)
+    //     )
+    //   )
+    // },
+    // {
+    //   src: {},
+    //   dest: { value: paths.actions.leftHand.matrix },
+    //   xform: xforms.always(
+    //     new THREE.Matrix4().compose(
+    //       new THREE.Vector3(-0.2, 1.4, -0.8),
+    //       new THREE.Quaternion(0, 0, 0, 0),
+    //       new THREE.Vector3(1, 1, 1)
+    //     )
+    //   )
+    // }
   ],
 
   [sets.cursorHoldingPen]: [


### PR DESCRIPTION
The old avatar skeleton had incorrect bone rotations for the right hand. This has been fixed in the updated skeleton we use for skinning, but this requires a different set of rotations to orient each hand correctly. This contains a bit of a hack to switch these rotations on the fly, which can go away once we remove the legacy avatars (when we ship an avatar picker that aligns with the new scene picker).