### PR TITLE
Bump naf version to revert deepEqual changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12039,7 +12039,7 @@
       "dev": true
     },
     "networked-aframe": {
-      "version": "github:mozillareality/networked-aframe#359434618ca1ff25fab136c1895d78c159dcdb94",
+      "version": "github:mozillareality/networked-aframe#483fddcae07c1025fe160cedc50ad6c04ceb0f3c",
       "from": "github:mozillareality/networked-aframe#master",
       "requires": {
         "buffered-interpolation": "^0.2.5",


### PR DESCRIPTION
fixes https://github.com/mozilla/hubs/issues/1254 and who knows what other networking issues we didn't notice yet.