### PR TITLE
Always show in world HUD until first hover on children

### DIFF
--- a/src/components/hud-controller.js
+++ b/src/components/hud-controller.js
@@ -20,6 +20,7 @@ AFRAME.registerComponent("hud-controller", {
   },
   init() {
     this.onChildHovered = this.onChildHovered.bind(this);
+    this.removeHoverEvents = this.removeHoverEvents.bind(this);
     this.isYLocked = false;
     this.lockedHeadPositionY = 0;
     this.lookDir = new THREE.Vector3();
@@ -88,6 +89,10 @@ AFRAME.registerComponent("hud-controller", {
   },
 
   pause() {
+    this.removeHoverEvents();
+  },
+
+  removeHoverEvents() {
     for (let i = 0; i < this.hoverableChildren.length; i++) {
       this.hoverableChildren[i].object3D.removeEventListener("hovered", this.onChildHovered);
     }
@@ -96,6 +101,7 @@ AFRAME.registerComponent("hud-controller", {
   onChildHovered() {
     if (!this.store.state.activity.hasHoveredInWorldHud) {
       this.store.update({ activity: { hasHoveredInWorldHud: true } });
+      this.removeHoverEvents();
     }
   }
 });

--- a/src/components/hud-controller.js
+++ b/src/components/hud-controller.js
@@ -19,10 +19,13 @@ AFRAME.registerComponent("hud-controller", {
     showTip: { type: "bool" }
   },
   init() {
+    this.onChildHovered = this.onChildHovered.bind(this);
     this.isYLocked = false;
     this.lockedHeadPositionY = 0;
     this.lookDir = new THREE.Vector3();
     this.lookEuler = new THREE.Euler();
+    this.store = window.APP.store;
+    this.hoverableChildren = this.el.querySelectorAll("[is-remote-hover-target]");
   },
 
   tick() {
@@ -34,11 +37,14 @@ AFRAME.registerComponent("hud-controller", {
     const pitch = head.rotation.x * THREE.Math.RAD2DEG;
     const yawDif = deltaAngle(head.rotation.y, hud.rotation.y) * THREE.Math.RAD2DEG;
 
+    // HUD is always visible until first hover, to increase discoverability.
+    const forceHudVisible = !this.store.state.activity.hasHoveredInWorldHud;
+
     // animate the hud into place over animRange degrees as the user aproaches the lookCutoff angle
     let t = 1 - THREE.Math.clamp(lookCutoff - pitch, 0, animRange) / animRange;
 
-    // HUD is locked down while showing tooltip
-    if (showTip) {
+    // HUD is locked down while showing tooltip or if forced.
+    if (showTip || !this.store.state.activity.hasHoveredInWorldHud) {
       t = 1;
     }
 
@@ -69,9 +75,27 @@ AFRAME.registerComponent("hud-controller", {
       hud.rotation.z = 0;
     }
 
-    hud.visible = !hudOutOfView;
+    hud.visible = !hudOutOfView || forceHudVisible;
     hud.position.y = (this.isYLocked ? this.lockedHeadPositionY : head.position.y) + offset + (1 - t) * offset;
     hud.rotation.x = (1 - t) * THREE.Math.DEG2RAD * 90;
     hud.matrixNeedsUpdate = true;
+  },
+
+  play() {
+    for (let i = 0; i < this.hoverableChildren.length; i++) {
+      this.hoverableChildren[i].object3D.addEventListener("hovered", this.onChildHovered);
+    }
+  },
+
+  pause() {
+    for (let i = 0; i < this.hoverableChildren.length; i++) {
+      this.hoverableChildren[i].object3D.removeEventListener("hovered", this.onChildHovered);
+    }
+  },
+
+  onChildHovered() {
+    if (!this.store.state.activity.hasHoveredInWorldHud) {
+      this.store.update({ activity: { hasHoveredInWorldHud: true } });
+    }
   }
 });

--- a/src/components/hud-controller.js
+++ b/src/components/hud-controller.js
@@ -44,7 +44,7 @@ AFRAME.registerComponent("hud-controller", {
     let t = 1 - THREE.Math.clamp(lookCutoff - pitch, 0, animRange) / animRange;
 
     // HUD is locked down while showing tooltip or if forced.
-    if (showTip || !this.store.state.activity.hasHoveredInWorldHud) {
+    if (showTip || forceHudVisible) {
       t = 1;
     }
 

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -44,7 +44,8 @@ export const SCHEMA = {
         hasPinned: { type: "boolean" },
         hasRotated: { type: "boolean" },
         hasRecentered: { type: "boolean" },
-        hasScaled: { type: "boolean" }
+        hasScaled: { type: "boolean" },
+        hasHoveredInWorldHud: { type: "boolean" }
       }
     },
 

--- a/src/systems/userinput/resolve-action-sets.js
+++ b/src/systems/userinput/resolve-action-sets.js
@@ -38,7 +38,10 @@ export function resolveActionSets() {
   userinput.toggleSet(sets.leftHandHoldingCamera, leftHand.held && leftHand.held.components["camera-tool"]);
   userinput.toggleSet(sets.leftHandHoldingInteractable, leftHand.held);
 
-  userinput.toggleSet(sets.rightHandHoveringOnNothing, !rightRemote.held && !rightRemote.hovered && !rightHand.held && !rightHand.hovered);
+  userinput.toggleSet(
+    sets.rightHandHoveringOnNothing,
+    !rightRemote.held && !rightRemote.hovered && !rightHand.held && !rightHand.hovered
+  );
   userinput.toggleSet(
     sets.rightHandHoveringOnPen,
     !rightHand.held &&


### PR DESCRIPTION
This PR improves the discoverability of the in-VR HUD by ensuring it's always visible until the user first hovers over any of the buttons, at which point it begins doing the hide-on-not-looking behavior for all subsequent sessions.