### PR TITLE
Handle avatar loading errors

### DIFF
--- a/src/assets/stylesheets/avatar-preview.scss
+++ b/src/assets/stylesheets/avatar-preview.scss
@@ -1,9 +1,28 @@
+@import 'shared';
+
 :local(.preview) {
   position: relative;
   overflow: hidden;
+  background: #eaeaea;
+
   .loader {
     position: absolute;
     left: calc(50% - 4.3em);
     top: calc(50% - 4.5em);
+  }
+  .error {
+    color: $error-color;
+    text-align: center;
+    padding: 1.5em;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    font-weight: bold;
+    white-space: pre-wrap;
+    box-sizing: border-box;
+    width: 100%;
+  }
+  .error-icon {
+    margin: 0 0.2em;
   }
 }

--- a/src/assets/stylesheets/avatar-preview.scss
+++ b/src/assets/stylesheets/avatar-preview.scss
@@ -11,7 +11,7 @@
     top: calc(50% - 4.5em);
   }
   .error {
-    color: $error-color;
+    color: $grey-text;
     text-align: center;
     padding: 1.5em;
     position: absolute;
@@ -23,6 +23,9 @@
     width: 100%;
   }
   .error-icon {
-    margin: 0 0.2em;
+    width: 16px;
+    height: 16px;
+    transform: translateY(2px);
+    margin: 0 0.3em;
   }
 }

--- a/src/assets/stylesheets/shared.scss
+++ b/src/assets/stylesheets/shared.scss
@@ -18,7 +18,6 @@ $action-color-light: #FF74A4;
 $action-color-transparent: rgba(255, 52, 100, 0.9);
 $hud-panel-background: rgba(79, 79, 79, 0.45);
 $spoke-action-color: $bright-blue;
