### PR TITLE
Fix bug where visual effects bounding sphere not up-to-date

### DIFF
--- a/src/components/hoverable-visuals.js
+++ b/src/components/hoverable-visuals.js
@@ -1,6 +1,8 @@
 const interactorOneTransform = [];
 const interactorTwoTransform = [];
 
+const boundingBox = new THREE.Box3();
+
 /**
  * Applies effects to a hoverable based on hover state.
  * @namespace interactables
@@ -17,6 +19,7 @@ AFRAME.registerComponent("hoverable-visuals", {
     this.boundingSphere = new THREE.Sphere();
 
     this.sweepParams = [0, 0];
+    this.currentObjectScale = null;
   },
   remove() {
     this.uniforms = null;
@@ -24,6 +27,20 @@ AFRAME.registerComponent("hoverable-visuals", {
   },
   tick(time) {
     if (!this.uniforms || !this.uniforms.size) return;
+
+    const currentScale = this.el.object3D.scale;
+
+    // Ensure bounding sphere is up-to-date
+    if (!this.currentObjectScale || !this.currentObjectScale.equals(currentScale)) {
+      if (!this.currentObjectScale) {
+        this.currentObjectScale = new THREE.Vector3();
+      }
+
+      this.currentObjectScale.copy(currentScale);
+
+      boundingBox.setFromObject(this.el.object3DMap.mesh);
+      boundingBox.getBoundingSphere(this.boundingSphere);
+    }
 
     const { hoverers } = this.el.components["hoverable"];
     const isFrozen = this.el.sceneEl.is("frozen");

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -29,8 +29,6 @@ const fetchMaxContentIndex = url => {
   return fetch(url).then(r => parseInt(r.headers.get("x-max-content-index")));
 };
 
-const boundingBox = new THREE.Box3();
-
 AFRAME.registerComponent("media-loader", {
   schema: {
     fileId: { type: "string" },
@@ -127,8 +125,6 @@ AFRAME.registerComponent("media-loader", {
     const hoverableVisuals = this.el.components["hoverable-visuals"];
     if (hoverableVisuals) {
       hoverableVisuals.uniforms = injectCustomShaderChunks(this.el.object3D);
-      boundingBox.setFromObject(this.el.object3DMap.mesh);
-      boundingBox.getBoundingSphere(hoverableVisuals.boundingSphere);
     }
   },
 


### PR DESCRIPTION
The visual hover effect relies upon a bounding sphere for the object being hovered over, which previously was set once at media loading time. If the object was scaled, the bounding sphere was out-of-date. This updates the `hoverable-visuals` component to maintain the bounding sphere by checking if the scale has changed on the object on a given tick.