### PR TITLE
Turn 'kicked' message into 'disconnected' message

### DIFF
--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -146,7 +146,7 @@
     "exit.subtitle.exited": "Your session has ended. Refresh your browser to start a new one.",
     "exit.subtitle.closed": "This room is no longer available.",
     "exit.subtitle.denied": "You are not permitted to join this room. Please request permission from the room creator.",
-    "exit.subtitle.kicked": "You have been kicked from the room.",
+    "exit.subtitle.disconnected": "You have disconnected from the room. Refresh the page to try to reconnect.",
     "exit.subtitle.left": "You have left the room.",
     "exit.subtitle.full": "This room is full, please try again later.",
     "exit.subtitle.connect_error": "Unable to connect to this room, please try again later.",

--- a/src/hub.js
+++ b/src/hub.js
@@ -910,11 +910,13 @@ document.addEventListener("DOMContentLoaded", async () => {
   const socket = await connectToReticulum(isDebug);
 
   socket.onClose(e => {
-    // The socket should close normally if the server has explicitly killed it.
+    // We don't currently have an easy way to distinguish between being kicked (server closes socket)
+    // and a variety of other network issues that seem to produce the 1000 closure code, but the
+    // latter are probably more common. Either way, we just tell the user they got disconnected.
     const NORMAL_CLOSURE = 1000;
     if (e.code === NORMAL_CLOSURE) {
       entryManager.exitScene();
-      remountUI({ roomUnavailableReason: "kicked" });
+      remountUI({ roomUnavailableReason: "disconnected" });
     }
   });
 

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -918,7 +918,7 @@ class UIRoot extends Component {
         <div>
           <FormattedMessage id={exitSubtitleId} />
           <p />
-          {!["left", "kicked"].includes(this.props.roomUnavailableReason) && (
+          {!["left", "disconnected"].includes(this.props.roomUnavailableReason) && (
             <div>
               You can also{" "}
               <WithHoverSound>


### PR DESCRIPTION
As we talked about a while ago, this is probably a better default assumption to present to the user. Examples of times I definitely get this message:

- If I leave the debugger paused for a little bit
- If a tab gets backgrounded too hard by the browser (seems especially common on mobile, but sometimes happens on desktop)
- If my wireless connection dies for a little bit