### PR TITLE
Fix getGamepads usage in chromium browsers

### DIFF
--- a/src/systems/userinput/devices/oculus-touch-controller.js
+++ b/src/systems/userinput/devices/oculus-touch-controller.js
@@ -56,6 +56,7 @@ export class OculusTouchControllerDevice {
   }
 
   write(frame) {
+    this.gamepad = navigator.getGamepads()[this.gamepad.index];
     if (!this.gamepad.connected) return;
 
     this.buttonMap.forEach(b => {

--- a/src/systems/userinput/devices/vive-controller.js
+++ b/src/systems/userinput/devices/vive-controller.js
@@ -37,6 +37,7 @@ export class ViveControllerDevice {
   }
 
   write(frame) {
+    this.gamepad = navigator.getGamepads()[this.gamepad.index];
     if (!this.gamepad.connected) return;
 
     this.buttonMap.forEach(b => {

--- a/src/systems/userinput/devices/windows-mixed-reality-controller.js
+++ b/src/systems/userinput/devices/windows-mixed-reality-controller.js
@@ -31,6 +31,7 @@ export class WindowsMixedRealityControllerDevice {
     this.orientation = new THREE.Quaternion();
   }
   write(frame) {
+    this.gamepad = navigator.getGamepads()[this.gamepad.index];
     if (!this.gamepad.connected) return;
 
     const path = paths.device.wmr[this.gamepad.hand || "right"];

--- a/src/systems/userinput/devices/xbox-controller.js
+++ b/src/systems/userinput/devices/xbox-controller.js
@@ -30,6 +30,7 @@ export class XboxControllerDevice {
   }
 
   write(frame) {
+    this.gamepad = navigator.getGamepads()[this.gamepad.index];
     if (this.gamepad.connected) {
       this.buttonMap.forEach(b => {
         const path = paths.device.xbox.button(b.name);


### PR DESCRIPTION
In some browsers (e.g. Oculus Browser), you must call `navigator.getGamepads()` in order to get an updated snapshot of gamepad state. 