### PR TITLE
Extend maximum raycast distance to 25 meters

### DIFF
--- a/src/components/cursor-controller.js
+++ b/src/components/cursor-controller.js
@@ -10,8 +10,9 @@ AFRAME.registerComponent("cursor-controller", {
   schema: {
     cursor: { type: "selector" },
     camera: { type: "selector" },
-    far: { default: 4 },
+    far: { default: 25 },
     near: { default: 0.01 },
+    defaultDistance: { default: 4 },
     minDistance: { default: 0.18 }
   },
 
@@ -81,7 +82,7 @@ AFRAME.registerComponent("cursor-controller", {
         );
         intersection = rawIntersections[0];
         interaction.updateCursorIntersection(intersection);
-        this.distance = intersection ? intersection.distance : this.data.far;
+        this.distance = intersection ? intersection.distance : this.data.defaultDistance;
       }
 
       const { cursor, minDistance, far, camera } = this.data;


### PR DESCRIPTION
I chose 25 meters because it's a distance at which the "highlight" effect and cursor are still barely visible on small objects, so it's unlikely that you will find that your cursor got "lost" because you're hovering over a large object far away.

I'm sure there is some better strategy for how to draw selections on faraway objects rather than this awkward position-a-little-ball business, but I'm not sure what it is and this is an easy thing to do.