### PR TITLE
Invalidate text bounding box/sphere on update

### DIFF
--- a/src/components/hubs-text.js
+++ b/src/components/hubs-text.js
@@ -296,6 +296,8 @@ AFRAME.registerComponent("text", {
         .replace(tabRegex, "\t");
       geometryUpdateData.width = computeWidth(data.wrapPixels, data.wrapCount, font.widthFactor);
       geometry.update(Object.assign(geometryUpdateBase, data, geometryUpdateData));
+      geometry.boundingBox = null;
+      geometry.boundingSphere = null;
     };
   })()
 });


### PR DESCRIPTION
For example, if someone's name on their nametag gets bigger or smaller. Not doing this is just wrong and bit us earlier. Let's fix it.