### PR TITLE
Fix bug with releasing of src that is not retained

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -731,7 +731,6 @@ AFRAME.registerComponent("media-image", {
   async update(oldData) {
     let texture;
     let ratio = 1;
-    this._hasRetainedTexture = false;
 
     try {
       const { src, contentType } = this.data;
@@ -744,6 +743,7 @@ AFRAME.registerComponent("media-image", {
         this.mesh.material.needsUpdate = true;
         if (this.mesh.map !== errorTexture) {
           textureCache.release(oldData.src);
+          this._hasRetainedTexture = false;
         }
       }
 
@@ -768,6 +768,7 @@ AFRAME.registerComponent("media-image", {
         // No way to cancel promises, so if src has changed while we were creating the texture just throw it away.
         if (this.data.src !== src) {
           textureCache.release(src);
+          this._hasRetainedTexture = false;
           return;
         }
       }

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -743,7 +743,6 @@ AFRAME.registerComponent("media-image", {
         this.mesh.material.needsUpdate = true;
         if (this.mesh.map !== errorTexture) {
           textureCache.release(oldData.src);
-          this._hasRetainedTexture = false;
         }
       }
 

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -767,7 +767,6 @@ AFRAME.registerComponent("media-image", {
         // No way to cancel promises, so if src has changed while we were creating the texture just throw it away.
         if (this.data.src !== src) {
           textureCache.release(src);
-          this._hasRetainedTexture = false;
           return;
         }
       }

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -776,6 +776,7 @@ AFRAME.registerComponent("media-image", {
     } catch (e) {
       console.error("Error loading image", this.data.src, e);
       texture = errorTexture;
+      this._hasRetainedTexture = false;
     }
 
     const projection = this.data.projection;

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -249,6 +249,12 @@ class TextureCache {
 
   release(src) {
     const cacheItem = this.cache.get(src);
+
+    if (!cacheItem) {
+      console.error(`Releasing uncached texture src ${src}`);
+      return;
+    }
+
     cacheItem.count--;
     // console.log("release", src, cacheItem.count);
     if (cacheItem.count <= 0) {
@@ -716,12 +722,17 @@ AFRAME.registerComponent("media-image", {
   },
 
   remove() {
-    textureCache.release(this.data.src);
+    if (this._hasRetainedTexture) {
+      textureCache.release(this.data.src);
+      this._hasRetainedTexture = false;
+    }
   },
 
   async update(oldData) {
     let texture;
     let ratio = 1;
+    this._hasRetainedTexture = false;
+
     try {
       const { src, contentType } = this.data;
       if (!src) return;
@@ -760,6 +771,8 @@ AFRAME.registerComponent("media-image", {
           return;
         }
       }
+
+      this._hasRetainedTexture = true;
     } catch (e) {
       console.error("Error loading image", this.data.src, e);
       texture = errorTexture;


### PR DESCRIPTION
There is a control flow in `media-image` in an error condition where if an error occurs when loading the image, we do not retain any new textures in the texture cache, but the `remove` handler still calls `release`. Previously, calling `release` on an uncached `src` resulted in an error, which caused other `remove` handlers in the chain for the object to not run. 

This PR fixes the issues at both levels: we no longer call `release` if the `media-image` did not retain a texture on its last `update`, and the `release` function in the texture cache gracefully handles the case where the user passes an uncached `src`.

(Note that we can't just check to see if the texture in this case is the `errorTexture`, since in some cases we actually do cache that texture, and in some cases we don't. It seemed wrong to cache the error texture in the case that is addressed here, since it would mean if it was a temporary error, that we'd end up using the error texture even if the error was a one-time thing.)