### PR TITLE
Adds graceful channel migration

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -946,7 +946,8 @@ document.addEventListener("DOMContentLoaded", async () => {
                   newName: meta.profile.displayName
                 });
               }
-            } else {
+            } else if (info.metas.length === 1) {
+              // Skip if len > 1, may be re-connect
               // New presence
               const meta = info.metas[0];
 

--- a/src/react-components/presence-list.js
+++ b/src/react-components/presence-list.js
@@ -38,7 +38,7 @@ export default class PresenceList extends Component {
   };
 
   domForPresence = ([sessionId, data]) => {
-    const meta = data.metas[0];
+    const meta = data.metas[data.metas.length - 1];
     const context = meta.context;
     const profile = meta.profile;
     const image = getPresenceImage(context);

--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -31,7 +31,7 @@ export default class HubChannel extends EventTarget {
   }
 
   // Migrates this hub channel to a new phoenix channel and presence
-  async migrateToSocket(socket) {
+  async migrateToSocket(socket, params) {
     let presenceBindings;
 
     // Unbind presence, and then set up bindings after reconnect
@@ -47,7 +47,7 @@ export default class HubChannel extends EventTarget {
       this.presence.onSync(function() {});
     }
 
-    this.channel = await migrateChannelToSocket(this.channel, socket);
+    this.channel = await migrateChannelToSocket(this.channel, socket, params);
     this.presence = new Presence(this.channel);
 
     if (presenceBindings) {

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -148,7 +148,7 @@ export function getPresenceProfileForSession(presences, sessionId) {
 
 // Takes the given channel, and creates a new channel with the same bindings
 // with the given socket, joins it, and leaves the old channel after joining.
-export function migrateChannel(oldChannel, socket) {
+export function migrateChannelToSocket(oldChannel, socket) {
   const channel = socket.channel(oldChannel.topic, oldChannel.params);
 
   for (let i = 0, l = oldChannel.bindings.length; i < l; i++) {
@@ -171,13 +171,9 @@ export function migrateChannel(oldChannel, socket) {
     }
 
     joinPush.receive("ok", () => {
-      // Leave after a delay to ensure presence always has an entry. Clear all event handlers first so
-      // no duplicate messages come in.
+      // Clear all event handlers first so no duplicate messages come in.
       oldChannel.bindings = [];
-
-      setTimeout(() => {
-        oldChannel.leave().receive("ok", () => resolve(channel));
-      }, 1000);
+      resolve(channel);
     });
   });
 }

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -148,8 +148,8 @@ export function getPresenceProfileForSession(presences, sessionId) {
 
 // Takes the given channel, and creates a new channel with the same bindings
 // with the given socket, joins it, and leaves the old channel after joining.
-export function migrateChannelToSocket(oldChannel, socket) {
-  const channel = socket.channel(oldChannel.topic, oldChannel.params);
+export function migrateChannelToSocket(oldChannel, socket, params) {
+  const channel = socket.channel(oldChannel.topic, params || oldChannel.params);
 
   for (let i = 0, l = oldChannel.bindings.length; i < l; i++) {
     const item = oldChannel.bindings[i];


### PR DESCRIPTION
This PR makes it so the client transparently migrates to a new reticulum server when notified of a deploy. A few highlights:

- There's now a generic `migrateChannelToSocket` routine in `phoenix-utils` which lets you copy over the various bindings/handlers to a new channel instance for a new socket

- `HubChannel` now exposes a `migrateToSocket` function which can do the necessary internal munging of state to transition the channel and presence to the new server

- Fixed up a number of edge cases in presence event handling that were straight up bugs, and also made the handlers compatible with the scenario where a new `Presence` object may be attached to the hub channel across event handler calls. (This is what happens when we migrate to a new server.)

- Updates the presence event handlers to recognize the scenario where a user is leaving while still having other presence (eg, they are reconnecting) and so do not show a leave event
