### PR TITLE
Featured Avatars

### DIFF
--- a/src/storage/media-search-store.js
+++ b/src/storage/media-search-store.js
@@ -1,8 +1,6 @@
 import { EventTarget } from "event-target-shim";
 import { getReticulumFetchUrl } from "../utils/phoenix-utils";
 import { pushHistoryPath, sluglessPath, withSlug } from "../utils/history";
-import { avatars } from "../assets/avatars/avatars";
-import qsTruthy from "../utils/qs_truthy";
 
 export const SOURCES = ["videos", "sketchfab", "poly", "scenes", "gifs", "images", "twitch"];
 
@@ -97,12 +95,7 @@ export default class MediaSearchStore extends EventTarget {
     this.dispatchEvent(new CustomEvent("statechanged"));
   };
 
-  _fetchMedia = async (url, source) => {
-    if (source === "avatar_listings" && !qsTruthy("use_avatar_listings")) {
-      // Use our legacy avatars until we are ready with real featured avatars.
-      return { entries: avatars.map(this._legacyAvatarToSearchEntry) };
-    }
-
+  _fetchMedia = async url => {
     const headers = { "Content-Type": "application/json" };
     const credentialsToken = window.APP.store.state.credentials.token;
     if (credentialsToken) headers.authorization = `bearer ${credentialsToken}`;


### PR DESCRIPTION
Avatars set to "allow promotion" that have been selected by our content team will now appear in Featured Avatars. Many new options are available now, but be sure to check back as new ones are being added! If you are an avatar creator,  be sure to check the "allow promotion" box to let others see your work.
![image](https://user-images.githubusercontent.com/130735/58738861-77e38300-83bc-11e9-9e13-d599c68b0abc.png)

This PR simply removes the query parameter check letting featured avatars always use avatar_listings instead of hard-coded legacy avatars.