### PR TITLE
Remove no-longer-accurate min room name length

### DIFF
--- a/src/react-components/rename-room-dialog.js
+++ b/src/react-components/rename-room-dialog.js
@@ -36,7 +36,6 @@ export default class RenameRoomDialog extends Component {
             required
             autoFocus
             autoComplete="off"
-            minLength={5}
             placeholder="Room name"
             value={this.state.name}
             onFocus={e => handleTextFieldFocus(e.target)}


### PR DESCRIPTION
I forgot to change it in this rename UI when I changed it in https://github.com/mozilla/hubs/pull/956/.