### PR TITLE
Fix more avatar browser bugs

### DIFF
--- a/src/react-components/avatar-preview.js
+++ b/src/react-components/avatar-preview.js
@@ -161,6 +161,7 @@ export default class AvatarPreview extends Component {
         this.avatar = null;
       }
       if (this.props.avatarGltfUrl) {
+        this.setState({ loading: true });
         await this.loadPreviewAvatar(this.props.avatarGltfUrl).then(this.setAvatar);
       }
     }

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -212,16 +212,12 @@ class MediaBrowser extends Component {
   };
 
   showCustomMediaDialog = source => {
-    this.pushExitMediaBrowserHistory();
-    pushHistoryState(
-      this.props.history,
-      "modal",
-      source === "scene_listings" || source === "scenes"
-        ? "change_scene"
-        : source === "avatar_listings" || source === "avatar"
-          ? "avatar_url"
-          : "create"
-    );
+    const isSceneApiType = source === "scene_listings" || source === "scenes";
+    // Note: The apiSource for avatars *is* actually singular. We should probably fix this on the backend.
+    const isAvatarApiType = source === "avatar_listings" || source === "avatar";
+    this.pushExitMediaBrowserHistory(!isAvatarApiType);
+    const dialog = isSceneApiType ? "change_scene" : isAvatarApiType ? "avatar_url" : "create";
+    pushHistoryState(this.props.history, "modal", dialog);
   };
 
   close = () => {
@@ -249,6 +245,7 @@ class MediaBrowser extends Component {
     const apiSource = (hasMeta && this.state.result.meta.source) || null;
     const isVariableWidth = this.state.result && ["bing_images", "tenor"].includes(apiSource);
     const isSceneApiType = apiSource === "scene_listings" || apiSource === "scenes";
+    // Note: The apiSource for avatars *is* actually singular. We should probably fix this on the backend.
     const isAvatarApiType = apiSource === "avatar_listings" || apiSource === "avatar";
     const showCustomOption = !isSceneApiType || this.props.hubChannel.canOrWillIfCreator("update_hub");
     const [createTileWidth, createTileHeight] = this.getTileDimensions(false, urlSource === "avatars");

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -218,7 +218,7 @@ class MediaBrowser extends Component {
       "modal",
       source === "scene_listings" || source === "scenes"
         ? "change_scene"
-        : source === "avatars"
+        : source === "avatar_listings" || source === "avatar"
           ? "avatar_url"
           : "create"
     );
@@ -249,7 +249,7 @@ class MediaBrowser extends Component {
     const apiSource = (hasMeta && this.state.result.meta.source) || null;
     const isVariableWidth = this.state.result && ["bing_images", "tenor"].includes(apiSource);
     const isSceneApiType = apiSource === "scene_listings" || apiSource === "scenes";
-    const isAvatarApiType = apiSource === "avatar_listings" || apiSource === "avatars";
+    const isAvatarApiType = apiSource === "avatar_listings" || apiSource === "avatar";
     const showCustomOption = !isSceneApiType || this.props.hubChannel.canOrWillIfCreator("update_hub");
     const [createTileWidth, createTileHeight] = this.getTileDimensions(false, urlSource === "avatars");
     const entries = (this.state.result && this.state.result.entries) || [];
@@ -259,7 +259,7 @@ class MediaBrowser extends Component {
     if (this.state.selectNextResult) return <div />;
     const handleCustomClicked = apiSource => {
       if (isAvatarApiType) {
-        this.showCustomMediaDialog(urlSource);
+        this.showCustomMediaDialog(apiSource);
       } else {
         this.props.performConditionalSignIn(
           () => !isSceneApiType || this.props.hubChannel.can("update_hub"),

--- a/src/react-components/profile-entry-panel.js
+++ b/src/react-components/profile-entry-panel.js
@@ -12,6 +12,7 @@ import { WithHoverSound } from "./wrap-with-audio";
 import { AVATAR_TYPES, getAvatarGltfUrl, getAvatarType } from "../utils/avatar-utils";
 import { handleTextFieldFocus, handleTextFieldBlur } from "../utils/focus-utils";
 import { replaceHistoryState } from "../utils/history";
+import { proxiedUrlFor } from "../utils/media-utils";
 import StateLink from "./state-link";
 
 import AvatarPreview from "./avatar-preview";
@@ -51,7 +52,7 @@ class ProfileEntryPanel extends Component {
     const avatarType = getAvatarType(avatarId);
     const newState = { displayName, avatarId, avatarType };
     if (avatarType === AVATAR_TYPES.URL) {
-      newState.avatarGltfUrl = avatarId;
+      newState.avatarGltfUrl = proxiedUrlFor(avatarId);
     }
     return newState;
   };

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -151,12 +151,12 @@ export default class SceneEntryManager {
   };
 
   _setPlayerInfoFromProfile = async () => {
-    const { avatarId } = this.store.state.profile;
+    let avatarId = this.store.state.profile.avatarId;
     let avatarSrc = await getAvatarSrc(avatarId);
 
     if (!avatarSrc) {
       this.store.resetToRandomLegacyAvatar();
-      const { avatarId } = this.store.state.profile;
+      avatarId = this.store.state.profile.avatarId;
       avatarSrc = await getAvatarSrc(avatarId);
     }
 

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -141,8 +141,7 @@ export default class SceneEntryManager {
   };
 
   _setupPlayerRig = () => {
-    this._updatePlayerInfoFromProfile();
-    this.store.addEventListener("statechanged", this._updatePlayerInfoFromProfile);
+    this._setPlayerInfoFromProfile();
 
     const avatarScale = parseInt(qs.get("avatar_scale"), 10);
 
@@ -151,10 +150,18 @@ export default class SceneEntryManager {
     }
   };
 
-  _updatePlayerInfoFromProfile = async () => {
+  _setPlayerInfoFromProfile = async () => {
     const { avatarId } = this.store.state.profile;
-    const avatarSrc = await getAvatarSrc(avatarId);
+    let avatarSrc = await getAvatarSrc(avatarId);
+
+    if (!avatarSrc) {
+      this.store.resetToRandomLegacyAvatar();
+      const { avatarId } = this.store.state.profile;
+      avatarSrc = await getAvatarSrc(avatarId);
+    }
+
     this.playerRig.setAttribute("player-info", { avatarSrc, avatarType: getAvatarType(avatarId) });
+    this.store.addEventListener("statechanged", this._setPlayerInfoFromProfile);
   };
 
   _setupKicking = () => {

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -124,7 +124,7 @@ export default class Store extends EventTarget {
     const oauthFlowCredentials = Cookies.getJSON(OAUTH_FLOW_CREDENTIALS_KEY);
     if (oauthFlowCredentials) {
       this.update({ credentials: oauthFlowCredentials });
-      this.clearAvatar();
+      this.resetToRandomLegacyAvatar();
       Cookies.remove(OAUTH_FLOW_CREDENTIALS_KEY);
     }
   }
@@ -141,7 +141,7 @@ export default class Store extends EventTarget {
     }
   };
 
-  clearAvatar = () => {
+  resetToRandomLegacyAvatar = () => {
     this.update({
       profile: { ...(this.state.profile || {}), ...generateDefaultProfile() }
     });

--- a/src/utils/auth-channel.js
+++ b/src/utils/auth-channel.js
@@ -24,7 +24,7 @@ export default class AuthChannel {
       await hubChannel.signOut();
     }
     this.store.update({ credentials: { token: null, email: null } });
-    this.store.clearAvatar();
+    this.store.resetToRandomLegacyAvatar();
     this._signedIn = false;
   };
 


### PR DESCRIPTION
- If the avatar in your local storage 404s, reset to one of the legacy avatars.
- Fix custom avatar url dialog
- Fix avatar preview to support custom url avatars
- Fix loader animation in avatar preview when switching avatars
- Fix incorrect media browser param stashing when exiting custom url dialog