### PR TITLE
Show use scene permission tip

### DIFF
--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -366,9 +366,7 @@ AFRAME.registerComponent("media-loader", {
         this.el.addEventListener(
           "image-loaded",
           () => {
-            const mayChangeScene = this.el.sceneEl.systems.permissions.can("update_hub");
-
-            if (isHubsRoomUrl(src) || (isHubsSceneUrl(src) && mayChangeScene)) {
+            if (isHubsRoomUrl(src) || isHubsSceneUrl(src)) {
               this.el.setAttribute("hover-menu__hubs-item", {
                 template: "#hubs-destination-hover-menu",
                 dirs: ["forward", "back"]

--- a/src/components/open-media-button.js
+++ b/src/components/open-media-button.js
@@ -3,8 +3,6 @@ import { guessContentType } from "../utils/media-utils";
 
 AFRAME.registerComponent("window-open-button", {
   init() {
-    this.label = this.el.querySelector("[text]");
-
     this.updateSrc = () => {
       this.src = this.targetEl.components["media-loader"].data.src;
       this.el.object3D.visible = !!this.src;

--- a/src/hub.html
+++ b/src/hub.html
@@ -273,7 +273,7 @@
                                     position="0 0 0.001"
                                 ></a-image>
                             </a-entity>
-                            <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" open-media-button position="0.43 -0.375 0.01">
+                            <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" window-open-button position="0.43 -0.375 0.01">
                                 <a-entity text="value:open link; width:1.75; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
                             </a-entity>
                             <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" clone-media-button position="-0.43 -0.375 0.01">
@@ -487,15 +487,32 @@
 
             <template id="hubs-destination-hover-menu">
                 <a-entity class="ui interactable-ui hover-container" visible="false">
-                    <a-entity mixin="rounded-text-action-button ui" is-remote-hover-target tags="singleActionButton: true; isHoverMenuChild: true;" open-media-button position="0 -0.125 0.01">
+                    <a-entity mixin="rounded-text-action-button ui" is-remote-hover-target tags="singleActionButton: true; isHoverMenuChild: true;" open-media-button="useScenePermissionTipSelector:.use-scene-permission-tip" position="0 -0.125 0.01">
                         <a-entity text="value:value; width:1.5; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
+                    </a-entity>
+                    <a-entity
+                        class="use-scene-permission-tip"
+                        text="value:You do not have permission to change the scene.; width:1.15; align:center; color:#fff;"
+                        visible="false"
+                        text-raycast-hack
+                        slice9="
+                        color: #0F40A9;
+                        width: 1.2;
+                        height: 0.2;
+                        left: 56;
+                        top: 56;
+                        right: 58;
+                        bottom: 58;
+                        opacity: 1.0;
+                        src: #button"
+                        position="0 0.3 0.01">
                     </a-entity>
                 </a-entity>
             </template>
 
             <template id="link-hover-menu">
                 <a-entity class="ui interactable-ui hover-container" visible="false">
-                    <a-entity mixin="rounded-text-action-button ui" is-remote-hover-target tags="singleActionButton: true; isHoverMenuChild: true;" open-media-button position="0 -0.125 0.01">
+                    <a-entity mixin="rounded-text-action-button ui" is-remote-hover-target tags="singleActionButton: true; isHoverMenuChild: true;" window-open-button position="0 -0.125 0.01">
                         <a-entity text="value:open link; width:1.5; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
                     </a-entity>
                 </a-entity>

--- a/src/systems/button-systems.js
+++ b/src/systems/button-systems.js
@@ -46,7 +46,8 @@ function getHoverableButton(hovered) {
   if (
     hovered.components["icon-button"] ||
     hovered.components["text-button"] ||
-    hovered.components["pin-networked-object-button"]
+    hovered.components["pin-networked-object-button"] ||
+    hovered.components["open-media-button"]
   )
     return hovered;
   // TODO: fix this so that we aren't looping thru children here. I just did this to accomodate the new rounded buttons

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -438,7 +438,7 @@ export function spawnMediaAround(el, media, snapCount, mirrorOrientation = false
   return { entity, orientation };
 }
 
-const hubsSceneRegex = /https?:\/\/(hubs.local(:\d+)?|(smoke-)?hubs.mozilla.com)\/scenes\/(\w+)\/?\S*/;
+const hubsSceneRegex = /https?:\/\/((dev.reticulum.io)|(hubs.local(:\d+)?|(smoke-)?hubs.mozilla.com))\/scenes\/(\w+)\/?\S*/;
 const hubsRoomRegex = /https?:\/\/(hubs.local(:\d+)?|(smoke-)?hubs.mozilla.com)\/(\w+)\/?\S*/;
 export const isHubsSceneUrl = hubsSceneRegex.test.bind(hubsSceneRegex);
 export const isHubsRoomUrl = url => !isHubsSceneUrl(url) && hubsRoomRegex.test(url);

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -438,7 +438,7 @@ export function spawnMediaAround(el, media, snapCount, mirrorOrientation = false
   return { entity, orientation };
 }
 
-const hubsSceneRegex = /https?:\/\/((dev.reticulum.io)|(hubs.local(:\d+)?|(smoke-)?hubs.mozilla.com))\/scenes\/(\w+)\/?\S*/;
+const hubsSceneRegex = /https?:\/\/(hubs.local(:\d+)?|(smoke-)?hubs.mozilla.com)\/scenes\/(\w+)\/?\S*/;
 const hubsRoomRegex = /https?:\/\/(hubs.local(:\d+)?|(smoke-)?hubs.mozilla.com)\/(\w+)\/?\S*/;
 export const isHubsSceneUrl = hubsSceneRegex.test.bind(hubsSceneRegex);
 export const isHubsRoomUrl = url => !isHubsSceneUrl(url) && hubsRoomRegex.test(url);


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/1238

We now show the "use scene" button on hover for scene links, whether or not you have permission to change the scene. When you do not have permission, we explain that with a text label that appears.
![image](https://user-images.githubusercontent.com/4072106/56676790-ea519c80-6673-11e9-9446-9b24b1058cb0.png)

In the freeze menu for rooms and scenes, the "visit room" and "use scene" buttons are replaced with "open link", since "visit room" and "use scene" are available in the hover menu.
![image](https://user-images.githubusercontent.com/4072106/56676887-1a993b00-6674-11e9-834c-a2f1e11b2b70.png)
