### PR TITLE
Room owners can now mute other users

### DIFF
--- a/src/components/mute-button.js
+++ b/src/components/mute-button.js
@@ -1,0 +1,22 @@
+AFRAME.registerComponent("mute-button", {
+  init() {
+    this.onClick = () => {
+      this.mute(this.owner);
+    };
+    NAF.utils.getNetworkedEntity(this.el).then(networkedEl => {
+      this.owner = networkedEl.components.networked.data.owner;
+    });
+  },
+
+  play() {
+    this.el.object3D.addEventListener("interact", this.onClick);
+  },
+
+  pause() {
+    this.el.object3D.removeEventListener("interact", this.onClick);
+  },
+
+  async mute(clientId) {
+    window.APP.hubChannel.mute(clientId);
+  }
+});

--- a/src/hub.html
+++ b/src/hub.html
@@ -137,7 +137,10 @@
                                         <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" block-button position="0 0 .35">
                                             <a-entity text="value:Hide; width:2.5; align:center;" text-raycast-hack position="0 0 0.01"></a-entity>
                                         </a-entity>
-                                        <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" visible-if-permitted="kick_users" kick-button position="0 -0.25 .35">
+                                        <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" visible-if-permitted="mute_users" mute-button position="0 -0.3 .35" scale="0.8 0.8 0.8">
+                                            <a-entity text="value:Mute; width:2.5; align:center;" text-raycast-hack visible-if-permitted="mute_users" position="0 0 0.01"></a-entity>
+                                        </a-entity>
+                                        <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" visible-if-permitted="kick_users" kick-button position="0 -0.5 .35" scale="0.8 0.8 0.8">
                                             <a-entity text="value:Kick; width:2.5; align:center;" text-raycast-hack visible-if-permitted="kick_users" position="0 0 0.01"></a-entity>
                                         </a-entity>
                                         <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" camera-focus-button="track: false; selector: .Head;" position="-0.40 0.375 0.35">

--- a/src/hub.js
+++ b/src/hub.js
@@ -47,6 +47,7 @@ import "./components/freeze-controller";
 import "./components/icon-button";
 import "./components/text-button";
 import "./components/block-button";
+import "./components/mute-button";
 import "./components/kick-button";
 import "./components/leave-room-button";
 import "./components/visible-if-permitted";
@@ -986,6 +987,12 @@ document.addEventListener("DOMContentLoaded", async () => {
         name: userInfo.metas[0].profile.displayName,
         hubName: hub.name
       });
+    }
+  });
+
+  hubPhxChannel.on("mute", ({ session_id }) => {
+    if (session_id === NAF.clientId && !scene.is("muted")) {
+      scene.emit("action_mute");
     }
   });
 

--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -223,6 +223,10 @@ export default class HubChannel extends EventTarget {
     });
   };
 
+  mute = sessionId => {
+    this.channel.push("mute", { session_id: sessionId });
+  };
+
   kick = sessionId => {
     this.channel.push("kick", { session_id: sessionId });
   };


### PR DESCRIPTION
Room owners can now apply a soft mute to other users. Goes with https://github.com/mozilla/reticulum/pull/153

![image](https://user-images.githubusercontent.com/220020/55856198-6ef1d600-5b1e-11e9-9ba2-9ad0e799d250.png)

Note that this isn't a tool for dealing with abuse -- kicking is that facility. This is soft mute for non-bad actors who have open mics, etc.