### PR TITLE
Support selecting real avatar listings

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -407,7 +407,8 @@ async function handleHubChannelJoined(entryManager, hubChannel, messageDispatch,
   remountUI({
     onSendMessage: messageDispatch.dispatch,
     onMediaSearchResultEntrySelected: entry => scene.emit("action_selected_media_result_entry", entry),
-    onMediaSearchCancelled: entry => scene.emit("action_media_search_cancelled", entry)
+    onMediaSearchCancelled: entry => scene.emit("action_media_search_cancelled", entry),
+    onAvatarSaved: entry => scene.emit("action_avatar_saved", entry)
   });
 
   scene.addEventListener("action_selected_media_result_entry", e => {

--- a/src/react-components/profile-entry-panel.js
+++ b/src/react-components/profile-entry-panel.js
@@ -9,10 +9,9 @@ import { SCHEMA } from "../storage/store";
 import styles from "../assets/stylesheets/profile.scss";
 import hubLogo from "../assets/images/hub-preview-white.png";
 import { WithHoverSound } from "./wrap-with-audio";
-import { AVATAR_TYPES, getAvatarGltfUrl, getAvatarType } from "../utils/avatar-utils";
+import { fetchAvatar } from "../utils/avatar-utils";
 import { handleTextFieldFocus, handleTextFieldBlur } from "../utils/focus-utils";
 import { replaceHistoryState } from "../utils/history";
-import { proxiedUrlFor } from "../utils/media-utils";
 import StateLink from "./state-link";
 
 import AvatarPreview from "./avatar-preview";
@@ -31,9 +30,8 @@ class ProfileEntryPanel extends Component {
 
   state = {
     avatarId: null,
-    avatarType: null,
     displayName: null,
-    avatarGltfUrl: null
+    avatar: null
   };
 
   constructor(props) {
@@ -41,7 +39,6 @@ class ProfileEntryPanel extends Component {
     this.state = this.getStateFromProfile();
     if (props.avatarId) {
       this.state.avatarId = props.avatarId;
-      this.state.avatarType = getAvatarType(this.state.avatarId);
     }
     this.props.store.addEventListener("statechanged", this.storeUpdated);
     this.scene = document.querySelector("a-scene");
@@ -49,12 +46,7 @@ class ProfileEntryPanel extends Component {
 
   getStateFromProfile = () => {
     const { displayName, avatarId } = this.props.store.state.profile;
-    const avatarType = getAvatarType(avatarId);
-    const newState = { displayName, avatarId, avatarType };
-    if (avatarType === AVATAR_TYPES.URL) {
-      newState.avatarGltfUrl = proxiedUrlFor(avatarId);
-    }
-    return newState;
+    return { displayName, avatarId };
   };
 
   storeUpdated = () => this.setState(this.getStateFromProfile());
@@ -84,19 +76,14 @@ class ProfileEntryPanel extends Component {
   };
 
   setAvatarFromMediaResult = ({ detail: entry }) => {
-    this.setState({
-      avatarId: entry.id,
-      avatarType: getAvatarType(entry.id),
-      avatarGltfUrl: entry.gltfs.avatar
-    });
+    this.setState({ avatarId: entry.id });
     // Replace history state with the current avatar id since this component gets destroyed when we open the
     // avatar editor and we want the back button to work. We read the history state back via the avatarId prop.
     // We read the current state key from history since it could be "overlay" or "entry_step".
     replaceHistoryState(this.props.history, this.props.history.location.state.key, "profile", { avatarId: entry.id });
   };
 
-  async componentDidMount() {
-    this.setState({ avatarGltfUrl: await getAvatarGltfUrl(this.state.avatarId) });
+  componentDidMount() {
     if (this.nameInput) {
       // stop propagation so that avatar doesn't move when wasd'ing during text input.
       this.nameInput.addEventListener("keydown", this.stopPropagation);
@@ -104,6 +91,16 @@ class ProfileEntryPanel extends Component {
       this.nameInput.addEventListener("keyup", this.stopPropagation);
     }
     this.scene.addEventListener("action_selected_media_result_entry", this.setAvatarFromMediaResult);
+    // This handles editing avatars in the entry_step, since this component remains mounted with the same avatarId
+    this.scene.addEventListener("action_avatar_saved", this.refetchAvatar);
+
+    this.refetchAvatar();
+  }
+
+  componentDidUpdate(_prevProps, prevState) {
+    if (prevState.avatarId !== this.state.avatarId) {
+      this.refetchAvatar();
+    }
   }
 
   componentWillUnmount() {
@@ -114,7 +111,14 @@ class ProfileEntryPanel extends Component {
       this.nameInput.removeEventListener("keyup", this.stopPropagation);
     }
     this.scene.removeEventListener("action_selected_media_result_entry", this.setAvatarFromMediaResult);
+    this.scene.removeEventListener("action_avatar_saved", this.refetchAvatar);
   }
+
+  refetchAvatar = async () => {
+    const avatar = await fetchAvatar(this.state.avatarId);
+    if (this.state.avatarId !== avatar.avatar_id) return; // This is an old result, ignore it
+    this.setState({ avatar });
+  };
 
   render() {
     const { formatMessage } = this.props.intl;
@@ -151,21 +155,25 @@ class ProfileEntryPanel extends Component {
               <FormattedMessage id="profile.choose_avatar" />
             </a>
 
-            <div className={styles.preview}>
-              <AvatarPreview avatarGltfUrl={this.state.avatarGltfUrl} />
+            {this.state.avatar ? (
+              <div className={styles.preview}>
+                <AvatarPreview avatarGltfUrl={this.state.avatar.gltf_url} />
 
-              {this.state.avatarType === AVATAR_TYPES.SKINNABLE && (
-                <StateLink
-                  stateKey="overlay"
-                  stateValue="avatar-editor"
-                  stateDetail={{ avatarId: this.state.avatarId, hideDelete: true, returnToProfile: true }}
-                  history={this.props.history}
-                  className={styles.editAvatar}
-                >
-                  <FontAwesomeIcon icon={faPencilAlt} />
-                </StateLink>
-              )}
-            </div>
+                {this.state.avatar.account_id === this.props.store.credentialsAccountId && (
+                  <StateLink
+                    stateKey="overlay"
+                    stateValue="avatar-editor"
+                    stateDetail={{ avatarId: this.state.avatarId, hideDelete: true, returnToProfile: true }}
+                    history={this.props.history}
+                    className={styles.editAvatar}
+                  >
+                    <FontAwesomeIcon icon={faPencilAlt} />
+                  </StateLink>
+                )}
+              </div>
+            ) : (
+              <div className={styles.preview} />
+            )}
 
             <WithHoverSound>
               <input className={styles.formSubmit} type="submit" value={formatMessage({ id: "profile.save" })} />

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -165,6 +165,7 @@ class UIRoot extends Component {
     isCursorHoldingPen: PropTypes.bool,
     hasActiveCamera: PropTypes.bool,
     onMediaSearchResultEntrySelected: PropTypes.func,
+    onAvatarSaved: PropTypes.func,
     activeTips: PropTypes.object,
     location: PropTypes.object,
     history: PropTypes.object,
@@ -1480,6 +1481,7 @@ class UIRoot extends Component {
                       // my-avatars, now that we've saved an avatar.
                       this.props.mediaSearchStore.sourceNavigateWithNoNav("avatars");
                     }
+                    this.props.onAvatarSaved();
                   }}
                   onClose={() => this.props.history.goBack()}
                   store={this.props.store}

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -142,9 +142,9 @@ export default class SceneEntryManager {
 
   _setupPlayerRig = () => {
     this._setPlayerInfoFromProfile();
+    this.store.addEventListener("statechanged", this._setPlayerInfoFromProfile);
 
     const avatarScale = parseInt(qs.get("avatar_scale"), 10);
-
     if (avatarScale) {
       this.playerRig.setAttribute("scale", { x: avatarScale, y: avatarScale, z: avatarScale });
     }
@@ -155,7 +155,6 @@ export default class SceneEntryManager {
     const avatarSrc = await getAvatarSrc(avatarId);
 
     this.playerRig.setAttribute("player-info", { avatarSrc, avatarType: getAvatarType(avatarId) });
-    this.store.addEventListener("statechanged", this._setPlayerInfoFromProfile);
   };
 
   _setupKicking = () => {

--- a/src/utils/avatar-utils.js
+++ b/src/utils/avatar-utils.js
@@ -1,4 +1,4 @@
-import { getReticulumFetchUrl, fetchReticulumAuthenticated } from "./phoenix-utils";
+import { fetchReticulumAuthenticated } from "./phoenix-utils";
 import { proxiedUrlFor } from "./media-utils";
 import { avatars } from "../assets/avatars/avatars";
 

--- a/src/utils/avatar-utils.js
+++ b/src/utils/avatar-utils.js
@@ -54,17 +54,6 @@ export function getAvatarSrc(avatarId) {
   }
 }
 
-export function getAvatarGltfUrl(avatarId) {
-  switch (getAvatarType(avatarId)) {
-    case AVATAR_TYPES.LEGACY:
-      return avatars.find(avatar => avatar.id === avatarId).model;
-    case AVATAR_TYPES.SKINNABLE:
-      return fetchAvatarGltfUrl(avatarId);
-    case AVATAR_TYPES.URL:
-      return proxiedUrlFor(avatarId);
-  }
-}
-
 export async function getAvatarThumbnailUrl(avatarId) {
   switch (getAvatarType(avatarId)) {
     case AVATAR_TYPES.LEGACY:


### PR DESCRIPTION
Requires https://github.com/mozilla/reticulum/pull/179

Allows actually selecting avatar listings as an avatar. Only show the edit button when you have an avatar (not an avatar listing) selected, and you own it.

Using real avatar listings instead of legacy featured avatars still remains behind a flag (`use_avatar_listings`) so that we can test against the production database after configuring it correctly.

On production we will need to make sure all the featured avatar listings have their parent_avatar_listing_id set to the base avatar listing.