### PR TITLE
Grab session id in link channel

### DIFF
--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -729,7 +729,11 @@ class UIRoot extends Component {
     this.pushHistoryState("overlay", "link");
     const { code, cancel, onFinished } = await this.props.linkChannel.generateCode();
     this.setState({ linkCode: code, linkCodeCancel: cancel });
-    onFinished.then(() => this.setState({ log: false, linkCode: null, linkCodeCancel: null }));
+
+    onFinished.then(() => {
+      this.setState({ log: false, linkCode: null, linkCodeCancel: null });
+      this.props.history.goBack();
+    });
   };
 
   showInviteDialog = () => {

--- a/src/utils/link-channel.js
+++ b/src/utils/link-channel.js
@@ -136,7 +136,10 @@ export default class LinkChannel {
           decryptObject(payload.public_key, privateKey, payload.data).then(resolve);
         });
 
-        channel.join().receive("error", r => console.error(r));
+        channel
+          .join()
+          .receive("ok", data => (this.socket.params().session_id = data.session_id))
+          .receive("error", r => console.error(r));
       });
     });
   };


### PR DESCRIPTION
Fixes two regressions in link codes -- the dialog didn't close on success, and the mechanic broke when we added server-generated session ids.