### PR TITLE
Fix modal dialogs to prevent clicking background

### DIFF
--- a/src/assets/stylesheets/info-dialog.scss
+++ b/src/assets/stylesheets/info-dialog.scss
@@ -4,6 +4,7 @@
   top: 0;
   left: 0;
   position: fixed;
+  pointer-events: auto;
   color: black;
   z-index: 20;
 }


### PR DESCRIPTION
This was broken because at some point, it came to pass that the dialog overlay was a child of the root UI element, which has `pointer-events: none` (I don't know why, but there are so many overrides and counter-overrides of this that it's hard to understand the design.) So the overlay inherited `pointer-events: none`, so clicks passed through to things underneath that had `pointer-events: auto`, like most of our React UI, and the A-Frame scene.

Now, clicking outside the dialog will close the dialog, as intended. You can still use other input besides clicking to "do stuff" in the A-Frame scene while dialogs are open, which probably can be creatively used to generate some bugs, but this fixes 90% of what people might unintentionally screw up (stuff like clicking "pin" or "tweet" when in the middle of a pin or tweet requiring sign-in.)

A more principled fix might be to put the dialog container DOM as a child of the body, instead of being underneath the React UI root element, but that would be so much more effort that it's hard to justify when this patch takes care of it.