### PR TITLE
Use "basebot" as the default parent avatar id

### DIFF
--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -26,7 +26,7 @@ export default class AvatarEditor extends Component {
   };
 
   state = {
-    avatar: { name: "My Avatar", parent_avatar_id: BOT_PARENT_AVATAR, files: {} },
+    avatar: { name: "My Avatar", parent_avatar_listing_id: BOT_PARENT_AVATAR, files: {} },
     previewGltfUrl: null
   };
 
@@ -276,6 +276,7 @@ export default class AvatarEditor extends Component {
               <div className="form-body">
                 {debug && this.textField("avatar_id", "Avatar ID", true)}
                 {debug && this.textField("parent_avatar_id", "Parent Avatar ID")}
+                {debug && this.textField("parent_avatar_listing_id", "Parent Avatar Listing ID")}
                 {this.textField("name", "Name", false, true)}
                 {debug && this.textarea("description", "Description")}
                 {debug && this.fileField("glb", "Avatar GLB", "model/gltf+binary,.glb")}

--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -11,8 +11,7 @@ import AvatarPreview from "./avatar-preview";
 import styles from "../assets/stylesheets/avatar-editor.scss";
 
 const AVATARS_API = "/api/v1/avatars";
-const BOT_PARENT_AVATAR =
-  location.hostname === "hubs.mozilla.com" || location.hostname === "smoke-hubs.mozilla.com" ? "gZ6gPvQ" : "xf9xkIY";
+const BOT_PARENT_AVATAR = "basebot";
 
 export default class AvatarEditor extends Component {
   static propTypes = {

--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -11,7 +11,6 @@ import AvatarPreview from "./avatar-preview";
 import styles from "../assets/stylesheets/avatar-editor.scss";
 
 const AVATARS_API = "/api/v1/avatars";
-const BOT_PARENT_AVATAR = "basebot";
 
 export default class AvatarEditor extends Component {
   static propTypes = {
@@ -26,7 +25,7 @@ export default class AvatarEditor extends Component {
   };
 
   state = {
-    avatar: { name: "My Avatar", parent_avatar_listing_id: BOT_PARENT_AVATAR, files: {} },
+    avatar: { name: "My Avatar", parent_avatar_listing_id: "basebot", files: {} },
     previewGltfUrl: null
   };
 
@@ -45,7 +44,7 @@ export default class AvatarEditor extends Component {
       Object.assign(this.inputFiles, avatar.files);
       this.setState({ avatar, previewGltfUrl: avatar.base_gltf_url });
     } else {
-      const { base_gltf_url } = await this.fetchAvatar(BOT_PARENT_AVATAR);
+      const { base_gltf_url } = await this.fetchAvatar("basebot");
       this.setState({ previewGltfUrl: base_gltf_url });
     }
   };


### PR DESCRIPTION
We are renaming the base avatar listing to "basebot" to make it easier to deal with on both prod and dev