### PR TITLE
Friendly display names

### DIFF
--- a/src/assets/stylesheets/client-info-dialog.scss
+++ b/src/assets/stylesheets/client-info-dialog.scss
@@ -1,9 +1,21 @@
 @import 'shared';
 
+:local(.client-info-dialog) {
+  .dialog__box__contents__title {
+    margin-bottom: 10px;
+  }
+}
+
 :local(.title) {
   text-align: center;
   font-weight: bold;
   margin: 0 12px;
+}
+
+:local(.community-identifier) {
+  font-size: 12pt;
+  font-weight: normal;
+  margin-top: 3px;
 }
 
 :local(.client-info) {

--- a/src/assets/stylesheets/client-info-dialog.scss
+++ b/src/assets/stylesheets/client-info-dialog.scss
@@ -30,6 +30,8 @@
 }
 
 :local(.client-profile-image) {
+  min-width: 200px;
+
   img {
     border-radius: 12px;
     width: auto;

--- a/src/assets/stylesheets/client-info-dialog.scss
+++ b/src/assets/stylesheets/client-info-dialog.scss
@@ -36,7 +36,6 @@
     border-radius: 12px;
     width: auto;
     height: 240px;
-    filter: brightness(1.1) contrast(1.1);
   }
 
   margin: 0px 80px;

--- a/src/components/player-info.js
+++ b/src/components/player-info.js
@@ -12,6 +12,7 @@ AFRAME.registerComponent("player-info", {
   },
   init() {
     this.displayName = null;
+    this.communityIdentifier = null;
     this.applyProperties = this.applyProperties.bind(this);
     this.updateDisplayName = this.updateDisplayName.bind(this);
     this.applyDisplayName = this.applyDisplayName.bind(this);
@@ -52,12 +53,17 @@ AFRAME.registerComponent("player-info", {
   updateDisplayNameFromPresenceMeta(presenceMeta) {
     const isModerator = presenceMeta.roles && presenceMeta.roles.moderator;
     this.displayName = presenceMeta.profile.displayName + (isModerator ? " *" : "");
+    this.communityIdentifier = presenceMeta.profile.communityIdentifier;
     this.applyDisplayName();
   },
   applyDisplayName() {
     const nametagEl = this.el.querySelector(".nametag");
     if (this.displayName && nametagEl) {
       nametagEl.setAttribute("text", { value: this.displayName });
+    }
+    const communityIdentifierEl = this.el.querySelector(".communityIdentifier");
+    if (this.communityIdentifier && communityIdentifierEl) {
+      communityIdentifierEl.setAttribute("text", { value: this.communityIdentifier });
     }
   },
   applyProperties() {

--- a/src/hub.html
+++ b/src/hub.html
@@ -132,6 +132,15 @@
                                     position="0 1 0"
                                     scale="6 6 6"
                                 ></a-entity>
+                                <a-entity
+                                    class="communityIdentifier"
+                                    billboard
+                                    matrix-auto-update
+                                    text="side: double; align: center; color: #ddd"
+                                    visibility-while-frozen="withinDistance: 100; requireHoverOnNonMobile: false;"
+                                    position="0 0.8 0"
+                                    scale="3 3 3"
+                                ></a-entity>
                             </a-entity>
                         </template>
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -865,7 +865,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     };
 
     if (permsToken) {
-      params.perms_token = hubChannel.oauthFlowPermsToken;
+      params.perms_token = permsToken;
     }
 
     const { token } = store.state.credentials;

--- a/src/react-components/client-info-dialog.js
+++ b/src/react-components/client-info-dialog.js
@@ -70,14 +70,19 @@ export default class ClientInfoDialog extends Component {
     const { hubChannel, clientId, onClose } = this.props;
     const metas = presence[1].metas;
     const meta = metas[metas.length - 1];
-    const displayName = meta.profile.displayName;
-    const title = <div className={styles.title}>{displayName}</div>;
+    const { displayName, communityIdentifier } = meta.profile;
+    const title = (
+      <div className={styles.title}>
+        {displayName}
+        <div className={styles.communityIdentifier}>{communityIdentifier}</div>
+      </div>
+    );
     const mayKick = hubChannel.canOrWillIfCreator("kick_users");
     const mayMute = hubChannel.canOrWillIfCreator("mute_users");
     const isHidden = hubChannel.isHidden(clientId);
 
     return (
-      <DialogContainer title={title} wide={true} {...this.props}>
+      <DialogContainer className={styles.clientInfoDialog} title={title} wide={true} {...this.props}>
         <div className={styles.roomInfo}>
           <div className={styles.clientProfileImage}>
             <img src={profileAvatarPlaceholder} />

--- a/src/react-components/client-info-dialog.js
+++ b/src/react-components/client-info-dialog.js
@@ -2,9 +2,9 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import DialogContainer from "./dialog-container.js";
 import styles from "../assets/stylesheets/client-info-dialog.scss";
-import profileAvatarPlaceholder from "../assets/images/profile-avatar-placeholder.jpg";
 import { FormattedMessage } from "react-intl";
 import { sluglessPath } from "../utils/history";
+import { getAvatarThumbnailUrl } from "../utils/avatar-utils";
 
 export function getClientInfoClientId(location) {
   const { search } = location;
@@ -23,6 +23,10 @@ export default class ClientInfoDialog extends Component {
     presences: PropTypes.object,
     performConditionalSignIn: PropTypes.func,
     onClose: PropTypes.func
+  };
+
+  state = {
+    avatarThumbnailUrl: null
   };
 
   kick() {
@@ -61,16 +65,29 @@ export default class ClientInfoDialog extends Component {
     onClose();
   }
 
-  render() {
+  getPresenceProfile() {
     if (!this.props.presences) return null;
 
     const presence = Object.entries(this.props.presences).find(([k]) => k === this.props.clientId);
     if (!presence) return null;
 
-    const { hubChannel, clientId, onClose } = this.props;
     const metas = presence[1].metas;
-    const meta = metas[metas.length - 1];
-    const { displayName, communityIdentifier } = meta.profile;
+    return metas[metas.length - 1].profile;
+  }
+
+  componentDidMount() {
+    const { avatarId } = this.getPresenceProfile();
+    if (avatarId) {
+      getAvatarThumbnailUrl(avatarId).then(avatarThumbnailUrl => this.setState({ avatarThumbnailUrl }));
+    }
+  }
+
+  render() {
+    const profile = this.getPresenceProfile();
+    if (!profile) return null;
+
+    const { displayName, communityIdentifier } = profile;
+    const { hubChannel, clientId, onClose } = this.props;
     const title = (
       <div className={styles.title}>
         {displayName}
@@ -85,7 +102,7 @@ export default class ClientInfoDialog extends Component {
       <DialogContainer className={styles.clientInfoDialog} title={title} wide={true} {...this.props}>
         <div className={styles.roomInfo}>
           <div className={styles.clientProfileImage}>
-            <img src={profileAvatarPlaceholder} />
+            <img src={this.state.avatarThumbnailUrl} />
           </div>
           <div className={styles.clientActionButtons}>
             {!isHidden && (

--- a/src/utils/avatar-utils.js
+++ b/src/utils/avatar-utils.js
@@ -15,13 +15,17 @@ export function getAvatarType(avatarId) {
   return AVATAR_TYPES.SKINNABLE;
 }
 
-async function fetchAvatarGltfUrl(avatarId) {
+async function fetchAvatar(avatarId) {
   const resp = await fetch(getReticulumFetchUrl(`/api/v1/avatars/${avatarId}`));
   if (resp.status === 404) {
     return null;
   } else {
-    return resp.json().then(({ avatars }) => avatars[0].gltf_url);
+    return resp.json().then(({ avatars }) => avatars[0]);
   }
+}
+
+async function fetchAvatarGltfUrl(avatarId) {
+  return fetchAvatar(avatarId).then(avatar => avatar.gltf_url);
 }
 
 export function getAvatarSrc(avatarId) {
@@ -45,5 +49,16 @@ export function getAvatarGltfUrl(avatarId) {
       return fetchAvatarGltfUrl(avatarId);
     case AVATAR_TYPES.URL:
       return proxiedUrlFor(avatarId);
+  }
+}
+
+export async function getAvatarThumbnailUrl(avatarId) {
+  switch (getAvatarType(avatarId)) {
+    case AVATAR_TYPES.LEGACY:
+      return avatars.find(avatar => avatar.id === avatarId).thumbnail;
+    case AVATAR_TYPES.SKINNABLE:
+      return fetchAvatar(avatarId).then(avatar => avatar.files.thumbnail);
+    default:
+      return "https://asset-bundles-prod.reticulum.io/bots/avatar_unavailable.png";
   }
 }


### PR DESCRIPTION
- Show new `communityIdentifier` presence field in avatar nametag in pause mode, and in user info panel.
- Fix flow for unverified discord users
- Show avatar thumbnail in user info panel

Goes with https://github.com/mozilla/reticulum/pull/178