### PR TITLE
update aframe-physics-system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3352,7 +3352,7 @@
       }
     },
     "aframe-physics-system": {
-      "version": "github:mozillareality/aframe-physics-system#21c56951dad332321605c2b724fce944f1ea93c0",
+      "version": "github:mozillareality/aframe-physics-system#354a09e9fad29c7c5ad5f79fd1c4e7e8fe2ed5fb",
       "from": "github:mozillareality/aframe-physics-system#hubs/ammo_driver",
       "requires": {
         "ammo-debug-drawer": "github:infinitelee/ammo-debug-drawer",

--- a/src/components/super-networked-interactable.js
+++ b/src/components/super-networked-interactable.js
@@ -18,7 +18,7 @@ AFRAME.registerComponent("super-networked-interactable", {
       this.networkedEl = networkedEl;
       this._syncCounterRegistration();
       if (!NAF.utils.isMine(networkedEl)) {
-        this.el.setAttribute("ammo-body", { type: "kinematic", addCollideEventListener: true });
+        this.el.setAttribute("ammo-body", { type: "kinematic", emitCollisionEvents: true });
       } else {
         this.counter.register(networkedEl);
       }

--- a/src/hub.html
+++ b/src/hub.html
@@ -789,7 +789,7 @@
                 matrix-auto-update
                 haptic-feedback="path: /haptics/actuators/left"
                 mixin="controller-super-hands"
-                ammo-body="type: kinematic; addCollideEventListener: true; collisionFlags: 4; collisionFilterMask: 3; activationState: disable_deactivation; scaleAutoUpdate: false;"
+                ammo-body="type: kinematic; emitCollisionEvents: true; collisionFlags: 4; collisionFilterMask: 3; activationState: disable_deactivation; scaleAutoUpdate: false;"
                 ammo-shape="type: box; fit: manual; halfExtents: 0.03 0.04 0.05; offset: 0 0 -0.04"
                 action-to-event__c="path: /actions/leftHandGrab; event: primary_hand_grab;"
                 action-to-event__d="path: /actions/leftHandDrop; event: primary_hand_release;"
@@ -806,7 +806,7 @@
                 matrix-auto-update
                 haptic-feedback="path: /haptics/actuators/right"
                 mixin="controller-super-hands"
-                ammo-body="type: kinematic; addCollideEventListener: true; collisionFlags: 4; collisionFilterMask: 3; activationState: disable_deactivation; scaleAutoUpdate: false;"
+                ammo-body="type: kinematic; emitCollisionEvents: true; collisionFlags: 4; collisionFilterMask: 3; activationState: disable_deactivation; scaleAutoUpdate: false;"
                 ammo-shape="type: box; fit: manual; halfExtents: 0.03 0.04 0.05; offset: 0 0 -0.04"
                 action-to-event__c="path: /actions/rightHandGrab; event: primary_hand_grab;"
                 action-to-event__d="path: /actions/rightHandDrop; event: primary_hand_release;"


### PR DESCRIPTION
just a bump to update aframe-physics-system again. This has a small change to the API (renaming `addCollideEventListener` to `emitCollisionEvents`) as well as internally improving how collision events are handled to reduce garbage generation.