### PR TITLE
Update copy for desktop VR interstitial

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -881,7 +881,7 @@
                     textColor: #fff;
                     backgroundColor: #2f80ed;"
                 position="0 0 0.01">
-                <a-entity text="value:View desktop to continue; width:1; align:center;" position="0 0 0.01"></a-entity>
+                <a-entity text="value:View your desktop to continue; width:1; align:center;" position="0 0 0.01"></a-entity>
             </a-entity>
         </a-entity>
 

--- a/src/hub.html
+++ b/src/hub.html
@@ -881,7 +881,7 @@
                     textColor: #fff;
                     backgroundColor: #2f80ed;"
                 position="0 0 0.01">
-                <a-entity text="value:Lift your headset to continue; width:1; align:center;" position="0 0 0.01"></a-entity>
+                <a-entity text="value:View desktop to continue; width:1; align:center;" position="0 0 0.01"></a-entity>
             </a-entity>
         </a-entity>
 


### PR DESCRIPTION
The current copy in the notification when in desktop VR mode implies you have to lift your headset to proceed, when in fact you can also switch over to virtual desktop in Dash, etc. This updates the copy. 