### PR TITLE
Don't exit full screen in non-firefox browsers

### DIFF
--- a/src/utils/focus-utils.js
+++ b/src/utils/focus-utils.js
@@ -1,6 +1,8 @@
 import screenfull from "screenfull";
 import { showFullScreenIfWasFullScreen } from "./fullscreen";
+const { detect } = require("detect-browser");
 
+const browser = detect();
 let isExitingFullscreenDueToFocus = false;
 
 // Utility function that handles a bunch of incidental stuff related to text fields:
@@ -11,7 +13,7 @@ export function handleTextFieldFocus(target) {
   if (!window.AFRAME) return;
   const isMobile = AFRAME.utils.device.isMobile();
 
-  if (screenfull.isFullscreen && !AFRAME.utils.device.isMobileVR()) {
+  if (screenfull.isFullscreen && !AFRAME.utils.device.isMobileVR() && browser.name === "firefox") {
     // This will prevent focus, but its the only way to avoid getting into a
     // weird "firefox reports full screen but actually not". You end up having to tap
     // twice to ultimately get the focus.


### PR DESCRIPTION
The hack we have where we exit full screen mode on text field focus is only necessary in Firefox mobile -- previously Chrome full screen wasn't working at all but now that we've upgraded screenful it is, so this hack can be bypassed (resulting in a much nicer experience in Android Chrome.)