### PR TITLE
Fix appleOS/Safari/High-DPI avatar creation bugs

### DIFF
--- a/src/assets/stylesheets/avatar-editor.scss
+++ b/src/assets/stylesheets/avatar-editor.scss
@@ -15,10 +15,10 @@
   }
 
   .info {
-    display: flex;
-    justify-content: center;
+    text-align: center;
     width: 100%;
     color: $grey-text;
+    margin: 1em 0;
 
     p {
       margin: 0;
@@ -38,10 +38,12 @@
     flex: 1;
     align-items: center;
     overflow: auto;
+    @media (min-width: 768px) {
+      padding-top: 2em;
+    }
   }
 
   .form-body {
-    flex: 1.2;
     display: flex;
     flex-direction: column;
 
@@ -116,7 +118,6 @@
   }
 
   .preview {
-    flex: 1;
     margin-left: 2em;
     height: 450px;
     max-width: 200px;
@@ -135,8 +136,8 @@
   }
 
   .split {
-    flex: 1;
-    display: flex;
+    display: grid;
+    grid-template: 100% / 55% 45%;
     align-items: center;
   }
 

--- a/src/utils/image-bitmap-utils.js
+++ b/src/utils/image-bitmap-utils.js
@@ -5,18 +5,29 @@ export const createImageBitmap =
       // https://dev.to/nektro/createimagebitmap-polyfill-for-safari-and-edge-228
       // https://gist.github.com/MonsieurV/fb640c29084c171b4444184858a91bc7
 
-      const canvas = document.createElement("canvas");
-      const ctx = canvas.getContext("2d");
-      canvas.width = data.width;
-      canvas.height = data.height;
-      ctx.putImageData(data, 0, 0);
-      const dataURL = canvas.toDataURL();
+      let srcUrl;
+      if (data instanceof Blob) {
+        srcUrl = URL.createObjectURL(data);
+      } else {
+        const canvas = document.createElement("canvas");
+        const ctx = canvas.getContext("2d");
+        canvas.width = data.width;
+        canvas.height = data.height;
+        ctx.putImageData(data, 0, 0);
+        srcUrl = canvas.toDataURL();
+      }
       const img = document.createElement("img");
 
-      img.addEventListener("load", function() {
-        resolve(this);
-      });
+      img.addEventListener("load", () => resolve(img));
 
-      img.src = dataURL;
+      img.src = srcUrl;
     });
   };
+
+export function disposeImageBitmap(imageBitmap) {
+  if (imageBitmap instanceof HTMLImageElement && imageBitmap.src.startsWith("blob:")) {
+    URL.revokeObjectURL(imageBitmap.src);
+  } else {
+    imageBitmap.close && imageBitmap.close();
+  }
+}


### PR DESCRIPTION
- createImageBitmap polyfill now supports Blobs in addition to ImageData. Uses ObjectURLs when a blob is passed in. Added corresponding disposeImageBitmap to handle disposing real ImageBitmaps and HTMLImageElements with an ObjectURL src.
- Don't use devicePixelRatio for the snapshot canvas
- Fix weblg2 alpha in Safari

Fixes #1346, #1347 