### PR TITLE
Fix issues with invisible buttons in HUD

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -602,7 +602,6 @@
                 id="player-hud"
                 hud-controller="head: #player-camera;"
                 vr-mode-toggle-class="class: ui"
-                vr-mode-toggle-class__ui="class: interactable-ui"
                 vr-mode-toggle-visibility
                 vr-mode-toggle-playing__hud-controller
             >
@@ -617,11 +616,9 @@
                     <a-rounded height="0.08" width="0.2" color="#000000" position="-0.44 -0.045 0" radius="0.040" opacity="0.35" class="hud bg"></a-rounded>
                     <a-image scale="0.07 0.06 0.06" position="-0.38 -0.005 0.001" src="#presence-count" material="alphaTest:0.1;"></a-image>
                     <a-entity id="hud-presence-count" text="value:; width:1.1; align:center;" position="-0.30 -0.005 0" matrix-auto-update="target: text;"></a-entity>
-                    <a-entity>
-                        <a-entity class="invite-btn" position="0 0.18 0" scale="0.7 0.7 0.7" is-remote-hover-target tags="singleActionButton: true;">
-                            <a-entity mixin="rounded-text-action-button" slice9="width: 0.7" scale="0.8 0.8 1.0">
-                                <a-entity text=" value:invite; width:2; align:center;" text-raycast-hack position="0 0 0.01"></a-entity>
-                            </a-entity>
+                    <a-entity class="invite-btn" position="0 0.18 0" scale="0.7 0.7 0.7" is-remote-hover-target tags="singleActionButton: true;">
+                        <a-entity mixin="rounded-text-action-button" slice9="width: 0.7" scale="0.8 0.8 1.0">
+                            <a-entity text=" value:invite; width:2; align:center;" text-raycast-hack position="0 0 0.01"></a-entity>
                         </a-entity>
                     </a-entity>
                 <a-image

--- a/src/hub.html
+++ b/src/hub.html
@@ -601,24 +601,19 @@
             <a-entity
                 id="player-hud"
                 hud-controller="head: #player-camera;"
-                vr-mode-toggle-class="class: ui"
-                vr-mode-toggle-visibility
-                vr-mode-toggle-playing__hud-controller
             >
-                <a-entity visibility-while-frozen="requireHoverOnNonMobile: false;" rotation="30 0 0">
-                    <a-entity class="ui interactable-ui">
-                        <a-entity class="leave-btn" position="0 -0.2 0" scale="0.7 0.7 0.7" leave-room-button is-remote-hover-target tags="singleActionButton: true;">
-                            <a-entity mixin="rounded-text-action-button" slice9="width: 0.8" scale="0.8 0.8 1.0">
-                                <a-entity text=" value:leave room; width:2; align:center;" text-raycast-hack position="0 0 0.01"></a-entity>
-                            </a-entity>
+                <a-entity class="ui interactable-ui" visibility-while-frozen="requireHoverOnNonMobile: false;" rotation="30 0 0">
+                    <a-entity class="leave-btn" position="0 0 0" scale="0.7 0.7 0.7" leave-room-button is-remote-hover-target tags="singleActionButton: true;">
+                        <a-entity mixin="rounded-text-action-button" slice9="width: 0.8" scale="0.8 0.8 1.0">
+                            <a-entity text=" value:leave room; width:2; align:center;" text-raycast-hack position="0 0 0.01"></a-entity>
                         </a-entity>
                     </a-entity>
                 </a-entity>
-                <a-entity in-world-hud visibility-while-frozen="visible: false; requireHoverOnNonMobile: false;" rotation="30 0 0">
+                <a-entity in-world-hud visibility-while-frozen="visible: false; requireHoverOnNonMobile: false;" rotation="30 0 0"  class="ui interactable-ui">
                     <a-rounded height="0.08" width="0.2" color="#000000" position="-0.44 -0.045 0" radius="0.040" opacity="0.35" class="hud bg"></a-rounded>
                     <a-image scale="0.07 0.06 0.06" position="-0.38 -0.005 0.001" src="#presence-count" material="alphaTest:0.1;"></a-image>
                     <a-entity id="hud-presence-count" text="value:; width:1.1; align:center;" position="-0.30 -0.005 0" matrix-auto-update="target: text;"></a-entity>
