### PR TITLE
hide submenus when clicking a-canvas

### DIFF
--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -245,7 +245,9 @@ class UIRoot extends Component {
     document
       .querySelector(".a-canvas")
       .addEventListener("mouseup", () =>
-        this.setState({ showPresenceList: false, showSettingsMenu: false, showShareDialog: false })
+        if (this.state.showPresenceList || this.state.showSettingsMenu || this.state.showShareDialog) {
+          this.setState({ showPresenceList: false, showSettingsMenu: false, showShareDialog: false })
+        }
       );
 
     this.props.scene.addEventListener(

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -242,6 +242,12 @@ class UIRoot extends Component {
 
   componentDidMount() {
     window.addEventListener("concurrentload", this.onConcurrentLoad);
+    document
+      .querySelector(".a-canvas")
+      .addEventListener("mouseup", () =>
+        this.setState({ showPresenceList: false, showSettingsMenu: false, showShareDialog: false })
+      );
+
     this.props.scene.addEventListener(
       "didConnectToNetworkedScene",
       () => {

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -244,10 +244,10 @@ class UIRoot extends Component {
     window.addEventListener("concurrentload", this.onConcurrentLoad);
     document
       .querySelector(".a-canvas")
-      .addEventListener("mouseup", () =>
+      .addEventListener("mouseup", () => {
         if (this.state.showPresenceList || this.state.showSettingsMenu || this.state.showShareDialog) {
           this.setState({ showPresenceList: false, showSettingsMenu: false, showShareDialog: false })
-        }
+        }}
       );
 
     this.props.scene.addEventListener(


### PR DESCRIPTION
Small UX tweak which will hide the settings menu, presence list, and share dialog if you click the background canvas. (Nice on mobile, etc)