### PR TITLE
Add a stats panel in VR

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This will allow the CSP checks to pass that are served up by Reticulum so you ca
 - `disable_telemetry` - If `true` disables Sentry telemetry.
 - `log_filter` - A `debug` style filter for setting the logging level.
 - `debug` - If `true` performs verbose logging of Janus and NAF traffic.
+- `vrstats` - If `true` shows stats in VR.
 - `debug_log` - If `true`, enables an on-screen debug log and console. Useful for debugging on mobile devices.
 - `userinput_debug` - If `true`, enables an on-screen userinput debug status panel. Press "L" on your keyboard to show the panel.
 - `disableTunnel` - Tunnel vision is on by default. Disable the tunnel vision by this parameter.

--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -220,6 +220,7 @@
     "commands.leave": "Disconnect from the room.",
     "commands.duck": "The duck tested well. Quack.",
     "commands.debug": "Toggle physics debug rendering.",
+    "commands.vrstats": "Toggle stats in VR.",
     "settings.change-avatar": "Set Name & Avatar",
     "settings.change-scene": "Choose a Scene",
     "settings.rename-room": "Set Room Name...",

--- a/src/hub.html
+++ b/src/hub.html
@@ -55,7 +55,6 @@
         action-to-event__mute="path: /actions/muteMic; event: action_mute;"
         freeze-controller="toggleEvent: action_freeze"
         personal-space-bubble="debug: false;"
-        stats-plus="false"
         rotate-selected-object
         environment-map
     >
@@ -728,6 +727,7 @@
                     position = "0.15 0 0"
                     teleporter="start: /actions/startTeleport; confirm: /actions/stopTeleport; collisionEntities: [nav-mesh];"
                 ></a-entity>
+                <a-entity id="stats" stats-plus="false" position="0 0 -1"></a-entity>
             </a-entity>
 
             <a-entity
@@ -832,7 +832,6 @@
                 <a-entity text="value:View your desktop to continue; width:1; align:center;" position="0 0 0.01"></a-entity>
             </a-entity>
         </a-entity>
-
     </a-scene>
 
     <div id="ui-root"></div>

--- a/src/message-dispatch.js
+++ b/src/message-dispatch.js
@@ -37,6 +37,7 @@ export default class MessageDispatch {
     const curScale = playerRig.object3D.scale;
     let err;
     let physicsSystem;
+    let statsPlus;
 
     switch (command) {
       case "fly":
@@ -82,6 +83,9 @@ export default class MessageDispatch {
       case "debug":
         physicsSystem = document.querySelector("a-scene").systems.physics;
         physicsSystem.setDebug(!physicsSystem.debug);
+        break;
+      case "vrstats":
+        document.getElementById("stats").components["stats-plus"].toggleVRStats();
         break;
       case "scene":
         if (args[0]) {

--- a/src/message-dispatch.js
+++ b/src/message-dispatch.js
@@ -37,7 +37,6 @@ export default class MessageDispatch {
     const curScale = playerRig.object3D.scale;
     let err;
     let physicsSystem;
-    let statsPlus;
 
     switch (command) {
       case "fly":

--- a/src/react-components/chat-command-help.js
+++ b/src/react-components/chat-command-help.js
@@ -11,7 +11,17 @@ export default class ChatCommandHelp extends Component {
   };
 
   render() {
-    const commands = ["leave", "fly", "grow", "shrink", "duck", "debug", "scene <scene url>", "rename <new name>"];
+    const commands = [
+      "leave",
+      "fly",
+      "grow",
+      "shrink",
+      "duck",
+      "debug",
+      "vrstats",
+      "scene <scene url>",
+      "rename <new name>"
+    ];
 
     return (
       <div className={classNames({ [styles.commandHelp]: true, [styles.commandHelpOnTop]: this.props.onTop })}>


### PR DESCRIPTION
Adds a `vrstats` query param and chat command to display a simple, head-locked, stats panel in VR with info for framerate, render time, physics time, draw calls and triangle count

![image](https://user-images.githubusercontent.com/79419/58851388-6661db80-8647-11e9-894a-606ecc76bd8a.png)
