### PR TITLE
Use auth payload to store email

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ const remountUI = function() {
       authVerify={qs.has("auth_topic")}
       authTopic={qs.get("auth_topic")}
       authToken={qs.get("auth_token")}
+      authPayload={qs.get("auth_payload")}
       authOrigin={qs.get("auth_origin")}
       listSignup={qs.has("list_signup")}
       hideHero={hideHero}

--- a/src/react-components/home-root.js
+++ b/src/react-components/home-root.js
@@ -43,6 +43,7 @@ class HomeRoot extends Component {
     authVerify: PropTypes.bool,
     authTopic: PropTypes.string,
     authToken: PropTypes.string,
+    authPayload: PropTypes.string,
     authOrigin: PropTypes.string,
     listSignup: PropTypes.bool,
     report: PropTypes.bool,
@@ -88,7 +89,7 @@ class HomeRoot extends Component {
   async verifyAuth() {
     const authChannel = new AuthChannel(this.props.store);
     authChannel.setSocket(await connectToReticulum());
-    await authChannel.verifyAuthentication(this.props.authTopic, this.props.authToken);
+    await authChannel.verifyAuthentication(this.props.authTopic, this.props.authToken, this.props.authPayload);
     this.setState({ signedIn: true, email: this.props.store.state.credentials.email });
   }
 


### PR DESCRIPTION
See: https://github.com/mozilla/reticulum/pull/198

Grabs the email out of the responding auth payload from the auth channel message, to allow logging in from the verifier side without a dependency upon the remote end being alive.