### PR TITLE
Fix up aframe version in package.json again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3313,7 +3313,7 @@
     },
     "aframe": {
       "version": "github:mozillareality/aframe#1d216f1e179150b5b6db53c85c93125197ccdac7",
-      "from": "github:mozillareality/aframe#1d216f1e179150b5b6db53c85c93125197ccdac7",
+      "from": "github:mozillareality/aframe#hubs/master",
       "requires": {
         "animejs": "github:mozillareality/anime#hubs/master",
         "browserify-css": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.2",
     "@fortawesome/free-solid-svg-icons": "^5.2.0",
     "@fortawesome/react-fontawesome": "^0.1.0",
-    "aframe": "github:mozillareality/aframe#remove-text",
+    "aframe": "github:mozillareality/aframe#hubs/master",
     "aframe-physics-system": "github:infinitelee/aframe-physics-system#feature/heightfields",
     "aframe-rounded": "^1.0.3",
     "aframe-slice9-component": "^1.0.0",


### PR DESCRIPTION
This got accidentally mucked up in https://github.com/mozilla/hubs/commit/610adadc07333d5a6b02e5234a2dee28e1703f37. Now it is right. Note that this was already the commit that package-lock.json pointed to, so there's no change to what's running.