### PR TITLE
Don't recreate new workers for every message

### DIFF
--- a/src/utils/promisify-worker.js
+++ b/src/utils/promisify-worker.js
@@ -1,0 +1,36 @@
+// Wrapper for a worker which accepts work items and responds with results.
+//
+// The worker must receive messages with data of the shape { id, payload }, and then respond
+// with messages containing matching IDs of the shape { id, result, err }.
+//
+// Returns a function that accepts a work item, sends it to the worker, and returns a promise that
+// will resolve with the result or reject with the error.
+//
+export function promisifyWorker(worker) {
+  let nextItemId = 0;
+  const outstanding = {}; // item ID: { resolve, reject }
+
+  worker.onmessage = msg => {
+    const { id, result, err } = msg.data;
+    const handlers = outstanding[id];
+    if (handlers == null) {
+      console.error(`Unknown message with ID ${id} received from ${worker}.`);
+    } else {
+      delete outstanding[id];
+      if (err != null) {
+        handlers.reject(new Error(err));
+      } else {
+        handlers.resolve(result);
+      }
+    }
+  };
+
+  return function(data, transfer) {
+    const id = nextItemId++;
+    const promise = new Promise((resolve, reject) => {
+      outstanding[id] = { resolve, reject };
+    });
+    worker.postMessage({ id, payload: data }, transfer);
+    return promise;
+  };
+}

--- a/src/workers/sketchfab-zip.worker.js
+++ b/src/workers/sketchfab-zip.worker.js
@@ -18,12 +18,11 @@ async function fetchZipAndGetBlobs(src) {
   });
 }
 
-self.onmessage = async e => {
+self.onmessage = async msg => {
   try {
-    const fileMap = await fetchZipAndGetBlobs(e.data);
-    self.postMessage([true, fileMap]);
+    const result = await fetchZipAndGetBlobs(msg.data.payload);
+    self.postMessage({ id: msg.data.id, result });
   } catch (e) {
-    self.postMessage([false, e.message]);
+    self.postMessage({ id: msg.data.id, err: e.message });
   }
-  delete self.onmessage;
 };


### PR DESCRIPTION
Pretty self-explanatory. This interface should be suitable for any worker that takes work items and processes them independently into some kind of results.

I'm not sure exactly how inefficient the old version was (does it make a thread for every worker? do the threads stay around forever? does it have to re-run all the worker Javascript, which is a lot in the case of the Sketchfab worker, every time the worker is created?) but now we don't have to think about it.