### PR TITLE
Bump Ammo, remove Node fs shim

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3420,7 +3420,7 @@
       "from": "github:infinitelee/ammo-debug-drawer"
     },
     "ammo.js": {
-      "version": "github:mozillareality/ammo.js#3bca414e916ee37e8b1e5079b2c05a6ef329087e",
+      "version": "github:mozillareality/ammo.js#c2136d3ade8e6e43ddc368515d72e140eddff98c",
       "from": "github:mozillareality/ammo.js#hubs/master"
     },
     "an-array": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -330,8 +330,5 @@ module.exports = (env, argv) => ({
         POSTGREST_SERVER: process.env.POSTGREST_SERVER
       })
     })
-  ],
-  node: {
-    fs: "empty"
-  }
+  ]
 });


### PR DESCRIPTION
Self-explanatory. The Ammo bump is for https://github.com/MozillaReality/ammo.js/pull/2.