### PR TITLE
Fix hover flicker issue

### DIFF
--- a/src/utils/auto-box-collider.js
+++ b/src/utils/auto-box-collider.js
@@ -15,9 +15,10 @@ export function getBox(entity, boxRoot) {
     entity.object3D.worldToLocal(box.max);
     entity.object3D.rotation.copy(rotation);
     entity.object3D.matrixNeedsUpdate = true;
-    boxRoot.matrixWorldNeedsUpdate = true;
-    boxRoot.updateMatrices();
   }
+
+  boxRoot.matrixWorldNeedsUpdate = true;
+  boxRoot.updateMatrices();
 
   return box;
 }

--- a/src/utils/auto-box-collider.js
+++ b/src/utils/auto-box-collider.js
@@ -15,6 +15,8 @@ export function getBox(entity, boxRoot) {
     entity.object3D.worldToLocal(box.max);
     entity.object3D.rotation.copy(rotation);
     entity.object3D.matrixNeedsUpdate = true;
+    boxRoot.matrixWorldNeedsUpdate = true;
+    boxRoot.updateMatrices();
   }
 
   return box;


### PR DESCRIPTION
The forced matrix updates above end up leaving the `boxRoot` in a bad state, which doesn't get resolved until the following render. We never encountered this as an issue before because we never cared to have this be correct until the next render, but with my most recent change our raycasting happens later, and the raycasting code cares that the `boxRoot` (which in the error case is the video's PlaneGeometry object3D) has a correct matrixWorld. 

Another way to fix this would have been to set `boxRoot.matrixWorldNeedsUpdate = true` and then call `updateMatrices` from within THREE.Mesh.raycast. Right now THREE doesn't know about our `updateMatrices` method so we will have to patch that in. I believe that is the more correct solution.

It does not work to call `entity.object3D.updateMatrices()` instead of `boxRoot.updateMatrices()`. I thought that maybe it would, but it doesn't and I'm not sure if that's expected. In any case, this ensures that by the end of this method, the `boxRoot` has a correct `matrixWorld`, which is used later when we raycast. 

This whole `getBox` function seems suspicious to me... We have two calls to `updateMatrices` with both force flags set to true, and then the call to `box.setFromObject(boxRoot)` calls `expandByObject` which then calls `boxRoot.updateMatrixWorld(true)`. I don't know what the "right way" to handle this is, so this is my proposed solution to the problem. Still, it seems a bit fishy.