### PR TITLE
Enable batching of images by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2985,9 +2985,9 @@
       }
     },
     "@mozillareality/three-batch-manager": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@mozillareality/three-batch-manager/-/three-batch-manager-0.1.3.tgz",
-      "integrity": "sha512-x3OLa+kA51ZI9sB9U2lM6k+lqLZ3ZYTy3GspWPiCvXLeDoVnMEmKeLDf+4WaccDA51NJZeK5aUBRlUCP9CqsKw=="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@mozillareality/three-batch-manager/-/three-batch-manager-0.1.4.tgz",
+      "integrity": "sha512-cPcgCF2DG6SL4E0gjIQOsJ7SxcMGbGNWjKS9pXxhLp6GTV63nEUZ0geWBnImEG48BQvyXT6Kbjw2xBiGPxE3tA=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.2",
     "@fortawesome/free-solid-svg-icons": "^5.2.0",
     "@fortawesome/react-fontawesome": "^0.1.0",
-    "@mozillareality/three-batch-manager": "^0.1.3",
+    "@mozillareality/three-batch-manager": "^0.1.4",
     "aframe": "github:mozillareality/aframe#hubs/master",
     "aframe-physics-system": "github:infinitelee/aframe-physics-system#feature/heightfields",
     "aframe-rounded": "^1.0.3",

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -34,8 +34,8 @@ const fetchMaxContentIndex = url => {
 
 const boundingBox = new THREE.Box3();
 
-const forceBatching = qsTruthy("forceBatching");
-const enableBatching = qsTruthy("enableBatching");
+const batchMeshes = qsTruthy("batchMeshes");
+const disableBatching = qsTruthy("disableBatching");
 
 AFRAME.registerComponent("media-loader", {
   schema: {
@@ -342,7 +342,7 @@ AFRAME.registerComponent("media-loader", {
         this.el.setAttribute("floaty-object", { reduceAngularFloat: true, releaseGravity: -1 });
         this.el.setAttribute(
           "media-image",
-          Object.assign({}, this.data.mediaOptions, { src: accessibleUrl, contentType, batch: enableBatching })
+          Object.assign({}, this.data.mediaOptions, { src: accessibleUrl, contentType, batch: !disableBatching })
         );
 
         if (this.el.components["position-at-box-shape-border__freeze"]) {
@@ -386,7 +386,7 @@ AFRAME.registerComponent("media-loader", {
             src: accessibleUrl,
             contentType: contentType,
             inflate: true,
-            batch: forceBatching,
+            batch: !disableBatching && batchMeshes,
             modelToWorldScale: this.data.resize ? 0.0001 : 1.0
           })
         );
@@ -422,7 +422,7 @@ AFRAME.registerComponent("media-loader", {
           Object.assign({}, this.data.mediaOptions, {
             src: thumbnail,
             contentType: guessContentType(thumbnail) || "image/png",
-            batch: enableBatching
+            batch: !disableBatching
           })
         );
         if (this.el.components["position-at-box-shape-border__freeze"]) {

--- a/src/systems/render-manager-system.js
+++ b/src/systems/render-manager-system.js
@@ -14,8 +14,8 @@ export class BatchManagerSystem {
     this.meshToEl = new WeakMap();
     const gl = renderer.context;
 
-    if (!qsTruthy("enableBatching")) {
-      console.warn("Batching is not on by default and must be turned on with enableBatching. Disabling batching.");
+    if (qsTruthy("disableBatching")) {
+      console.warn("Batching disabled by user via disableBatching. Disabling batching.");
       return;
     }
 


### PR DESCRIPTION
After fixing issues, seems ok to enable by default for now. It can still be disabled via `disableBatching`.  The `forceBatching` flag has been renamed to `batchMeshes` to better indicate what it actually does.

Also this updates three-batch-manager to 0.1.4 which has fixes to mipmapping and correctly marks the UBO as dynamic, which should help with perf.