### PR TITLE
Feature/blue green deploys

### DIFF
--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -125,6 +125,7 @@
     "presence.entered_room": "entered the room.",
     "presence.entered_lobby": "entered the lobby.",
     "presence.join_lobby": "joined the lobby.",
+    "presence.join_room": "joined the room.",
     "presence.leave": "left.",
     "presence.name_change": "is now known as",
     "presence.scene_change": "changed the scene to",

--- a/src/hub.js
+++ b/src/hub.js
@@ -21,7 +21,7 @@ import "./utils/threejs-positional-audio-updatematrixworld";
 import "./utils/threejs-world-update";
 import patchThreeAllocations from "./utils/threejs-allocation-patches";
 import { detectOS, detect } from "detect-browser";
-import { getReticulumFetchUrl, getReticulumMeta } from "./utils/phoenix-utils";
+import { getReticulumFetchUrl, getReticulumMeta, invalidateReticulumMeta } from "./utils/phoenix-utils";
 
 import nextTick from "./utils/next-tick";
 import { addAnimationComponents } from "./utils/animation";
@@ -788,6 +788,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     hmd: availableVREntryTypes.isInHMD
   };
 
+  let retDeployReconnectInterval;
+  let ignorePresenceDueToRetDeploy = false; // Ignore presence messages for some grace period around ret re-connections.
+  const retReconnectMaxDelayMs = 15000;
+
   // Reticulum global channel
   const retPhxChannel = socket.channel(`ret`, { hub_id: hubId });
   retPhxChannel
@@ -797,6 +801,29 @@ document.addEventListener("DOMContentLoaded", async () => {
       subscriptions.setVapidPublicKey(null);
       console.error(res);
     });
