### PR TITLE
Don't add colliders on 360 content

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -639,7 +639,7 @@ AFRAME.registerComponent("media-video", {
       this.videoMutedAt = performance.now();
     }
 
-    this.el.emit("video-loaded");
+    this.el.emit("video-loaded", { projection: projection });
   },
 
   updateHoverMenuBasedOnLiveState() {
@@ -811,6 +811,6 @@ AFRAME.registerComponent("media-image", {
       scaleToAspectRatio(this.el, ratio);
     }
 
-    this.el.emit("image-loaded", { src: this.data.src });
+    this.el.emit("image-loaded", { src: this.data.src, projection: projection });
   }
 });


### PR DESCRIPTION
When a photo or video loads, don't add a physics shape in the case its using a 360 projection.
This PR adds "projection" to the evtDetail of "image-loaded" and "video-loaded" and changes media-loader.onMediaLoaded to take a shape type as an argument.