### PR TITLE
Add multiview and glsl 3.0 conversion to sprite shaders

### DIFF
--- a/src/systems/sprites/sprite.vert
+++ b/src/systems/sprites/sprite.vert
@@ -1,6 +1,3 @@
-uniform mat4 modelViewMatrix;
-uniform mat4 projectionMatrix;
-
 attribute vec4 mvCol0;
 attribute vec4 mvCol1;
 attribute vec4 mvCol2;


### PR DESCRIPTION
Since we enabled multiview on mobile VR headsets, the sprite shader needs to check for this and accomodate.