### PR TITLE
Disable gyro in lobby

### DIFF
--- a/src/components/pitch-yaw-rotator.js
+++ b/src/components/pitch-yaw-rotator.js
@@ -37,8 +37,9 @@ AFRAME.registerComponent("pitch-yaw-rotator", {
   },
 
   tick() {
-    const userinput = AFRAME.scenes[0].systems.userinput;
-    const cameraDelta = userinput.get(paths.actions.cameraDelta);
+    const scene = AFRAME.scenes[0];
+    const userinput = scene.systems.userinput;
+    const cameraDelta = userinput.get(scene.is("entered") ? paths.actions.cameraDelta : paths.actions.lobbyCameraDelta);
     let lookX = this.pendingXRotation;
     let lookY = 0;
     if (cameraDelta) {

--- a/src/systems/userinput/bindings/keyboard-mouse-user.js
+++ b/src/systems/userinput/bindings/keyboard-mouse-user.js
@@ -150,6 +150,11 @@ export const keyboardMouseUserBindings = addSetsToBindings({
       xform: xforms.compose_vec2
     },
     {
+      src: { value: paths.actions.cameraDelta },
+      dest: { value: paths.actions.lobbyCameraDelta },
+      xform: xforms.copy
+    },
+    {
       src: {
         value: paths.device.keyboard.key("m")
       },

--- a/src/systems/userinput/bindings/touchscreen-user.js
+++ b/src/systems/userinput/bindings/touchscreen-user.js
@@ -91,6 +91,11 @@ export const touchscreenUserBindings = addSetsToBindings({
       xform: xforms.add_vec2
     },
     {
+      src: { value: touchCamDelta },
+      dest: { value: paths.actions.lobbyCameraDelta },
+      xform: xforms.copy
+    },
+    {
       src: { value: paths.device.touchscreen.isTouchingGrabbable },
       dest: { value: paths.actions.cursor.grab },
       xform: xforms.rising

--- a/src/systems/userinput/bindings/xbox-controller-user.js
+++ b/src/systems/userinput/bindings/xbox-controller-user.js
@@ -124,6 +124,11 @@ export const xboxControllerUserBindings = addSetsToBindings({
       xform: xforms.compose_vec2
     },
     {
+      src: { value: paths.actions.cameraDelta },
+      dest: { value: paths.actions.lobbyCameraDelta },
+      xform: xforms.copy
+    },
+    {
       src: { value: axis("leftJoystickHorizontal") },
       dest: { value: deadzonedLeftJoystickHorizontal },
       xform: xforms.deadzone(0.1)

--- a/src/systems/userinput/paths.js
+++ b/src/systems/userinput/paths.js
@@ -9,6 +9,7 @@ paths.actions.angularVelocity = "/actions/angularVelocity";
 paths.actions.logDebugFrame = "/actions/logDebugFrame";
 paths.actions.logInteractionState = "/actions/logInteractionState";
 paths.actions.cameraDelta = "/actions/cameraDelta";
+paths.actions.lobbyCameraDelta = "/actions/lobbyCameraDelta";
 paths.actions.characterAcceleration = "/actions/characterAcceleration";
 paths.actions.boost = "/actions/boost";
 paths.actions.startGazeTeleport = "/actions/startTeleport";


### PR DESCRIPTION
It seems possible that some confusion on mobile about the lobby vs non-lobby stems from the gyro camera being enabled in the lobby, which implies a fairly high level of agency for the user and therefore may lead to them thinking they are embodied. This PR disables the gyro in the lobby.