### PR TITLE
Embed rooms in web pages

### DIFF
--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -220,7 +220,7 @@
     "invite.or_visit": "or share permalink",
     "invite.or_visit_modal": "or by visiting permalink",
     "invite.embed": "or embed on a page",
-    "invite.embed-tip": "Please be mindful of where you embed a Hubs room.\nAnyone who can access the page can enter and create/remove objects.",
+    "invite.embed-tip": "Please be mindful of where you embed a Hubs room.\nGo to Room Settings to lock down permissions for this room.",
     "spoke.primary_tagline": "make your space",
     "spoke.secondary_tagline": "Create 3D social scenes for ",
     "spoke.thank_you": "Thank you for downloading Spoke!",

--- a/src/hub.js
+++ b/src/hub.js
@@ -159,8 +159,6 @@ if (isEmbed && !qs.get("embed_token")) {
   throw new Error("no embed token");
 }
 
-const embedsEnabled = qs.get("embeds");
-
 THREE.Object3D.DefaultMatrixAutoUpdate = false;
 window.APP.quality = qs.get("quality") || (isMobile || isMobileVR) ? "low" : "high";
 
@@ -438,7 +436,7 @@ async function handleHubChannelJoined(entryManager, hubChannel, messageDispatch,
     onMediaSearchResultEntrySelected: entry => scene.emit("action_selected_media_result_entry", entry),
     onMediaSearchCancelled: entry => scene.emit("action_media_search_cancelled", entry),
     onAvatarSaved: entry => scene.emit("action_avatar_saved", entry),
-    embedToken: embedsEnabled ? embedToken : null
+    embedToken: embedToken
   });
 
   scene.addEventListener("action_selected_media_result_entry", e => {


### PR DESCRIPTION
If you go to the Share menu, you can now get a embed tag you can use to add a Hubs room onto existing web pages.

![image](https://user-images.githubusercontent.com/220020/61566272-78011600-aa30-11e9-99f3-852ed5b9a480.png)
