### PR TITLE
Settings menu is responsible for its own expanded state

### DIFF
--- a/src/react-components/settings-menu.js
+++ b/src/react-components/settings-menu.js
@@ -10,17 +10,18 @@ import { faStar } from "@fortawesome/free-solid-svg-icons/faStar";
 import { faDoorClosed } from "@fortawesome/free-solid-svg-icons/faDoorClosed";
 import { faPencilAlt } from "@fortawesome/free-solid-svg-icons/faPencilAlt";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons/faInfoCircle";
+import { faBars } from "@fortawesome/free-solid-svg-icons/faBars";
 import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus";
 import { faVideo } from "@fortawesome/free-solid-svg-icons/faVideo";
 import { showFullScreenIfAvailable } from "../utils/fullscreen";
 import LeaveRoomDialog from "./leave-room-dialog.js";
 
 import styles from "../assets/stylesheets/settings-menu.scss";
+import rootStyles from "../assets/stylesheets/ui-root.scss";
 
 export default class SettingsMenu extends Component {
   static propTypes = {
     history: PropTypes.object,
-    hideSettings: PropTypes.func,
     isStreaming: PropTypes.bool,
     toggleStreamerMode: PropTypes.func,
     mediaSearchStore: PropTypes.object,
@@ -32,7 +33,19 @@ export default class SettingsMenu extends Component {
     pushHistoryState: PropTypes.func
   };
 
-  render() {
+  state = {
+    expanded: false
+  };
+
+  componentDidMount() {
+    document.querySelector(".a-canvas").addEventListener("mouseup", () => {
+      if (this.state.expanded) {
+        this.setState({ expanded: false });
+      }
+    });
+  }
+
+  renderExpandedMenu() {
     const rowClasses = classNames([styles.row, styles.settingsRow]);
     const rowHeader = classNames([styles.row, styles.settingsRow, styles.rowHeader]);
     const showRoomSettings = !!this.props.hubChannel.canOrWillIfCreator("update_hub");
@@ -59,7 +72,7 @@ export default class SettingsMenu extends Component {
                   stateKey="overlay"
                   stateValue="profile"
                   history={this.props.history}
-                  onClick={this.props.hideSettings}
+                  onClick={() => this.setState({ expanded: false })}
                 >
                   <FormattedMessage id="settings.change-avatar" />
                 </StateLink>
@@ -110,7 +123,7 @@ export default class SettingsMenu extends Component {
                         () => {
                           showFullScreenIfAvailable();
                           this.props.mediaSearchStore.sourceNavigateWithNoNav("scenes");
-                          this.props.hideSettings();
+                          this.setState({ expanded: false });
                         },
                         "change-scene"
                       );
@@ -138,7 +151,7 @@ export default class SettingsMenu extends Component {
                         () => this.props.hubChannel.can("update_hub"),
                         () => {
                           this.props.pushHistoryState("modal", "rename_room");
-                          this.props.hideSettings();
+                          this.setState({ expanded: false });
                         },
                         "rename-room"
                       );
@@ -166,7 +179,7 @@ export default class SettingsMenu extends Component {
                         () => this.props.hubChannel.can("update_hub"),
                         () => {
                           this.props.pushHistoryState("modal", "close_room");
-                          this.props.hideSettings();
+                          this.setState({ expanded: false });
                         },
                         "close-room"
                       );
@@ -189,7 +202,7 @@ export default class SettingsMenu extends Component {
                     stateKey="modal"
                     stateValue="room_info"
                     history={this.props.history}
-                    onClick={this.props.hideSettings}
+                    onClick={() => this.setState({ expanded: false })}
                   >
                     <FormattedMessage id="settings.room-info" />
                   </StateLink>
@@ -211,7 +224,7 @@ export default class SettingsMenu extends Component {
                       destinationUrl: "/",
                       messageType: "create-room"
                     });
-                    this.props.hideSettings();
+                    this.setState({ expanded: false });
                   }}
                 >
                   <FormattedMessage id="settings.create-room" />
@@ -237,6 +250,7 @@ export default class SettingsMenu extends Component {
                     className={styles.listItemLink}
                     onClick={() => {
                       this.props.toggleStreamerMode(true);
+                      this.setState({ expanded: false });
                     }}
                   >
                     <FormattedMessage id="settings.enable-streamer-mode" />
@@ -254,7 +268,7 @@ export default class SettingsMenu extends Component {
                 onClick={e => {
                   e.preventDefault();
                   resetTips();
-                  this.props.hideSettings();
+                  this.setState({ expanded: false });
                 }}
               >
                 <FormattedMessage id="settings.tips" />
@@ -295,6 +309,22 @@ export default class SettingsMenu extends Component {
             </div>
           </div>
         </div>
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        <FontAwesomeIcon
+          icon={faBars}
+          onClick={() => this.setState({ expanded: !this.state.expanded })}
+          className={classNames({
+            [rootStyles.cornerButton]: true,
+            [rootStyles.cornerButtonSelected]: this.state.expanded
+          })}
+        />
+        {this.state.expanded && this.renderExpandedMenu()}
       </div>
     );
   }

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -66,7 +66,6 @@ import { handleReEntryToVRFrom2DInterstitial } from "../utils/vr-interstitial";
 import { handleTipClose } from "../systems/tips.js";
 
 import { faUsers } from "@fortawesome/free-solid-svg-icons/faUsers";
-import { faBars } from "@fortawesome/free-solid-svg-icons/faBars";
 import { faTimes } from "@fortawesome/free-solid-svg-icons/faTimes";
 import { faStar } from "@fortawesome/free-solid-svg-icons/faStar";
 import { faArrowLeft } from "@fortawesome/free-solid-svg-icons/faArrowLeft";
@@ -1837,20 +1836,21 @@ class UIRoot extends Component {
               />
             )}
 
-            {!streaming && !preload && (
-              <SettingsMenu
-                history={this.props.history}
-                mediaSearchStore={this.props.mediaSearchStore}
-                isStreaming={streaming}
-                toggleStreamerMode={this.toggleStreamerMode}
-                hubChannel={this.props.hubChannel}
-                hubScene={this.props.hubScene}
-                scene={this.props.scene}
-                performConditionalSignIn={this.props.performConditionalSignIn}
-                showNonHistoriedDialog={this.showNonHistoriedDialog}
-                pushHistoryState={this.pushHistoryState}
-              />
-            )}
+            {!streaming &&
+              !preload && (
+                <SettingsMenu
+                  history={this.props.history}
+                  mediaSearchStore={this.props.mediaSearchStore}
+                  isStreaming={streaming}
+                  toggleStreamerMode={this.toggleStreamerMode}
+                  hubChannel={this.props.hubChannel}
+                  hubScene={this.props.hubScene}
+                  scene={this.props.scene}
+                  performConditionalSignIn={this.props.performConditionalSignIn}
+                  showNonHistoriedDialog={this.showNonHistoriedDialog}
+                  pushHistoryState={this.pushHistoryState}
+                />
+              )}
 
             {!entered && !streaming && !isMobile && streamerName && <SpectatingLabel name={streamerName} />}
 

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -171,7 +171,6 @@ class UIRoot extends Component {
     dialog: null,
     showShareDialog: false,
     showPresenceList: false,
-    showSettingsMenu: false,
     broadcastTipDismissed: false,
     linkCode: null,
     linkCodeCancel: null,
@@ -260,8 +259,8 @@ class UIRoot extends Component {
   componentDidMount() {
     window.addEventListener("concurrentload", this.onConcurrentLoad);
     document.querySelector(".a-canvas").addEventListener("mouseup", () => {
-      if (this.state.showPresenceList || this.state.showSettingsMenu || this.state.showShareDialog) {
-        this.setState({ showPresenceList: false, showSettingsMenu: false, showShareDialog: false });
+      if (this.state.showPresenceList || this.state.showShareDialog) {
+        this.setState({ showPresenceList: false, showShareDialog: false });
       }
     });
 
@@ -747,7 +746,7 @@ class UIRoot extends Component {
 
     if (enable) {
       this.props.hubChannel.beginStreaming();
-      this.setState({ isStreaming: true, showStreamingTip: true, showSettingsMenu: false });
+      this.setState({ isStreaming: true, showStreamingTip: true });
     } else {
       this.props.hubChannel.endStreaming();
       this.setState({ isStreaming: false });
@@ -1815,19 +1814,6 @@ class UIRoot extends Component {
 
             {streamingTip}
 
-            {!streaming &&
-              !preload && (
-                <div
-                  onClick={() => this.setState({ showSettingsMenu: !this.state.showSettingsMenu })}
-                  className={classNames({
-                    [styles.cornerButton]: true,
-                    [styles.cornerButtonSelected]: this.state.showSettingsMenu
-                  })}
-                >
-                  <FontAwesomeIcon icon={faBars} />
-                </div>
-              )}
-
             <div
               onClick={() => this.setState({ showPresenceList: !this.state.showPresenceList })}
               className={classNames({
@@ -1851,11 +1837,10 @@ class UIRoot extends Component {
               />
             )}
 
-            {this.state.showSettingsMenu && (
+            {!streaming && !preload && (
               <SettingsMenu
                 history={this.props.history}
                 mediaSearchStore={this.props.mediaSearchStore}
-                hideSettings={() => this.setState({ showSettingsMenu: false })}
                 isStreaming={streaming}
                 toggleStreamerMode={this.toggleStreamerMode}
                 hubChannel={this.props.hubChannel}


### PR DESCRIPTION
This pattern is more efficient with regard to re-rendering and moves some conceptually settings-menu-related stuff (its non-expanded look and behavior) outside of the root component, which feels nice.