### PR TITLE
Re-create mic stream if oculus browser 6 ends audio stream

### DIFF
--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -553,7 +553,19 @@ class UIRoot extends Component {
 
     try {
       const mediaStream = await navigator.mediaDevices.getUserMedia(constraints);
-      this.setState({ audioTrack: mediaStream.getAudioTracks()[0] });
+      const audioTrack = mediaStream.getAudioTracks()[0];
+      this.setState({ audioTrack });
+
+      if (/Oculus/.test(navigator.userAgent)) {
+        // TODO remove, being used to diagnose issues with Oculus Browser
+        audioTrack.addEventListener("ended", async () => {
+          console.warn(
+            "Oculus Browser 6 bug hit: Audio stream track ended without calling stop. Recreating audio stream."
+          );
+          NAF.connection.adapter.setLocalMediaStream(await navigator.mediaDevices.getUserMedia(constraints));
+        });
+      }
+
       return true;
     } catch (e) {
       // Error fetching audio track, most likely a permission denial.

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -557,7 +557,8 @@ class UIRoot extends Component {
       this.setState({ audioTrack });
 
       if (/Oculus/.test(navigator.userAgent)) {
-        // TODO remove, being used to diagnose issues with Oculus Browser
+        // HACK Oculus Browser 6 seems to randomly end the microphone audio stream. This re-creates it.
+        // Note the ended event will only fire if some external event ends the stream, not if we call stop().
         audioTrack.addEventListener("ended", async () => {
           console.warn(
             "Oculus Browser 6 bug hit: Audio stream track ended without calling stop. Recreating audio stream."


### PR DESCRIPTION
It seems Oculus Browser 6 has a bug where the AudioTrack for the microphone can randomly end. This is an attempted fix. Currently I have been unable to repo the issue with bots so I'm hoping I can just use adb to see that this is working in our next standup, etc.