-                    <a-entity class="ui interactable-ui">
+                    <a-entity>
                         <a-entity class="invite-btn" position="0 0.18 0" scale="0.7 0.7 0.7" is-remote-hover-target tags="singleActionButton: true;">
                             <a-entity mixin="rounded-text-action-button" slice9="width: 0.7" scale="0.8 0.8 1.0">
                                 <a-entity text=" value:invite; width:2; align:center;" text-raycast-hack position="0 0 0.01"></a-entity>

--- a/src/hub.html
+++ b/src/hub.html
@@ -601,6 +601,9 @@
             <a-entity
                 id="player-hud"
                 hud-controller="head: #player-camera;"
+                vr-mode-toggle-class="class: ui"
+                vr-mode-toggle-visibility
+                vr-mode-toggle-playing__hud-controller
             >
                 <a-entity class="ui interactable-ui" visibility-while-frozen="requireHoverOnNonMobile: false;" rotation="30 0 0">
                     <a-entity class="leave-btn" position="0 0 0" scale="0.7 0.7 0.7" leave-room-button is-remote-hover-target tags="singleActionButton: true;">

--- a/src/hub.html
+++ b/src/hub.html
@@ -602,17 +602,18 @@
                 id="player-hud"
                 hud-controller="head: #player-camera;"
                 vr-mode-toggle-class="class: ui"
+                vr-mode-toggle-class__ui="class: interactable-ui"
                 vr-mode-toggle-visibility
                 vr-mode-toggle-playing__hud-controller
             >
-                <a-entity class="ui interactable-ui" visibility-while-frozen="requireHoverOnNonMobile: false;" rotation="30 0 0">
+                <a-entity visibility-while-frozen="requireHoverOnNonMobile: false;" rotation="30 0 0">
                     <a-entity class="leave-btn" position="0 0 0" scale="0.7 0.7 0.7" leave-room-button is-remote-hover-target tags="singleActionButton: true;">
                         <a-entity mixin="rounded-text-action-button" slice9="width: 0.8" scale="0.8 0.8 1.0">
                             <a-entity text=" value:leave room; width:2; align:center;" text-raycast-hack position="0 0 0.01"></a-entity>
                         </a-entity>
                     </a-entity>
                 </a-entity>
-                <a-entity in-world-hud visibility-while-frozen="visible: false; requireHoverOnNonMobile: false;" rotation="30 0 0"  class="ui interactable-ui">
+                <a-entity in-world-hud visibility-while-frozen="visible: false; requireHoverOnNonMobile: false;" rotation="30 0 0" >
                     <a-rounded height="0.08" width="0.2" color="#000000" position="-0.44 -0.045 0" radius="0.040" opacity="0.35" class="hud bg"></a-rounded>
                     <a-image scale="0.07 0.06 0.06" position="-0.38 -0.005 0.001" src="#presence-count" material="alphaTest:0.1;"></a-image>
                     <a-entity id="hud-presence-count" text="value:; width:1.1; align:center;" position="-0.30 -0.005 0" matrix-auto-update="target: text;"></a-entity>


### PR DESCRIPTION
This PR manages to fix the invisible buttons in the HUD by making it so the `.visible` flag is set to false on the same object(s) the raycaster hits (the ones tagged with the `ui` class.)

However we should understand what is going on before merging. My only working theory right now is that the raycaster checks the visible flag on the hit object and its parent, which would explain why they icon buttons don't have the bug (they are direct children of the invisible root HUD object) but the other buttons do, which have additional layers of nesting between them and the invisible root HUD object.