### PR TITLE
Hide UI if in VR in immersive browser

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -590,6 +590,11 @@ document.addEventListener("DOMContentLoaded", async () => {
   scene.addEventListener("enter-vr", () => {
     if (handleEarlyVRMode()) return true;
 
+    if (!isMobileVR) {
+      // Optimization, stop drawing UI if not visible
+      remountUI({ hide: true });
+    }
+
     document.body.classList.add("vr-mode");
 
     // Don't stretch canvas on cardboard, since that's drawing the actual VR view :)
@@ -623,6 +628,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   scene.addEventListener("exit-vr", () => {
     document.body.classList.remove("vr-mode");
     document.body.classList.remove("vr-mode-stretch");
+
+    remountUI({ hide: false });
 
     // HACK: Oculus browser pauses videos when exiting VR mode, so we need to resume them after a timeout.
     if (/OculusBrowser/i.test(window.navigator.userAgent)) {

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -161,7 +161,8 @@ class UIRoot extends Component {
     location: PropTypes.object,
     history: PropTypes.object,
     showInterstitialPrompt: PropTypes.bool,
-    onInterstitialPromptClicked: PropTypes.func
+    onInterstitialPromptClicked: PropTypes.func,
+    hide: PropTypes.bool
   };
 
   state = {
@@ -1310,6 +1311,8 @@ class UIRoot extends Component {
   };
 
   render() {
+    if (this.props.hide) return <div />;
+
     const isExited = this.state.exited || this.props.roomUnavailableReason || this.props.platformUnsupportedReason;
 
     const isLoading =


### PR DESCRIPTION
This change stops rendering the React UI when in immersive mode VR on mobile headsets. (which results in a lot of memory allocations, re-layout, etc) 