### PR TITLE
Make water component better

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -67,7 +67,6 @@
             <img id="snap-camera" crossorigin="anonymous" src="./assets/images/snap_camera.png">
             <img id="camera" crossorigin="anonymous" src="./assets/images/camera.png">
             <img id="presence-count" crossorigin="anonymous" src="./assets/hud/presence-count.png">
-            <img id="water-normal-map" crossorigin="anonymous" src="./assets/waternormals.jpg">
             <img id="camera-action" crossorigin="anonymous" src="./assets/camera-action.png">
             <img id="scale-action" crossorigin="anonymous" src="./assets/scale-action.png">
             <img id="rotate-action" crossorigin="anonymous" src="./assets/rotate-action.png">


### PR DESCRIPTION
1. Now we don't load the water normal map in environments with no water. (AFAIK only the meeting room has a water.)

2. Since the water normal map isn't an asset anymore, we won't block loading on it.