### PR TITLE
Add preview to avatar admin

### DIFF
--- a/src/react-components/admin/avatar-listings.js
+++ b/src/react-components/admin/avatar-listings.js
@@ -7,6 +7,7 @@ import {
   Edit,
   SimpleForm,
   TextInput,
+  NumberInput,
   EditButton,
   SelectInput,
   Datagrid,
@@ -28,6 +29,8 @@ export const AvatarListingEdit = props => (
     <SimpleForm>
       <TextInput source="name" />
       <TextInput source="description" />
+      <TextInput source="attribution" />
+      <NumberInput source="order" />
       <SelectInput source="state" choices={[{ id: "active", name: "active" }, { id: "delisted", name: "delisted" }]} />
     </SimpleForm>
   </Edit>
@@ -46,6 +49,7 @@ export const AvatarListingList = props => (
         defaultImage="https://asset-bundles-prod.reticulum.io/bots/avatar_unavailable.png"
       />
       <TextField source="name" />
+      <TextField source="order" />
       <AvatarLink source="avatar_listing_sid" />
       <ConditionalReferenceField reference="avatar_listings" source="parent_avatar_listing_id">
         <TextField source="name" />
@@ -54,6 +58,7 @@ export const AvatarListingList = props => (
       <OwnedFileImage source="emissive_map_owned_file_id" aspect="square" />
       <OwnedFileImage source="normal_map_owned_file_id" aspect="square" />
       <OwnedFileImage source="orm_map_owned_file_id" aspect="square" />
+      <TextField source="attributions" />
       <BooleanField source="allow_remixing" />
       <TextField source="reviewed_at" />
       <DateField source="inserted_at" />

--- a/src/react-components/admin/avatars.js
+++ b/src/react-components/admin/avatars.js
@@ -68,13 +68,15 @@ const rowStyle = record => ({
 
 export const AvatarList = props => (
   <List {...props} filters={<AvatarFilter />} bulkActionButtons={false}>
-    <Datagrid rowStyle={rowStyle} expand={<Preview />}>
+    <Datagrid rowStyle={rowStyle}>
       <OwnedFileImage
         source="thumbnail_owned_file_id"
         aspect="tall"
         defaultImage="https://asset-bundles-prod.reticulum.io/bots/avatar_unavailable.png"
       />
+      <Preview />
       <TextField source="name" />
+      <TextField source="account_id" />
       <AvatarLink source="avatar_sid" />
       <ConditionalReferenceField reference="avatars" source="parent_avatar_id">
         <TextField source="name" />

--- a/src/react-components/admin/avatars.js
+++ b/src/react-components/admin/avatars.js
@@ -17,6 +17,13 @@ import {
   BooleanField,
   Filter
 } from "react-admin";
+import { withStyles } from "@material-ui/core/styles";
+
+// Quite ugly but simplest way to have AvatarPreview work is to import aframe.
+// We can technically untangle the dependencies for this, but doesn't seem worth it for admin.
+import "aframe";
+import AvatarPreview from "../avatar-preview";
+import { getReticulumFetchUrl } from "../../utils/phoenix-utils";
 
 const AvatarFilter = props => (
   <Filter {...props}>
@@ -38,13 +45,30 @@ export const AvatarEdit = props => (
   </Edit>
 );
 
+const styles = {
+  preview: {
+    flex: 1,
+    borderRadius: 20,
+    overflow: "hidden",
+    width: 200,
+    height: 200 * (16 / 9)
+  }
+};
+
+const Preview = withStyles(styles)(({ record, classes }) => (
+  <AvatarPreview
+    className={classes.preview}
+    avatarGltfUrl={getReticulumFetchUrl(`/api/v1/avatars/${record.avatar_sid}/avatar.gltf?v=${record.updated_at}`)}
+  />
+));
+
 const rowStyle = record => ({
   opacity: record.state === "removed" ? 0.3 : 1
 });
 
 export const AvatarList = props => (
   <List {...props} filters={<AvatarFilter />} bulkActionButtons={false}>
-    <Datagrid rowStyle={rowStyle}>
+    <Datagrid rowStyle={rowStyle} expand={<Preview />}>
       <OwnedFileImage
         source="thumbnail_owned_file_id"
         aspect="tall"

--- a/src/react-components/admin/avatars.js
+++ b/src/react-components/admin/avatars.js
@@ -47,11 +47,8 @@ export const AvatarEdit = props => (
 
 const styles = {
   preview: {
-    flex: 1,
-    borderRadius: 20,
-    overflow: "hidden",
-    width: 200,
-    height: 200 * (16 / 9)
+    height: 200,
+    width: 200 * (9 / 16)
   }
 };
 

--- a/src/react-components/admin/avatars.js
+++ b/src/react-components/admin/avatars.js
@@ -86,7 +86,7 @@ export const AvatarList = props => (
       <OwnedFileImage source="emissive_map_owned_file_id" aspect="square" />
       <OwnedFileImage source="normal_map_owned_file_id" aspect="square" />
       <OwnedFileImage source="orm_map_owned_file_id" aspect="square" />
-
+      <TextField source="attributions" />
       <BooleanField source="allow_remixing" />
       <BooleanField source="allow_promotion" />
       <TextField source="reviewed_at" />

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -295,7 +295,7 @@ module.exports = (env, argv) => ({
     new HTMLWebpackPlugin({
       filename: "admin.html",
       template: path.join(__dirname, "src", "admin.html"),
-      chunks: ["vendor", "admindeps", "admin"]
+      chunks: ["vendor", "engine", "admindeps", "admin"]
     }),
     new CopyWebpackPlugin([
       {


### PR DESCRIPTION
Adds preview as a column for avatars in the admin panel, and exposes account, order and attribution columns.