### PR TITLE
Update pen/drawings to properly use environment maps

### DIFF
--- a/src/components/tools/networked-drawing.js
+++ b/src/components/tools/networked-drawing.js
@@ -7,6 +7,7 @@
  */
 
 import SharedBufferGeometryManager from "../../utils/sharedbuffergeometrymanager";
+import MobileStandardMaterial from "../../materials/MobileStandardMaterial";
 
 const MSG_CONFIRM_CONNECT = 0;
 const MSG_BUFFER_DATA = 1;
@@ -53,7 +54,11 @@ AFRAME.registerComponent("networked-drawing", {
     this.radius = this.data.defaultRadius;
     this.segments = this.data.segments;
 
-    const material = new THREE.MeshStandardMaterial(options);
+    let material = new THREE.MeshStandardMaterial(options);
+    if (window.APP && window.APP.quality === "low") {
+      material = MobileStandardMaterial.fromStandardMaterial(material);
+    }
+
     this.sharedBufferGeometryManager = new SharedBufferGeometryManager();
     // NOTE: 20 is approximate for how many floats per point are added.
     // maxLines + 1 because a line can be currently drawing while at maxLines.
@@ -81,6 +86,11 @@ AFRAME.registerComponent("networked-drawing", {
     const sceneEl = document.querySelector("a-scene");
     this.scene = sceneEl.object3D;
     this.scene.add(this.drawing);
+
+    const environmentMapComponent = this.el.sceneEl.components["environment-map"];
+    if (environmentMapComponent) {
+      environmentMapComponent.applyEnvironmentMap(this.drawing);
+    }
 
     this.prevIdx = Object.assign({}, this.sharedBuffer.idx);
     this.idx = Object.assign({}, this.sharedBuffer.idx);

--- a/src/components/tools/pen.js
+++ b/src/components/tools/pen.js
@@ -143,7 +143,7 @@ AFRAME.registerComponent("pen", {
     if (window.APP && window.APP.quality === "low") {
       material = MobileStandardMaterial.fromStandardMaterial(material);
     }
-    this.penTip = new THREE.Mesh(new THREE.SphereGeometry(1, 16, 12), material);
+    this.penTip = new THREE.Mesh(new THREE.SphereBufferGeometry(1, 16, 12), material);
     this.penTip.scale.setScalar(this.data.radius / this.el.parentEl.object3D.scale.x);
     this.penTip.matrixNeedsUpdate = true;
 
@@ -151,7 +151,6 @@ AFRAME.registerComponent("pen", {
 
     const environmentMapComponent = this.el.sceneEl.components["environment-map"];
     if (environmentMapComponent) {
-      environmentMapComponent.applyEnvironmentMap(this.el.object3D);
       environmentMapComponent.applyEnvironmentMap(this.el.parentEl.object3D);
     }
 

--- a/src/components/tools/pen.js
+++ b/src/components/tools/pen.js
@@ -7,6 +7,7 @@ import {
   SOUND_PEN_CHANGE_COLOR
 } from "../../systems/sound-effects-system";
 import { waitForDOMContentLoaded } from "../../utils/async-utils";
+import MobileStandardMaterial from "../../materials/MobileStandardMaterial";
 
 const pathsMap = {
   "player-right-controller": {
@@ -138,6 +139,22 @@ AFRAME.registerComponent("pen", {
     this.setDirty = this.setDirty.bind(this);
     this.dirty = true;
 
+    let material = new THREE.MeshStandardMaterial();
+    if (window.APP && window.APP.quality === "low") {
+      material = MobileStandardMaterial.fromStandardMaterial(material);
+    }
+    this.penTip = new THREE.Mesh(new THREE.SphereGeometry(1, 16, 12), material);
+    this.penTip.scale.setScalar(this.data.radius / this.el.parentEl.object3D.scale.x);
+    this.penTip.matrixNeedsUpdate = true;
+
+    this.el.setObject3D("mesh", this.penTip);
+
+    const environmentMapComponent = this.el.sceneEl.components["environment-map"];
+    if (environmentMapComponent) {
+      environmentMapComponent.applyEnvironmentMap(this.el.object3D);
+      environmentMapComponent.applyEnvironmentMap(this.el.parentEl.object3D);
+    }
+
     // TODO: Use the MutationRecords passed into the callback function to determine added/removed nodes!
     this.observer = new MutationObserver(this.setDirty);
 
@@ -157,7 +174,7 @@ AFRAME.registerComponent("pen", {
 
   update(prevData) {
     if (prevData.color != this.data.color) {
-      this.el.setAttribute("color", this.data.color);
+      this.penTip.material.color.set(this.data.color);
       this.line.material.color.set(this.data.color);
     }
     if (prevData.radius != this.data.radius) {
@@ -381,13 +398,14 @@ AFRAME.registerComponent("pen", {
   _changeColor(mod) {
     this.colorIndex = (this.colorIndex + mod + this.data.availableColors.length) % this.data.availableColors.length;
     this.data.color = this.data.availableColors[this.colorIndex];
-    this.el.setAttribute("color", this.data.color);
+    this.penTip.material.color.set(this.data.color);
     this.line.material.color.set(this.data.color);
   },
 
   _changeRadius(mod) {
     this.data.radius = Math.max(this.data.minRadius, Math.min(this.data.radius + mod, this.data.maxRadius));
-    this.el.setAttribute("radius", this.data.radius);
+    this.penTip.scale.setScalar(this.data.radius / this.el.parentEl.object3D.scale.x);
+    this.penTip.matrixNeedsUpdate = true;
   },
 
   setDirty() {

--- a/src/hub.html
+++ b/src/hub.html
@@ -352,16 +352,11 @@
                     position-at-box-shape-border="target:.pen-menu"
 
                 >
-                    <a-sphere
+                    <a-entity
                         id="pen"
-                        scale="1.5, 1.5, 1.5"
                         position="0 -0.18 0"
-                        radius="0.02"
-                        color="#FF0033"
                         pen="camera: #player-camera; drawingManager: #drawing-manager"
-                        segments-width="16"
-                        segments-height="12"
-                    ></a-sphere>
+                    ></a-entity>
                     <a-entity class="ui delete-button pen-menu" visibility-while-frozen="withinDistance: 10;" >
                         <a-entity mixin="rounded-button" is-remote-hover-target tags="singleActionButton: true" remove-networked-object-button position="0 0 0.01">
                             <a-entity


### PR DESCRIPTION
set environment map for pens and drawings; create a three mesh for pen tip instead of using an a-sphere; use MobileStandardShader when app quality is low.

![876941a0180d639a0bd5052764ff3a1c](https://user-images.githubusercontent.com/1821537/60057598-01276600-969a-11e9-934b-f19b5a47eb47.png)
