### PR TITLE
Fix avatar switching when recording videos

### DIFF
--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -222,10 +222,6 @@ AFRAME.registerComponent("camera-tool", {
     };
   })(),
 
-  onAvatarUpdated() {
-    delete this.playerHead;
-  },
-
   snapClicked() {
     if (this.data.isSnapping) return;
     if (!NAF.utils.isMine(this.el) && !NAF.utils.takeOwnership(this.el)) return;
@@ -506,6 +502,7 @@ AFRAME.registerComponent("camera-tool", {
       const sceneEl = this.el.sceneEl;
       const renderer = this.renderer || sceneEl.renderer;
       const now = performance.now();
+      const playerHead = this.cameraSystem.playerHead;
 
       // Perform lookAt in tock so it will re-orient after grabs, etc.
       if (this.trackTarget) {
@@ -514,11 +511,6 @@ AFRAME.registerComponent("camera-tool", {
         } else {
           this.trackTarget = null; // Target removed
         }
-      }
-
-      if (!this.playerHead) {
-        const headEl = document.getElementById("player-head");
-        this.playerHead = headEl && headEl.object3D;
       }
 
       if (!this.playerHud) {
@@ -530,8 +522,8 @@ AFRAME.registerComponent("camera-tool", {
         this.takeSnapshotNextTick ||
         (this.updateRenderTargetNextTick && (this.viewfinderInViewThisFrame || this.videoRecorder))
       ) {
-        if (this.playerHead) {
-          tempHeadScale.copy(this.playerHead.scale);
+        if (playerHead) {
+          tempHeadScale.copy(playerHead.scale);
 
           // We want to scale our own head in between frames now that we're taking a video/photo.
           let scale = 1;
@@ -540,13 +532,13 @@ AFRAME.registerComponent("camera-tool", {
           // has the networked media stream instead.
           const analyser = this.el.sceneEl.systems["local-audio-analyser"];
 
-          if (analyser && this.playerHead.el.components["scale-audio-feedback"]) {
-            scale = getAudioFeedbackScale(this.el.object3D, this.playerHead, 1, 2, analyser.volume);
+          if (analyser && playerHead.el.components["scale-audio-feedback"]) {
+            scale = getAudioFeedbackScale(this.el.object3D, playerHead, 1, 2, analyser.volume);
           }
 
-          this.playerHead.scale.set(scale, scale, scale);
-          this.playerHead.updateMatrices(true, true);
-          this.playerHead.updateMatrixWorld(true, true);
+          playerHead.scale.set(scale, scale, scale);
+          playerHead.updateMatrices(true, true);
+          playerHead.updateMatrixWorld(true, true);
         }
 
         let playerHudWasVisible = false;
@@ -586,10 +578,10 @@ AFRAME.registerComponent("camera-tool", {
 
         renderer.vr.enabled = tmpVRFlag;
         sceneEl.object3D.onAfterRender = tmpOnAfterRender;
-        if (this.playerHead) {
-          this.playerHead.scale.copy(tempHeadScale);
-          this.playerHead.updateMatrices(true, true);
-          this.playerHead.updateMatrixWorld(true, true);
+        if (playerHead) {
+          playerHead.scale.copy(tempHeadScale);
+          playerHead.updateMatrices(true, true);
+          playerHead.updateMatrixWorld(true, true);
         }
         if (this.playerHud) {
           this.playerHud.visible = playerHudWasVisible;

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -460,10 +460,7 @@ AFRAME.registerComponent("gltf-model-plus", {
 
       if (src === this.lastSrc) return;
 
-      if (this.lastSrc) {
-        gltfCache.release(this.lastSrc);
-      }
-
+      const lastSrc = this.lastSrc;
       this.lastSrc = src;
 
       if (!src) {
@@ -546,6 +543,9 @@ AFRAME.registerComponent("gltf-model-plus", {
         environmentMapComponent.applyEnvironmentMap(object3DToSet);
       }
 
+      if (lastSrc) {
+        gltfCache.release(lastSrc);
+      }
       this.el.setObject3D("mesh", object3DToSet);
 
       rewires.forEach(f => f());

--- a/src/components/player-info.js
+++ b/src/components/player-info.js
@@ -126,7 +126,6 @@ AFRAME.registerComponent("player-info", {
     if (this.data.avatarSrc && modelEl) {
       modelEl.components["gltf-model-plus"].jsonPreprocessor = ensureAvatarNodes;
       modelEl.setAttribute("gltf-model-plus", "src", this.data.avatarSrc);
-      this.el.sceneEl.systems["camera-tools"].avatarUpdated();
     }
 
     const uniforms = injectCustomShaderChunks(this.el.object3D);

--- a/src/systems/camera-tools.js
+++ b/src/systems/camera-tools.js
@@ -7,6 +7,16 @@ AFRAME.registerSystem("camera-tools", {
     this.cameraEls = [];
     this.cameraUpdateCount = 0;
     this.ticks = 0;
+
+    const playerModelEl = document.querySelector("#player-rig .model");
+    playerModelEl.addEventListener("model-loading", () => (this.playerHead = null));
+    playerModelEl.addEventListener("model-loaded", this.updatePlayerHead.bind(this));
+    this.updatePlayerHead();
+  },
+
+  updatePlayerHead() {
+    const headEl = document.getElementById("player-head");
+    this.playerHead = headEl && headEl.object3D;
   },
 
   register(el) {
@@ -19,10 +29,6 @@ AFRAME.registerSystem("camera-tools", {
     this.cameraEls = this.cameraEls.filter(c => c !== el);
     el.removeEventListener("ownership-changed", this._onOwnershipChange);
     delete this.myCamera;
-  },
-
-  avatarUpdated() {
-    this.cameraEls.forEach(el => delete el.components["camera-tool"].onAvatarUpdated());
   },
 
   getMyCamera() {

--- a/src/utils/media-url-utils.js
+++ b/src/utils/media-url-utils.js
@@ -110,9 +110,9 @@ export const guessContentType = url => {
   const extension = new URL(url, window.location).pathname.split(".").pop();
   return commonKnownContentTypes[extension];
 };
-const hubsSceneRegex = /https?:\/\/(hubs.local(:\d+)?|(smoke-)?hubs.mozilla.com)\/scenes\/(\w+)\/?\S*/;
-const hubsAvatarRegex = /https?:\/\/(hubs.local(:\d+)?|(smoke-)?hubs.mozilla.com)\/avatars\/(\w+)\/?\S*/;
-const hubsRoomRegex = /https?:\/\/(hubs.local(:\d+)?|(smoke-)?hubs.mozilla.com)\/(\w+)\/?\S*/;
+const hubsSceneRegex = /https?:\/\/(hubs.local(:\d+)?|(smoke-)?hubs.mozilla.com|(dev\.)?reticulum.io)\/scenes\/(\w+)\/?\S*/;
+const hubsAvatarRegex = /https?:\/\/(hubs.local(:\d+)?|(smoke-)?hubs.mozilla.com|(dev\.)?reticulum.io)\/avatars\/(\w+)\/?\S*/;
+const hubsRoomRegex = /https?:\/\/(hubs.local(:\d+)?|(smoke-)?hubs.mozilla.com|(dev\.)?reticulum.io)\/(\w+)\/?\S*/;
 export const isHubsSceneUrl = hubsSceneRegex.test.bind(hubsSceneRegex);
 export const isHubsRoomUrl = url => !isHubsSceneUrl(url) && hubsRoomRegex.test(url);
 export const isHubsDestinationUrl = url => isHubsSceneUrl(url) || isHubsRoomUrl(url);


### PR DESCRIPTION
Fixes #1555 
Also fixes error found in the process where we release the assets for the avatar you are switching from while we are still rendering it (resulting in some log spam as it attempts to re-upload an empty texture).
Lastly makes this actually testable on dev by fixing regexes to recognize in world avatar (and room/scene) links on dev.