### PR TITLE
Read Discord presence data from new profile field

### DIFF
--- a/src/components/pin-networked-object-button.js
+++ b/src/components/pin-networked-object-button.js
@@ -80,7 +80,11 @@ AFRAME.registerComponent("pin-networked-object-button", {
     } else {
       const channels = [];
       for (const p of Object.values(presences)) {
-        Array.prototype.push.apply(channels, p.metas.map(m => m.context.discord).filter(ch => !!ch));
+        for (const m of p.metas) {
+          if (m.profile && m.profile.discordBridges) {
+            Array.prototype.push.apply(channels, m.profile.discordBridges.map(b => b.channel.name));
+          }
+        }
       }
       return channels;
     }

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -833,7 +833,11 @@ class UIRoot extends Component {
     } else {
       const channels = [];
       for (const p of Object.values(this.props.presences)) {
-        Array.prototype.push.apply(channels, p.metas.map(m => m.context.discord).filter(ch => !!ch));
+        for (const m of p.metas) {
+          if (m.profile && m.profile.discordBridges) {
+            Array.prototype.push.apply(channels, m.profile.discordBridges.map(b => b.channel.name));
+          }
+        }
       }
       return channels;
     }


### PR DESCRIPTION
See https://github.com/MozillaReality/hubs-discord-bot/pull/49. It was necessary to move this into the "profile" field so that it could be easily updated by the bot without reconnecting. While we're at it, now there's lots more information about the bridges in there (both channel and guild name and ID) so we can make much nicer UI with it.