### PR TITLE
Remap undo drawing on oculus touch devices

### DIFF
--- a/src/systems/userinput/bindings/oculus-touch-user.js
+++ b/src/systems/userinput/bindings/oculus-touch-user.js
@@ -783,7 +783,7 @@ export const oculusTouchUserBindings = addSetsToBindings({
       priority: 1
     },
     {
-      src: { value: rightButton("b").pressed },
+      src: { value: leftButton("x").pressed },
       dest: { value: paths.actions.leftHand.undoDrawing },
       xform: xforms.rising,
       priority: 1
@@ -974,7 +974,7 @@ export const oculusTouchUserBindings = addSetsToBindings({
       priority: 1
     },
     {
-      src: { value: leftButton("y").pressed },
+      src: { value: rightButton("a").pressed },
       dest: { value: paths.actions.rightHand.undoDrawing },
       xform: xforms.rising,
       priority: 1


### PR DESCRIPTION
On Oculus Touch: move "undo drawing" back to the same controller that is holding the pen to the "x" and "a" buttons.