### PR TITLE
Interaction system feedback followup

### DIFF
--- a/src/components/hover-menu.js
+++ b/src/components/hover-menu.js
@@ -36,10 +36,6 @@ AFRAME.registerComponent("hover-menu", {
     this.applyHoverState();
   },
 
-  tick() {
-    this.applyHoverState();
-  },
-
   applyHoverState() {
     if (!this.menu) return;
     this.menu.object3D.visible = !this.el.sceneEl.is("frozen") && this.hovering;

--- a/src/components/networked-counter.js
+++ b/src/components/networked-counter.js
@@ -30,9 +30,7 @@ AFRAME.registerComponent("networked-counter", {
   },
 
   deregister(el) {
-    if (this.timestamps.has(el)) {
-      this.timestamps.delete(el);
-    }
+    this.timestamps.delete(el);
   },
 
   isHeld(el) {

--- a/src/components/networked-counter.js
+++ b/src/components/networked-counter.js
@@ -1,3 +1,4 @@
+/* global AFRAME performance */
 /**
  * Limits networked interactables to a maximum number at any given time
  * @namespace network
@@ -24,7 +25,7 @@ AFRAME.registerComponent("networked-counter", {
   register(el) {
     if (this.data.max <= 0 || this.timestamps.has(el)) return;
 
-    this.timestamps.set(el, Date.now());
+    this.timestamps.set(el, performance.now());
     this._destroyOldest();
   },
 

--- a/src/components/networked-counter.js
+++ b/src/components/networked-counter.js
@@ -33,17 +33,13 @@ AFRAME.registerComponent("networked-counter", {
     this.timestamps.delete(el);
   },
 
-  isHeld(el) {
-    const { leftHand, rightHand, rightRemote } = this.el.sceneEl.systems.interaction.state;
-    return leftHand.held === el || rightHand.held === el || rightRemote.held === el;
-  },
-
   _destroyOldest() {
     if (this.timestamps.size > this.data.max) {
+      const interaction = this.el.sceneEl.systems.interaction;
       let oldestEl = null,
         minTs = Number.MAX_VALUE;
       this.timestamps.forEach((ts, el) => {
-        if (ts < minTs && !this.isHeld(el)) {
+        if (ts < minTs && !interaction.isHeld(el)) {
           oldestEl = el;
           minTs = ts;
         }

--- a/src/components/owned-object-limiter.js
+++ b/src/components/owned-object-limiter.js
@@ -1,4 +1,4 @@
-/* global NAF */
+/* global AFRAME NAF performance */
 AFRAME.registerComponent("owned-object-limiter", {
   schema: {
     counter: { type: "selector" }
@@ -17,7 +17,7 @@ AFRAME.registerComponent("owned-object-limiter", {
     this._syncCounterRegistration();
     const isHeld = this.isHeld(this.el);
     if (!isHeld && this.wasHeld && this.counter.timestamps.has(this.el)) {
-      this.counter.timestamps.set(this.el, Date.now());
+      this.counter.timestamps.set(this.el, performance.now());
     }
     this.wasHeld = isHeld;
   },

--- a/src/components/owned-object-limiter.js
+++ b/src/components/owned-object-limiter.js
@@ -8,14 +8,9 @@ AFRAME.registerComponent("owned-object-limiter", {
     this.counter = this.data.counter.components["networked-counter"];
   },
 
-  isHeld(el) {
-    const { leftHand, rightHand, rightRemote } = this.el.sceneEl.systems.interaction.state;
-    return leftHand.held === el || rightHand.held === el || rightRemote.held === el;
-  },
-
   tick() {
     this._syncCounterRegistration();
-    const isHeld = this.isHeld(this.el);
+    const isHeld = this.el.sceneEl.systems.interaction.isHeld(this.el);
     if (!isHeld && this.wasHeld && this.counter.timestamps.has(this.el)) {
       this.counter.timestamps.set(this.el, performance.now());
     }

--- a/src/components/set-unowned-body-kinematic.js
+++ b/src/components/set-unowned-body-kinematic.js
@@ -8,9 +8,9 @@ AFRAME.registerComponent("set-unowned-body-kinematic", {
   play() {
     this.el.addEventListener("ownership-lost", this.setBodyKinematic);
 
-    if (!this.hasBeenHereBefore) {
+    if (!this.didThisOnce) {
       // Do this in play instead of init so that the ammo-body and networked components are done
-      this.hasBeenHereBefore = true;
+      this.didThisOnce = true;
 
       if (!NAF.utils.isMine(this.el)) {
         this.setBodyKinematic();

--- a/src/components/set-unowned-body-kinematic.js
+++ b/src/components/set-unowned-body-kinematic.js
@@ -2,8 +2,10 @@
 const COLLISION_LAYERS = require("../constants").COLLISION_LAYERS;
 
 AFRAME.registerComponent("set-unowned-body-kinematic", {
-  play() {
+  init() {
     this.setBodyKinematic = this.setBodyKinematic.bind(this);
+  },
+  play() {
     this.el.addEventListener("ownership-lost", this.setBodyKinematic);
 
     if (!this.hasBeenHereBefore) {

--- a/src/components/sticky-object.js
+++ b/src/components/sticky-object.js
@@ -22,33 +22,17 @@ AFRAME.registerComponent("sticky-object", {
 
   tick() {
     const interaction = AFRAME.scenes[0].systems.interaction;
-    const heldLeftHand = interaction.state.leftHand.held === this.el;
-    const heldRightHand = interaction.state.rightHand.held === this.el;
-    const heldRightRemote = interaction.state.rightRemote.held === this.el;
-
-    if (
-      !heldLeftHand &&
-      !heldRightHand &&
-      !heldRightRemote &&
-      (this.heldLeftHand || this.heldRightHand || this.heldRightRemote)
-    ) {
-      this.onRelease();
-    }
-
-    if (
-      (heldLeftHand && !this.heldLeftHand) ||
-      (heldRightHand && !this.heldRightHand) ||
-      (heldRightRemote && !this.heldRightRemote)
-    ) {
+    const isHeld = interaction.isHeld(this.el);
+    if (isHeld && !this.wasHeld) {
       this.onGrab();
     }
-
-    this.heldLeftHand = heldLeftHand;
-    this.heldRightHand = heldRightHand;
-    this.heldRightRemote = heldRightRemote;
+    if (this.wasHeld && !isHeld) {
+      this.onRelease();
+    }
+    this.wasHeld = isHeld;
 
     if (!almostEquals(0.001, this.prevScale, this.el.object3D.scale)) {
-      if ((this.heldLeftHand || this.heldRightHand || this.heldRightRemote) && !this.wasScaled) {
+      if (isHeld && !this.wasScaled) {
         this.wasScaled = true;
         this.el.setAttribute("ammo-body", { collisionFilterMask: COLLISION_LAYERS.HANDS });
       }

--- a/src/components/tags.js
+++ b/src/components/tags.js
@@ -1,5 +1,6 @@
 AFRAME.registerComponent("tags", {
   schema: {
+    isHandCollisionTarget: { default: false },
     isHoldable: { default: false },
     offersHandConstraint: { default: false },
     offersRemoteConstraint: { default: false },
@@ -10,7 +11,7 @@ AFRAME.registerComponent("tags", {
   },
   update() {
     if (this.didUpdateOnce) {
-      console.error("Do not edit tags with .setAttribute");
+      console.warn("Do not edit tags with .setAttribute");
     }
     this.didUpdateOnce = true;
   }

--- a/src/components/transform-object-button.js
+++ b/src/components/transform-object-button.js
@@ -34,6 +34,7 @@ AFRAME.registerComponent("transform-button", {
     NAF.utils.getNetworkedEntity(this.el).then(networkedEl => {
       this.targetEl = networkedEl;
     });
+    const rightHand = document.querySelector("#player-right-controller");
     this.onGrabStart = e => {
       if (!this.targetEl) {
         return;
@@ -47,7 +48,7 @@ AFRAME.registerComponent("transform-button", {
       this.transformSystem = this.transformSystem || AFRAME.scenes[0].systems["transform-selected-object"];
       this.transformSystem.startTransform(
         this.targetEl.object3D,
-        e.path === paths.actions.cursor.grab ? "cursor" : e.path === paths.actions.rightHand.grab ? "right" : "left",
+        e.object3D.el.id === "cursor" ? rightHand.object3D : e.object3D,
         this.data
       );
     };
@@ -158,10 +159,7 @@ AFRAME.registerSystem("transform-selected-object", {
 
   startTransform(target, hand, data) {
     this.target = target;
-    this.hand =
-      hand === "cursor" || hand === "right"
-        ? document.querySelector("#player-right-controller").object3D
-        : document.querySelector("#player-left-controller").object3D;
+    this.hand = hand;
     this.mode = data.mode;
     this.transforming = true;
 

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -17,7 +17,7 @@ AFRAME.GLTFModelPlus.registerComponent("interactable", "css-class", (el, compone
 AFRAME.GLTFModelPlus.registerComponent("super-spawner", "super-spawner", (el, componentName, componentData) => {
   //TODO: Do not automatically add these components
   el.setAttribute("is-remote-hover-target", "");
-  el.setAttribute("tags", {isHandCollisionTarget: true});
+  el.setAttribute("tags", { isHandCollisionTarget: true });
   el.setAttribute(componentName, componentData);
 });
 AFRAME.GLTFModelPlus.registerComponent("gltf-model-plus", "gltf-model-plus");
@@ -210,7 +210,7 @@ AFRAME.GLTFModelPlus.registerComponent("link", "link", mediaInflator);
 
 AFRAME.GLTFModelPlus.registerComponent("hoverable", "is-remote-hover-target", el => {
   el.setAttribute("is-remote-hover-target", "");
-  el.setAttribute("tags", {isHandCollisionTarget: true});
+  el.setAttribute("tags", { isHandCollisionTarget: true });
 });
 
 AFRAME.GLTFModelPlus.registerComponent("spawner", "spawner", (el, componentName, componentData) => {
@@ -233,7 +233,7 @@ AFRAME.GLTFModelPlus.registerComponent("spawner", "spawner", (el, componentName,
     collisionFilterMask: COLLISION_LAYERS.DEFAULT_SPAWNER
   });
   el.setAttribute("is-remote-hover-target", "");
-  el.setAttribute("tags", {isHandCollisionTarget: true});
+  el.setAttribute("tags", { isHandCollisionTarget: true });
 });
 
 const publicComponents = {

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -17,7 +17,7 @@ AFRAME.GLTFModelPlus.registerComponent("interactable", "css-class", (el, compone
 AFRAME.GLTFModelPlus.registerComponent("super-spawner", "super-spawner", (el, componentName, componentData) => {
   //TODO: Do not automatically add these components
   el.setAttribute("is-remote-hover-target", "");
-  el.setAttribute("is-hand-collision-target", "");
+  el.setAttribute("tags", {isHandCollisionTarget: true});
   el.setAttribute(componentName, componentData);
 });
 AFRAME.GLTFModelPlus.registerComponent("gltf-model-plus", "gltf-model-plus");
@@ -210,7 +210,7 @@ AFRAME.GLTFModelPlus.registerComponent("link", "link", mediaInflator);
 
 AFRAME.GLTFModelPlus.registerComponent("hoverable", "is-remote-hover-target", el => {
   el.setAttribute("is-remote-hover-target", "");
-  el.setAttribute("is-hand-collision-target", "");
+  el.setAttribute("tags", {isHandCollisionTarget: true});
 });
 
 AFRAME.GLTFModelPlus.registerComponent("spawner", "spawner", (el, componentName, componentData) => {
@@ -233,7 +233,7 @@ AFRAME.GLTFModelPlus.registerComponent("spawner", "spawner", (el, componentName,
     collisionFilterMask: COLLISION_LAYERS.DEFAULT_SPAWNER
   });
   el.setAttribute("is-remote-hover-target", "");
-  el.setAttribute("is-hand-collision-target", "");
+  el.setAttribute("tags", {isHandCollisionTarget: true});
 });
 
 const publicComponents = {

--- a/src/hub.html
+++ b/src/hub.html
@@ -206,8 +206,7 @@
                     owned-object-limiter="counter: #media-counter"
                     set-unowned-body-kinematic
                     is-remote-hover-target
-                    is-hand-collision-target
-                    tags="isHoldable: true; offersHandConstraint: true; offersRemoteConstraint: true;"
+                    tags="isHandCollisionTarget: true; isHoldable: true; offersHandConstraint: true; offersRemoteConstraint: true;"
                     destroy-at-extreme-distances
                     scalable-when-grabbed
                     sticky-object="autoLockOnRelease: true; autoLockOnLoad: true;"
@@ -300,8 +299,7 @@
                     owned-object-limiter="counter: #pen-counter"
                     set-unowned-body-kinematic
                     is-remote-hover-target
-                    is-hand-collision-target
-                    tags="isHoldable: true; offersHandConstraint: true; offersRemoteConstraint: true; isPen: true;"
+                    tags="isHandCollisionTarget: true; isHoldable: true; offersHandConstraint: true; offersRemoteConstraint: true; isPen: true;"
                     sticky-object="autoLockOnRelease: true; autoLockOnLoad: true; autoLockSpeedLimit: 0;"
                     matrix-auto-update
                     scale="0.5 0.5 0.5"
@@ -337,8 +335,7 @@
                     ammo-body="type: dynamic; mass: 0.001; collisionFilterGroup: 1; collisionFilterMask: 8;"
                     camera-tool
                     is-remote-hover-target
-                    is-hand-collision-target
-                    tags="isHoldable: true; offersHandConstraint: true; offersRemoteConstraint: true;"
+                    tags="isHandCollisionTarget: true; isHoldable: true; offersHandConstraint: true; offersRemoteConstraint: true;"
                     matrix-auto-update
                     scale="0.5 0.5 0.5"
                     animation__spawn="property: scale; delay: 50; dur: 200; from: 0.5 0.5 0.5; to: 1 1 1; easing: easeOutQuad"

--- a/src/hub.html
+++ b/src/hub.html
@@ -30,12 +30,12 @@
 <body>
     <a-scene
         loading-screen="enabled: false"
+        physics="gravity: -9.8; debug: false; driver: ammo; debugDrawMode: 1;"
         hubs-systems
         class="grab-cursor"
         renderer="antialias: true; colorManagement: true; sortObjects: true; physicallyCorrectLights: true; alpha: false; webgl2: true; multiview: false;"
         shadow="type: pcfsoft"
         networked-scene="adapter: janus; audio: true; debug: true; connectOnLoad: false;"
-        physics="gravity: -9.8; debug: false; driver: ammo; debugDrawMode: 1;"
         mute-mic="eventSrc: a-scene; toggleEvents: action_mute"
         action-to-event__mute="path: /actions/muteMic; event: action_mute;"
         freeze-controller="toggleEvent: action_freeze"

--- a/src/systems/button-systems.js
+++ b/src/systems/button-systems.js
@@ -3,16 +3,11 @@ export class SingleActionButtonSystem {
     this.didInteractThisFrame = false;
     const interaction = AFRAME.scenes[0].systems.interaction;
     const userinput = AFRAME.scenes[0].systems.userinput;
-    const state = interaction.state.rightRemote;
+    const hovered = interaction.state.rightRemote.hovered;
     const grab = interaction.options.rightRemote.grabPath;
-    if (
-      userinput.get(grab) &&
-      state.hovered &&
-      state.hovered.components.tags &&
-      state.hovered.components.tags.data.singleActionButton
-    ) {
+    if (hovered && userinput.get(grab) && hovered.components.tags && hovered.components.tags.data.singleActionButton) {
       this.didInteractThisFrame = true;
-      state.hovered.object3D.dispatchEvent({
+      hovered.object3D.dispatchEvent({
         type: "interact",
         path: grab
       });

--- a/src/systems/button-systems.js
+++ b/src/systems/button-systems.js
@@ -4,12 +4,16 @@ export class SingleActionButtonSystem {
     const interaction = AFRAME.scenes[0].systems.interaction;
     const userinput = AFRAME.scenes[0].systems.userinput;
     const hovered = interaction.state.rightRemote.hovered;
-    const grab = interaction.options.rightRemote.grabPath;
-    if (hovered && userinput.get(grab) && hovered.components.tags && hovered.components.tags.data.singleActionButton) {
+    if (
+      hovered &&
+      userinput.get(interaction.options.rightRemote.grabPath) &&
+      hovered.components.tags &&
+      hovered.components.tags.data.singleActionButton
+    ) {
       this.didInteractThisFrame = true;
       hovered.object3D.dispatchEvent({
         type: "interact",
-        path: grab
+        object3D: interaction.options.rightRemote.entity.object3D
       });
     }
   }
@@ -19,18 +23,17 @@ export class HoldableButtonSystem {
   tick() {
     const interaction = AFRAME.scenes[0].systems.interaction;
     const held = interaction.state.rightRemote.held;
-    const options = interaction.options.rightRemote;
 
     if (this.prevHeld && this.prevHeld !== held) {
       this.prevHeld.object3D.dispatchEvent({
         type: "holdable-button-up",
-        path: options.dropPath
+        object3D: interaction.options.rightRemote.entity.object3D
       });
     }
     if (held && this.prevHeld !== held) {
       held.object3D.dispatchEvent({
         type: "holdable-button-down",
-        path: options.grabPath
+        object3D: interaction.options.rightRemote.entity.object3D
       });
     }
 

--- a/src/systems/constraints-system.js
+++ b/src/systems/constraints-system.js
@@ -56,7 +56,7 @@ export class ConstraintsSystem {
         });
         state.held.setAttribute("ammo-constraint__" + entityId, { target: "#" + entityId });
       } else {
-        // TODO communicate failure to obtain network ownership
+        console.log("Failed to obtain ownership while trying to create constraint on networked object.");
       }
     }
   }

--- a/src/systems/constraints-system.js
+++ b/src/systems/constraints-system.js
@@ -25,12 +25,12 @@ export class ConstraintsSystem {
     };
   }
 
-  tickInteractor(options, state, prevState) {
+  tickInteractor(constraintTag, entityId, state, prevState) {
     if (prevState.held === state.held) {
       if (
         state.held &&
         state.held.components.tags &&
-        state.held.components.tags.data[options.constraintTag] &&
+        state.held.components.tags.data[constraintTag] &&
         prevState.spawning &&
         !state.spawning
       ) {
@@ -38,16 +38,12 @@ export class ConstraintsSystem {
           type: "dynamic",
           activationState: ACTIVATION_STATE.DISABLE_DEACTIVATION
         });
-        state.held.setAttribute("ammo-constraint__" + options.entity.id, { target: "#" + options.entity.id });
+        state.held.setAttribute("ammo-constraint__" + entityId, { target: "#" + entityId });
       }
       return;
     }
-    if (
-      prevState.held &&
-      prevState.held.components.tags &&
-      prevState.held.components.tags.data[options.constraintTag]
-    ) {
-      prevState.held.removeAttribute("ammo-constraint__" + options.entity.id);
+    if (prevState.held && prevState.held.components.tags && prevState.held.components.tags.data[constraintTag]) {
+      prevState.held.removeAttribute("ammo-constraint__" + entityId);
       let hasAnotherConstraint = false;
       for (const componentName in prevState.held.components) {
         if (componentName.startsWith("ammo-constraint")) {
@@ -58,18 +54,13 @@ export class ConstraintsSystem {
         prevState.held.setAttribute("ammo-body", { activationState: ACTIVATION_STATE.ACTIVE_TAG });
       }
     }
-    if (
-      state.held &&
-      state.held.components.tags &&
-      state.held.components.tags.data[options.constraintTag] &&
-      !state.spawning
-    ) {
+    if (state.held && state.held.components.tags && state.held.components.tags.data[constraintTag] && !state.spawning) {
       if (!state.held.components["networked"] || NAF.utils.isMine(state.held) || NAF.utils.takeOwnership(state.held)) {
         state.held.setAttribute("ammo-body", {
           type: "dynamic",
           activationState: ACTIVATION_STATE.DISABLE_DEACTIVATION
         });
-        state.held.setAttribute("ammo-constraint__" + options.entity.id, { target: "#" + options.entity.id });
+        state.held.setAttribute("ammo-constraint__" + entityId, { target: "#" + entityId });
       } else {
         // TODO communicate failure to obtain network ownership
       }
@@ -79,9 +70,24 @@ export class ConstraintsSystem {
   tick() {
     const interaction = AFRAME.scenes[0].systems.interaction;
 
-    this.tickInteractor(interaction.options.leftHand, interaction.state.leftHand, this.prevLeftHand);
-    this.tickInteractor(interaction.options.rightHand, interaction.state.rightHand, this.prevRightHand);
-    this.tickInteractor(interaction.options.rightRemote, interaction.state.rightRemote, this.prevRightRemote);
+    this.tickInteractor(
+      "offersHandConstraint",
+      interaction.options.leftHand.entity.id,
+      interaction.state.leftHand,
+      this.prevLeftHand
+    );
+    this.tickInteractor(
+      "offersHandConstraint",
+      interaction.options.rightHand.entity.id,
+      interaction.state.rightHand,
+      this.prevRightHand
+    );
+    this.tickInteractor(
+      "offersRemoteConstraint",
+      interaction.options.rightRemote.entity.id,
+      interaction.state.rightRemote,
+      this.prevRightRemote
+    );
 
     storeState(this.prevLeftHand, interaction.state.leftHand);
     storeState(this.prevRightHand, interaction.state.rightHand);

--- a/src/systems/constraints-system.js
+++ b/src/systems/constraints-system.js
@@ -1,11 +1,5 @@
 const ACTIVATION_STATE = require("aframe-physics-system/src/constants").ACTIVATION_STATE;
 
-function storeState(prev, curr) {
-  prev.held = curr.held;
-  prev.hovered = curr.hovered;
-  prev.spawning = curr.spawning;
-}
-
 export class ConstraintsSystem {
   constructor() {
     this.prevLeftHand = {
@@ -89,8 +83,8 @@ export class ConstraintsSystem {
       this.prevRightRemote
     );
 
-    storeState(this.prevLeftHand, interaction.state.leftHand);
-    storeState(this.prevRightHand, interaction.state.rightHand);
-    storeState(this.prevRightRemote, interaction.state.rightRemote);
+    Object.assign(this.prevLeftHand, interaction.state.leftHand);
+    Object.assign(this.prevRightHand, interaction.state.rightHand);
+    Object.assign(this.prevRightRemote, interaction.state.rightRemote);
   }
 }

--- a/src/systems/constraints-system.js
+++ b/src/systems/constraints-system.js
@@ -1,3 +1,4 @@
+/* global NAF AFRAME */
 const ACTIVATION_STATE = require("aframe-physics-system/src/constants").ACTIVATION_STATE;
 
 export class ConstraintsSystem {
@@ -21,13 +22,7 @@ export class ConstraintsSystem {
 
   tickInteractor(constraintTag, entityId, state, prevState) {
     if (prevState.held === state.held) {
-      if (
-        state.held &&
-        state.held.components.tags &&
-        state.held.components.tags.data[constraintTag] &&
-        prevState.spawning &&
-        !state.spawning
-      ) {
+      if (!state.spawning && prevState.spawning && state.held && state.held.components.tags.data[constraintTag]) {
         state.held.setAttribute("ammo-body", {
           type: "dynamic",
           activationState: ACTIVATION_STATE.DISABLE_DEACTIVATION
@@ -36,7 +31,7 @@ export class ConstraintsSystem {
       }
       return;
     }
-    if (prevState.held && prevState.held.components.tags && prevState.held.components.tags.data[constraintTag]) {
+    if (prevState.held && prevState.held.components.tags.data[constraintTag]) {
       prevState.held.removeAttribute("ammo-constraint__" + entityId);
       let hasAnotherConstraint = false;
       for (const componentName in prevState.held.components) {
@@ -48,7 +43,7 @@ export class ConstraintsSystem {
         prevState.held.setAttribute("ammo-body", { activationState: ACTIVATION_STATE.ACTIVE_TAG });
       }
     }
-    if (state.held && state.held.components.tags && state.held.components.tags.data[constraintTag] && !state.spawning) {
+    if (!state.spawning && state.held && state.held.components.tags.data[constraintTag]) {
       if (!state.held.components["networked"] || NAF.utils.isMine(state.held) || NAF.utils.takeOwnership(state.held)) {
         state.held.setAttribute("ammo-body", {
           type: "dynamic",

--- a/src/systems/haptic-feedback-system.js
+++ b/src/systems/haptic-feedback-system.js
@@ -94,10 +94,8 @@ export class HapticFeedbackSystem {
     const buttonPressedStrength = didClickButton ? STRENGTH.BUTTON_PRESSED : 0;
     const stretchingStrength = determineStretchStrength(twoPointStretchingSystem);
 
-    const leftStrength = leftActuator ? Math.max(leftHandStrength, stretchingStrength) : 0;
-    const rightStrength = rightActuator
-      ? Math.max(rightHandStrength, rightRemoteStrength, stretchingStrength, buttonPressedStrength)
-      : 0;
+    const leftStrength = Math.max(leftHandStrength, stretchingStrength);
+    const rightStrength = Math.max(rightHandStrength, rightRemoteStrength, stretchingStrength, buttonPressedStrength);
 
     if (leftStrength && leftActuator) {
       leftActuator.pulse(leftStrength, 15);

--- a/src/systems/interactions.js
+++ b/src/systems/interactions.js
@@ -2,19 +2,13 @@
 import { paths } from "./userinput/paths";
 import { SOUND_HOVER_OR_GRAB } from "./sound-effects-system";
 
-const handCollisionTargets = new Map();
-AFRAME.registerComponent("is-hand-collision-target", {
-  init: function() {
-    handCollisionTargets.set(this.el.object3D, this.el);
-  },
-  remove: function() {
-    handCollisionTargets.delete(this.el.object3D);
-  }
-});
 function findHandCollisionTarget(object3D) {
   if (!object3D) return null;
-  const target = handCollisionTargets.get(object3D);
-  return target || findHandCollisionTarget(object3D.parent);
+  if (object3D.el && object3D.el.components.tags && object3D.el.components.tags.data.isHandCollisionTarget) {
+    return object3D.el;
+  } else {
+    return findHandCollisionTarget(object3D.parent);
+  }
 }
 function findHandCollisionTargetForHand(body) {
   const driver = AFRAME.scenes[0].systems.physics.driver;

--- a/src/systems/interactions.js
+++ b/src/systems/interactions.js
@@ -2,14 +2,6 @@
 import { paths } from "./userinput/paths";
 import { SOUND_HOVER_OR_GRAB } from "./sound-effects-system";
 
-function findHandCollisionTarget(object3D) {
-  if (!object3D) return null;
-  if (object3D.el && object3D.el.components.tags && object3D.el.components.tags.data.isHandCollisionTarget) {
-    return object3D.el;
-  } else {
-    return findHandCollisionTarget(object3D.parent);
-  }
-}
 function findHandCollisionTargetForHand(body) {
   const driver = AFRAME.scenes[0].systems.physics.driver;
   const numManifolds = driver.dispatcher.getNumManifolds();
@@ -25,7 +17,11 @@ function findHandCollisionTargetForHand(body) {
     for (let j = 0; j < numContacts; j++) {
       const manifoldPoint = persistentManifold.getContactPoint(j);
       if (manifoldPoint.getDistance() <= 10e-6) {
-        return findHandCollisionTarget(driver.els.get(handPtr === body0ptr ? body1ptr : body0ptr).object3D);
+        const object3D = driver.els.get(handPtr === body0ptr ? body1ptr : body0ptr).object3D;
+        if (object3D.el && object3D.el.components.tags && object3D.el.components.tags.data.isHandCollisionTarget) {
+          return object3D.el;
+        }
+        return null;
       }
     }
   }

--- a/src/systems/interactions.js
+++ b/src/systems/interactions.js
@@ -5,16 +5,16 @@ import { SOUND_HOVER_OR_GRAB } from "./sound-effects-system";
 const handCollisionTargets = new Map();
 AFRAME.registerComponent("is-hand-collision-target", {
   init: function() {
-    handCollisionTargets.set(this.el.object3D.uuid, this.el);
+    handCollisionTargets.set(this.el.object3D, this.el);
   },
   remove: function() {
-    handCollisionTargets.delete(this.el.object3D.uuid);
+    handCollisionTargets.delete(this.el.object3D);
   }
 });
-function findHandCollisionTarget(o) {
-  if (!o) return null;
-  const target = handCollisionTargets.get(o.uuid);
-  return target || findHandCollisionTarget(o.parent);
+function findHandCollisionTarget(object3D) {
+  if (!object3D) return null;
+  const target = handCollisionTargets.get(object3D);
+  return target || findHandCollisionTarget(object3D.parent);
 }
 function findHandCollisionTargetForHand(body) {
   const driver = AFRAME.scenes[0].systems.physics.driver;
@@ -38,17 +38,17 @@ function findHandCollisionTargetForHand(body) {
 }
 
 const remoteHoverTargets = new Map();
-function findRemoteHoverTarget(o) {
-  if (!o) return null;
-  const target = remoteHoverTargets.get(o.uuid);
-  return target || findRemoteHoverTarget(o.parent);
+function findRemoteHoverTarget(object3D) {
+  if (!object3D) return null;
+  const target = remoteHoverTargets.get(object3D);
+  return target || findRemoteHoverTarget(object3D.parent);
 }
 AFRAME.registerComponent("is-remote-hover-target", {
   init: function() {
-    remoteHoverTargets.set(this.el.object3D.uuid, this.el);
+    remoteHoverTargets.set(this.el.object3D, this.el);
   },
   remove: function() {
-    remoteHoverTargets.delete(this.el.object3D.uuid);
+    remoteHoverTargets.delete(this.el.object3D);
   }
 });
 

--- a/src/systems/interactions.js
+++ b/src/systems/interactions.js
@@ -35,6 +35,7 @@ function findHandCollisionTargetForHand(body) {
       }
     }
   }
+  return null;
 }
 
 const remoteHoverTargets = new Map();

--- a/src/systems/interactions.js
+++ b/src/systems/interactions.js
@@ -69,21 +69,18 @@ AFRAME.registerSystem("interaction", {
         entity: document.querySelector("#player-left-controller"),
         grabPath: paths.actions.leftHand.grab,
         dropPath: paths.actions.leftHand.drop,
-        constraintTag: "offersHandConstraint",
         hoverFn: findHandCollisionTargetForHand
       },
       rightHand: {
         entity: document.querySelector("#player-right-controller"),
         grabPath: paths.actions.rightHand.grab,
         dropPath: paths.actions.rightHand.drop,
-        constraintTag: "offersHandConstraint",
         hoverFn: findHandCollisionTargetForHand
       },
       rightRemote: {
         entity: document.querySelector("#cursor"),
         grabPath: paths.actions.cursor.grab,
         dropPath: paths.actions.cursor.drop,
-        constraintTag: "offersRemoteConstraint",
         hoverFn: this.getRightRemoteHoverTarget
       }
     };

--- a/src/systems/interactions.js
+++ b/src/systems/interactions.js
@@ -54,6 +54,10 @@ AFRAME.registerSystem("interaction", {
     this.rightRemoteHoverTarget = intersection && findRemoteHoverTarget(intersection.object);
   },
 
+  isHeld(el) {
+    return this.state.leftHand.held === el || this.state.rightHand.held === el || this.state.rightRemote.held === el;
+  },
+
   init: function() {
     this.options = {
       leftHand: {

--- a/src/systems/two-point-stretching-system.js
+++ b/src/systems/two-point-stretching-system.js
@@ -11,9 +11,6 @@ export const distanceBetweenStretchers = (() => {
 
 export class TwoPointStretchingSystem {
   constructor() {
-    this.heldLeftHand = null;
-    this.heldRightHand = null;
-    this.heldRightRemote = null;
     this.initialScale = new THREE.Vector3();
   }
 
@@ -48,8 +45,5 @@ export class TwoPointStretchingSystem {
     this.stretcherLeft = stretcherLeft;
     this.stretcherRight = stretcherRight;
 
-    this.heldLeftHand = leftHand.held;
-    this.heldRightHand = rightHand.held;
-    this.heldRightRemote = rightRemote.held;
   }
 }

--- a/src/systems/two-point-stretching-system.js
+++ b/src/systems/two-point-stretching-system.js
@@ -19,31 +19,30 @@ export class TwoPointStretchingSystem {
     const { leftHand, rightHand, rightRemote } = interaction.state;
 
     const stretching = leftHand.held && (leftHand.held === rightHand.held || leftHand.held === rightRemote.held);
-    let stretcherLeft, stretcherRight;
+    let leftStretcher, rightStretcher;
     if (stretching) {
-      stretcherLeft = interaction.options.leftHand.entity.object3D;
-      stretcherRight =
+      leftStretcher = interaction.options.leftHand.entity.object3D;
+      rightStretcher =
         leftHand.held === rightHand.held
           ? interaction.options.rightHand.entity.object3D
           : interaction.options.rightRemote.entity.object3D;
       if (
-        this.stretcherLeft !== stretcherLeft ||
-        this.stretcherRight !== stretcherRight ||
+        leftStretcher !== this.previousLeftStretcher ||
+        rightStretcher !== this.previousRightStretcher ||
         leftHand.held !== this.stretched
       ) {
-        this.initialStretchDistance = distanceBetweenStretchers(stretcherLeft, stretcherRight);
+        this.initialStretchDistance = distanceBetweenStretchers(leftStretcher, rightStretcher);
         this.stretched = leftHand.held;
         this.initialScale.copy(this.stretched.object3D.scale);
       }
 
       this.stretched.object3D.scale
         .copy(this.initialScale)
-        .multiplyScalar(distanceBetweenStretchers(stretcherLeft, stretcherRight) / this.initialStretchDistance);
+        .multiplyScalar(distanceBetweenStretchers(leftStretcher, rightStretcher) / this.initialStretchDistance);
       this.stretched.object3D.matrixNeedsUpdate = true;
     }
 
-    this.stretcherLeft = stretcherLeft;
-    this.stretcherRight = stretcherRight;
-
+    this.previousLeftStretcher = leftStretcher;
+    this.previousRightStretcher = rightStretcher;
   }
 }

--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -163,8 +163,7 @@ AFRAME.registerSystem("userinput", {
   },
 
   toggleSet(set, value) {
-    const b = !!value;
-    this.pendingSetChanges.push({ set, value: b });
+    this.pendingSetChanges.push({ set, value: !!value });
   },
 
   init() {


### PR DESCRIPTION
Addresses all but a few points of feedback from the interaction system PR (https://github.com/mozilla/hubs/pull/1091)

Suggestions I like but did not do in this PR:
-  Turn `hoverable-visuals` into a system to avoid every instance from having to ask, "Am I the thing being hovered or held this frame?" (Might do this eventually but I'm too lazy now.)
- Change `userinput` and `interaction` systems so that they aren't aframe systems. (Will do this in its own PR)
- Move `is-remote-hover-target` into `tags`. (Will do this in its own PR)
- Communicate system dependencies (not sure what exactly I want to do here.)
- Remove the many places where `interaction` system state is duplicated. (Will do this once spawned objects get a physics body synchronously, and the `spawning` boolean goes away.)
- Change resolve-action-sets to rely on the interaction system to provide only valid states about hovering/held (with respect to right hand / right cursor / right teleporter interdependence)

