### PR TITLE
Fix regression in pin button hover event naming

### DIFF
--- a/src/components/pin-networked-object-button.js
+++ b/src/components/pin-networked-object-button.js
@@ -29,12 +29,12 @@ AFRAME.registerComponent("pin-networked-object-button", {
       this.targetEl.addEventListener("unpinned", this._updateUI);
     });
 
-    this.onHover = () => {
+    this.onHovered = () => {
       this.hovering = true;
       this._updateUI();
     };
 
-    this.onHoverOut = () => {
+    this.onUnhovered = () => {
       this.hovering = false;
       this._updateUI();
     };
@@ -49,14 +49,14 @@ AFRAME.registerComponent("pin-networked-object-button", {
 
   play() {
     this.el.object3D.addEventListener("interact", this.onClick);
-    this.el.object3D.addEventListener("hover", this.onHover);
-    this.el.object3D.addEventListener("unhover", this.onHoverOut);
+    this.el.object3D.addEventListener("hovered", this.onHovered);
+    this.el.object3D.addEventListener("unhovered", this.onUnhovered);
   },
 
   pause() {
     this.el.object3D.removeEventListener("interact", this.onClick);
-    this.el.object3D.removeEventListener("hover", this.onHover);
-    this.el.object3D.removeEventListener("unhover", this.onHoverOut);
+    this.el.object3D.removeEventListener("hovered", this.onHovered);
+    this.el.object3D.removeEventListener("unhovered", this.onUnhovered);
   },
 
   remove() {


### PR DESCRIPTION
This made it so that the Discord bridging tip didn't pop up as it should.