### PR TITLE
XboxController bindings for standard gamepads

### DIFF
--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -312,7 +312,7 @@ AFRAME.registerSystem("userinput", {
         gamepadDevice = new GearVRControllerDevice(e.gamepad);
       } else if (e.gamepad.id === "Daydream Controller") {
         gamepadDevice = new DaydreamControllerDevice(e.gamepad);
-      } else {
+      } else if (e.gamepad.mapping === "standard") {
         // Our XboxController device and bindings should be generic enough for most gamepads.
         gamepadDevice = new XboxControllerDevice(e.gamepad);
       }

--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -315,6 +315,9 @@ AFRAME.registerSystem("userinput", {
       } else if (e.gamepad.mapping === "standard") {
         // Our XboxController device and bindings should be generic enough for most gamepads.
         gamepadDevice = new XboxControllerDevice(e.gamepad);
+      } else {
+        // This device doesn't actually have any bindings, but we need to fallback to something.
+        gamepadDevice = new GamepadDevice(e.gamepad);
       }
 
       this.activeDevices.add(gamepadDevice);

--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -312,10 +312,9 @@ AFRAME.registerSystem("userinput", {
         gamepadDevice = new GearVRControllerDevice(e.gamepad);
       } else if (e.gamepad.id === "Daydream Controller") {
         gamepadDevice = new DaydreamControllerDevice(e.gamepad);
-      } else if (e.gamepad.id.toLowerCase().includes("xinput")) {
-        gamepadDevice = new XboxControllerDevice(e.gamepad);
       } else {
-        gamepadDevice = new GamepadDevice(e.gamepad);
+        // Our XboxController device and bindings should be generic enough for most gamepads.
+        gamepadDevice = new XboxControllerDevice(e.gamepad);
       }
 
       this.activeDevices.add(gamepadDevice);


### PR DESCRIPTION
This should enable support for most non-xbox gamepad controllers, such as the PS4 controller and SteelSeries controllers