### PR TITLE
Improve concurrent media resolving

### DIFF
--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -35,6 +35,7 @@ const fetchMaxContentIndex = url => {
 const boundingBox = new THREE.Box3();
 
 const forceBatching = qsTruthy("forceBatching");
+const enableBatching = qsTruthy("enableBatching");
 
 AFRAME.registerComponent("media-loader", {
   schema: {
@@ -341,7 +342,7 @@ AFRAME.registerComponent("media-loader", {
         this.el.setAttribute("floaty-object", { reduceAngularFloat: true, releaseGravity: -1 });
         this.el.setAttribute(
           "media-image",
-          Object.assign({}, this.data.mediaOptions, { src: accessibleUrl, contentType })
+          Object.assign({}, this.data.mediaOptions, { src: accessibleUrl, contentType, batch: enableBatching })
         );
 
         if (this.el.components["position-at-box-shape-border__freeze"]) {
@@ -420,7 +421,8 @@ AFRAME.registerComponent("media-loader", {
           "media-image",
           Object.assign({}, this.data.mediaOptions, {
             src: thumbnail,
-            contentType: guessContentType(thumbnail) || "image/png"
+            contentType: guessContentType(thumbnail) || "image/png",
+            batch: enableBatching
           })
         );
         if (this.el.components["position-at-box-shape-border__freeze"]) {

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -730,7 +730,7 @@ AFRAME.registerComponent("media-image", {
     }
     if (this._hasRetainedTexture) {
       textureCache.release(this.data.src);
-      this._hasRetainedTexture = false;
+      this.currentSrcIsRetained = false;
     }
   },
 
@@ -749,6 +749,7 @@ AFRAME.registerComponent("media-image", {
         this.mesh.material.needsUpdate = true;
         if (this.mesh.map !== errorTexture) {
           textureCache.release(oldData.src);
+          this.currentSrcIsRetained = false;
         }
       }
 
@@ -776,8 +777,8 @@ AFRAME.registerComponent("media-image", {
           cacheItem = textureCache.set(src, texture);
         }
 
-        // No way to cancel promises, so if src has changed while we were creating the texture just throw it away.
-        if (this.data.src !== src) {
+        // No way to cancel promises, so if src has changed or this entity was removed while we were creating the texture just throw it away.
+        if (this.data.src !== src || !this.el.parentNode) {
           textureCache.release(src);
           return;
         }
@@ -786,11 +787,11 @@ AFRAME.registerComponent("media-image", {
       texture = cacheItem.texture;
       ratio = cacheItem.ratio;
 
-      this._hasRetainedTexture = true;
+      this.currentSrcIsRetained = true;
     } catch (e) {
       console.error("Error loading image", this.data.src, e);
       texture = errorTexture;
-      this._hasRetainedTexture = false;
+      this.currentSrcIsRetained = false;
     }
 
     const projection = this.data.projection;

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -275,6 +275,7 @@ errorTexture.magFilter = THREE.NearestFilter;
 errorImage.onload = () => {
   errorTexture.needsUpdate = true;
 };
+const errorCacheItem = { texture: errorTexture, ratio: 1 };
 
 function timeFmt(t) {
   let s = Math.floor(t),
@@ -756,7 +757,7 @@ AFRAME.registerComponent("media-image", {
         cacheItem = textureCache.retain(src);
       } else {
         if (src === "error") {
-          texture = errorTexture;
+          cacheItem = errorCacheItem;
         } else if (inflightTextures.has(src)) {
           await inflightTextures.get(src);
           cacheItem = textureCache.retain(src);
@@ -813,7 +814,7 @@ AFRAME.registerComponent("media-image", {
     }
 
     // We only support transparency on gifs. Other images will support cutout as part of batching, but not alpha transparency for now
-    this.mesh.material.transparent = this.data.contentType.includes("image/gif");
+    this.mesh.material.transparent = texture == errorTexture || this.data.contentType.includes("image/gif");
     this.mesh.material.map = texture;
     this.mesh.material.needsUpdate = true;
 
@@ -821,7 +822,7 @@ AFRAME.registerComponent("media-image", {
       scaleToAspectRatio(this.el, ratio);
     }
 
-    if (this.data.batch) {
+    if (texture !== errorTexture && this.data.batch) {
       this.el.sceneEl.systems["hubs-systems"].batchManagerSystem.addObject(this.mesh);
     }
 

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -266,6 +266,7 @@ class TextureCache {
 }
 
 const textureCache = new TextureCache();
+const inflightTextures = new Map();
 
 const errorImage = new Image();
 errorImage.src = errorImageSrc;
@@ -750,23 +751,29 @@ AFRAME.registerComponent("media-image", {
         }
       }
 
+      let cacheItem;
       if (textureCache.has(src)) {
-        const cacheItem = textureCache.retain(src);
-        texture = cacheItem.texture;
-        ratio = cacheItem.ratio;
+        cacheItem = textureCache.retain(src);
       } else {
         if (src === "error") {
           texture = errorTexture;
-        } else if (contentType.includes("image/gif")) {
-          texture = await createGIFTexture(src);
-        } else if (contentType.startsWith("image/")) {
-          texture = await createImageTexture(src);
+        } else if (inflightTextures.has(src)) {
+          await inflightTextures.get(src);
+          cacheItem = textureCache.retain(src);
         } else {
-          throw new Error(`Unknown image content type: ${contentType}`);
+          let promise;
+          if (contentType.includes("image/gif")) {
+            promise = createGIFTexture(src);
+          } else if (contentType.startsWith("image/")) {
+            promise = createImageTexture(src);
+          } else {
+            throw new Error(`Unknown image content type: ${contentType}`);
+          }
+          inflightTextures.set(src, promise);
+          texture = await promise;
+          inflightTextures.delete(src);
+          cacheItem = textureCache.set(src, texture);
         }
-
-        const cacheItem = textureCache.set(src, texture);
-        ratio = cacheItem.ratio;
 
         // No way to cancel promises, so if src has changed while we were creating the texture just throw it away.
         if (this.data.src !== src) {
@@ -774,6 +781,9 @@ AFRAME.registerComponent("media-image", {
           return;
         }
       }
+
+      texture = cacheItem.texture;
+      ratio = cacheItem.ratio;
 
       this._hasRetainedTexture = true;
     } catch (e) {

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -802,8 +802,9 @@ AFRAME.registerComponent("media-image", {
       this.el.setObject3D("mesh", this.mesh);
     }
 
+    // We only support transparency on gifs. Other images will support cutout as part of batching, but not alpha transparency for now
+    this.mesh.material.transparent = this.data.contentType.includes("image/gif");
     this.mesh.material.map = texture;
-    this.mesh.material.transparent = texture.format === THREE.RGBAFormat;
     this.mesh.material.needsUpdate = true;
 
     if (projection === "flat") {

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -721,7 +721,7 @@ AFRAME.registerComponent("media-image", {
     src: { type: "string" },
     projection: { type: "string", default: "flat" },
     contentType: { type: "string" },
-    batch: { default: true }
+    batch: { default: false }
   },
 
   remove() {
@@ -815,7 +815,9 @@ AFRAME.registerComponent("media-image", {
     }
 
     // We only support transparency on gifs. Other images will support cutout as part of batching, but not alpha transparency for now
-    this.mesh.material.transparent = texture == errorTexture || this.data.contentType.includes("image/gif");
+    this.mesh.material.transparent =
+      !this.data.batch || texture == errorTexture || this.data.contentType.includes("image/gif");
+    console.log(this.data.batch, this.mesh.material.transparent);
     this.mesh.material.map = texture;
     this.mesh.material.needsUpdate = true;
 

--- a/src/loaders/HubsTextureLoader.js
+++ b/src/loaders/HubsTextureLoader.js
@@ -1,43 +1,5 @@
-//
-// Based on THREE.TextureLoader
-// https://github.com/mrdoob/three.js/blob/master/src/loaders/TextureLoader.js
-// Licensed under the MIT license.
-// https://github.com/mrdoob/three.js/blob/master/LICENSE
-//
-
-// http://www.libpng.org/pub/png/spec/1.2/PNG-Structure.html
-const PNGFileSignature = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
-
-// https://en.wikipedia.org/wiki/JPEG_File_Interchange_Format#File_format_structure
-// SOI Chunk Header: FF D8
-// JFIF / EXIF Chunk Header: FF ?? (either E0 or E1)
-const JPEGFileSignature = new Uint8Array([255, 216, 255]);
-
-function signaturesEqual(referenceFileSignature, arrayBuffer) {
-  const signatureLength = referenceFileSignature.byteLength;
-
-  if (signatureLength > arrayBuffer.byteLength) {
-    return false;
-  }
-
-  const bufferView = new Uint8Array(arrayBuffer, 0, signatureLength);
-
-  for (let i = 0; i < signatureLength; i++) {
-    if (referenceFileSignature[i] !== bufferView[i]) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 function loadAsync(loader, url, onProgress) {
   return new Promise((resolve, reject) => loader.load(url, resolve, onProgress, reject));
-}
-
-function getChunkType(arrayBuffer, byteOffset) {
-  const arr = new Uint8Array(arrayBuffer, byteOffset, 4);
-  return String.fromCharCode.apply(null, arr);
 }
 
 export default class HubsTextureLoader {
@@ -58,53 +20,6 @@ export default class HubsTextureLoader {
   }
 
   async loadTextureAsync(texture, src, onProgress) {
-    let url = src;
-    let transparent = true;
-
-    const fileLoader = new THREE.FileLoader(this.manager);
-    fileLoader.setResponseType("blob");
-
-    const blob = await loadAsync(fileLoader, src, onProgress);
-
-    const bytes = await new Response(blob).arrayBuffer();
-
-    if (signaturesEqual(PNGFileSignature, bytes)) {
-      const dataView = new DataView(bytes);
-      const colorType = dataView.getUint8(25);
-
-      if (colorType === 3) {
-        // Chunk layout:
-        // length - 4 bytes
-        // type - 4 bytes
-        // data - length bytes
-        // crc - 4 bytes
-
-        const chunkHeaderSize = 12; // length + type + crc (excludes data)
-
-        let curChunkOffset = PNGFileSignature.byteLength;
-        let curChunkType = getChunkType(bytes, curChunkOffset + 4);
-
-        while (curChunkType !== "IEND") {
-          if (curChunkType === "tRNS") {
-            transparent = true;
-            break;
-          }
-
-          curChunkOffset = curChunkOffset + dataView.getUint32(curChunkOffset) + chunkHeaderSize;
-          curChunkType = getChunkType(bytes, curChunkOffset + 4);
-        }
-      } else if (colorType === 0 || colorType === 2) {
-        transparent = false;
-      }
-    } else if (signaturesEqual(JPEGFileSignature, bytes)) {
-      // JPEGs can't have an alpha channel, so memory can be saved by storing them as RGB.
-      transparent = false;
-    } else {
-      console.warn(`Couldn't detect image type for: "${src}". Using RGBA pixel format.`);
-    }
-
-    url = URL.createObjectURL(blob);
-
     let imageLoader;
 
     if (window.createImageBitmap !== undefined) {
@@ -119,28 +34,17 @@ export default class HubsTextureLoader {
 
     const cacheKey = this.manager.resolveURL(src);
 
-    let image;
-
-    try {
-      image = await loadAsync(imageLoader, url, onProgress);
-    } catch (e) {
-      // Clean up blob url if loading the image fails.
-      URL.revokeObjectURL(url);
-      throw e;
-    }
+    texture.image = await loadAsync(imageLoader, src, onProgress);
 
     // Image was just added to cache before this function gets called, disable caching by immediatly removing it
     THREE.Cache.remove(cacheKey);
 
-    texture.image = image;
-    texture.format = transparent ? THREE.RGBAFormat : THREE.RGBFormat;
     texture.needsUpdate = true;
 
     texture.onUpdate = function() {
       // Delete texture data once it has been uploaded to the GPU
       texture.image.close && texture.image.close();
       delete texture.image;
-      URL.revokeObjectURL(url);
     };
 
     return texture;

--- a/src/systems/render-manager/unlit-batch.frag
+++ b/src/systems/render-manager/unlit-batch.frag
@@ -62,6 +62,9 @@ void main() {
 
   int mapIdx = int(vMapSettings.x);
   outColor = texture(map, vec3(uv, mapIdx)) * vColor;
+  if(outColor.a == 0.0) {
+      discard;
+  }
 
   bool hubs_HighlightInteractorOne = instanceData.hubs_SweepParams[vInstance].z > 0.0;
   bool hubs_HighlightInteractorTwo = instanceData.hubs_SweepParams[vInstance].w > 0.0;


### PR DESCRIPTION
Right now if multiple concurrent requests are made for the same piece of media (for example you are joining a room where someone has cloned an image multiple times) your client may make multiple requests to reticulum, make multiple requests to get the image, and create multiple THREE.Textures (incorrectly messing up the retain count in the texture cache in the process). This is made worse by the fact that image loading is currently more expensive due to trying to detect the datatype of the image.

This PR fixes these issues by:
1. Removing image type detection
It turns out that modern GPUs like store things in RGBA format anyway, so we aren't actually getting any memory savings, and actually taking a performance hit for our trouble. This does mean that we no longer know if an image may be transparent. For now I have just made all images be considered opaque except for gifs. This means all non-gif images will be batched. To help with the common case of images with cutout alpha (like our chat bubbles), I have added support to the batch shader for this. We lose anti-aliasing of the chat messages, but gain batching of chat messages. We can expand on this later, likely doing transparency detection on the backend by actually looking through the alpha channel (also possible to do this on the client in a GPU accelerated way).
2. Preventing concurrent resolve media requests by updating resolveUrlCache to contain promises to the resolved json which are immediately cached at the start of the first request
3. Preventing concurrent image texture creation by adding an inflightTextures map to keep track of inflight requests.

We might be able to do something to DRY up 2 and 3 a bit, but it's so little code I am not really bothered by it. That said I would be interested to hear opinions on which technique people prefer.