### PR TITLE
Camera timer, frame rate limiting

### DIFF
--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -72,7 +72,7 @@ AFRAME.registerComponent("camera-tool", {
       map: this.renderTarget.texture
     });
 
-    // Bit of a hack here to only update the renderTarget when the screens are in view 
+    // Bit of a hack here to only update the renderTarget when the screens are in view
     material.map.isVideoTexture = true;
     material.map.update = () => {
       if (this.showCameraViewport) {

--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -193,7 +193,7 @@ AFRAME.registerComponent("camera-tool", {
       this.snapCountdown--;
 
       if (this.snapCountdown === 0) {
-        this.el.setAttribute("camera-tool", { label: " ", isSnapping: false });
+        this.el.setAttribute("camera-tool", { label: "", isSnapping: false });
         this.takeSnapshotNextTick = true;
         clearInterval(interval);
       } else {

--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -39,7 +39,7 @@ const isMobileVR = AFRAME.utils.device.isMobileVR();
 
 AFRAME.registerComponent("camera-tool", {
   schema: {
-    previewFPS: { default: 6 },
+    heldOrSnappingViewportFPS: { default: 6 },
     imageWidth: { default: 1024 },
     imageHeight: { default: 1024 / (16 / 9) },
     isSnapping: { default: false },
@@ -240,7 +240,10 @@ AFRAME.registerComponent("camera-tool", {
     }
 
     // Always draw held or snapping camera viewports with a decent framerate
-    if ((isHolding || this.data.isSnapping) && performance.now() - this.lastUpdate >= 1000 / this.data.previewFPS) {
+    if (
+      (isHolding || this.data.isSnapping) &&
+      performance.now() - this.lastUpdate >= 1000 / this.data.heldOrSnappingViewportFPS
+    ) {
       this.updateRenderTargetNextTick = true;
     }
 

--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -72,7 +72,7 @@ AFRAME.registerComponent("camera-tool", {
       map: this.renderTarget.texture
     });
 
-    // Bit of a hack here to only update the renderTarget when the screens are in view and at a reduced FPS
+    // Bit of a hack here to only update the renderTarget when the screens are in view 
     material.map.isVideoTexture = true;
     material.map.update = () => {
       if (this.showCameraViewport) {

--- a/src/hub.html
+++ b/src/hub.html
@@ -388,6 +388,22 @@
                     position-at-box-shape-border__freeze="target: .camera-menu"
                     set-yxz-order
                 >
+                    <a-entity
+                        class="label"
+                        text="value: text; align: center; color: #efefef"
+                        position="0 0 0.1"
+                        scale="3.5 3.5 3.5"
+                    ></a-entity>
+                    <a-entity class="ui interactable-ui camera-snap-menu" mixin="button-container">
+                        <a-entity class="snap-button" mixin="rounded-action-button" is-remote-hover-target tags="singleActionButton: true;" position="0 -0.15 0.075" scale="0.75 0.75 0.75">
+                            <a-entity
+                                sprite
+                                icon-button="image: snap_camera.png; hoverImage: snap_camera.png;"
+                                scale="0.225 0.225 0.225"
+                                position="0 0.005 0.01"
+                            ></a-entity>
+                        </a-entity>
+                    </a-entity>
                     <a-entity class="ui interactable-ui camera-menu" visibility-while-frozen="withinDistance: 10;">
                         <a-entity mixin="rounded-text-action-button" is-remote-hover-target tags="singleActionButton: true;" mirror-camera-button="labelSelector:.mirror-button-label;" position="0 0.125 0.01">
                             <a-entity text=" value:mirror; width:2.5; align:center;" class="mirror-button-label" text-raycast-hack position="0 0 0.02"></a-entity>
@@ -416,19 +432,6 @@
                                 position="0 0 0.001"
                             ></a-entity>
                         </a-entity>
-                    </a-entity>
-                </a-entity>
-            </template>
-
-            <template id="camera-hover-menu">
-                <a-entity class="ui interactable-ui hover-container camera-snap-menu" mixin="button-container" visible="false">
-                    <a-entity class="snap-button" mixin="rounded-action-button" is-remote-hover-target tags="isHoverMenuChild: true; singleActionButton: true;" position="0 -0.145 0.0" scale="0.75 0.75 0.75">
-                        <a-entity
-                            sprite
-                            icon-button="image: snap_camera.png; hoverImage: snap_camera.png;"
-                            scale="0.225 0.225 0.225"
-                            position="0 0.005 0.01"
-                        ></a-entity>
                     </a-entity>
                 </a-entity>
             </template>

--- a/src/network-schemas.js
+++ b/src/network-schemas.js
@@ -152,7 +152,18 @@ function registerNetworkSchemas() {
 
   NAF.schemas.add({
     template: "#interactable-camera",
-    components: ["position", "rotation"]
+    components: [
+      "position",
+      "rotation",
+      {
+        component: "camera-tool",
+        property: "isSnapping"
+      },
+      {
+        component: "camera-tool",
+        property: "label"
+      }
+    ]
   });
 
   NAF.schemas.add({

--- a/src/systems/camera-tools.js
+++ b/src/systems/camera-tools.js
@@ -1,7 +1,12 @@
 // Used for tracking and managing camera tools in the scene
+
+const CAMERA_UPDATE_FRAME_DELAY = 10; // Update one camera every N'th frame
+
 AFRAME.registerSystem("camera-tools", {
   init() {
     this.cameraEls = [];
+    this.cameraUpdateCount = 0;
+    this.ticks = 0;
   },
 
   register(el) {
@@ -28,5 +33,17 @@ AFRAME.registerSystem("camera-tools", {
 
   _onOwnershipChange() {
     this.myCamera = null;
+  },
+
+  tick() {
+    this.ticks++;
+
+    // We update at most one camera viewport per frame.
+    if (this.ticks % CAMERA_UPDATE_FRAME_DELAY === 0) {
+      if (this.cameraEls.length == 0) return;
+
+      this.cameraUpdateCount++;
+      this.cameraEls[this.cameraUpdateCount % this.cameraEls.length].components["camera-tool"].updateViewport();
+    }
   }
 });

--- a/src/systems/hover-menu-system.js
+++ b/src/systems/hover-menu-system.js
@@ -2,7 +2,6 @@ function getSpecificHoverMenu(el) {
   return (
     el.components["hover-menu"] ||
     el.components["hover-menu__video"] ||
-    el.components["hover-menu__camera"] ||
     el.components["hover-menu__hubs-item"] ||
     el.components["hover-menu__link"]
   );

--- a/src/systems/sound-effects-system.js
+++ b/src/systems/sound-effects-system.js
@@ -36,6 +36,7 @@ export const SOUND_FREEZE = soundEnum++;
 export const SOUND_PIN = soundEnum++;
 export const SOUND_MEDIA_LOADING = soundEnum++;
 export const SOUND_MEDIA_LOADED = soundEnum++;
+export const SOUND_CAMERA_TOOL_COUNTDOWN = soundEnum++;
 
 // Safari doesn't support the promise form of decodeAudioData, so we polyfill it.
 function decodeAudioData(audioContext, arrayBuffer) {
@@ -55,6 +56,7 @@ export class SoundEffectsSystem {
       [SOUND_PEN_UNDO_DRAW, URL_TICK],
       [SOUND_PEN_CHANGE_COLOR, URL_TICK],
       [SOUND_TOGGLE_MIC, URL_TICK],
+      [SOUND_CAMERA_TOOL_COUNTDOWN, URL_TICK],
       [SOUND_TELEPORT_START, URL_TELEPORT_LOOP],
       [SOUND_TELEPORT_END, URL_QUICK_TURN],
       [SOUND_SNAP_ROTATE, URL_TAP_MELLOW],


### PR DESCRIPTION
Update: Video camera functionality now on https://github.com/mozilla/hubs/pull/1494

Fixes up a bunch of camera behavior:

- Adds a 3 second timer to the camera. The timer is networked so other users a) will see the countdown and b) will not be able to take a photo during the countdown.

- On mobile VR, draw the camera viewfinder if we're holding the camera or if the camera is taking a picture

- Draw at most one camera viewfinder per frame, and only once per every 10 frames. (Except if you are holding a camera, in which case we force drawing it at a higher frame rate so it's more usable.)

- Moves the snapshot button out of the hover menu and into a fixed place on the camera (removes awkward "hover then place over button" UX, and also improves discovery on mobile greatly.)

video/GIF will be separate PR