### PR TITLE
Fix a number of UX/regressions due to inspector mode

### DIFF
--- a/src/assets/stylesheets/ui-emoji.scss
+++ b/src/assets/stylesheets/ui-emoji.scss
@@ -31,6 +31,7 @@
   background-position: center;
   background-repeat: no-repeat;
   background-color: transparent;
+  cursor: pointer;
 }
 
 :local(.iconEmoji.angry) {

--- a/src/components/inspect-button.js
+++ b/src/components/inspect-button.js
@@ -18,9 +18,7 @@ AFRAME.registerComponent("inspect-button", {
       this.el.sceneEl.systems["hubs-systems"].cameraSystem.inspect(this.inspectable.object3D);
     });
     this.el.object3D.addEventListener("holdable-button-up", () => {
-      if (this.el.sceneEl.is("vr-mode")) {
-        this.el.sceneEl.systems["hubs-systems"].cameraSystem.uninspect();
-      }
+      this.el.sceneEl.systems["hubs-systems"].cameraSystem.uninspect();
     });
   }
 });

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -501,7 +501,7 @@ class UIRoot extends Component {
       this.setState({ emojiState: reason });
       this.emojiEvent.emojiType = reason;
     }
-    this.props.scene.querySelector("#player-rig").setAttribute("player-info", this.emojiEvent);
+    this.props.scene.querySelector("#avatar-rig").setAttribute("player-info", this.emojiEvent);
   };
 
   isWaitingForAutoExit = () => {

--- a/src/systems/camera-system.js
+++ b/src/systems/camera-system.js
@@ -105,7 +105,7 @@ export class CameraSystem {
     const offset = new THREE.Vector3();
     return function tick() {
       this.playerHead = this.playerHead || document.getElementById("avatar-head");
-      if (!this.playerHead) return;
+      if (!AFRAME.scenes[0].is("entered")) return;
 
       this.avatarPOV.components["pitch-yaw-rotator"].on = true;
       this.cameraEl.components["pitch-yaw-rotator"].on = true;
@@ -123,8 +123,11 @@ export class CameraSystem {
       }
 
       const headShouldBeVisible = this.mode !== CAMERA_MODE_FIRST_PERSON;
-      if (headShouldBeVisible !== this.playerHead.object3D.visible) {
+      if (this.playerHead && headShouldBeVisible !== this.playerHead.object3D.visible) {
         this.playerHead.object3D.visible = headShouldBeVisible;
+
+        // Skip a frame so we don't see our own avatar, etc.
+        return;
       }
 
       this.avatarRig.object3D.updateMatrices();


### PR DESCRIPTION
Fixes:

- Emojis breaking
- Changes inspect to be tap-and-hold because of confusing UX otherwise
- Immediately transition camera on entry, don't wait on avatar spawn
- Ensure we don't see a frame with avatar head enabled