### PR TITLE
Bug/re pin while moving

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -258,12 +258,14 @@ if (document.location.pathname.includes("hub.html")) {
 const history = createBrowserHistory({ basename: routerBaseName });
 window.APP.history = history;
 
+const qsVREntryType = qs.get("vr_entry_type");
+
 function mountUI(props = {}) {
   const scene = document.querySelector("a-scene");
   const disableAutoExitOnConcurrentLoad = qsTruthy("allow_multi");
-  const forcedVREntryType = qs.get("vr_entry_type");
   const isCursorHoldingPen = scene && scene.systems.userinput.activeSets.includes(userinputSets.cursorHoldingPen);
   const hasActiveCamera = scene && !!scene.systems["camera-tools"].getMyCamera();
+  const forcedVREntryType = qsVREntryType;
 
   ReactDOM.render(
     <Router history={history}>
@@ -874,7 +876,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       availableVREntryTypes.generic !== VR_DEVICE_AVAILABILITY.no ||
       availableVREntryTypes.daydream !== VR_DEVICE_AVAILABILITY.no;
 
-    remountUI({ availableVREntryTypes, forcedVREntryType: !hasVREntryDevice ? "2d" : null });
+    remountUI({ availableVREntryTypes, forcedVREntryType: qsVREntryType || (!hasVREntryDevice ? "2d" : null) });
   }
 
   const environmentScene = document.querySelector("#environment-scene");

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -275,19 +275,11 @@ export default class SceneEntryManager {
 
     this.scene.addEventListener("pinned", e => {
       if (this._disableSignInOnPinAction) return;
-
-      // Don't go into pin/unpin flow if the pin state didn't actually change and this was just initialization
-      if (!e.detail.changed) return;
-
       this._signInAndPinOrUnpinElement(e.detail.el, true);
     });
 
     this.scene.addEventListener("unpinned", e => {
       if (this._disableSignInOnPinAction) return;
-
-      // Don't go into pin/unpin flow if the pin state didn't actually change and this was just initialization
-      if (!e.detail.changed) return;
-
       this._signInAndPinOrUnpinElement(e.detail.el, false);
     });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/1447

This commit:

https://github.com/mozilla/hubs/commit/788a75f5021ebd4cdc83343285189a9ab6b2f0fa

Unwired the event handler on `grabEnd`, which it turned out was actually mis-configured in the first place since it did not pass `oldData` along properly (`oldData` ended up being bound to the grab event.) this mis-configuration actually is what was allowing "move an object in pause mode if its pinned and it will re-pin": the relevant event handler control flow would save the pin because of this erroneous use of `oldData`.

anyhow, this refactors the code somewhat and parameterizes things in a way to make it explicit when we want to forcibly fire `pinned` and `unpinned` events even if the state itself has not changed. i wasn't able to determine what condition causes us to need to check for the state changing and avoid the side effect, but presumably it was to prevent the sign in dialog from popping up during some kind of object initialization flow. in any case, this new `force` flag allows us to override that behavior in the specific case where we are letting go of the object during pause mode.

this also pulls in https://github.com/mozilla/hubs/commit/ebd0c997752aa9cb6ffd064013c8fcf130d5602f in order to fix `vr_entry_type=2d_now` since I wasn't sure if that was the case to check.