### PR TITLE
Add hack to deal with videos in Oculus Browser when exiting VR mode

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -612,6 +612,17 @@ document.addEventListener("DOMContentLoaded", async () => {
   scene.addEventListener("exit-vr", () => {
     document.body.classList.remove("vr-mode");
     document.body.classList.remove("vr-mode-stretch");
+
+    // HACK: Oculus browser pauses videos when exiting VR mode, so we need to resume them after a timeout.
+    if (/OculusBrowser/i.test(window.navigator.userAgent)) {
+      document.querySelectorAll("[media-video]").forEach(m => {
+        const video = m.components["media-video"].video;
+
+        if (!video.paused) {
+          setTimeout(() => video.play(), 1000);
+        }
+      });
+    }
   });
 
   registerNetworkSchemas();

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -458,10 +458,11 @@ export default class SceneEntryManager {
       if (entry.type === "scene_listing" && this.hubChannel.permissions.update_hub) return;
 
       // If user has HMD lifted up, delay spawning for now. eventually show a modal
-      const delaySpawn = isIn2DInterstitial();
+      const spawnDelay = isIn2DInterstitial() ? (isMobileVR ? 1000 : 3000) : 0;
+
       setTimeout(() => {
         spawnMediaInfrontOfPlayer(entry.url, ObjectContentOrigins.URL);
-      }, delaySpawn ? 3000 : 0);
+      }, spawnDelay);
 
       handleReEntryToVRFrom2DInterstitial();
     });

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -458,7 +458,7 @@ export default class SceneEntryManager {
       if (entry.type === "scene_listing" && this.hubChannel.permissions.update_hub) return;
 
       // If user has HMD lifted up, delay spawning for now. eventually show a modal
-      const delaySpawn = isIn2DInterstitial() && !isMobileVR;
+      const delaySpawn = isIn2DInterstitial();
       setTimeout(() => {
         spawnMediaInfrontOfPlayer(entry.url, ObjectContentOrigins.URL);
       }, delaySpawn ? 3000 : 0);


### PR DESCRIPTION
This PR adds a hack because Oculus Browser pauses all videos in the scene when exiting VR mode. It also flips on a 1s delay on spawning on for mobile VR browsers because when you exit VR mode the head orientation is locked (so if you were looking up at the hud, the object you spawn will be above your head).