### PR TITLE
More efficient AABB for object hierarchies

### DIFF
--- a/src/utils/auto-box-collider.js
+++ b/src/utils/auto-box-collider.js
@@ -1,3 +1,8 @@
+// Computes an AABB that surrounds the object in question and all of its children.
+// Note that if the children have rotations, this probably won't return the tightest
+// possible AABB -- we could return a tighter one if we examined all of the vertices
+// of the geometry for ourselves, but we don't care enough for what we're using this
+// for to do so much work.
 const computeObjectAABB = (function() {
   const bounds = new THREE.Box3();
   return function(root, target) {

--- a/src/utils/auto-box-collider.js
+++ b/src/utils/auto-box-collider.js
@@ -1,3 +1,20 @@
+const computeObjectAABB = (function() {
+  const bounds = new THREE.Box3();
+  return function(root, target) {
+    target.makeEmpty();
+    root.traverse(node => {
+      const geometry = node.geometry;
+      if (geometry != null) {
+        if (geometry.boundingBox == null) {
+          geometry.computeBoundingBox();
+        }
+        target.union(bounds.copy(geometry.boundingBox).applyMatrix4(node.matrixWorld));
+      }
+    });
+    return target;
+  };
+})();
+
 const rotation = new THREE.Euler();
 export function getBox(entity, boxRoot) {
   const box = new THREE.Box3();
@@ -7,8 +24,9 @@ export function getBox(entity, boxRoot) {
 
   entity.object3D.updateMatrices(true, true);
   boxRoot.updateMatrices(true, true);
+  boxRoot.updateMatrixWorld(true);
 
-  box.setFromObject(boxRoot);
+  computeObjectAABB(boxRoot, box);
 
   if (!box.isEmpty()) {
     entity.object3D.worldToLocal(box.min);


### PR DESCRIPTION
We will typically already have the geometry's `boundingBox` cached ([for example, when building a BVH](https://github.com/gkjohnson/three-mesh-bvh/pull/102)), so this is much faster than the previous implementation, which looks at every vertex in the hierarchy fresh every time.

This implementation should get a less tight AABB in some cases (where there are rotations inside the object hierarchy) but it shouldn't be that much worse, and we only rely on this for things that need to be roughly correct (object scale and menu offset), not precisely correct.