### PR TITLE
Moderately improve cursor target acquisition

### DIFF
--- a/src/systems/cursor-targetting-system.js
+++ b/src/systems/cursor-targetting-system.js
@@ -3,23 +3,19 @@ import { waitForDOMContentLoaded } from "../utils/async-utils";
 export class CursorTargettingSystem {
   constructor() {
     this.targets = [];
-    this.setDirty = this.setDirty.bind(this);
     this.dirty = true;
-
+    this.onMutation = this.onMutation.bind(this);
+    this.onObject3DSet = this.onObject3DSet.bind(this);
+    this.onObject3DRemove = this.onObject3DRemove.bind(this);
     // TODO: Use the MutationRecords passed into the callback function to determine added/removed nodes!
-    this.observer = new MutationObserver(this.setDirty);
-
+    this.observer = new MutationObserver(this.onMutation);
     waitForDOMContentLoaded().then(() => {
       const scene = document.querySelector("a-scene");
       this.rightRemote = document.querySelector("#cursor-controller");
       this.observer.observe(scene, { childList: true, attributes: true, subtree: true });
-      scene.addEventListener("object3dset", this.setDirty);
-      scene.addEventListener("object3dremove", this.setDirty);
+      scene.addEventListener("object3dset", this.onObject3DSet);
+      scene.addEventListener("object3dremove", this.onObject3DRemove);
     });
-  }
-
-  setDirty() {
-    this.dirty = true;
   }
 
   tick(t) {
@@ -29,6 +25,21 @@ export class CursorTargettingSystem {
     }
 
     this.rightRemote.components["cursor-controller"].tick2(t);
+  }
+
+  onObject3DSet() {
+    this.dirty = true;
+  }
+
+  onObject3DRemove() {
+    this.dirty = true;
+  }
+
+  onMutation(records) {
+    // let's try to avoid re-querying the targets on attribute changes we know we can ignore
+    if (records.some(r => r.type === "childList" || (r.type === "attributes" && r.attributeName === "class"))) {
+      this.dirty = true;
+    }
   }
 
   populateEntities(targets) {
@@ -44,7 +55,7 @@ export class CursorTargettingSystem {
 
   remove() {
     this.observer.disconnect();
-    AFRAME.scenes[0].removeEventListener("object3dset", this.setDirty);
-    AFRAME.scenes[0].removeEventListener("object3dremove", this.setDirty);
+    AFRAME.scenes[0].removeEventListener("object3dset", this.onObject3DSet);
+    AFRAME.scenes[0].removeEventListener("object3dremove", this.onObject3DRemove);
   }
 }


### PR DESCRIPTION
Populating the targets here seems like it can take a substantial fraction of a second. This cuts the number of times it has to happen on object spawn down to 2 from a handful, and removes the need to call it at all in cases where we're using `setAttribute` but not modifying the class.

In the future we should do something totally different with more mechanical sympathy, like making a single class, A-Frame component, or key on the tags component be responsible for determining whether something is a valid target or not, and making the raycasting code take as input a list of A-Frame entities instead of a list of `Object3D`s.