### PR TITLE
Discord Bot Beta

### DIFF
--- a/src/discord.js
+++ b/src/discord.js
@@ -13,8 +13,7 @@ import en from "react-intl/locale-data/en";
 import { lang, messages } from "./utils/i18n";
 
 addLocaleData([...en]);
-const contactEmail = "hubs@mozilla.com";
-const contactSubject = "Hubs Discord Bot Invite";
+const inviteUrl = "https://forms.gle/GGPgarSuY5WaTNCT8";
 
 class DiscordLanding extends Component {
   componentDidMount() {}
@@ -47,7 +46,7 @@ class DiscordLanding extends Component {
                 </div>
                 <div className={styles.actionButtons}>
                   <a
-                    href={`mailto:${contactEmail}?subject=${encodeURIComponent(contactSubject)}`}
+                    href={inviteUrl}
                     className={styles.downloadButton}
                   >
                     <div>

--- a/src/discord.js
+++ b/src/discord.js
@@ -45,10 +45,7 @@ class DiscordLanding extends Component {
                   <FormattedMessage id="discord.secondary_tagline" />
                 </div>
                 <div className={styles.actionButtons}>
-                  <a
-                    href={inviteUrl}
-                    className={styles.downloadButton}
-                  >
+                  <a href={inviteUrl} className={styles.downloadButton}>
                     <div>
                       <FormattedMessage id="discord.contact_us" />
                     </div>


### PR DESCRIPTION
The Discord Bot is now in open beta! Discord server owners can now invite the Hubs Discord bot beta to Discord servers that they own. We do ask that you give us a quick data point about the type of server that you plan to add the bot to so that we can improve features down the road based on your feedback. The rest is optional, and you will receive the invitation link and setup guide link after finishing the survey. The invitation link can be used to add the bot to multiple servers that you run - no need to fill out the survey multiple times. 