### PR TITLE
Bug/environment collision while holding

### DIFF
--- a/src/components/drop-object-button.js
+++ b/src/components/drop-object-button.js
@@ -1,3 +1,5 @@
+const COLLISION_LAYERS = require("../constants").COLLISION_LAYERS;
+
 AFRAME.registerComponent("drop-object-button", {
   init() {
     this.onClick = () => {
@@ -10,7 +12,8 @@ AFRAME.registerComponent("drop-object-button", {
         angularDamping: 0.01,
         linearDamping: 0.01,
         linearSleepingThreshold: 1.6,
-        angularSleepingThreshold: 2.5
+        angularSleepingThreshold: 2.5,
+        collisionFilterMask: COLLISION_LAYERS.DEFAULT_INTERACTABLE
       });
       this.targetEl.components["ammo-body"].body.activate();
 

--- a/src/components/floaty-object.js
+++ b/src/components/floaty-object.js
@@ -102,7 +102,7 @@ AFRAME.registerComponent("floaty-object", {
         });
 
         this._makeStaticWhenAtRest = true;
-        this.el.setAttribute("ammo-body", { collisionFilterMask: COLLISION_LAYERS.NON_COLLIDING_INTERACTABLE });
+        this.el.setAttribute("ammo-body", { collisionFilterMask: COLLISION_LAYERS.HANDS });
       } else {
         this.el.setAttribute("ammo-body", {
           gravity: { x: 0, y: this.data.releaseGravity, z: 0 },

--- a/src/components/floaty-object.js
+++ b/src/components/floaty-object.js
@@ -102,6 +102,7 @@ AFRAME.registerComponent("floaty-object", {
         });
 
         this._makeStaticWhenAtRest = true;
+        this.el.setAttribute("ammo-body", { collisionFilterMask: COLLISION_LAYERS.NON_COLLIDING_INTERACTABLE });
       } else {
         this.el.setAttribute("ammo-body", {
           gravity: { x: 0, y: this.data.releaseGravity, z: 0 },
@@ -110,19 +111,20 @@ AFRAME.registerComponent("floaty-object", {
           linearSleepingThreshold: 1.6,
           angularSleepingThreshold: 2.5
         });
+        this.el.setAttribute("ammo-body", { collisionFilterMask: COLLISION_LAYERS.DEFAULT_INTERACTABLE });
       }
+    } else {
+      this.el.setAttribute("ammo-body", { collisionFilterMask: COLLISION_LAYERS.DEFAULT_INTERACTABLE });
     }
 
     if (this.data.autoLockOnRelease) {
       this.setLocked(true);
     }
-
-    this.el.setAttribute("ammo-body", { collisionFilterMask: COLLISION_LAYERS.DEFAULT_INTERACTABLE });
   },
 
   onGrab() {
     this.el.setAttribute("ammo-body", {
-      collisionFilterMask: this.locked ? COLLISION_LAYERS.HANDS : COLLISION_LAYERS.DEFAULT_INTERACTABLE
+      collisionFilterMask: COLLISION_LAYERS.HANDS
     });
     this.setLocked(false);
   },

--- a/src/components/floaty-object.js
+++ b/src/components/floaty-object.js
@@ -98,20 +98,20 @@ AFRAME.registerComponent("floaty-object", {
           angularDamping: this.data.reduceAngularFloat ? 0.98 : 0.5,
           linearDamping: 0.95,
           linearSleepingThreshold: 0.1,
-          angularSleepingThreshold: 0.1
+          angularSleepingThreshold: 0.1,
+          collisionFilterMask: COLLISION_LAYERS.HANDS
         });
 
         this._makeStaticWhenAtRest = true;
-        this.el.setAttribute("ammo-body", { collisionFilterMask: COLLISION_LAYERS.HANDS });
       } else {
         this.el.setAttribute("ammo-body", {
           gravity: { x: 0, y: this.data.releaseGravity, z: 0 },
           angularDamping: 0.01,
           linearDamping: 0.01,
           linearSleepingThreshold: 1.6,
-          angularSleepingThreshold: 2.5
+          angularSleepingThreshold: 2.5,
+          collisionFilterMask: COLLISION_LAYERS.DEFAULT_INTERACTABLE
         });
-        this.el.setAttribute("ammo-body", { collisionFilterMask: COLLISION_LAYERS.DEFAULT_INTERACTABLE });
       }
     } else {
       this.el.setAttribute("ammo-body", { collisionFilterMask: COLLISION_LAYERS.DEFAULT_INTERACTABLE });

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,7 +7,6 @@ module.exports = {
     AVATAR: 4,
     HANDS: 8,
     DEFAULT_INTERACTABLE: 1 | 2 | 4 | 8,
-    NON_COLLIDING_INTERACTABLE: 1 | 8,
     UNOWNED_INTERACTABLE: 1 | 8,
     DEFAULT_SPAWNER: 1 | 8
   }

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,6 +7,7 @@ module.exports = {
     AVATAR: 4,
     HANDS: 8,
     DEFAULT_INTERACTABLE: 1 | 2 | 4 | 8,
+    NON_COLLIDING_INTERACTABLE: 1 | 8,
     UNOWNED_INTERACTABLE: 1 | 8,
     DEFAULT_SPAWNER: 1 | 8
   }


### PR DESCRIPTION
This PR updates the behavior so that floaty objects do not intersect with other objects unless they have some form of gravity. (This fixes the issue where, for example, trying to place objects using the cursor results in environment collision.)