### PR TITLE
Fix Spoke download link and update repository links

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -47,7 +47,7 @@ In this Privacy Notice, we explain what data may be accessible to Mozilla or oth
 - **Publishing Your Scene or Avatar**: When you publish a scene or avatar to Hubs, Mozilla will ask for your email address to send you a link to verify your email. Mozilla will receive and store your email address to allow you to log in and view your 3D Room models and Avatars. Mozilla stores a hashed version of email addresses you use to publish a scene, so the stored versions are not available in readable form. 
 - **Remixing and Promotion**: When you publish a scene or avatar to Hubs, you have the option to “Allow Remixing with Creative Commons [CC-BY 3.0](https://creativecommons.org/licenses/by/3.0/)” or allow Mozilla to promote your scene or avatar. If you choose one or both of these options, Mozilla will share your scene or avatar publicly and you will have the option of including attribution information, which will also be publicly available.
 
-- You can learn more by looking at the [code itself](https://github.com/mozillareality/spoke) for Spoke. 
+- You can learn more by looking at the [code itself](https://github.com/mozilla/spoke) for Spoke. 
 </details>
 
 <details open>

--- a/TERMS.md
+++ b/TERMS.md
@@ -24,7 +24,7 @@ When you submit information to Hubs or Spoke, you grant us a worldwide, royalty-
 You also represent and warrant that you have the authority to grant Mozilla all rights and permissions necessary for the operation of Hubs and Spoke. 
 
 To learn more about how Hubs operates, you can see the source code [here](https://github.com/mozilla/hubs).
-To learn more about how Spoke operates, you can see the source code [here](https://github.com/mozillareality/spoke).
+To learn more about how Spoke operates, you can see the source code [here](https://github.com/mozilla/spoke).
 
 Any ideas, suggestions, and feedback about Hubs or Spoke that you provide to us are entirely voluntary, and you agree that Mozilla may use such ideas, suggestions, and feedback without compensation or obligation to you.
 
@@ -38,7 +38,7 @@ Please also be aware of [Mozilla’s Community Participation Guidelines](https:/
 ### 4. Mozilla's Rights
 Mozilla does not grant you any intellectual property rights in Hubs or Spoke unless these Terms specifically say otherwise. For example, these Terms do not provide the right to use any of Mozilla’s copyrights, trade names, trademarks, service marks, logos, domain names, or other distinctive brand features.
 
-Mozilla distributes the Hubs and Spoke software under an open source license. To learn more, you can read the [license for Spoke]((https://github.com/mozillareality/spoke/blob/master/LICENSE)), and you can read the [license for Hubs](https://github.com/mozilla/hubs/blob/master/LICENSE) or read the [FAQ](https://www.mozilla.org/en-US/MPL/2.0/FAQ/).
+Mozilla distributes the Hubs and Spoke software under an open source license. To learn more, you can read the [license for Spoke]((https://github.com/mozilla/spoke/blob/master/LICENSE)), and you can read the [license for Hubs](https://github.com/mozilla/hubs/blob/master/LICENSE) or read the [FAQ](https://www.mozilla.org/en-US/MPL/2.0/FAQ/).
 
 ### 5. Services Interruption; Term; Termination
 We are continuing to develop Hubs and Spoke. As a result, we plan to upgrade and change them over time. To do this, we might have to temporarily suspend their service and it is not always possible for us to give notice. You will not be entitled to claim expenses or damages for such suspension or limitation of the use of Hubs or Spoke.

--- a/src/spoke.js
+++ b/src/spoke.js
@@ -77,7 +77,7 @@ class SpokeLanding extends Component {
       body: JSON.stringify({
         query: `
           {
-            repository(owner: "mozillareality", name: "spoke") {
+            repository(owner: "mozilla", name: "spoke") {
               releases(
                 orderBy: { field: CREATED_AT, direction: DESC },
                 first: 5
@@ -124,7 +124,7 @@ class SpokeLanding extends Component {
 
   render() {
     const platform = this.state.platform;
-    const releasesLink = "https://github.com/MozillaReality/Spoke/releases/latest";
+    const releasesLink = "https://github.com/mozilla/Spoke/releases/latest";
     const downloadLink = platform === "unsupported" ? releasesLink : this.state.downloadLinkForCurrentPlatform;
 
     return (
@@ -132,7 +132,7 @@ class SpokeLanding extends Component {
         <div className={styles.ui}>
           <div className={styles.header}>
             <div className={styles.headerLinks}>
-              <a href="https://github.com/mozillareality/spoke" rel="noopener noreferrer">
+              <a href="https://github.com/mozilla/spoke" rel="noopener noreferrer">
                 <FormattedMessage id="home.source_link" />
               </a>
               <a href="https://discord.gg/wHmY4nd" rel="noreferrer noopener">


### PR DESCRIPTION
I forgot to change the repository in the graphql query when we migrated Spoke to Mozilla. I forgot that I needed to search the Hubs repo for anything that needed to be updated 😐 

Fixes https://github.com/mozilla/Spoke/issues/612