### PR TITLE
Stop walking camera objects every frame

### DIFF
--- a/src/systems/camera-tools.js
+++ b/src/systems/camera-tools.js
@@ -7,13 +7,13 @@ AFRAME.registerSystem("camera-tools", {
   register(el) {
     this.cameraEls.push(el);
     el.addEventListener("ownership-changed", this._onOwnershipChange);
-    this.myCamera = null;
+    delete this.myCamera;
   },
 
   deregister(el) {
     this.cameraEls = this.cameraEls.filter(c => c !== el);
     el.removeEventListener("ownership-changed", this._onOwnershipChange);
-    this.myCamera = null;
+    delete this.myCamera;
   },
 
   avatarUpdated() {
@@ -21,8 +21,8 @@ AFRAME.registerSystem("camera-tools", {
   },
 
   getMyCamera() {
-    if (this.myCamera) return this.myCamera;
-    this.myCamera = this.cameraEls.find(NAF.utils.isMine);
+    if (this.myCamera !== undefined) return this.myCamera;
+    this.myCamera = this.cameraEls.find(NAF.utils.isMine) || null;
     return this.myCamera;
   },
 


### PR DESCRIPTION
this function call stack appeared in my chrome profiler (likely just sampling noise) but I uncovered a small inefficiency where we are walking the list of camera objects every frame in the case where a user doesn't have a camera.