### PR TITLE
Fix missing update matrices

### DIFF
--- a/src/utils/three-utils.js
+++ b/src/utils/three-utils.js
@@ -2,16 +2,19 @@ const tempVector3 = new THREE.Vector3();
 const tempQuaternion = new THREE.Quaternion();
 
 export function getLastWorldPosition(src, target) {
+  src.updateMatrices();
   target.setFromMatrixPosition(src.matrixWorld);
   return target;
 }
 
 export function getLastWorldQuaternion(src, target) {
+  src.updateMatrices();
   src.matrixWorld.decompose(tempVector3, target, tempVector3);
   return target;
 }
 
 export function getLastWorldScale(src, target) {
+  src.updateMatrices();
   src.matrixWorld.decompose(tempVector3, tempQuaternion, target);
   return target;
 }


### PR DESCRIPTION
We were missing calls to updateMatrices in three-utils, which (I think) was causing spawn points to sometimes not be applied properly.