### PR TITLE
Fix camera ownership transfer bugs

### DIFF
--- a/src/components/networked-counter.js
+++ b/src/components/networked-counter.js
@@ -54,6 +54,6 @@ AFRAME.registerComponent("networked-counter", {
     el.pause();
     // networked-interactable's remove will also call deregister, but it will happen async so we do it here as well.
     this.deregister(el);
-    if (el.parentNode) el.parentNode.removeChild(el);
+    el.parentNode.removeChild(el);
   }
 });

--- a/src/components/networked-counter.js
+++ b/src/components/networked-counter.js
@@ -26,31 +26,34 @@ AFRAME.registerComponent("networked-counter", {
     if (this.data.max <= 0 || this.timestamps.has(el)) return;
 
     this.timestamps.set(el, performance.now());
-    this._destroyOldest();
+    if (this.timestamps.size > this.data.max) {
+      this._destroyOldest();
+    }
   },
 
   deregister(el) {
+    if (!this.timestamps.has(el)) return;
     this.timestamps.delete(el);
   },
 
   _destroyOldest() {
-    if (this.timestamps.size > this.data.max) {
-      const interaction = this.el.sceneEl.systems.interaction;
-      let oldestEl = null,
-        minTs = Number.MAX_VALUE;
-      this.timestamps.forEach((ts, el) => {
-        if (ts < minTs && !interaction.isHeld(el)) {
-          oldestEl = el;
-          minTs = ts;
-        }
-      });
-      this._destroy(oldestEl);
-    }
+    const interaction = this.el.sceneEl.systems.interaction;
+    let oldestEl = null,
+      minTs = Number.MAX_VALUE;
+    this.timestamps.forEach((ts, el) => {
+      if (ts < minTs && !interaction.isHeld(el) && NAF.utils.isMine(el)) {
+        oldestEl = el;
+        minTs = ts;
+      }
+    });
+    this._destroy(oldestEl);
   },
 
   _destroy(el) {
-    // networked-interactable's remvoe will also call deregister, but it will happen async so we do it here as well.
+    // Pause the entity so that it won't just re-register itself immediately in owned-object-limiter.
+    el.pause();
+    // networked-interactable's remove will also call deregister, but it will happen async so we do it here as well.
     this.deregister(el);
-    el.parentNode.removeChild(el);
+    if (el.parentNode) el.parentNode.removeChild(el);
   }
 });


### PR DESCRIPTION
Camera ownerships bugs could previously break a client.
Repro with:
1. Spawn a camera in Chrome
2. Spawn a camera in Firefox
3. Have the Firefox user move the Chrome user's camera