### PR TITLE
Bug/pwa sign in

### DIFF
--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -1,6 +1,5 @@
 {
   "en": {
-    "auth.verifying": "Verifying...",
     "auth.verified-title": "E-Mail Verified!",
     "auth.verified": "Your email has been verified!\nYou can now close this browser tab and return to Hubs.",
     "auth.spoke-verified": "You email has been verified!\nYou can now close this browser tab and return to Spoke.",

--- a/src/react-components/auth-dialog.js
+++ b/src/react-components/auth-dialog.js
@@ -13,12 +13,16 @@ class AuthDialog extends Component {
   render() {
     const { authOrigin, verifying } = this.props;
     const { formatMessage } = this.props.intl;
-    const title = verifying ? formatMessage({ id: "auth.verifying" }) : formatMessage({ id: "auth.verified-title" });
+    const title = verifying ? "" : formatMessage({ id: "auth.verified-title" });
 
     return (
-      <DialogContainer title={title} {...this.props}>
+      <DialogContainer title={title} closable={!verifying} {...this.props}>
         {verifying ? (
-          <FormattedMessage id="auth.verifying" />
+          <div className="loader-wrap loader-mid">
+            <div className="loader">
+              <div className="loader-center" />
+            </div>
+          </div>
         ) : authOrigin === "spoke" ? (
           <FormattedMessage className="preformatted" id="auth.spoke-verified" />
         ) : (

--- a/src/react-components/home-root.js
+++ b/src/react-components/home-root.js
@@ -18,6 +18,7 @@ import maskEmail from "../utils/mask-email";
 import checkIsMobile from "../utils/is-mobile";
 import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus";
 import mediaBrowserStyles from "../assets/stylesheets/media-browser.scss";
+import AuthChannel from "../utils/auth-channel";
 
 import styles from "../assets/stylesheets/index.scss";
 
@@ -85,15 +86,10 @@ class HomeRoot extends Component {
   }
 
   async verifyAuth() {
-    const socket = await connectToReticulum();
-    const channel = socket.channel(this.props.authTopic);
-    await new Promise((resolve, reject) =>
-      channel
-        .join()
-        .receive("ok", resolve)
-        .receive("error", reject)
-    );
-    channel.push("auth_verified", { token: this.props.authToken });
+    const authChannel = new AuthChannel(this.props.store);
+    authChannel.setSocket(await connectToReticulum());
+    await authChannel.verifyAuthentication(this.props.authTopic, this.props.authToken);
+    this.setState({ signedIn: true, email: this.props.store.state.credentials.email });
   }
 
   showDialog = (DialogClass, props = {}) => {
@@ -103,7 +99,7 @@ class HomeRoot extends Component {
   };
 
   showAuthDialog = verifying => {
-    this.showDialog(AuthDialog, { closable: false, verifying, authOrigin: this.props.authOrigin });
+    this.showDialog(AuthDialog, { verifying, authOrigin: this.props.authOrigin });
   };
 
   loadHomeVideo = () => {

--- a/src/utils/auth-channel.js
+++ b/src/utils/auth-channel.js
@@ -28,6 +28,18 @@ export default class AuthChannel {
     this._signedIn = false;
   };
 
+  async verifyAuthentication(authTopic, authToken) {
+    const channel = this.stocket.channel(authTopic);
+    await new Promise((resolve, reject) =>
+      channel
+        .join()
+        .receive("ok", () => {
+          channel.push("auth_verified", { token: authToken });
+        })
+        .receive("error", reject)
+    );
+  }
+
   async startAuthentication(email, hubChannel) {
     const channel = this.socket.channel(`auth:${uuid()}`);
     await new Promise((resolve, reject) =>
@@ -39,11 +51,7 @@ export default class AuthChannel {
 
     const authComplete = new Promise(resolve =>
       channel.on("auth_credentials", async ({ credentials: token }) => {
-        this.store.update({ credentials: { email, token } });
-        if (hubChannel) {
-          await hubChannel.signIn(token);
-        }
-        this._signedIn = true;
+        await this.handleAuthCredentials(email, token, hubChannel);
         resolve();
       })
     );
@@ -53,5 +61,15 @@ export default class AuthChannel {
     // Returning an object with the authComplete promise since we want the caller to wait for the above await but not
     // for authComplete.
     return { authComplete };
+  }
+
+  async handleAuthCredentials(email, token, hubChannel) {
+    this.store.update({ credentials: { email, token } });
+
+    if (hubChannel) {
+      await hubChannel.signIn(token);
+    }
+
+    this._signedIn = true;
   }
 }

--- a/src/utils/auth-channel.js
+++ b/src/utils/auth-channel.js
@@ -28,12 +28,44 @@ export default class AuthChannel {
     this._signedIn = false;
   };
 
-  async verifyAuthentication(authTopic, authToken) {
-    const channel = this.stocket.channel(authTopic);
-    await new Promise((resolve, reject) =>
+  verifyAuthentication(authTopic, authToken) {
+    const channel = this.socket.channel(authTopic);
+    return new Promise((resolve, reject) =>
       channel
         .join()
         .receive("ok", () => {
+          let receivedEmail;
+          let receivedToken;
+
+          // On the verifier side, also update local storage so we log in on both sides.
+          //
+          // In the case where it's the same browser, it should be updated with the same values in
+          // both tabs, so nbd.
+          const storeCredentials = async () => {
+            if (!receivedEmail || !receivedToken) return;
+            await this.handleAuthCredentials(receivedEmail, receivedToken);
+            resolve();
+          };
+
+          // We need to receive both the credentials token and the email (these come over via separate messages,
+          // since the email needs to be send from the origin process)
+          //
+          // If the user closed the other tab, which would cause the email to not show up, or the token failed,
+          // give up after a timeout.
+          setTimeout(() => {
+            if (!receivedEmail || !receivedToken) resolve();
+          }, 5000);
+
+          channel.on("auth_credentials", async ({ credentials: token }) => {
+            receivedToken = token;
+            storeCredentials();
+          });
+
+          channel.on("auth_email", async ({ email: email }) => {
+            receivedEmail = email;
+            storeCredentials();
+          });
+
           channel.push("auth_verified", { token: authToken });
         })
         .receive("error", reject)


### PR DESCRIPTION
Goes with https://github.com/mozilla/reticulum/pull/194

This updates the authentication flow so both contexts of the authentication flow are logged in. (the page which requested the login, as well as the page which loads in response to the user clicking the link.) This is particularly necessary for the PWA. However, I am not sure if this is going to work there or not, since it relies up on the originating channel process to be alive long enough to send over the original email address. (will test in prod :))

Also fixes up the design a bit.