### PR TITLE
Reduce memory allocations in physics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3352,7 +3352,7 @@
       }
     },
     "aframe-physics-system": {
-      "version": "github:mozillareality/aframe-physics-system#ce2f82e744ec0a97654e21d6b115ec140374c991",
+      "version": "github:mozillareality/aframe-physics-system#937b1e62f0b31c13b9f3bf7e48e5fb64ef4718fe",
       "from": "github:mozillareality/aframe-physics-system#hubs/ammo_driver",
       "requires": {
         "ammo-debug-drawer": "github:infinitelee/ammo-debug-drawer",


### PR DESCRIPTION
update aframe-physics-system to newest version with less per-frame memory allocations