### PR TITLE
Fix Safari/WebView bugs

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -533,6 +533,14 @@ document.addEventListener("DOMContentLoaded", async () => {
   const detectedOS = detectOS(navigator.userAgent);
   const browser = detect();
   if (["iOS", "Mac OS"].includes(detectedOS) && ["safari", "ios"].includes(browser.name)) {
+    // If we appear to be in Safari but we don't have the mediaDevices API, then we are likely in a WebView preview
+    // used in apps like Twitter and Discord. So we show the dialog that tells users to open the room 
+    // in the real Safari.
+    if (!navigator.mediaDevices) {
+      remountUI({ showSafariDialog: true });
+      return;
+    }
+
     try {
       await navigator.mediaDevices.getUserMedia({ audio: true });
     } catch (e) {

--- a/src/hub.js
+++ b/src/hub.js
@@ -534,8 +534,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const browser = detect();
   if (["iOS", "Mac OS"].includes(detectedOS) && ["safari", "ios"].includes(browser.name)) {
     // If we appear to be in Safari but we don't have the mediaDevices API, then we are likely in a WebView preview
-    // used in apps like Twitter and Discord. So we show the dialog that tells users to open the room 
-    // in the real Safari.
+    // used in apps like Twitter and Discord. So we show the dialog that tells users to open the room in the real Safari.
     if (!navigator.mediaDevices) {
       remountUI({ showSafariDialog: true });
       return;

--- a/src/react-components/entry-buttons.js
+++ b/src/react-components/entry-buttons.js
@@ -97,17 +97,6 @@ export const DaydreamEntryButton = props => {
   return <EntryButton {...entryButtonProps} />;
 };
 
-export const SafariEntryButton = props => {
-  const entryButtonProps = {
-    ...props,
-    iconSrc: MobileScreenEntryImg,
-    prefixMessageId: "entry.screen-prefix",
-    mediumMessageId: "entry.mobile-safari"
-  };
-
-  return <EntryButton {...entryButtonProps} />;
-};
-
 export const DeviceEntryButton = props => {
   const entryButtonProps = {
     ...props,

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -26,13 +26,7 @@ import { getClientInfoClientId } from "./client-info-dialog";
 import { lang, messages } from "../utils/i18n";
 import Loader from "./loader";
 import AutoExitWarning from "./auto-exit-warning";
-import {
-  TwoDEntryButton,
-  DeviceEntryButton,
-  GenericEntryButton,
-  DaydreamEntryButton,
-  SafariEntryButton
-} from "./entry-buttons.js";
+import { TwoDEntryButton, DeviceEntryButton, GenericEntryButton, DaydreamEntryButton } from "./entry-buttons.js";
 import ProfileEntryPanel from "./profile-entry-panel";
 import MediaBrowser from "./media-browser";
 
@@ -144,6 +138,7 @@ class UIRoot extends Component {
     signInCompleteMessageId: PropTypes.string,
     signInContinueTextId: PropTypes.string,
     onContinueAfterSignIn: PropTypes.func,
+    showSafariDialog: PropTypes.bool,
     showSafariMicDialog: PropTypes.bool,
     showOAuthDialog: PropTypes.bool,
     oauthInfo: PropTypes.array,
@@ -205,6 +200,9 @@ class UIRoot extends Component {
     super(props);
     if (props.showSafariMicDialog) {
       this.state.dialog = <SafariMicDialog closable={false} />;
+    }
+    if (props.showSafariDialog) {
+      this.state.dialog = <SafariDialog closable={false} />;
     }
 
     props.mediaSearchStore.setHistory(props.history);
@@ -1027,11 +1025,6 @@ class UIRoot extends Component {
               <DaydreamEntryButton secondary={true} onClick={this.enterDaydream} subtitle={null} />
             )}
             <DeviceEntryButton secondary={true} onClick={() => this.attemptLink()} isInHMD={isMobileVR} />
-            {this.props.availableVREntryTypes.safari === VR_DEVICE_AVAILABILITY.maybe && (
-              <StateLink stateKey="modal" stateValue="safari" history={this.props.history}>
-                <SafariEntryButton onClick={this.showSafariDialog} />
-              </StateLink>
-            )}
             {this.props.availableVREntryTypes.screen === VR_DEVICE_AVAILABILITY.yes && (
               <TwoDEntryButton onClick={this.enter2D} />
             )}
@@ -1231,7 +1224,8 @@ class UIRoot extends Component {
     const isExited = this.state.exited || this.props.roomUnavailableReason || this.props.platformUnsupportedReason;
 
     const isLoading =
-      (!this.state.hideLoader || !this.state.didConnectToNetworkedScene) && !this.props.showSafariMicDialog;
+      (!this.state.hideLoader || !this.state.didConnectToNetworkedScene) &&
+      !(this.props.showSafariMicDialog || this.props.showSafariDialog);
 
     const rootStyles = {
       [styles.ui]: true,
@@ -1409,12 +1403,6 @@ class UIRoot extends Component {
               stateValue="help"
               history={this.props.history}
               render={() => this.renderDialog(HelpDialog)}
-            />
-            <StateRoute
-              stateKey="modal"
-              stateValue="safari"
-              history={this.props.history}
-              render={() => this.renderDialog(SafariDialog)}
             />
             <StateRoute
               stateKey="modal"

--- a/src/systems/sound-effects-system.js
+++ b/src/systems/sound-effects-system.js
@@ -37,6 +37,13 @@ export const SOUND_PIN = soundEnum++;
 export const SOUND_MEDIA_LOADING = soundEnum++;
 export const SOUND_MEDIA_LOADED = soundEnum++;
 
+// Safari doesn't support the promise form of decodeAudioData, so we polyfill it.
+function decodeAudioData(audioContext, arrayBuffer) {
+  return new Promise((resolve, reject) => {
+    audioContext.decodeAudioData(arrayBuffer, resolve, reject);
+  });
+}
+
 export class SoundEffectsSystem {
   constructor() {
     this.pendingEffects = [];
@@ -69,7 +76,7 @@ export class SoundEffectsSystem {
       if (!audioBufferPromise) {
         audioBufferPromise = fetch(url)
           .then(r => r.arrayBuffer())
-          .then(arrayBuffer => this.audioContext.decodeAudioData(arrayBuffer));
+          .then(arrayBuffer => decodeAudioData(this.audioContext, arrayBuffer));
         loading.set(url, audioBufferPromise);
       }
       return audioBufferPromise;

--- a/src/utils/debug-log.js
+++ b/src/utils/debug-log.js
@@ -5,18 +5,19 @@ const showLog = qsTruthy("debug_log");
 if (showLog) {
   const template = document.createElement("template");
   template.innerHTML = `
-	<style>
-	  #debug-log {
-		position: absolute;
-		top: 13em;
-		background: white;
-		opacity: 0.7;
+    <style>
+      #debug-log {
+        position: absolute;
+        top: 13em;
+        background: white;
+        opacity: 0.7;
+        z-index: 1000;
       }
       #debug-log, #debug-log-input {
-		font-family: monospace;
-		font-size: 11px;
-		width: 100%;
-	  }
+        font-family: monospace;
+        font-size: 11px;
+        width: 100%;
+      }
 
       #debug-log-controls {
         display: flex;
@@ -48,8 +49,8 @@ if (showLog) {
       }
       #debug-log-log .entry.error { background-color: pink; }
       #debug-log-log .entry.warn { background-color: orange; }
-	</style>
-	<div id="debug-log">
+    </style>
+    <div id="debug-log">
         <div id="debug-log-controls">
           <form id="debug-log-eval">
             <input id="debug-log-input" placeholder="&gt;&gt;" autocorrect="off" autocapitalize="none" />
@@ -57,8 +58,8 @@ if (showLog) {
           </form>
           <button id="debug-log-minimize">_</button>
         </div>
-		<div id="debug-log-log"></div>
-	</div>
+        <div id="debug-log-log"></div>
+    </div>
   `;
 
   document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
Previously we would allow Firefox and Chrome on iOS to load a room lobby and only then prompt you to switch to Safari. This is problematic since the WebView suffers from the same WebRTC negotiation bug that real Safari does, so you could get stuck on the loading screen if the bug was triggered. 
We were also failing to detect WebViews that are used by iOS apps such as Discord and Twitter. These apps launch links in to a "preview" WebView that look like real Safari, according to the useragent, except they don't actually have a `getUserMedia` API.

This PR now detects these WebViews correctly and immediately displays a dialog informing users to use real Safari.
Lastly, this PR works around Safari's promise-less `decodeAudioData` API, so that sound effects actually work.