### PR TITLE
Move back to 4x anisotropy

### DIFF
--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -302,7 +302,7 @@ export async function createImageTexture(url, contentType) {
   }
 
   texture.encoding = THREE.sRGBEncoding;
-  texture.anisotropy = 16;
+  texture.anisotropy = 4;
 
   return texture;
 }


### PR DESCRIPTION
Most images look great with 4x anisotropy and text doesn't get clearer at 16x. We should just special case text media to use linear filtering without mipmapping or mipmapping with different filtering and special LOD behavior to keep text clear at a reasonable distance. Better yet, we could use SDF text and avoid this altogether.