### PR TITLE
Fix dependency issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3338,15 +3338,6 @@
       "resolved": "https://registry.yarnpkg.com/aframe-slice9-component/-/aframe-slice9-component-1.0.0.tgz",
       "integrity": "sha1-+w+EQdrdHosRzCRRK6eqaS1iK+E="
     },
-    "agent-base": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
-      "dev": true,
-      "requires": {
-        "es6-promisify": "^5.0.0"
-      }
-    },
     "ajv": {
       "version": "6.5.2",
       "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-6.5.2.tgz",
@@ -3615,6 +3606,11 @@
       "resolved": "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
+    },
+    "ast-types": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+      "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -14467,11 +14463,6 @@
         "source-map": "~0.5.0"
       },
       "dependencies": {
-        "ast-types": {
-          "version": "0.9.6",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
-          "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
-        },
         "esprima": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
@@ -15160,12 +15151,6 @@
         "neo-async": "^2.5.0",
         "pify": "^3.0.0"
       }
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
     },
     "schema-utils": {
       "version": "0.4.5",
@@ -18522,21 +18507,6 @@
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
       "dev": true
-    },
-    "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "dev": true,
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
-      }
-    },
-    "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xregexp": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3289,7 +3289,7 @@
     },
     "aframe": {
       "version": "github:mozillareality/aframe#c3a99b442a80872b64cb3e72ab839af64993dac5",
-      "from": "github:mozillareality/aframe#remove-text",
+      "from": "github:mozillareality/aframe#c3a99b442a80872b64cb3e72ab839af64993dac5",
       "requires": {
         "animejs": "^2.2.0",
         "browserify-css": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.2",
     "@fortawesome/free-solid-svg-icons": "^5.2.0",
     "@fortawesome/react-fontawesome": "^0.1.0",
-    "aframe": "github:mozillareality/aframe#remove-text",
+    "aframe": "github:mozillareality/aframe#c3a99b442a80872b64cb3e72ab839af64993dac5",
     "aframe-billboard-component": "^2.0.0",
     "aframe-physics-system": "github:infinitelee/aframe-physics-system#feature/heightfields",
     "aframe-rounded": "^1.0.3",


### PR DESCRIPTION
I believe I introduced these problems earlier by accidentally not bumping the package.json version of aframe to `hubs/master` when I merged #1362, and by mismanaging the merge between #1362 and #1365 (I'm not sure exactly what went wrong, but the problems seem related.)

The resulting package-lock.json looks reasonable, `npm ci` works cleanly, and `npm install` on a new package works cleanly, so I think this is sufficient to tidy everything up.

@InfiniteLee or anyone else should feel free to point aframe back at `hubs/master` whenever they are ready to bring in the most recent changes in our aframe fork again.