### PR TITLE
fix collision filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3352,7 +3352,7 @@
       }
     },
     "aframe-physics-system": {
-      "version": "github:mozillareality/aframe-physics-system#354a09e9fad29c7c5ad5f79fd1c4e7e8fe2ed5fb",
+      "version": "github:mozillareality/aframe-physics-system#e4e5b1c12e152aa6759480d3372e2afab1577ba2",
       "from": "github:mozillareality/aframe-physics-system#hubs/ammo_driver",
       "requires": {
         "ammo-debug-drawer": "github:infinitelee/ammo-debug-drawer",

--- a/src/components/set-unowned-body-kinematic.js
+++ b/src/components/set-unowned-body-kinematic.js
@@ -1,4 +1,6 @@
 /* global NAF */
+const COLLISION_LAYERS = require("../constants").COLLISION_LAYERS;
+
 AFRAME.registerComponent("set-unowned-body-kinematic", {
   play() {
     this.setBodyKinematic = this.setBodyKinematic.bind(this);
@@ -9,7 +11,7 @@ AFRAME.registerComponent("set-unowned-body-kinematic", {
       this.hasBeenHereBefore = true;
 
       if (!NAF.utils.isMine(this.el)) {
-        this.el.setAttribute("ammo-body", { type: "kinematic" });
+        this.setBodyKinematic();
       }
     }
   },
@@ -17,6 +19,9 @@ AFRAME.registerComponent("set-unowned-body-kinematic", {
     this.el.removeEventListener("ownership-lost", this.setBodyKinematic);
   },
   setBodyKinematic() {
-    this.el.setAttribute("ammo-body", { type: "kinematic" });
+    this.el.setAttribute("ammo-body", { type: "kinematic", collisionFilterMask: COLLISION_LAYERS.INTERACTABLES });
+    if (this.el.components["sticky-object"]) {
+      this.el.components["sticky-object"].locked = true;
+    }
   }
 });

--- a/src/components/set-unowned-body-kinematic.js
+++ b/src/components/set-unowned-body-kinematic.js
@@ -19,7 +19,10 @@ AFRAME.registerComponent("set-unowned-body-kinematic", {
     this.el.removeEventListener("ownership-lost", this.setBodyKinematic);
   },
   setBodyKinematic() {
-    this.el.setAttribute("ammo-body", { type: "kinematic", collisionFilterMask: COLLISION_LAYERS.INTERACTABLES });
+    this.el.setAttribute("ammo-body", {
+      type: "kinematic",
+      collisionFilterMask: COLLISION_LAYERS.UNOWNED_INTERACTABLE
+    });
     if (this.el.components["sticky-object"]) {
       this.el.components["sticky-object"].locked = true;
     }

--- a/src/components/sticky-object.js
+++ b/src/components/sticky-object.js
@@ -50,7 +50,7 @@ AFRAME.registerComponent("sticky-object", {
     if (!almostEquals(0.001, this.prevScale, this.el.object3D.scale)) {
       if ((this.heldLeftHand || this.heldRightHand || this.heldRightRemote) && !this.wasScaled) {
         this.wasScaled = true;
-        this.el.setAttribute("ammo-body", { collisionFilterMask: COLLISION_LAYERS.NONE });
+        this.el.setAttribute("ammo-body", { collisionFilterMask: COLLISION_LAYERS.HANDS });
       }
 
       this.prevScale.copy(this.el.object3D.scale);
@@ -96,7 +96,7 @@ AFRAME.registerComponent("sticky-object", {
 
   onGrab() {
     this.el.setAttribute("ammo-body", {
-      collisionFilterMask: this.locked ? COLLISION_LAYERS.NONE : COLLISION_LAYERS.DEFAULT_INTERACTABLE
+      collisionFilterMask: this.locked ? COLLISION_LAYERS.HANDS : COLLISION_LAYERS.DEFAULT_INTERACTABLE
     });
     this.setLocked(false);
     this.wasScaled = false;

--- a/src/components/sticky-object.js
+++ b/src/components/sticky-object.js
@@ -1,5 +1,11 @@
-const COLLISION_LAYERS = require("../constants").COLLISION_LAYERS;
 /* global AFRAME */
+
+const COLLISION_LAYERS = require("../constants").COLLISION_LAYERS;
+
+function almostEquals(epsilon, u, v) {
+  return Math.abs(u.x - v.x) < epsilon && Math.abs(u.y - v.y) < epsilon && Math.abs(u.z - v.z) < epsilon;
+}
+
 AFRAME.registerComponent("sticky-object", {
   schema: {
     autoLockOnLoad: { default: false },
@@ -10,6 +16,8 @@ AFRAME.registerComponent("sticky-object", {
   init() {
     this.onGrab = this.onGrab.bind(this);
     this.onRelease = this.onRelease.bind(this);
+    this.prevScale = this.el.object3D.scale.clone();
+    this.wasScaled = false;
   },
 
   tick() {
@@ -38,6 +46,15 @@ AFRAME.registerComponent("sticky-object", {
     this.heldLeftHand = heldLeftHand;
     this.heldRightHand = heldRightHand;
     this.heldRightRemote = heldRightRemote;
+
+    if (!almostEquals(0.001, this.prevScale, this.el.object3D.scale)) {
+      if ((this.heldLeftHand || this.heldRightHand || this.heldRightRemote) && !this.wasScaled) {
+        this.wasScaled = true;
+        this.el.setAttribute("ammo-body", { collisionFilterMask: COLLISION_LAYERS.NONE });
+      }
+
+      this.prevScale.copy(this.el.object3D.scale);
+    }
   },
 
   play() {
@@ -74,14 +91,15 @@ AFRAME.registerComponent("sticky-object", {
       this.setLocked(true);
     }
 
-    this.el.setAttribute("ammo-body", { collisionFilterGroup: COLLISION_LAYERS.DYNAMIC_OBJECTS });
+    this.el.setAttribute("ammo-body", { collisionFilterMask: COLLISION_LAYERS.DEFAULT_INTERACTABLE });
   },
 
   onGrab() {
     this.el.setAttribute("ammo-body", {
-      collisionFilterGroup: this.locked ? COLLISION_LAYERS.STICKY_OBJECTS : COLLISION_LAYERS.DYNAMIC_OBJECTS
+      collisionFilterMask: this.locked ? COLLISION_LAYERS.NONE : COLLISION_LAYERS.DEFAULT_INTERACTABLE
     });
     this.setLocked(false);
+    this.wasScaled = false;
   },
 
   remove() {

--- a/src/components/super-spawner.js
+++ b/src/components/super-spawner.js
@@ -3,7 +3,7 @@ import { waitForEvent } from "../utils/async-utils";
 import { ObjectContentOrigins } from "../object-types";
 import { paths } from "../systems/userinput/paths";
 
-const COLLISION_FLAG = require("aframe-physics-system/src/constants").COLLISION_FLAG;
+const COLLISION_LAYERS = require("../constants").COLLISION_LAYERS;
 
 /**
  * Spawns networked objects when grabbed or when a specified event is fired.
@@ -155,11 +155,11 @@ AFRAME.registerComponent("super-spawner", {
       this.el.object3D.scale.set(0.001, 0.001, 0.001);
       this.el.object3D.matrixNeedsUpdate = true;
       this.el.classList.remove("interactable");
-      this.el.setAttribute("ammo-body", { collisionFlags: COLLISION_FLAG.NO_CONTACT_RESPONSE });
+      this.el.setAttribute("ammo-body", { collisionFilterMask: COLLISION_LAYERS.NONE });
       this.cooldownTimeout = setTimeout(() => {
         this.el.setAttribute("visible", true);
         this.el.classList.add("interactable");
-        this.el.setAttribute("ammo-body", { collisionFlags: COLLISION_FLAG.STATIC_OBJECT });
+        this.el.setAttribute("ammo-body", { collisionFilterMask: COLLISION_LAYERS.DEFAULT_SPAWNER });
         this.el.removeAttribute("animation__spawner-cooldown");
         this.el.setAttribute("animation__spawner-cooldown", {
           property: "scale",

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,8 @@ module.exports = {
     ENVIRONMENT: 2,
     AVATAR: 4,
     HANDS: 8,
-    DEFAULT_INTERACTABLE: 1 | 2 | 4 | 8
+    DEFAULT_INTERACTABLE: 1 | 2 | 4 | 8,
+    UNOWNED_INTERACTABLE: 1 | 8,
+    DEFAULT_SPAWNER: 1 | 8
   }
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,8 +1,11 @@
 module.exports = {
   COLLISION_LAYERS: {
-    NO_COLLISION: 0,
-    DYNAMIC_OBJECTS: 1,
-    STICKY_OBJECTS: 2,
-    ALL_OBJECTS: 3
+    ALL: -1,
+    NONE: 0,
+    INTERACTABLES: 1,
+    ENVIRONMENT: 2,
+    AVATAR: 4,
+    HANDS: 8,
+    DEFAULT_INTERACTABLE: 1 | 2 | 4 | 8
   }
 };

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -2,10 +2,10 @@ import "./components/gltf-model-plus";
 import { getSanitizedComponentMapping } from "./utils/component-mappings";
 import { isHubsDestinationUrl } from "./utils/media-utils";
 const PHYSICS_CONSTANTS = require("aframe-physics-system/src/constants"),
-  COLLISION_FLAG = PHYSICS_CONSTANTS.COLLISION_FLAG,
   TYPE = PHYSICS_CONSTANTS.TYPE,
   SHAPE = PHYSICS_CONSTANTS.SHAPE,
   FIT = PHYSICS_CONSTANTS.FIT;
+const COLLISION_LAYERS = require("./constants").COLLISION_LAYERS;
 
 AFRAME.GLTFModelPlus.registerComponent("duck", "duck");
 AFRAME.GLTFModelPlus.registerComponent("quack", "quack");
@@ -28,7 +28,8 @@ AFRAME.GLTFModelPlus.registerComponent("body", "ammo-body", el => {
   el.setAttribute("ammo-body", {
     mass: 0,
     type: TYPE.STATIC,
-    collisionFlags: COLLISION_FLAG.NO_CONTACT_RESPONSE
+    collisionFilterGroup: COLLISION_LAYERS.INTERACTABLES,
+    collisionFilterMask: COLLISION_LAYERS.DEFAULT_INTERACTABLE
   });
 });
 AFRAME.GLTFModelPlus.registerComponent("ammo-shape", "ammo-shape");
@@ -228,7 +229,8 @@ AFRAME.GLTFModelPlus.registerComponent("spawner", "spawner", (el, componentName,
   el.setAttribute("ammo-body", {
     mass: 0,
     type: TYPE.STATIC,
-    collisionFlags: COLLISION_FLAG.NO_CONTACT_RESPONSE
+    collisionFilterGroup: COLLISION_LAYERS.INTERACTABLES,
+    collisionFilterMask: COLLISION_LAYERS.DEFAULT_SPAWNER
   });
   el.setAttribute("is-remote-hover-target", "");
   el.setAttribute("is-hand-collision-target", "");

--- a/src/hub.html
+++ b/src/hub.html
@@ -173,7 +173,7 @@
                                 networked-audio-analyser
                                 personal-space-invader="radius: 0.15; useMaterial: true;"
                                 bone-visibility
-                                ammo-body="type: kinematic;"
+                                ammo-body="type: kinematic; collisionFilterGroup: 4; collisionFilterMask: 1;"
                                 ammo-shape="type: cylinder; fit: manual; halfExtents: 0.11 0.10 0.11; offset: 0 0.06 0.04;"
                             ></a-entity>
                         </template>
@@ -191,7 +191,7 @@
 
             <template id="static-media">
                 <a-entity
-                    ammo-body="type: static; mass: 1;"
+                    ammo-body="type: static; mass: 1; collisionFilterGroup: 1; collisionFilterMask: 11;"
                     set-sounds-invisible
                 >
                 </a-entity>
@@ -200,7 +200,7 @@
             <template id="static-controlled-media">
                 <a-entity
                     class="interactable"
-                    ammo-body="type: static; mass: 1;"
+                    ammo-body="type: static; mass: 1; collisionFilterGroup: 1; collisionFilterMask: 11;"
                     is-remote-hover-target
                     hoverable-visuals="cursorController: #cursor-controller"
                 >
@@ -210,7 +210,7 @@
             <template id="interactable-media">
                 <a-entity
                     class="interactable"
-                    ammo-body="type: dynamic; mass: 1;"
+                    ammo-body="type: dynamic; mass: 1; collisionFilterGroup: 1; collisionFilterMask: 15;"
                     owned-object-limiter="counter: #media-counter"
                     set-unowned-body-kinematic
                     is-remote-hover-target
@@ -304,7 +304,7 @@
             <template id="pen-interactable">
                 <a-entity
                     class="pen interactable"
-                    ammo-body="type: dynamic; mass: 0.001;"
+                    ammo-body="type: dynamic; mass: 0.001; collisionFilterGroup: 1; collisionFilterMask: 15;"
                     owned-object-limiter="counter: #pen-counter"
                     set-unowned-body-kinematic
                     is-remote-hover-target
@@ -352,8 +352,8 @@
 
             <template id="interactable-camera">
                 <a-entity
-                    class="interactable icamera"
-                    ammo-body="type: dynamic; mass: 0.001;"
+                    class="interactable"
+                    ammo-body="type: dynamic; mass: 0.001; collisionFilterGroup: 1; collisionFilterMask: 8;"
                     camera-tool
                     is-remote-hover-target
                     is-hand-collision-target
@@ -594,7 +594,7 @@
             radius="0.02"
             segments-width="9"
             segments-height="9"
-            ammo-body="type: kinematic; collisionFlags: 4; collisionFilterMask: 3; scaleAutoUpdate: false; activationState: disable_deactivation;"
+            ammo-body="type: kinematic; collisionFlags: 4; collisionFilterGroup: 8; collisionFilterMask: 0; scaleAutoUpdate: false; activationState: disable_deactivation;"
             ammo-shape="type: sphere; sphereRadius: 0.02; fit: manual;"
         >
             <a-image
@@ -749,7 +749,7 @@
                 hand-controls2="left"
                 teleporter="start: /actions/leftHand/startTeleport; confirm: /actions/leftHand/stopTeleport; collisionEntities: [nav-mesh]"
                 matrix-auto-update
-                ammo-body="type: kinematic; emitCollisionEvents: false; collisionFlags: 4; collisionFilterMask: 3; activationState: disable_deactivation; scaleAutoUpdate: false;"
+                ammo-body="type: kinematic; emitCollisionEvents: false; collisionFlags: 4; collisionFilterGroup: 8; collisionFilterMask: 3; activationState: disable_deactivation; scaleAutoUpdate: false;"
                 ammo-shape="type: box; fit: manual; halfExtents: 0.03 0.04 0.05; offset: 0 0 -0.04"
             >
             </a-entity>
@@ -762,7 +762,7 @@
                 hand-controls2="right"
                 teleporter="start: /actions/rightHand/startTeleport; confirm: /actions/rightHand/stopTeleport; collisionEntities: [nav-mesh]"
                 matrix-auto-update
-                ammo-body="type: kinematic; emitCollisionEvents: false; collisionFlags: 4; collisionFilterMask: 3; activationState: disable_deactivation; scaleAutoUpdate: false;"
+                ammo-body="type: kinematic; emitCollisionEvents: false; collisionFlags: 4; collisionFilterGroup: 8; collisionFilterMask: 3; activationState: disable_deactivation; scaleAutoUpdate: false;"
                 ammo-shape="type: box; fit: manual; halfExtents: 0.03 0.04 0.05; offset: 0 0 -0.04"
             >
             </a-entity>
@@ -803,7 +803,7 @@
         <!-- Environment -->
         <a-entity
             id="environment-root"
-            ammo-body="type: static; mass: 0;"
+            ammo-body="type: static; mass: 0; collisionFilterGroup: 2; collisionFilterMask: 1;"
             nav-mesh-helper
         >
             <a-entity id="environment-scene"></a-entity>


### PR DESCRIPTION
-Fix collisionFilters so that the intended behaviour of grabbing sticky/nonsticky objects works.
-Prevent physics collisions against the environment for objects that you don't own.
-Objects that are scaled are automatically set to be sticky on release.
fixes #1169