+
+  retPhxChannel.on("notice", async data => {
+    // On Reticulum deploys, reconnect after a random delay until pool + version match deployed version/pool
+    if (data.event === "ret-deploy") {
+      console.log(`Reticulum deploy detected v${data.ret_version} on ${data.ret_pool}`);
+      ignorePresenceDueToRetDeploy = true;
+      clearInterval(retDeployReconnectInterval);
+
+      setTimeout(() => {
+        retDeployReconnectInterval = setInterval(async () => {
+          invalidateReticulumMeta();
+          const reticulumMeta = await getReticulumMeta();
+
+          if (reticulumMeta.pool === data.ret_pool && reticulumMeta.version === data.ret_version) {
+            console.log("Reticulum reconnection completed.");
+            clearInterval(retDeployReconnectInterval);
+            retPhxChannel.socket.conn.close();
+            setTimeout(() => (ignorePresenceDueToRetDeploy = false), retReconnectMaxDelayMs); // Restore presence messages after 30s once everyone has rejoined
+          }
+        }, 5000);
+      }, Math.floor(Math.random() * retReconnectMaxDelayMs));
+    }
+  });
 
   const pushSubscriptionEndpoint = await subscriptions.getCurrentEndpoint();
   const joinPayload = {
@@ -912,7 +939,7 @@ document.addEventListener("DOMContentLoaded", async () => {
               // New presence
               const meta = info.metas[0];
 
-              if (meta.presence && meta.profile.displayName) {
+              if (meta.presence && meta.profile.displayName && !ignorePresenceDueToRetDeploy) {
                 addToPresenceLog({
                   type: "join",
                   presence: meta.presence,
@@ -929,7 +956,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
             const meta = info.metas[0];
 
-            if (meta.profile.displayName) {
+            if (meta.profile.displayName && !ignorePresenceDueToRetDeploy) {
               addToPresenceLog({
                 type: "leave",
                 name: meta.profile.displayName

--- a/src/hub.js
+++ b/src/hub.js
@@ -21,7 +21,7 @@ import "./utils/threejs-positional-audio-updatematrixworld";
 import "./utils/threejs-world-update";
 import patchThreeAllocations from "./utils/threejs-allocation-patches";
 import { detectOS, detect } from "detect-browser";
-import { getReticulumFetchUrl } from "./utils/phoenix-utils";
+import { getReticulumFetchUrl, getReticulumMeta } from "./utils/phoenix-utils";
 
 import nextTick from "./utils/next-tick";
 import { addAnimationComponents } from "./utils/animation";
@@ -712,6 +712,20 @@ document.addEventListener("DOMContentLoaded", async () => {
       return;
     }
   }
+
+  getReticulumMeta().then(reticulumMeta => {
+    console.log(`Reticulum @ ${reticulumMeta.phx_host}: v${reticulumMeta.version} on ${reticulumMeta.pool}`);
+
+    if (
+      qs.get("required_ret_version") &&
+      (qs.get("required_ret_version") !== reticulumMeta.version || qs.get("required_ret_pool") !== reticulumMeta.pool)
+    ) {
+      remountUI({ roomUnavailableReason: "version_mismatch" });
+      setTimeout(() => document.location.reload(), 5000);
+      entryManager.exitScene();
+      return;
+    }
+  });
 
   if (isMobileVR) {
     remountUI({ availableVREntryTypes, forcedVREntryType: "vr" });

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -48,6 +48,34 @@ export function getReticulumFetchUrl(path, absolute = false) {
   }
 }
 
+let reticulumMeta = null;
+
+export async function getReticulumMeta() {
+  if (!reticulumMeta) {
+    // Initially look up version based upon page, otherwise fetch.
+    if (document.querySelector("meta[name='ret:version']")) {
+      reticulumMeta = {
+        version: document.querySelector("meta[name='ret:version']").getAttribute("value"),
+        pool: document.querySelector("meta[name='ret:pool']").getAttribute("value"),
+        phx_host: document.querySelector("meta[name='ret:phx_host']").getAttribute("value")
+      };
+    } else {
+      await fetch(getReticulumFetchUrl("/api/v1/meta")).then(async res => {
+        reticulumMeta = await res.json();
+      });
+    }
+  }
+
+  const qs = new URLSearchParams(location.search);
+  const phxHostOverride = qs.get("phx_host");
+
+  if (phxHostOverride) {
+    reticulumMeta.phx_host = phxHostOverride;
+  }
+
+  return reticulumMeta;
+}
+
 export function getLandingPageForPhoto(photoUrl) {
   const parsedUrl = new URL(photoUrl);
   return getReticulumFetchUrl(parsedUrl.pathname.replace(".png", ".html") + parsedUrl.search, true);

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -49,11 +49,17 @@ export function getReticulumFetchUrl(path, absolute = false) {
 }
 
 let reticulumMeta = null;
+let invalidatedReticulumMetaThisSession = false;
+
+export async function invalidateReticulumMeta() {
+  invalidatedReticulumMetaThisSession = true;
+  reticulumMeta = null;
+}
 
 export async function getReticulumMeta() {
   if (!reticulumMeta) {
-    // Initially look up version based upon page, otherwise fetch.
-    if (document.querySelector("meta[name='ret:version']")) {
+    // Initially look up version based upon page, avoiding round-trip, otherwise fetch.
+    if (!invalidatedReticulumMetaThisSession && document.querySelector("meta[name='ret:version']")) {
       reticulumMeta = {
         version: document.querySelector("meta[name='ret:version']").getAttribute("value"),
         pool: document.querySelector("meta[name='ret:pool']").getAttribute("value"),


### PR DESCRIPTION
Adds necessary plumbing to deal with new blue/green deploys:

- Track + report reticulum version/pool metadata during session.

- Adds reconnect logic when a ret deploy notification is received. After a random timeout (to reduce stampede) the client will poll the main ALB until it sees the proper version + pool are responding (usually unnecessary, because this will already have happened during smoke testing.) Once that happens, the socket is disconnected so the phoenix driver will reconnect. During this period, presence join/leave messages are ignored in the client because those presences will change as users in the room roll over to the new socket.

- Adds the necessary logic to support the smoke test + verification test to check when the proper version and pool are live for smoke testing reticulum