### PR TITLE
Bug/hide leave button if tip

### DIFF
--- a/src/react-components/2d-hud.js
+++ b/src/react-components/2d-hud.js
@@ -5,7 +5,6 @@ import cx from "classnames";
 const { detect } = require("detect-browser");
 import styles from "../assets/stylesheets/2d-hud.scss";
 import uiStyles from "../assets/stylesheets/ui-root.scss";
-import { WithHoverSound } from "./wrap-with-audio";
 import { FormattedMessage } from "react-intl";
 
 const browser = detect();
@@ -82,81 +81,78 @@ class TopHUD extends Component {
     };
 
     return (
-      <WithHoverSound>
-        <div
-          className={cx(styles.iconButton, styles[`share_${primaryVideoShareType}`], {
-            [styles.active]: this.props.videoShareMediaSource === primaryVideoShareType,
-            [styles.videoShare]: true
-          })}
-          title={this.props.videoShareMediaSource !== null ? "Stop sharing" : `Share ${primaryVideoShareType}`}
-          onClick={() => {
-            if (!this.state.showVideoShareOptions) {
-              this.handleVideoShareClicked(primaryVideoShareType);
-            }
-          }}
-          onMouseOver={showExtrasOnHover}
-        >
-          {videoShareExtraOptionTypes.length > 0 && (
-            <div className={cx(styles.videoShareExtraOptions)} onMouseOut={hideExtrasOnOut}>
-              {videoShareExtraOptionTypes.map(type => (
-                <WithHoverSound key={type}>
-                  <div
-                    key={type}
-                    className={cx(styles.iconButton, styles[`share_${type}`], {
-                      [styles.active]: this.props.videoShareMediaSource === type
-                    })}
-                    title={this.props.videoShareMediaSource === type ? "Stop sharing" : `Share ${type}`}
-                    onClick={() => this.handleVideoShareClicked(type)}
-                    onMouseOver={showExtrasOnHover}
-                  />
-                </WithHoverSound>
-              ))}
-            </div>
-          )}
-        </div>
-      </WithHoverSound>
+      <div
+        className={cx(styles.iconButton, styles[`share_${primaryVideoShareType}`], {
+          [styles.active]: this.props.videoShareMediaSource === primaryVideoShareType,
+          [styles.videoShare]: true
+        })}
+        title={this.props.videoShareMediaSource !== null ? "Stop sharing" : `Share ${primaryVideoShareType}`}
+        onClick={() => {
+          if (!this.state.showVideoShareOptions) {
+            this.handleVideoShareClicked(primaryVideoShareType);
+          }
+        }}
+        onMouseOver={showExtrasOnHover}
+      >
+        {videoShareExtraOptionTypes.length > 0 && (
+          <div className={cx(styles.videoShareExtraOptions)} onMouseOut={hideExtrasOnOut}>
+            {videoShareExtraOptionTypes.map(type => (
+              <div
+                key={type}
+                className={cx(styles.iconButton, styles[`share_${type}`], {
+                  [styles.active]: this.props.videoShareMediaSource === type
+                })}
+                title={this.props.videoShareMediaSource === type ? "Stop sharing" : `Share ${type}`}
+                onClick={() => this.handleVideoShareClicked(type)}
+                onMouseOver={showExtrasOnHover}
+              />
+            ))}
+          </div>
+        )}
+      </div>
     );
   };
 
   render() {
     const videoSharingButtons = this.buildVideoSharingButtons();
 
+    const tip = this.props.activeTip && (
+      <div className={cx(styles.topTip)}>
+        <div className={cx([styles.attachPoint, styles[`attach_${this.props.activeTip.split(".")[1]}`]])} />
+        <FormattedMessage id={`tips.${this.props.activeTip}`} />
+      </div>
+    );
+
+    // Hide buttons when frozen.
     return (
       <div className={cx(styles.container, styles.top, styles.unselectable, uiStyles.uiInteractive)}>
-        <div className={cx(uiStyles.uiInteractive, styles.panel)}>
-          {this.props.activeTip && (
-            <div className={cx(styles.topTip)}>
-              <div className={cx([styles.attachPoint, styles[`attach_${this.props.activeTip.split(".")[1]}`]])} />
-              <FormattedMessage id={`tips.${this.props.activeTip}`} />
-            </div>
-          )}
-          {videoSharingButtons}
-          <WithHoverSound>
+        {this.props.frozen ? (
+          <div className={cx(uiStyles.uiInteractive, styles.panel)}>{tip}</div>
+        ) : (
+          <div className={cx(uiStyles.uiInteractive, styles.panel)}>
+            {tip}
+            {videoSharingButtons}
             <div
               className={cx(styles.iconButton, styles.mute, { [styles.active]: this.props.muted })}
               title={this.props.muted ? "Unmute Mic" : "Mute Mic"}
               onClick={this.props.onToggleMute}
             />
-          </WithHoverSound>
-          <button
-            className={cx(uiStyles.uiInteractive, styles.iconButton, styles.spawn)}
-            onClick={() => this.props.mediaSearchStore.sourceNavigateToDefaultSource()}
-          />
-          <WithHoverSound>
+            <button
+              className={cx(uiStyles.uiInteractive, styles.iconButton, styles.spawn)}
+              onClick={() => this.props.mediaSearchStore.sourceNavigateToDefaultSource()}
+            />
             <div
               className={cx(styles.iconButton, styles.pen, { [styles.active]: this.props.isCursorHoldingPen })}
               title={"Pen"}
               onClick={this.props.onSpawnPen}
             />
-          </WithHoverSound>
-          <WithHoverSound>
             <div
               className={cx(styles.iconButton, styles.camera, { [styles.active]: this.props.hasActiveCamera })}
               title={"Camera"}
               onClick={this.props.onSpawnCamera}
             />
-          </WithHoverSound>
-        </div>
+          </div>
+        )}
       </div>
     );
   }

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1424,6 +1424,7 @@ class UIRoot extends Component {
 
     // Allow scene picker pre-entry, otherwise wait until entry
     const showMediaBrowser = mediaSource && (mediaSource === "scenes" || this.state.entered);
+    const hasTopTip = this.props.activeTips && this.props.activeTips.top;
 
     return (
       <ReactAudioContext.Provider value={this.state.audioContext}>
@@ -1670,11 +1671,12 @@ class UIRoot extends Component {
               </form>
             )}
 
-            {this.state.frozen && (
-              <button className={styles.leaveButton} onClick={() => this.exit("left")}>
-                <FormattedMessage id="entry.leave-room" />
-              </button>
-            )}
+            {this.state.frozen &&
+              !hasTopTip && (
+                <button className={styles.leaveButton} onClick={() => this.exit("left")}>
+                  <FormattedMessage id="entry.leave-room" />
+                </button>
+              )}
 
             {!this.state.frozen && (
               <div
@@ -1685,7 +1687,7 @@ class UIRoot extends Component {
                 })}
               >
                 {!showVREntryButton &&
-                  (!this.props.activeTips || !this.props.activeTips.top) && (
+                  !hasTopTip && (
                     <WithHoverSound>
                       <button
                         className={classNames({ [styles.hideSmallScreens]: this.occupantCount() > 1 && entered })}
@@ -1697,7 +1699,7 @@ class UIRoot extends Component {
                   )}
                 {!showVREntryButton &&
                   this.occupantCount() > 1 &&
-                  (!this.props.activeTips || !this.props.activeTips.top) &&
+                  !hasTopTip &&
                   entered && (
                     <WithHoverSound>
                       <button onClick={this.onMiniInviteClicked} className={styles.inviteMiniButton}>
@@ -1806,7 +1808,7 @@ class UIRoot extends Component {
               />
             )}
 
-            {entered && !this.state.frozen ? (
+            {entered && (!this.state.frozen || hasTopTip) ? (
               <div className={styles.topHud}>
                 <TwoDHUD.TopHUD
                   history={this.props.history}

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1671,12 +1671,11 @@ class UIRoot extends Component {
               </form>
             )}
 
-            {this.state.frozen &&
-              !hasTopTip && (
-                <button className={styles.leaveButton} onClick={() => this.exit("left")}>
-                  <FormattedMessage id="entry.leave-room" />
-                </button>
-              )}
+            {this.state.frozen && (
+              <button className={styles.leaveButton} onClick={() => this.exit("left")}>
+                <FormattedMessage id="entry.leave-room" />
+              </button>
+            )}
 
             {!this.state.frozen && (
               <div
@@ -1808,7 +1807,7 @@ class UIRoot extends Component {
               />
             )}
 
-            {entered && (!this.state.frozen || hasTopTip) ? (
+            {entered && (
               <div className={styles.topHud}>
                 <TwoDHUD.TopHUD
                   history={this.props.history}
@@ -1841,7 +1840,7 @@ class UIRoot extends Component {
                   </div>
                 )}
               </div>
-            ) : null}
+            )}
           </div>
         </IntlProvider>
       </ReactAudioContext.Provider>


### PR DESCRIPTION
The new "Leave Room" button introduced a regression where the top tip was no longer shown on touchscreen to tell the user how to exit pause mode (two-fingered tap.) This PR updates the react UI so that the HUD tip is always shown but the HUD buttons are hidden when frozen, and also does some refactoring to remove `WithHoverSound`.