### PR TITLE
Fix some random bugs seen during 7/19 meetup Sentry

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -809,12 +809,12 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     remountUI({ hide: false });
 
-    // HACK: Oculus browser pauses videos when exiting VR mode, so we need to resume them after a timeout.
-    if (/OculusBrowser/i.test(window.navigator.userAgent)) {
+    // HACK: Oculus browser 5 pauses videos when exiting VR mode, so we need to resume them after a timeout.
+    if (/OculusBrowser\/5/i.test(window.navigator.userAgent)) {
       document.querySelectorAll("[media-video]").forEach(m => {
         const video = m.components["media-video"].video;
 
-        if (!video.paused) {
+        if (video && !video.paused) {
           setTimeout(() => video.play(), 1000);
         }
       });

--- a/src/react-components/home-root.js
+++ b/src/react-components/home-root.js
@@ -242,6 +242,7 @@ class HomeRoot extends Component {
             <div className={styles.heroContent}>
               {!this.props.hideHero &&
                 (this.props.favoriteHubsResult &&
+                this.props.favoriteHubsResult.entries &&
                 this.props.favoriteHubsResult.entries.length > 0 &&
                 this.state.signedIn
                   ? this.renderFavoriteHero()

--- a/src/utils/media-url-utils.js
+++ b/src/utils/media-url-utils.js
@@ -32,14 +32,22 @@ const farsparkEncodeUrl = url => {
 };
 
 export const scaledThumbnailUrlFor = (url, width, height) => {
-  const urlHostname = new URL(url).hostname;
+  const farsparkUrl = `https://${process.env.FARSPARK_SERVER}/thumbnail/${farsparkEncodeUrl(
+    url
+  )}?w=${width}&h=${height}`;
 
-  if (process.env.RETICULUM_SERVER) {
-    const retHostname = new URL(`https://${process.env.RETICULUM_SERVER}`).hostname;
-    if (retHostname === urlHostname) return url;
+  try {
+    const urlHostname = new URL(url).hostname;
+
+    if (process.env.RETICULUM_SERVER) {
+      const retHostname = new URL(`https://${process.env.RETICULUM_SERVER}`).hostname;
+      if (retHostname === urlHostname) return url;
+    }
+  } catch (e) {
+    return farsparkUrl;
   }
 
-  return `https://${process.env.FARSPARK_SERVER}/thumbnail/${farsparkEncodeUrl(url)}?w=${width}&h=${height}`;
+  return farsparkUrl;
 };
 
 export const proxiedUrlFor = (url, index = null) => {


### PR DESCRIPTION
- Oculus Browser 6 no longer pauses videos when exiting VR mode, so we can remove an ugly hack that breaks videos easily
- It seems the favorites API can sometimes return an invalid response, handle this case properly on the homepage
- Deal with the case where we can't parse a URL that we'd like to thumbnail