### PR TITLE
Stop autofocusing on mobile, and go into full screen mode for scene browser

### DIFF
--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -107,7 +107,7 @@ class MediaBrowser extends Component {
   };
 
   sourceChanged = () => {
-    if (this.inputRef && !isMobileVR) {
+    if (this.inputRef && !isMobile && !isMobileVR) {
       this.inputRef.focus();
     }
   };
@@ -231,7 +231,7 @@ class MediaBrowser extends Component {
                 </i>
                 <input
                   type="text"
-                  autoFocus={!isMobileVR}
+                  autoFocus={!isMobile && !isMobileVR}
                   ref={r => (this.inputRef = r)}
                   placeholder={formatMessage({
                     id: `media-browser.search-placeholder.${urlSource}`

--- a/src/react-components/settings-menu.js
+++ b/src/react-components/settings-menu.js
@@ -9,6 +9,7 @@ import { faImage } from "@fortawesome/free-solid-svg-icons/faImage";
 import { faPencilAlt } from "@fortawesome/free-solid-svg-icons/faPencilAlt";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons/faInfoCircle";
 import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus";
+import { showFullScreenIfAvailable } from "../utils/fullscreen";
 
 import styles from "../assets/stylesheets/settings-menu.scss";
 
@@ -68,6 +69,7 @@ export default class SettingsMenu extends Component {
                   <div
                     className={styles.listItemLink}
                     onClick={() => {
+                      showFullScreenIfAvailable();
                       this.props.mediaSearchStore.sourceNavigateWithNoNav("scenes");
                       this.props.hideSettings();
                     }}

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1044,7 +1044,10 @@ class UIRoot extends Component {
             <WithHoverSound>
               <div
                 className={entryStyles.chooseScene}
-                onClick={() => this.props.mediaSearchStore.sourceNavigateWithNoNav("scenes")}
+                onClick={() => {
+                  showFullScreenIfAvailable();
+                  this.props.mediaSearchStore.sourceNavigateWithNoNav("scenes");
+                }}
               >
                 <i>
                   <FontAwesomeIcon icon={faImage} />


### PR DESCRIPTION
This makes some more slight improvements to media browser on mobile -- it pops into full screen when entering scene browser from landing page, and also stops the autofocus business altogether on mobile which is annoying due to the keyboard popping up when trying to switch tabs, etc.