### PR TITLE
Custom Avatar Skins

### DIFF
--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -18,7 +18,7 @@ export default class AvatarEditor extends Component {
     onSignIn: PropTypes.func,
     onSignOut: PropTypes.func,
     signedIn: PropTypes.bool,
-    advanced: PropTypes.bool,
+    debug: PropTypes.bool,
     onAvatarChanged: PropTypes.func,
     saveStateAndFinish: PropTypes.func
   };
@@ -26,6 +26,7 @@ export default class AvatarEditor extends Component {
   constructor(props) {
     super(props);
     this.state = {};
+    // Blank avatar, used to create base avatar
     // this.state = { avatar: { name: "Base bot avatar", files: {} } };
 
     this.inputFiles = {
@@ -108,6 +109,27 @@ export default class AvatarEditor extends Component {
       URL.revokeObjectURL(gltfUrl);
 
       const { content, body } = parser.extensions.KHR_binary_glTF;
+
+      // Inject hubs components on upload. Used to create base avatar
+      // const gltf = parser.json;
+      // Object.assign(gltf.scenes[0], {
+      //   extensions: {
+      //     HUBS_components: {
+      //       "loop-animation": {
+      //         clip: "idle_eyes"
+      //       }
+      //     }
+      //   }
+      // });
+      // Object.assign(gltf.nodes.find(n => n.name === "Head"), {
+      //   extensions: {
+      //     HUBS_components: {
+      //       "scale-audio-feedback": ""
+      //     }
+      //   }
+      // });
+      // content = JSON.stringify(gltf);
+
       this.inputFiles.gltf = new File([content], "file.gltf", {
         type: "model/gltf"
       });
@@ -228,18 +250,18 @@ export default class AvatarEditor extends Component {
       return <div>Loading...</div>;
     }
 
-    const { advanced } = this.props;
+    const { debug } = this.props;
 
     return (
       <div className={classNames(styles.avatarSelectorContainer, "avatar-editor")}>
         <div className="form-body">
-          {advanced && this.textField("avatar_id", "Avatar ID", true)}
-          {advanced && this.textField("parent_avatar_id", "Parent Avatar ID")}
-          {advanced && this.textField("name", "Name")}
-          {advanced && this.textField("description", "Description")}
-          {advanced && this.checkbox("allow_remixing", "Allow Remixing")}
-          {advanced && this.checkbox("allow_promotion", "Allow Promotion")}
-          {advanced && this.fileField("glb", "Avatar GLB", "model/gltf+binary,.glb")}
+          {debug && this.textField("avatar_id", "Avatar ID", true)}
+          {debug && this.textField("parent_avatar_id", "Parent Avatar ID")}
+          {debug && this.textField("name", "Name")}
+          {debug && this.textField("description", "Description")}
+          {debug && this.checkbox("allow_remixing", "Allow Remixing")}
+          {debug && this.checkbox("allow_promotion", "Allow Promotion")}
+          {debug && this.fileField("glb", "Avatar GLB", "model/gltf+binary,.glb")}
 
           {this.fileField("base_map", "Base Map", "image/*")}
           {this.fileField("emissive_map", "Emissive Map", "image/*")}

--- a/src/react-components/profile-entry-panel.js
+++ b/src/react-components/profile-entry-panel.js
@@ -20,8 +20,7 @@ class ProfileEntryPanel extends Component {
     onSignIn: PropTypes.func,
     onSignOut: PropTypes.func,
     signedIn: PropTypes.bool,
-    customSkinEnabled: PropTypes.bool,
-    advanced: PropTypes.bool
+    debug: PropTypes.bool
   };
 
   constructor(props) {
@@ -130,7 +129,7 @@ class ProfileEntryPanel extends Component {
             store={this.props.store}
             onAvatarChanged={avatarId => this.setState({ avatarId })}
             saveStateAndFinish={this.saveStateAndFinish}
-            advanced={this.props.advanced}
+            debug={this.props.debug}
           />
         );
         break;
@@ -185,14 +184,12 @@ class ProfileEntryPanel extends Component {
               >
                 <FormattedMessage id="profile.tabs.legacy" />
               </a>
-              {(this.props.customSkinEnabled || this.state.avatarType === "skinnable") && (
-                <a
-                  onClick={() => this.setState({ avatarType: "skinnable", avatarId: null })}
-                  className={classNames({ selected: this.state.avatarType === "skinnable" })}
-                >
-                  <FormattedMessage id="profile.tabs.skinnable" />
-                </a>
-              )}
+              <a
+                onClick={() => this.setState({ avatarType: "skinnable", avatarId: null })}
+                className={classNames({ selected: this.state.avatarType === "skinnable" })}
+              >
+                <FormattedMessage id="profile.tabs.skinnable" />
+              </a>
               <a
                 onClick={() => this.setState({ avatarType: "url", avatarId: "" })}
                 className={classNames({ selected: this.state.avatarType === "url" })}

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1464,8 +1464,6 @@ class UIRoot extends Component {
                   signedIn={this.state.signedIn}
                   onSignIn={this.showSignInDialog}
                   onSignOut={this.signOut}
-                  customSkinEnabled={customSkinEnabled}
-                  advanced={advancedAvatarEditor}
                 />
               )}
             />

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -71,9 +71,7 @@ import { faArrowLeft } from "@fortawesome/free-solid-svg-icons/faArrowLeft";
 import { faPencilAlt } from "@fortawesome/free-solid-svg-icons/faPencilAlt";
 
 import qsTruthy from "../utils/qs_truthy";
-// TODO temp feature flags
-const customSkinEnabled = qsTruthy("customSkin");
-const advancedAvatarEditor = qsTruthy("advancedAvatarEditor");
+const avatarEditorDebug = qsTruthy("avatarEditorDebug");
 
 addLocaleData([...en]);
 
@@ -1430,8 +1428,7 @@ class UIRoot extends Component {
                   onSignOut={this.signOut}
                   finished={this.onProfileFinished}
                   store={this.props.store}
-                  customSkinEnabled={customSkinEnabled}
-                  advanced={advancedAvatarEditor}
+                  debug={avatarEditorDebug}
                 />
               )}
             />


### PR DESCRIPTION
It is now possible to to upload custom skins to the default Hubs avatar! For a super easy way to customize your avatar, you can simply upload a new base color map - or dig in a bit deeper and change the emissive, normal, and ORM maps for even more control. This is only the first step in our planned avatar customization features, with more features planned to grant you even greater control over your appearance in Hubs! As always, you can still use a completely custom GLTF file hosted anywhere on the web as your avatar if you want the greatest control over your avatar's look and feel.

![image](https://user-images.githubusercontent.com/130735/55045846-a16ae180-4ffc-11e9-9783-5ac74c0a154c.png)

This PR just removes the feature flag so that its always on. It also renames `advancedAvatarEditor` to `avatarEditorDebug`.