### PR TITLE
Re-sync hoverable visual bounding sphere after animation completes

### DIFF
--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -123,10 +123,15 @@ AFRAME.registerComponent("media-loader", {
     this.removeShape("loader");
   },
 
-  setupHoverableVisuals() {
+  updateHoverableVisuals() {
     const hoverableVisuals = this.el.components["hoverable-visuals"];
+
     if (hoverableVisuals) {
-      hoverableVisuals.uniforms = injectCustomShaderChunks(this.el.object3D);
+      if (!this.injectedCustomShaderChunks) {
+        this.injectedCustomShaderChunks = true;
+        hoverableVisuals.uniforms = injectCustomShaderChunks(this.el.object3D);
+      }
+
       boundingBox.setFromObject(this.el.object3DMap.mesh);
       boundingBox.getBoundingSphere(hoverableVisuals.boundingSphere);
     }
@@ -134,7 +139,7 @@ AFRAME.registerComponent("media-loader", {
 
   onMediaLoaded() {
     this.clearLoadingTimeout();
-    this.setupHoverableVisuals();
+    this.updateHoverableVisuals();
     if (!this.el.components["animation-mixer"]) {
       generateMeshBVH(this.el.object3D);
     }

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -237,6 +237,7 @@ export const addMedia = (src, template, contentOrigin, resolve = false, resize =
           easing: "easeOutElastic"
         });
 
+        // Hoverable visauls need to be updated so the initial scale is properly taken into account.
         entity.addEventListener("animationcomplete", () => entity.components["media-loader"].updateHoverableVisuals(), {
           once: true
         });

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -236,6 +236,10 @@ export const addMedia = (src, template, contentOrigin, resolve = false, resize =
           to: { x: sx, y: sy, z: sz },
           easing: "easeOutElastic"
         });
+
+        entity.addEventListener("animationcomplete", () => entity.components["media-loader"].updateHoverableVisuals(), {
+          once: true
+        });
       }
 
       entity.object3D.visible = true;


### PR DESCRIPTION
Fixes a bug causing the hover effect to not work due to the new initial scale of objects of 0.001