### PR TITLE
Use CORS proxy for custom avatar urls (take 2)

### DIFF
--- a/src/assets/avatars/avatars.js
+++ b/src/assets/avatars/avatars.js
@@ -1,5 +1,3 @@
-import { getReticulumFetchUrl } from "../../utils/phoenix-utils";
-
 export const avatars = [
   {
     id: "botdefault",
@@ -42,28 +40,3 @@ export const avatars = [
     model: "https://asset-bundles-prod.reticulum.io/bots/BotWoody_Avatar-0140485a23.gltf"
   }
 ];
-
-export const AVATAR_TYPES = {
-  LEGACY: "legacy",
-  SKINNABLE: "skinnable",
-  URL: "url"
-};
-
-const legacyAvatarIds = avatars.map(a => a.id);
-export function getAvatarType(avatarId) {
-  if (!avatarId || legacyAvatarIds.indexOf(avatarId) !== -1) return AVATAR_TYPES.LEGACY;
-  if (avatarId.startsWith("http")) return AVATAR_TYPES.URL;
-  return AVATAR_TYPES.SKINNABLE;
-}
-
-export async function getAvatarSrc(avatarId) {
-  switch (getAvatarType(avatarId)) {
-    case AVATAR_TYPES.LEGACY:
-      return `#${avatarId}`;
-    case AVATAR_TYPES.SKINNABLE:
-      return fetch(getReticulumFetchUrl(`/api/v1/avatars/${avatarId}`))
-        .then(r => r.json())
-        .then(({ avatars }) => avatars[0].gltf_url);
-  }
-  return avatarId;
-}

--- a/src/components/ik-controller.js
+++ b/src/components/ik-controller.js
@@ -1,6 +1,6 @@
 const { Vector3, Quaternion, Matrix4, Euler } = THREE;
 
-import { AVATAR_TYPES } from "../assets/avatars/avatars";
+import { AVATAR_TYPES } from "../utils/avatar-utils";
 
 function quaternionAlmostEquals(epsilon, u, v) {
   // Note: q and -q represent same rotation

--- a/src/components/player-info.js
+++ b/src/components/player-info.js
@@ -1,5 +1,5 @@
 import { injectCustomShaderChunks } from "../utils/media-utils";
-import { AVATAR_TYPES } from "../assets/avatars/avatars";
+import { AVATAR_TYPES } from "../utils/avatar-utils";
 /**
  * Sets player info state, including avatar choice and display name.
  * @namespace avatar

--- a/src/react-components/profile-entry-panel.js
+++ b/src/react-components/profile-entry-panel.js
@@ -6,7 +6,7 @@ import styles from "../assets/stylesheets/profile.scss";
 import classNames from "classnames";
 import hubLogo from "../assets/images/hub-preview-white.png";
 import { WithHoverSound } from "./wrap-with-audio";
-import { AVATAR_TYPES, getAvatarType } from "../assets/avatars/avatars";
+import { AVATAR_TYPES, getAvatarType } from "../utils/avatar-utils";
 import { handleTextFieldFocus, handleTextFieldBlur } from "../utils/focus-utils";
 
 import AvatarEditor from "./avatar-editor";

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -16,7 +16,7 @@ import {
   forceExitFrom2DInterstitial
 } from "./utils/vr-interstitial";
 import { ObjectContentOrigins } from "./object-types";
-import { getAvatarSrc, getAvatarType } from "./assets/avatars/avatars";
+import { getAvatarSrc, getAvatarType } from "./utils/avatar-utils";
 import { pushHistoryState } from "./utils/history";
 import { SOUND_ENTER_SCENE } from "./systems/sound-effects-system";
 

--- a/src/utils/avatar-utils.js
+++ b/src/utils/avatar-utils.js
@@ -1,0 +1,33 @@
+import { getReticulumFetchUrl } from "./phoenix-utils";
+import { proxiedUrlFor } from "./media-utils";
+import { avatars } from "../assets/avatars/avatars";
+
+export const AVATAR_TYPES = {
+  LEGACY: "legacy",
+  SKINNABLE: "skinnable",
+  URL: "url"
+};
+
+const legacyAvatarIds = avatars.map(a => a.id);
+export function getAvatarType(avatarId) {
+  if (!avatarId || legacyAvatarIds.indexOf(avatarId) !== -1) return AVATAR_TYPES.LEGACY;
+  if (avatarId.startsWith("http")) return AVATAR_TYPES.URL;
+  return AVATAR_TYPES.SKINNABLE;
+}
+
+console.log("loading avatars.js");
+export async function getAvatarSrc(avatarId) {
+  console.log("getAvatarSrc");
+  switch (getAvatarType(avatarId)) {
+    case AVATAR_TYPES.LEGACY:
+      return `#${avatarId}`;
+    case AVATAR_TYPES.SKINNABLE:
+      return fetch(getReticulumFetchUrl(`/api/v1/avatars/${avatarId}`))
+        .then(r => r.json())
+        .then(({ avatars }) => avatars[0].gltf_url);
+    case AVATAR_TYPES.URL:
+      return proxiedUrlFor(avatarId);
+  }
+
+  return avatarId;
+}


### PR DESCRIPTION
Same as the previous PR that attempted to do this, except this one doesn't break the homepage. (fix was to move the avatar utility functions into their own file so they don't get included by the login flow code that exists in index.js)