### PR TITLE
Add lobby disclosure

### DIFF
--- a/src/assets/stylesheets/entry.scss
+++ b/src/assets/stylesheets/entry.scss
@@ -148,18 +148,26 @@
     width: 100%;
   }
 
-  :local(.choose-scene) {
+  :local(.lobby-label) {
     margin-top: 4px;
     margin-bottom: 32px;
     @extend %default-font;
-    font-size: 1.1em;
-    color: $action-color;
+    font-size: 0.8em;
     text-decoration: none;
     cursor: pointer;
-    font-weight: bold;
     display: flex;
+    color: $dark-grey;
     align-items: center;
     justify-content: center;
+    i {
+      margin-right: 8px;
+    }
+  }
+
+  :local(.choose-scene) {
+    font-size: 1.1em;
+    font-weight: bold;
+    color: $action-color;
     i {
       margin-right: 8px;
     }

--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -23,6 +23,7 @@
     "entry.enter-room": "Enter Room",
     "entry.leave-room": "Leave Room",
     "entry.change-scene": "Choose a Scene",
+    "entry.in-lobby-notice": "You are viewing the room from the lobby.",
     "entry.screen-prefix": "Enter on ",
     "entry.desktop-screen": "Screen",
     "entry.mobile-screen": "Phone",

--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -23,7 +23,7 @@
     "entry.enter-room": "Enter Room",
     "entry.leave-room": "Leave Room",
     "entry.change-scene": "Choose a Scene",
-    "entry.in-lobby-notice": "You are viewing the room from the lobby.",
+    "entry.in-lobby-notice": "You are viewing this room from the lobby.",
     "entry.screen-prefix": "Enter on ",
     "entry.desktop-screen": "Screen",
     "entry.mobile-screen": "Phone",

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -978,10 +978,10 @@ class UIRoot extends Component {
         </div>
 
         <div className={entryStyles.center}>
-          {this.props.hubChannel.permissions.update_hub && (
+          {this.props.hubChannel.permissions.update_hub ? (
             <WithHoverSound>
               <div
-                className={entryStyles.chooseScene}
+                className={classNames([entryStyles.lobbyLabel, entryStyles.chooseScene])}
                 onClick={() => {
                   showFullScreenIfAvailable();
                   this.props.mediaSearchStore.sourceNavigateWithNoNav("scenes");
@@ -993,6 +993,10 @@ class UIRoot extends Component {
                 <FormattedMessage id="entry.change-scene" />
               </div>
             </WithHoverSound>
+          ) : (
+            <div className={entryStyles.lobbyLabel}>
+              <FormattedMessage id="entry.in-lobby-notice" />
+            </div>
           )}
 
           <LobbyChatBox


### PR DESCRIPTION
Adds a disclosure to help users grok they are a) in the lobby, which is a thing and b) they cannot be seen from the lobby, both of which has been a reported point of confusion.

![image](https://user-images.githubusercontent.com/220020/57034673-05d51e00-6c05-11e9-8680-db9a66ea975b.png)
