### PR TITLE
Check for scene in interaction system

### DIFF
--- a/src/systems/button-systems.js
+++ b/src/systems/button-systems.js
@@ -1,8 +1,11 @@
 export class SingleActionButtonSystem {
   tick() {
     this.didInteractThisFrame = false;
-    const interaction = AFRAME.scenes[0].systems.interaction;
-    const userinput = AFRAME.scenes[0].systems.userinput;
+    const scene = AFRAME.scenes[0];
+    if (!scene) return;
+
+    const interaction = scene.systems.interaction;
+    const userinput = scene.systems.userinput;
     const state = interaction.state.rightRemote;
     const grab = interaction.options.rightRemote.grabPath;
     if (
@@ -22,7 +25,10 @@ export class SingleActionButtonSystem {
 
 export class HoldableButtonSystem {
   tick() {
-    const interaction = AFRAME.scenes[0].systems.interaction;
+    const scene = AFRAME.scenes[0];
+    if (!scene) return;
+
+    const interaction = scene.systems.interaction;
     const held = interaction.state.rightRemote.held;
     const options = interaction.options.rightRemote;
 
@@ -69,7 +75,9 @@ const HOVERED = { type: "hovered" };
 const UNHOVERED = { type: "unhovered" };
 export class HoverButtonSystem {
   tick() {
-    const interaction = AFRAME.scenes[0].systems.interaction;
+    const scene = AFRAME.scenes[0];
+    if (!scene) return;
+    const interaction = scene.systems.interaction;
     const button = getHoverableButton(interaction.state.rightRemote.hovered);
 
     if (this.prevButton && this.prevButton !== button) {

--- a/src/systems/haptic-feedback-system.js
+++ b/src/systems/haptic-feedback-system.js
@@ -74,14 +74,17 @@ export class HapticFeedbackSystem {
   }
 
   tick(twoPointStretchingSystem, didClickButton) {
-    const userinput = AFRAME.scenes[0].systems.userinput;
+    const scene = AFRAME.scenes[0];
+    if (!scene) return;
+
+    const userinput = scene.systems.userinput;
     const leftActuator = userinput.get(paths.haptics.actuators.left);
     const rightActuator = userinput.get(paths.haptics.actuators.right);
     if (!leftActuator && !rightActuator) {
       return;
     }
 
-    const interaction = AFRAME.scenes[0].systems.interaction;
+    const interaction = scene.systems.interaction;
     const { leftHand, rightHand, rightRemote } = interaction.state;
     this.leftTeleporter =
       this.leftTeleporter || document.querySelector("#player-left-controller").components.teleporter;

--- a/src/systems/hover-menu-system.js
+++ b/src/systems/hover-menu-system.js
@@ -25,7 +25,9 @@ function findHoverMenu(hovered) {
 
 export class HoverMenuSystem {
   tick() {
-    const interaction = AFRAME.scenes[0].systems.interaction;
+    const scene = AFRAME.scenes[0];
+    if (!scene) return;
+    const interaction = scene.systems.interaction;
     const hoverMenu = findHoverMenu(interaction.state.rightRemote.hovered);
 
     if (this.prevHoverMenu && this.prevHoverMenu !== hoverMenu) {


### PR DESCRIPTION
leaving the room throws an error because `AFRAME.scenes[0]` becomes undefined on exit but the interaction system doesn't know to check if the scene is missing.