### PR TITLE
Update three-pathfinding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17839,8 +17839,8 @@
       "integrity": "sha512-CYcODvb9jgXQdTt99Uj6Ec6+CiYc3S1NE7jp1iUud9+7ACWe358qpERF7qxJjJa3+XLQxz2pDCigwZHGc9LLjQ=="
     },
     "three-pathfinding": {
-      "version": "github:mozillareality/three-pathfinding#a52f437eaaf1b608c5f7fed046846bdbd79c75e7",
-      "from": "github:mozillareality/three-pathfinding#hubs/master"
+      "version": "github:MozillaReality/three-pathfinding#9934636508ff8f445ac1b1bba5dd55c5a69266ff",
+      "from": "github:MozillaReality/three-pathfinding#hubs/master2"
     },
     "three-to-ammo": {
       "version": "github:infinitelee/three-to-ammo#7b3a717994e90b48eb9bc4d13cbae948151ce2f1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "screenfull": "^4.0.1",
     "three": "github:mozillareality/three.js#hubs/master",
     "three-mesh-bvh": "^0.1.0",
-    "three-pathfinding": "github:mozillareality/three-pathfinding#hubs/master",
+    "three-pathfinding": "github:MozillaReality/three-pathfinding#hubs/master2",
     "three-to-cannon": "1.3.0",
     "uuid": "^3.2.1",
     "webrtc-adapter": "^6.0.2",


### PR DESCRIPTION
This brings three-pathfinding up to date with upstream master, which includes [some fixes to navigation mesh construction performance](https://github.com/donmccurdy/three-pathfinding/pull/38) that we value.