### PR TITLE
Move to MOZ_hubs_components

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -80,7 +80,9 @@ function cloneGltf(gltf) {
 }
 
 function getHubsComponents(node) {
-  const hubsComponents = node.userData.gltfExtensions && node.userData.gltfExtensions.HUBS_components;
+  const hubsComponents =
+    node.userData.gltfExtensions &&
+    (node.userData.gltfExtensions.MOZ_hubs_components || node.userData.gltfExtensions.HUBS_components);
 
   // We can remove support for legacy components when our environment, avatar and interactable models are
   // updated to match Spoke output.

--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -114,7 +114,7 @@ export default class AvatarEditor extends Component {
       // const gltf = parser.json;
       // Object.assign(gltf.scenes[0], {
       //   extensions: {
-      //     HUBS_components: {
+      //     MOZ_hubs_components: {
       //       "loop-animation": {
       //         clip: "idle_eyes"
       //       }
@@ -123,7 +123,7 @@ export default class AvatarEditor extends Component {
       // });
       // Object.assign(gltf.nodes.find(n => n.name === "Head"), {
       //   extensions: {
-      //     HUBS_components: {
+      //     MOZ_hubs_components: {
       //       "scale-audio-feedback": ""
       //     }
       //   }

--- a/src/utils/pinned-entity-to-gltf.js
+++ b/src/utils/pinned-entity-to-gltf.js
@@ -7,6 +7,8 @@ export default function pinnedEntityToGltf(el) {
   const networkId = components.networked.data.networkId;
 
   const gltfComponents = {};
+  // TODO: Move to MOZ_hubs_components and include version number. Requires migration of existing room objects.
+  // Please do this before making a breaking change to the data stored here.
   const gltfNode = { name: networkId, extensions: { HUBS_components: gltfComponents } };
 
   // Adapted from three.js GLTFExporter


### PR DESCRIPTION
- Uses the correct vendor extension `MOZ_`
- Includes a version number for backwards compatible migrations. This number will be incremented when making a breaking change to the component data.
- Keeps support for `HUBS_components` until we completely switch over.

Example:
```
{
  "extensions": {
    "MOZ_hubs_components": {
      "version": 1
    }
  },
  "scenes": [
    {
      "extensions": {
        "MOZ_hubs_components": {
          "animation-loop": { "clip": "environment" }
        }
      }
    }
  ],
  "nodes": [
    {
      "extensions": {
        "MOZ_hubs_components": {
          "shadow": { "cast": true, "receive": false }
        }
      }
    }
  ]
}
```