-$error-color: #aa0000;
 $semi-bold: 600;
 
 %unselectable {

--- a/src/assets/stylesheets/shared.scss
+++ b/src/assets/stylesheets/shared.scss
@@ -18,6 +18,7 @@ $action-color-light: #FF74A4;
 $action-color-transparent: rgba(255, 52, 100, 0.9);
 $hud-panel-background: rgba(79, 79, 79, 0.45);
 $spoke-action-color: $bright-blue;
+$error-color: #aa0000;
 $semi-bold: 600;
 
 %unselectable {

--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -81,6 +81,7 @@
 
     "avatar-editor.info": "Resources for creating custom avatar skins can be found",
     "avatar-editor.info-link": "here",
+    "avatar-preview.loading-failed": "Loading failed\nPlease choose another avatar",
 
     "media-browser.search-placeholder.scenes": "Search Scenes...",
     "media-browser.search-placeholder.avatars": "Search Avatars...",

--- a/src/components/player-info.js
+++ b/src/components/player-info.js
@@ -16,6 +16,7 @@ AFRAME.registerComponent("player-info", {
     this.applyProperties = this.applyProperties.bind(this);
     this.updateDisplayName = this.updateDisplayName.bind(this);
     this.applyDisplayName = this.applyDisplayName.bind(this);
+    this.handleModelError = this.handleModelError.bind(this);
 
     this.isLocalPlayerInfo = this.el.id === "player-rig";
     this.playerSessionId = null;
@@ -33,10 +34,12 @@ AFRAME.registerComponent("player-info", {
   play() {
     this.el.addEventListener("model-loaded", this.applyProperties);
     this.el.sceneEl.addEventListener("presence_updated", this.updateDisplayName);
+    this.el.querySelector(".model").addEventListener("model-error", this.handleModelError);
   },
   pause() {
     this.el.removeEventListener("model-loaded", this.applyProperties);
     this.el.sceneEl.removeEventListener("presence_updated", this.updateDisplayName);
+    this.el.querySelector(".model").removeEventListener("model-error", this.handleModelError);
   },
   update() {
     this.applyProperties();
@@ -82,5 +85,8 @@ AFRAME.registerComponent("player-info", {
     this.el.querySelectorAll("[hover-visuals]").forEach(el => {
       el.components["hover-visuals"].uniforms = uniforms;
     });
+  },
+  handleModelError() {
+    window.APP.store.resetToRandomLegacyAvatar();
   }
 });

--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -103,7 +103,9 @@ export default class AvatarEditor extends Component {
       });
     }
 
-    this.inputFiles.thumbnail = new File([await this.preview.snapshot()], "thumbnail.png", { type: "image/png" });
+    this.inputFiles.thumbnail = new File([await this.preview.getWrappedInstance().snapshot()], "thumbnail.png", {
+      type: "image/png"
+    });
 
     const filesToUpload = ["gltf", "bin", "base_map", "emissive_map", "normal_map", "orm_map", "thumbnail"].filter(
       k => this.inputFiles[k] === null || this.inputFiles[k] instanceof File

--- a/src/react-components/avatar-preview.js
+++ b/src/react-components/avatar-preview.js
@@ -2,8 +2,6 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { injectIntl, FormattedMessage } from "react-intl";
 import classNames from "classnames";
-import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons/faExclamationTriangle";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import "three/examples/js/controls/OrbitControls";
 
 import { createDefaultEnvironmentMap } from "../components/environment-map";
@@ -301,7 +299,11 @@ class AvatarPreview extends Component {
         {this.state.error &&
           !this.state.loading && (
             <div className="error">
-              <FontAwesomeIcon className="error-icon" icon={faExclamationTriangle} />
+              <img
+                src="../assets/images/warning_icon.png"
+                srcSet="../assets/images/warning_icon@2x.png 2x"
+                className="error-icon"
+              />
               <FormattedMessage id="avatar-preview.loading-failed" />
             </div>
           )}

--- a/src/react-components/avatar-preview.js
+++ b/src/react-components/avatar-preview.js
@@ -1,7 +1,10 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import "three/examples/js/controls/OrbitControls";
+import { injectIntl, FormattedMessage } from "react-intl";
 import classNames from "classnames";
+import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons/faExclamationTriangle";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import "three/examples/js/controls/OrbitControls";
 
 import { createDefaultEnvironmentMap } from "../components/environment-map";
 import { loadGLTF } from "../components/gltf-model-plus";
@@ -57,14 +60,14 @@ function fitBoxInFrustum(camera, box, center, margin = DEFAULT_MARGIN) {
   camera.lookAt(center);
 }
 
-export default class AvatarPreview extends Component {
+class AvatarPreview extends Component {
   static propTypes = {
     avatarGltfUrl: PropTypes.string,
     className: PropTypes.string
   };
   constructor(props) {
     super(props);
-    this.state = { loading: true };
+    this.state = { loading: true, error: null };
     this.avatar = null;
     this.imageBitmaps = {};
   }
@@ -125,7 +128,7 @@ export default class AvatarPreview extends Component {
     this.avatar = avatar;
     this.scene.add(avatar);
     this.resetCamera();
-    this.setState({ loading: false });
+    this.setState({ error: null, loading: false });
   };
 
   resetCamera = (() => {
@@ -176,7 +179,7 @@ export default class AvatarPreview extends Component {
         this.avatar = null;
       }
       if (this.props.avatarGltfUrl) {
-        this.setState({ loading: true });
+        this.setState({ error: null, loading: true });
         await this.loadPreviewAvatar(this.props.avatarGltfUrl).then(this.setAvatar);
       }
     }
@@ -201,9 +204,15 @@ export default class AvatarPreview extends Component {
   }
 
   loadPreviewAvatar = async avatarGltfUrl => {
-    const gltf = await loadGLTF(avatarGltfUrl, "model/gltf");
+    let gltf;
+    try {
+      gltf = await loadGLTF(avatarGltfUrl, "model/gltf");
+    } catch (e) {
+      this.setState({ loading: false, error: true });
+      return;
+    }
 
-    // On the bckend we look for a material called Bot_PBS, here we are looking for a mesh called Avatar.
+    // On the backend we look for a material called Bot_PBS, here we are looking for a mesh called Avatar.
     // When we "officially" support uploading custom GLTFs we need to decide what we are going to key things on
     this.previewMesh =
       gltf.scene.getObjectByName("AvatarMesh") ||
@@ -283,13 +292,23 @@ export default class AvatarPreview extends Component {
   render() {
     return (
       <div className={classNames(styles.preview, this.props.className)}>
-        {this.state.loading && (
-          <div className="loader">
-            <div className="loader-center" />
-          </div>
-        )}
+        {this.state.loading &&
+          !this.state.error && (
+            <div className="loader">
+              <div className="loader-center" />
+            </div>
+          )}
+        {this.state.error &&
+          !this.state.loading && (
+            <div className="error">
+              <FontAwesomeIcon className="error-icon" icon={faExclamationTriangle} />
+              <FormattedMessage id="avatar-preview.loading-failed" />
+            </div>
+          )}
         <canvas ref={c => (this.canvas = c)} />
       </div>
     );
   }
 }
+
+export default injectIntl(AvatarPreview, { withRef: true });

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -212,9 +212,8 @@ class MediaBrowser extends Component {
   };
 
   showCustomMediaDialog = source => {
-    const isSceneApiType = source === "scene_listings" || source === "scenes";
-    // Note: The apiSource for avatars *is* actually singular. We should probably fix this on the backend.
-    const isAvatarApiType = source === "avatar_listings" || source === "avatar";
+    const isSceneApiType = source === "scenes";
+    const isAvatarApiType = source === "avatars";
     this.pushExitMediaBrowserHistory(!isAvatarApiType);
     const dialog = isSceneApiType ? "change_scene" : isAvatarApiType ? "avatar_url" : "create";
     pushHistoryState(this.props.history, "modal", dialog);
@@ -244,9 +243,7 @@ class MediaBrowser extends Component {
     const urlSource = this.getUrlSource(searchParams);
     const apiSource = (hasMeta && this.state.result.meta.source) || null;
     const isVariableWidth = this.state.result && ["bing_images", "tenor"].includes(apiSource);
-    const isSceneApiType = apiSource === "scene_listings" || apiSource === "scenes";
-    // Note: The apiSource for avatars *is* actually singular. We should probably fix this on the backend.
-    const isAvatarApiType = apiSource === "avatar_listings" || apiSource === "avatar";
+    const isSceneApiType = urlSource === "scenes";
     const showCustomOption = !isSceneApiType || this.props.hubChannel.canOrWillIfCreator("update_hub");
     const [createTileWidth, createTileHeight] = this.getTileDimensions(false, urlSource === "avatars");
     const entries = (this.state.result && this.state.result.entries) || [];
@@ -254,13 +251,14 @@ class MediaBrowser extends Component {
 
     // Don't render anything if we just did a feeling lucky query and are waiting on result.
     if (this.state.selectNextResult) return <div />;
-    const handleCustomClicked = apiSource => {
+    const handleCustomClicked = urlSource => {
+      const isAvatarApiType = urlSource === "avatars";
       if (isAvatarApiType) {
-        this.showCustomMediaDialog(apiSource);
+        this.showCustomMediaDialog(urlSource);
       } else {
         this.props.performConditionalSignIn(
           () => !isSceneApiType || this.props.hubChannel.can("update_hub"),
-          () => this.showCustomMediaDialog(apiSource),
+          () => this.showCustomMediaDialog(urlSource),
           "change-scene"
         );
       }
@@ -338,14 +336,14 @@ class MediaBrowser extends Component {
             </div>
             <div className={styles.headerRight}>
               {showCustomOption && (
-                <a onClick={() => handleCustomClicked(apiSource)} className={styles.createButton}>
+                <a onClick={() => handleCustomClicked(urlSource)} className={styles.createButton}>
                   <i>
                     <FontAwesomeIcon icon={["scenes", "avatars"].includes(urlSource) ? faLink : faCloudUploadAlt} />
                   </i>
                 </a>
               )}
               {showCustomOption && (
-                <a onClick={() => handleCustomClicked(apiSource)} className={styles.createLink}>
+                <a onClick={() => handleCustomClicked(urlSource)} className={styles.createLink}>
                   <FormattedMessage
                     id={`media-browser.add_custom_${
                       this.state.result && isSceneApiType ? "scene" : urlSource === "avatars" ? "avatar" : "object"


### PR DESCRIPTION
- Catch model loading errors when loading avatars
- Display an error message in the avatar preview
- Reset to random legacy avatar if avatar in local storage is broken
- Also fixes issue with custom avatar url dialog where it would display the wrong dialog on the "my avatars" screen if you were not signed in.

![image](https://user-images.githubusercontent.com/79419/58908233-e0847580-86c4-11e9-8433-499676d87319.png)

Fixes #1315 