### PR TITLE
Perform step on complete handler for spawn animation

### DIFF
--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -205,6 +205,29 @@ AFRAME.registerComponent("media-loader", {
   },
 
   addMeshScaleAnimation(mesh, initialScale, onComplete) {
+    const step = (function() {
+      const lastValue = {};
+      return function(anim) {
+        const value = anim.animatables[0].target;
+
+        value.x = Math.max(Number.MIN_VALUE, value.x);
+        value.y = Math.max(Number.MIN_VALUE, value.y);
+        value.z = Math.max(Number.MIN_VALUE, value.z);
+
+        // For animation timeline.
+        if (value.x === lastValue.x && value.y === lastValue.y && value.z === lastValue.z) {
+          return;
+        }
+
+        lastValue.x = value.x;
+        lastValue.y = value.y;
+        lastValue.z = value.z;
+
+        mesh.scale.set(value.x, value.y, value.z);
+        mesh.matrixNeedsUpdate = true;
+      };
+    })();
+
     const config = {
       duration: 400,
       easing: "easeOutElastic",
@@ -215,29 +238,11 @@ AFRAME.registerComponent("media-loader", {
       y: mesh.scale.y,
       z: mesh.scale.z,
       targets: [initialScale],
-      update: (function() {
-        const lastValue = {};
-        return function(anim) {
-          const value = anim.animatables[0].target;
-
-          value.x = Math.max(Number.MIN_VALUE, value.x);
-          value.y = Math.max(Number.MIN_VALUE, value.y);
-          value.z = Math.max(Number.MIN_VALUE, value.z);
-
-          // For animation timeline.
-          if (value.x === lastValue.x && value.y === lastValue.y && value.z === lastValue.z) {
-            return;
-          }
-
-          lastValue.x = value.x;
-          lastValue.y = value.y;
-          lastValue.z = value.z;
-
-          mesh.scale.set(value.x, value.y, value.z);
-          mesh.matrixNeedsUpdate = true;
-        };
-      })(),
-      complete: onComplete
+      update: anim => step(anim),
+      complete: anim => {
+        step(anim);
+        onComplete();
+      }
     };
 
     mesh.scale.copy(initialScale);


### PR DESCRIPTION
When spawning a complex object which locks the browser up sufficiently long, the animation tick in `anime` can fire on an arbitrary frame, or not at all if a sufficient amount of time passes. This happens because `anime` pauses the animation after the duration completes, which prevents further ticks. This PR updates the anime spawn animation to set the final animated value in the `onComplete` handler.