### PR TITLE
Fix collision shape removal on scene switch

### DIFF
--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -382,12 +382,12 @@ export const traverseMeshesAndAddShapes = (function() {
       });
       shapes.push({ id: shapePrefix + floorPlan.name, entity: floorPlan.el });
     } else if (vertexCount < vertexLimit) {
-      el.setAttribute(shapePrefix + meshRoot.name, {
+      el.setAttribute(shapePrefix + "environment", {
         type: SHAPE.MESH,
         margin: 0.01,
         fit: FIT.COMPOUND
       });
-      shapes.push({ id: shapePrefix + meshRoot.name, entity: el });
+      shapes.push({ id: shapePrefix + "environment", entity: el });
       console.log("adding compound mesh shape");
     } else {
       el.setAttribute(shapePrefix + "defaultFloor", {


### PR DESCRIPTION
Don't use the name of the mesh as part of the attribute name for shape. Sometimes the names have characters (e.g. spaces) that won't work for attribute names.