### PR TITLE
Mute microphone before entering

### DIFF
--- a/src/assets/stylesheets/audio.scss
+++ b/src/assets/stylesheets/audio.scss
@@ -17,6 +17,29 @@
     @extend %bottom-action-button;
     @extend %wide-button;
   }
+  &__mute-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 12px 0;
+
+    input {
+      cursor: pointer;
+      @extend %checkbox;
+    }
+
+    input:checked {
+      @extend %checkbox-checked;
+    }
+
+    label {
+      cursor: pointer;
+      margin-right: 8px;
+    }
+
+    color: $darker-grey;
+  }
+
 
   &__title {
     @extend %top-title;

--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -63,6 +63,7 @@
     "entry.lobby": "Lobby",
     "entry.back": "Back",
     "entry.notify_me": "Notify me when others are here",
+    "entry.mute-on-entry": "Mute my microphone",
     "profile.save": "Accept",
     "profile.display_name.validation_warning": "Alphanumerics and hyphens. At least 3 characters, no more than 32",
     "profile.header": "Name & Avatar",

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1198,12 +1198,14 @@ class UIRoot extends Component {
                 srcSet="../assets/images/level_background@2x.png 2x"
                 className="audio-setup-panel__levels__icon-part"
               />
-              <img
-                src="../assets/images/level_fill.png"
-                srcSet="../assets/images/level_fill@2x.png 2x"
-                className="audio-setup-panel__levels__icon-part"
-                style={micClip}
-              />
+              {!this.state.muteOnEntry && (
+                <img
+                  src="../assets/images/level_fill.png"
+                  srcSet="../assets/images/level_fill@2x.png 2x"
+                  className="audio-setup-panel__levels__icon-part"
+                  style={micClip}
+                />
+              )}
               {this.state.audioTrack && !this.state.muteOnEntry ? (
                 <img
                   src="../assets/images/mic_level.png"

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -171,6 +171,7 @@ class UIRoot extends Component {
 
   state = {
     enterInVR: false,
+    muteOnEntry: false,
     entered: false,
     dialog: null,
     showInviteDialog: false,
@@ -700,7 +701,7 @@ class UIRoot extends Component {
       showFullScreenIfAvailable();
     }
 
-    this.props.enterScene(this.state.mediaStream, this.state.enterInVR, this.props.hubId);
+    this.props.enterScene(this.state.mediaStream, this.state.enterInVR, this.state.muteOnEntry);
 
     const mediaStream = this.state.mediaStream;
 
@@ -1203,7 +1204,7 @@ class UIRoot extends Component {
                 className="audio-setup-panel__levels__icon-part"
                 style={micClip}
               />
-              {this.state.audioTrack ? (
+              {this.state.audioTrack && !this.state.muteOnEntry ? (
                 <img
                   src="../assets/images/mic_level.png"
                   srcSet="../assets/images/mic_level@2x.png 2x"
@@ -1216,11 +1217,12 @@ class UIRoot extends Component {
                   className="audio-setup-panel__levels__icon-part"
                 />
               )}
-              {this.state.audioTrack && (
-                <div className="audio-setup-panel__levels__test_label">
-                  <FormattedMessage id="audio.talk_to_test" />
-                </div>
-              )}
+              {this.state.audioTrack &&
+                !this.state.muteOnEntry && (
+                  <div className="audio-setup-panel__levels__test_label">
+                    <FormattedMessage id="audio.talk_to_test" />
+                  </div>
+                )}
             </div>
             <WithHoverSound>
               <div className="audio-setup-panel__levels__icon_clickable" onClick={this.playTestTone}>
@@ -1288,6 +1290,17 @@ class UIRoot extends Component {
               </span>
             </div>
           )}
+        </div>
+        <div className="audio-setup-panel__mute-container">
+          <input
+            id="mute-on-entry"
+            type="checkbox"
+            onChange={() => this.setState({ muteOnEntry: !this.state.muteOnEntry })}
+            checked={this.state.muteOnEntry}
+          />
+          <label htmlFor="mute-on-entry">
+            <FormattedMessage id="entry.mute-on-entry" />
+          </label>
         </div>
         <div className="audio-setup-panel__enter-button-container">
           <WithHoverSound>

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -46,7 +46,7 @@ export default class SceneEntryManager {
     return this._entered;
   };
 
-  enterScene = async (mediaStream, enterInVR) => {
+  enterScene = async (mediaStream, enterInVR, muteOnEntry) => {
     const playerCamera = document.querySelector("#player-camera");
     playerCamera.removeAttribute("scene-preview-camera");
     playerCamera.object3D.position.set(0, playerHeight, 0);
@@ -110,6 +110,10 @@ export default class SceneEntryManager {
     })();
 
     this.scene.addState("entered");
+
+    if (muteOnEntry) {
+      this.scene.emit("action_mute");
+    }
   };
 
   whenSceneLoaded = callback => {


### PR DESCRIPTION
You can now mute your microphone before you enter a room. In the final confirmation page while in the room's lobby, you can check the 'Mute my Microphone' option to enter the room without an open mic. You will be able to mute and un-mute yourself as usual once in the room.

![image](https://user-images.githubusercontent.com/220020/57395520-28bf7f00-717d-11e9-8a11-072119e0c649.png)

