### PR TITLE
Don't do a ton of stuff whenever local storage changes

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -1054,7 +1054,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       const vrHudPresenceCount = document.querySelector("#hud-presence-count");
 
       if (isInitialJoin) {
-        store.addEventListener("statechanged", hubChannel.sendProfileUpdate.bind(hubChannel));
+        store.addEventListener("profilechanged", hubChannel.sendProfileUpdate.bind(hubChannel));
         hubChannel.presence.onSync(() => {
           const presence = hubChannel.presence;
 

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -217,6 +217,9 @@ export default class Store extends EventTarget {
     localStorage.setItem(LOCAL_STORE_KEY, JSON.stringify(finalState));
     delete this[STORE_STATE_CACHE_KEY];
 
+    if (newState.profile !== undefined) {
+      this.dispatchEvent(new CustomEvent("profilechanged"));
+    }
     this.dispatchEvent(new CustomEvent("statechanged"));
 
     return finalState;


### PR DESCRIPTION
Sending the new presence profile caused the code right below responding to presence updates to also run, which caused everyone in the room to, e.g., do a full React re-render because you clicked some button that updated its bit to say that you didn't need to see a tutorial tooltip anymore.

It's still really fishy that we re-render the whole React UI (multiple times, actually) whenever anything in presence changes, but this starts to minimize the damage.