### PR TITLE
Fix bug where pinned objects can fall through the floor

### DIFF
--- a/src/components/sticky-object.js
+++ b/src/components/sticky-object.js
@@ -1,10 +1,5 @@
 /* global AFRAME */
-
 const COLLISION_LAYERS = require("../constants").COLLISION_LAYERS;
-
-function almostEquals(epsilon, u, v) {
-  return Math.abs(u.x - v.x) < epsilon && Math.abs(u.y - v.y) < epsilon && Math.abs(u.z - v.z) < epsilon;
-}
 
 AFRAME.registerComponent("sticky-object", {
   schema: {
@@ -16,8 +11,6 @@ AFRAME.registerComponent("sticky-object", {
   init() {
     this.onGrab = this.onGrab.bind(this);
     this.onRelease = this.onRelease.bind(this);
-    this.prevScale = this.el.object3D.scale.clone();
-    this.wasScaled = false;
   },
 
   tick() {
@@ -30,15 +23,6 @@ AFRAME.registerComponent("sticky-object", {
       this.onRelease();
     }
     this.wasHeld = isHeld;
-
-    if (!almostEquals(0.001, this.prevScale, this.el.object3D.scale)) {
-      if ((!this.el.components.networked || NAF.utils.isMine(this.el)) && !this.wasScaled) {
-        this.wasScaled = true;
-        this.el.setAttribute("ammo-body", { collisionFilterMask: COLLISION_LAYERS.HANDS });
-      }
-
-      this.prevScale.copy(this.el.object3D.scale);
-    }
   },
 
   play() {
@@ -83,7 +67,6 @@ AFRAME.registerComponent("sticky-object", {
       collisionFilterMask: this.locked ? COLLISION_LAYERS.HANDS : COLLISION_LAYERS.DEFAULT_INTERACTABLE
     });
     this.setLocked(false);
-    this.wasScaled = false;
   },
 
   remove() {

--- a/src/components/transform-object-button.js
+++ b/src/components/transform-object-button.js
@@ -1,4 +1,5 @@
 import { paths } from "../systems/userinput/paths";
+const COLLISION_LAYERS = require("../constants").COLLISION_LAYERS;
 
 const TRANSFORM_MODE = {
   AXIS: "axis",
@@ -43,7 +44,7 @@ AFRAME.registerComponent("transform-button", {
         return;
       }
       if (this.targetEl.body) {
-        this.targetEl.setAttribute("ammo-body", { type: "kinematic" });
+        this.targetEl.setAttribute("ammo-body", { type: "kinematic", collisionFilterMask: COLLISION_LAYERS.HANDS });
       }
       this.transformSystem = this.transformSystem || AFRAME.scenes[0].systems["transform-selected-object"];
       this.transformSystem.startTransform(

--- a/src/components/transform-object-button.js
+++ b/src/components/transform-object-button.js
@@ -1,5 +1,6 @@
 import { paths } from "../systems/userinput/paths";
 const COLLISION_LAYERS = require("../constants").COLLISION_LAYERS;
+const AMMO_BODY_ATTRIBUTES = { type: "kinematic", collisionFilterMask: COLLISION_LAYERS.HANDS };
 
 const TRANSFORM_MODE = {
   AXIS: "axis",
@@ -44,7 +45,7 @@ AFRAME.registerComponent("transform-button", {
         return;
       }
       if (this.targetEl.body) {
-        this.targetEl.setAttribute("ammo-body", { type: "kinematic", collisionFilterMask: COLLISION_LAYERS.HANDS });
+        this.targetEl.setAttribute("ammo-body", AMMO_BODY_ATTRIBUTES);
       }
       this.transformSystem = this.transformSystem || AFRAME.scenes[0].systems["transform-selected-object"];
       this.transformSystem.startTransform(

--- a/src/systems/two-point-stretching-system.js
+++ b/src/systems/two-point-stretching-system.js
@@ -1,6 +1,6 @@
 /* global THREE AFRAME */
 const COLLISION_LAYERS = require("../constants").COLLISION_LAYERS;
-const collisionFilterMask = { collisionFilterMask: COLLISION_LAYERS.HANDS };
+const COLLISION_FILTER_MASK_HANDS = { collisionFilterMask: COLLISION_LAYERS.HANDS };
 export const distanceBetweenStretchers = (() => {
   const a = new THREE.Vector3();
   const b = new THREE.Vector3();
@@ -37,7 +37,7 @@ export class TwoPointStretchingSystem {
         this.stretched = leftHand.held;
         this.initialScale.copy(this.stretched.object3D.scale);
         if (this.stretched.components["ammo-body"]) {
-          this.stretched.setAttribute("ammo-body", collisionFilterMask);
+          this.stretched.setAttribute("ammo-body", COLLISION_FILTER_MASK_HANDS);
         }
       }
 

--- a/src/systems/two-point-stretching-system.js
+++ b/src/systems/two-point-stretching-system.js
@@ -1,4 +1,6 @@
 /* global THREE AFRAME */
+const COLLISION_LAYERS = require("../constants").COLLISION_LAYERS;
+const collisionFilterMask = { collisionFilterMask: COLLISION_LAYERS.HANDS };
 export const distanceBetweenStretchers = (() => {
   const a = new THREE.Vector3();
   const b = new THREE.Vector3();
@@ -34,6 +36,9 @@ export class TwoPointStretchingSystem {
         this.initialStretchDistance = distanceBetweenStretchers(leftStretcher, rightStretcher);
         this.stretched = leftHand.held;
         this.initialScale.copy(this.stretched.object3D.scale);
+        if (this.stretched.components["ammo-body"]) {
+          this.stretched.setAttribute("ammo-body", collisionFilterMask);
+        }
       }
 
       this.stretched.object3D.scale


### PR DESCRIPTION
Fixes #1239. (The bugged behavior is explained by `ammo-body`s getting their `collisionFilterMask`s set to `COLLISION_LAYERS.HANDS` when the `pin` animation fired, which would happen whenever you release a pinned object.)