### PR TITLE
Fix up pager and spawning event

### DIFF
--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -368,11 +368,13 @@ AFRAME.registerComponent("media-pager", {
   },
 
   onNext() {
+    if (!NAF.utils.isMine(this.el) && !NAF.utils.takeOwnership(this.el)) return;
     this.el.setAttribute("media-pager", "index", Math.min(this.data.index + 1, this.maxIndex));
     this.el.emit("pager-page-changed");
   },
 
   onPrev() {
+    if (!NAF.utils.isMine(this.el) && !NAF.utils.takeOwnership(this.el)) return;
     this.el.setAttribute("media-pager", "index", Math.max(this.data.index - 1, 0));
     this.el.emit("pager-page-changed");
   },

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -306,6 +306,10 @@ AFRAME.registerComponent("media-pager", {
     this.onNext = this.onNext.bind(this);
     this.onPrev = this.onPrev.bind(this);
 
+    NAF.utils.getNetworkedEntity(this.el).then(networkedEl => {
+      this.networkedEl = networkedEl;
+    });
+
     this.el.addEventListener("image-loaded", async e => {
       this.imageSrc = e.detail.src;
       await this._ensureUI();
@@ -368,13 +372,13 @@ AFRAME.registerComponent("media-pager", {
   },
 
   onNext() {
-    if (!NAF.utils.isMine(this.el) && !NAF.utils.takeOwnership(this.el)) return;
+    if (!NAF.utils.isMine(this.networkedEl) && !NAF.utils.takeOwnership(this.networkedEl)) return;
     this.el.setAttribute("media-pager", "index", Math.min(this.data.index + 1, this.maxIndex));
     this.el.emit("pager-page-changed");
   },
 
   onPrev() {
-    if (!NAF.utils.isMine(this.el) && !NAF.utils.takeOwnership(this.el)) return;
+    if (!NAF.utils.isMine(this.networkedEl) && !NAF.utils.takeOwnership(this.networkedEl)) return;
     this.el.setAttribute("media-pager", "index", Math.max(this.data.index - 1, 0));
     this.el.emit("pager-page-changed");
   },

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -209,7 +209,7 @@ function fitToTexture(el, texture) {
   const height = Math.min(1.0, ratio);
   el.object3DMap.mesh.scale.set(width, height, 1);
   el.addEventListener(
-    "media-scale-ready",
+    "media-spawned",
     () => {
       el.setAttribute("ammo-shape", {
         type: SHAPE.BOX,

--- a/src/components/super-spawner.js
+++ b/src/components/super-spawner.js
@@ -102,7 +102,7 @@ AFRAME.registerComponent("super-spawner", {
     this.tempSpawnHandPosition = new THREE.Vector3();
 
     //need to add this here because super-spawners don't use addMedia()
-    this.el.addState("media-scale-ready");
+    this.el.addState("media-spawned");
   },
 
   play() {

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -115,6 +115,17 @@ AFRAME.GLTFModelPlus.registerComponent("media", "media", (el, componentName, com
     });
   }
 
+  ["model-loaded", "video-loaded", "image-loaded"].forEach(eventName => {
+    el.addEventListener(
+      eventName,
+      () => {
+        el.addState("media-spawned");
+        el.emit("media-spawned");
+      },
+      { once: true }
+    );
+  });
+
   el.setAttribute("media-loader", { src: componentData.src, resize: true, resolve: true, fileIsOwned: true });
 
   if (componentData.pageIndex) {

--- a/src/hub.html
+++ b/src/hub.html
@@ -412,13 +412,13 @@
             </template>
 
             <template id="paging-toolbar">
-                <a-entity class="ui paging-toolbar" visible-to-owner>
+                <a-entity class="ui paging-toolbar" visibility-while-frozen="withinDistance: 10; requireHoverOnNonMobile: false;">
                     <a-entity class="prev-button" position="-0.3 0 0">
                         <a-entity mixin="rounded-text-button" slice9="width: 0.2">
                             <a-entity text=" value:<; width:2; align:center;" text-raycast-hack position="0 0 0.01"></a-entity>
                         </a-entity>
                     </a-entity>
-                    <a-entity class="page-label" text="width:2; align:center;" text-raycast-hack></a-entity>
+                    <a-entity class="page-label" text="value: .; width:2; align:center;" text-raycast-hack></a-entity>
                     <a-entity class="next-button" position="0.3 0 0">
                         <a-entity mixin="rounded-text-button" slice9="width: 0.2">
                             <a-entity text=" value:>; width:2; align:center;" text-raycast-hack position="0 0 0.01"></a-entity>

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -245,8 +245,8 @@ export const addMedia = (src, template, contentOrigin, resolve = false, resize =
         entity.addEventListener(
           "animationcomplete",
           () => {
-            entity.addState("media-scale-ready");
-            entity.emit("media-scale-ready");
+            entity.addState("media-spawned");
+            entity.emit("media-spawned");
           },
           {
             once: true


### PR DESCRIPTION
This fixes up a number of things:

- Adds a `value` to the text label for the pager so the initial position is correct (slightly cargo culted here)
- Renames the `media-scale-ready` event to `media-spawned`
- Fixes up race conditions in creating PDF pager so only one is created, and it appears after the object has spawned
- Makes it so the PDF pager is only shown in pause mode and takes ownership when trying to page -- this removes the weird case where the owner is the only one who can see it.
- Updates the glTF deserializer to fire `media-spawned` so pinned objects will have ammo shapes (pinned objects do not have `addMedia` called on them.)
