### PR TITLE
Update three to vao-ubo-prs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17113,7 +17113,7 @@
       }
     },
     "three": {
-      "version": "github:mozillareality/three.js#0a2465e6e976c5b9c5b50c6c043807cfe99376fc",
+      "version": "github:mozillareality/three.js#6041920b6f3c8929ee631a5e14460bf9db85835d",
       "from": "github:mozillareality/three.js#hubs/master"
     },
     "three-bmfont-text": {

--- a/src/utils/media-url-utils.js
+++ b/src/utils/media-url-utils.js
@@ -99,8 +99,7 @@ export const guessContentType = url => {
       matches[1];
     }
   }
-  const path = url.startsWith("/") ? url : new URL(url).pathname;
-  const extension = path.split(".").pop();
+  const extension = new URL(url, window.location).pathname.split(".").pop();
   return commonKnownContentTypes[extension];
 };
 const hubsSceneRegex = /https?:\/\/(hubs.local(:\d+)?|(smoke-)?hubs.mozilla.com)\/scenes\/(\w+)\/?\S*/;

--- a/src/utils/media-url-utils.js
+++ b/src/utils/media-url-utils.js
@@ -99,7 +99,8 @@ export const guessContentType = url => {
       matches[1];
     }
   }
-  const extension = new URL(url).pathname.split(".").pop();
+  const path = url.startsWith("/") ? url : new URL(url).pathname;
+  const extension = path.split(".").pop();
   return commonKnownContentTypes[extension];
 };
 const hubsSceneRegex = /https?:\/\/(hubs.local(:\d+)?|(smoke-)?hubs.mozilla.com)\/scenes\/(\w+)\/?\S*/;


### PR DESCRIPTION
This updates package.lock to point at our latest three.js fork that includes vao+ubo patches. Also fixes an issue introduced yesterday for relative url textures.