### PR TITLE
Use nearspark

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -4,9 +4,13 @@
 # See here for the server code: https://github.com/mozilla/reticulum
 RETICULUM_SERVER="dev.reticulum.io"
 
-# The Farspark backend to connect to. Used as a CORS proxy and transformer for in-world media objects.
+# The Farspark backend to connect to. Used as a CORS proxy.
 # See here for the server code: https://github.com/MozillaReality/farspark
 FARSPARK_SERVER="farspark-dev.reticulum.io"
+
+# The thumbnailing backend to connect to.
+# See here for the server code: https://github.com/MozillaReality/farspark or https://github.com/MozillaReality/nearspark
+THUMBNAIL_SERVER="nearspark-dev.reticulum.io"
 
 # The root URL under which Hubs expects environment GLTF bundles to be served.
 ASSET_BUNDLE_SERVER="https://asset-bundles-prod.reticulum.io"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
           def smokeURL = env.SMOKE_URL
           def reticulumServer = env.RETICULUM_SERVER
           def farsparkServer = env.FARSPARK_SERVER
+          def thumbnailServer = env.THUMBNAIL_SERVER
           def corsProxyServer = env.CORS_PROXY_SERVER
           def nonCorsProxyDomains = env.NON_CORS_PROXY_DOMAINS
           def defaultSceneSid = env.DEFAULT_SCENE_SID

--- a/scripts/hab-build-and-push.sh
+++ b/scripts/hab-build-and-push.sh
@@ -5,13 +5,14 @@ export BASE_ASSETS_PATH=$2
 export ASSET_BUNDLE_SERVER=$3
 export RETICULUM_SERVER=$4
 export FARSPARK_SERVER=$5
-export CORS_PROXY_SERVER=$6
-export NON_CORS_PROXY_DOMAINS=$7
-export TARGET_S3_URL=$8
-export SENTRY_DSN=$9
-export GA_TRACKING_ID=${10}
-export BUILD_NUMBER=${11}
-export GIT_COMMIT=${12}
+export THUMBNAIL_SERVER=$6
+export CORS_PROXY_SERVER=$7
+export NON_CORS_PROXY_DOMAINS=$8
+export TARGET_S3_URL=$9
+export SENTRY_DSN=${10}
+export GA_TRACKING_ID=${11}
+export BUILD_NUMBER=${12}
+export GIT_COMMIT=${13}
 export BUILD_VERSION="${BUILD_NUMBER} (${GIT_COMMIT})"
 
 # To build + push to S3 run:

--- a/src/react-components/media-tiles.js
+++ b/src/react-components/media-tiles.js
@@ -12,7 +12,7 @@ import { faPencilAlt } from "@fortawesome/free-solid-svg-icons/faPencilAlt";
 import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus";
 
 import styles from "../assets/stylesheets/media-browser.scss";
-import { scaledThumbnailUrlFor } from "../utils/media-url-utils";
+import { proxiedUrlFor, scaledThumbnailUrlFor } from "../utils/media-url-utils";
 import StateLink from "./state-link";
 
 dayjs.extend(relativeTime);
@@ -130,6 +130,23 @@ class MediaTiles extends Component {
 
     const [imageWidth, imageHeight] = this.getTileDimensions(isImage, isAvatar, imageAspect);
 
+    // Inline mp4s directly since far/nearspark cannot resize them.
+    const thumbnailElement =
+      entry.images.preview.type === "mp4" ? (
+        <video
+          className={classNames(styles.tileContent, styles.avatarTile)}
+          style={{ width: `${imageWidth}px`, height: `${imageHeight}px` }}
+          autoPlay
+          src={proxiedUrlFor(imageSrc)}
+        />
+      ) : (
+        <img
+          className={classNames(styles.tileContent, styles.avatarTile)}
+          style={{ width: `${imageWidth}px`, height: `${imageHeight}px` }}
+          src={scaledThumbnailUrlFor(imageSrc, imageWidth, imageHeight)}
+        />
+      );
+
     const publisherName =
       (entry.attributions && entry.attributions.publisher && entry.attributions.publisher.name) ||
       PUBLISHER_FOR_ENTRY_TYPE[entry.type];
@@ -143,10 +160,7 @@ class MediaTiles extends Component {
           className={styles.tileLink}
           style={{ width: `${imageWidth}px`, height: `${imageHeight}px` }}
         >
-          <img
-            className={classNames(styles.tileContent, styles.avatarTile)}
-            src={scaledThumbnailUrlFor(imageSrc, imageWidth, imageHeight)}
-          />
+          {thumbnailElement}
         </a>
         {entry.type === "avatar" && (
           <StateLink

--- a/src/utils/media-url-utils.js
+++ b/src/utils/media-url-utils.js
@@ -32,7 +32,7 @@ const farsparkEncodeUrl = url => {
 };
 
 export const scaledThumbnailUrlFor = (url, width, height) => {
-  const farsparkUrl = `https://${process.env.FARSPARK_SERVER}/thumbnail/${farsparkEncodeUrl(
+  const farsparkUrl = `https://${process.env.THUMBNAIL_SERVER}/thumbnail/${farsparkEncodeUrl(
     url
   )}?w=${width}&h=${height}`;
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -364,6 +364,7 @@ module.exports = (env, argv) => ({
         RETICULUM_SERVER: process.env.RETICULUM_SERVER,
         RETICULUM_SOCKET_SERVER: process.env.RETICULUM_SOCKET_SERVER,
         FARSPARK_SERVER: process.env.FARSPARK_SERVER,
+        THUMBNAIL_SERVER: process.env.THUMBNAIL_SERVER,
         CORS_PROXY_SERVER: process.env.CORS_PROXY_SERVER,
         NON_CORS_PROXY_DOMAINS: process.env.NON_CORS_PROXY_DOMAINS,
         ASSET_BUNDLE_SERVER: process.env.ASSET_BUNDLE_SERVER,


### PR DESCRIPTION
This updates Hubs to use the new nearspark lambda in dev and abstracts the thumbnail service away from farspark. It also deals with mp4 thumbnails, which are now necessary when searching GIFs.

Requires https://github.com/mozilla/reticulum/pull/211

spoke: https://github.com/mozilla/Spoke/pull/716