### PR TITLE
fix icon for iOS Safari's "Add to Homescreen" (PWA): add required `<link rel="apple-touch-icon">` tag (fixes issue #335)

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -12,6 +12,7 @@
     <link rel="manifest" href="/manifest.webmanifest">
     <!-- iOS (for "Add to Homescreen") -->
     <meta name="mobile-web-app-capable" content="yes">
+    <link rel="apple-touch-icon" sizes="180x180" href="https://assets-prod.reticulum.io/assets/images/pwaicon-180-hubs.png">
     <!-- Microsoft Edge (Windows) -->
     <meta name="application-name" content="Hubs">
     <title>Room | Hubs by Mozilla</title>

--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,7 @@
     <title>Hubs - Private social VR in your web browser</title>
     <!-- iOS (for "Add to Homescreen") -->
     <meta name="mobile-web-app-capable" content="yes">
+    <link rel="apple-touch-icon" href="https://assets-prod.reticulum.io/assets/images/pwaicon-180-hubs.png">
     <!-- Microsoft Edge (Windows) -->
     <meta name="application-name" content="Hubs">
     <!-- Web-App Manifest (https://w3c.github.io/manifest/) -->

--- a/src/link.html
+++ b/src/link.html
@@ -8,6 +8,7 @@
     <link rel="manifest" href="/manifest.webmanifest">
     <!-- iOS (for "Add to Homescreen") -->
     <meta name="mobile-web-app-capable" content="yes">
+    <link rel="apple-touch-icon" href="https://assets-prod.reticulum.io/assets/images/pwaicon-180-hubs.png">
     <!-- Microsoft Edge (Windows) -->
     <meta name="application-name" content="Hubs">
     <!-- Web-App Manifest (https://w3c.github.io/manifest/) -->


### PR DESCRIPTION
see discussion: https://github.com/mozilla/hubs/issues/335#issuecomment-514016281

## Context
- Apple shipped support in [Safari for iOS 11.1](https://developer.apple.com/library/archive/releasenotes/General/WhatsNewInSafari/Articles/Safari_11_1.html#//apple_ref/doc/uid/TP40014305-CH14-SW6) for parsing [web-app manifests](https://w3c.github.io/manifest/) via `<link rel="manifest">` but (for some reason) ignores the `icons` defined in the manifest. A `<meta name="apple-touch-icon">` tag appears to be still required for the time being. (I assume that'll change in an upcoming release.)
- This also replaces the icon of the scene pages, since A-Frame injects, if missing, [a few Apple-proprietary `<meta>` tags](https://github.com/aframevr/aframe/blob/c871d04e/src/core/scene/metaTags.js#L14-L16).