### PR TITLE
fix collision filters for old spawners

### DIFF
--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -29,7 +29,7 @@ AFRAME.GLTFModelPlus.registerComponent("body", "ammo-body", el => {
     mass: 0,
     type: TYPE.STATIC,
     collisionFilterGroup: COLLISION_LAYERS.INTERACTABLES,
-    collisionFilterMask: COLLISION_LAYERS.DEFAULT_INTERACTABLE
+    collisionFilterMask: COLLISION_LAYERS.DEFAULT_SPAWNER
   });
 });
 AFRAME.GLTFModelPlus.registerComponent("ammo-shape", "ammo-shape");


### PR DESCRIPTION
Old spawners (spawners in legacy scenes) were misconfigured to collide with the environment. This fixes that.