### PR TITLE
Ensure we only remove entities that are owned

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12039,7 +12039,7 @@
       "dev": true
     },
     "networked-aframe": {
-      "version": "github:mozillareality/networked-aframe#4f4640b00ca762ab39fe907104bf26521fae3c7d",
+      "version": "github:mozillareality/networked-aframe#27d9765bef5f0e10617a4f7dd8dc33572219db05",
       "from": "github:mozillareality/networked-aframe#master",
       "requires": {
         "buffered-interpolation": "^0.2.5",

--- a/src/components/destroy-at-extreme-distances.js
+++ b/src/components/destroy-at-extreme-distances.js
@@ -26,7 +26,9 @@ AFRAME.registerComponent("destroy-at-extreme-distances", {
       getLastWorldPosition(this.el.object3D, pos);
 
       if (pos.x < xMin || pos.x > xMax || pos.y < yMin || pos.y > yMax || pos.z < zMin || pos.z > zMax) {
-        this.el.parentNode.removeChild(this.el);
+        if (!this.el.components.networked || NAF.utils.isMine(this.el)) {
+          this.el.parentNode.removeChild(this.el);
+        }
       }
     };
   })()

--- a/src/components/networked-counter.js
+++ b/src/components/networked-counter.js
@@ -39,7 +39,7 @@ AFRAME.registerComponent("networked-counter", {
       let oldestEl = null,
         minTs = Number.MAX_VALUE;
       this.timestamps.forEach((ts, el) => {
-        if (ts < minTs && !interaction.isHeld(el)) {
+        if (ts < minTs && !interaction.isHeld(el) && NAF.utils.isMine(el)) {
           oldestEl = el;
           minTs = ts;
         }

--- a/src/components/remove-networked-object-button.js
+++ b/src/components/remove-networked-object-button.js
@@ -14,6 +14,7 @@ AFRAME.registerComponent("remove-networked-object-button", {
       this.el.parentNode.setAttribute("visible", false);
 
       this.targetEl.addEventListener("animationcomplete", () => {
+        NAF.utils.takeOwnership(this.targetEl);
         this.targetEl.parentNode.removeChild(this.targetEl);
       });
     };

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -417,6 +417,7 @@ export default class SceneEntryManager {
       isHandlingVideoShare = true;
 
       if (currentVideoShareEntity && currentVideoShareEntity.parentNode) {
+        NAF.utils.takeOwnership(currentVideoShareEntity);
         currentVideoShareEntity.parentNode.removeChild(currentVideoShareEntity);
       }
 


### PR DESCRIPTION
It's a bad idea to remove entities from the scene which are networked and not owned -- until https://github.com/MozillaReality/networked-aframe/pull/29 this manifests in a bug but in general this is a bad idea since you should either take ownership of an object before removing it, so all users see it removed, or you should skip removal of unowned objects in situations (like networked counter) where you are trying to rate limit.