### PR TITLE
Deal with lucky queries

### DIFF
--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -78,7 +78,7 @@ class MediaBrowser extends Component {
     onMediaSearchResultEntrySelected: PropTypes.func
   };
 
-  state = { query: "", facets: [], showNav: true, selectNextResult: false };
+  state = { query: "", facets: [], showNav: true, selectNextResult: false, clearStashedQueryOnClose: false };
 
   constructor(props) {
     super(props);
@@ -156,7 +156,17 @@ class MediaBrowser extends Component {
 
   handleEntryClicked = (evt, entry) => {
     evt.preventDefault();
-    this.selectEntry(entry);
+
+    if (!entry.lucky_query) {
+      this.selectEntry(entry);
+    } else {
+      // Entry has a pointer to another "i'm feeling lucky" query -- used for trending videos
+      //
+      // Also, mark the browser to clear the stashed query on close, since this is a temporary
+      // query we are running to get the result we want.
+      this.setState({ clearStashedQueryOnClose: true });
+      this.handleQueryUpdated(entry.lucky_query, true);
+    }
   };
 
   selectEntry = entry => {
@@ -195,6 +205,10 @@ class MediaBrowser extends Component {
   close = () => {
     showFullScreenIfWasFullScreen();
     this.pushExitMediaBrowserHistory();
+
+    if (this.state.clearStashedQueryOnClose) {
+      this.props.mediaSearchStore.clearStashedQuery();
+    }
   };
 
   handlePager = delta => {

--- a/src/storage/media-search-store.js
+++ b/src/storage/media-search-store.js
@@ -147,6 +147,11 @@ export default class MediaSearchStore extends EventTarget {
     }
   };
 
+  clearStashedQuery = () => {
+    if (!this._stashedParams) return;
+    delete this._stashedParams.q;
+  };
+
   sourceNavigate = source => {
     this._sourceNavigate(source, false, true);
   };


### PR DESCRIPTION
For trending videos the search engine hands back a query to run instead of a result. This PR updates the media browser to handle these cases.