### PR TITLE
Stop sound effect when media-loader's object is removed

### DIFF
--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -82,6 +82,13 @@ AFRAME.registerComponent("media-loader", {
     }
   },
 
+  remove() {
+    if (this.loadingSoundNode) {
+      this.el.sceneEl.systems["hubs-systems"].soundEffectsSystem.stopSoundNode(this.loadingSoundNode);
+      this.loadingSoundNode = null;
+    }
+  },
+
   onError() {
     this.el.removeAttribute("gltf-model-plus");
     this.el.removeAttribute("media-pager");
@@ -406,10 +413,6 @@ AFRAME.registerComponent("media-pager", {
   remove() {
     if (this.toolbar) {
       this.toolbar.parentNode.removeChild(this.toolbar);
-    }
-    if (this.loadingSoundNode) {
-      this.el.sceneEl.systems["hubs-systems"].soundEffectsSystem.stopSoundNode(this.loadingSoundNode);
-      this.loadingSoundNode = null;
     }
   },
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/1208

Note however that `gltf-model-plus` will still emit `model-loaded`, and the loaded sound will still play because the event listener is still hooked up. Both `media-loader` and `gltf-model-plus` need to be patched to take this possibility into account. I would not be surprised, for example, if the event listeners in `media-loader` are holding references to nodes that have been removed from the dom and are thus preventing them from getting GC'ed. I have not tested this.