### PR TITLE
Disable autofocus in media browser text search in mobile VR

### DIFF
--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -17,6 +17,7 @@ import { handleTextFieldFocus, handleTextFieldBlur } from "../utils/focus-utils"
 import { showFullScreenIfWasFullScreen } from "../utils/fullscreen";
 
 const isMobile = AFRAME.utils.device.isMobile();
+const isMobileVR = AFRAME.utils.device.isMobileVR();
 
 const PUBLISHER_FOR_ENTRY_TYPE = {
   sketchfab_model: "Sketchfab",
@@ -230,7 +231,7 @@ class MediaBrowser extends Component {
                 </i>
                 <input
                   type="text"
-                  autoFocus
+                  autoFocus={!isMobileVR}
                   ref={r => (this.inputRef = r)}
                   placeholder={formatMessage({
                     id: `media-browser.search-placeholder.${urlSource}`


### PR DESCRIPTION
Currently we autofocus the search box in the media browser -- however in immersive browsers this is somewhat jarring since it causes the virtual keyboard to show immediately. Especially once we have initial landing content we want the user to scroll/browse, this will get in the way, so this disables autofocus in mobile VR.