### PR TITLE
Fix content type check in HubsTextureLoader

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -756,7 +756,7 @@ AFRAME.registerComponent("media-image", {
         } else if (contentType.includes("image/gif")) {
           texture = await createGIFTexture(src);
         } else if (contentType.startsWith("image/")) {
-          texture = await createImageTexture(src, contentType);
+          texture = await createImageTexture(src);
         } else {
           throw new Error(`Unknown image content type: ${contentType}`);
         }

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -292,11 +292,11 @@ export function spawnMediaAround(el, media, snapCount, mirrorOrientation = false
 
 export const textureLoader = new HubsTextureLoader().setCrossOrigin("anonymous");
 
-export async function createImageTexture(url, contentType) {
+export async function createImageTexture(url) {
   const texture = new THREE.Texture();
 
   try {
-    await textureLoader.loadTextureAsync(texture, url, contentType);
+    await textureLoader.loadTextureAsync(texture, url);
   } catch (e) {
     throw new Error(`'${url}' could not be fetched (Error code: ${e.status}; Response: ${e.statusText})`);
   }


### PR DESCRIPTION
This fix uses the file header instead of the inferred content type from farspark or the url extension. This allows us to better check for file types of blob urls, urls without extensions, and resolved urls with incorrectly inferred content types.