### PR TITLE
Fix issues with camera spawning

### DIFF
--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -89,6 +89,7 @@ AFRAME.registerComponent("camera-tool", {
   },
 
   init() {
+    this.el.object3D.visible = false; // Make invisible until model ready
     this.lastUpdate = performance.now();
     this.localSnapCount = 0; // Counter that is used to arrange photos/videos
 
@@ -129,6 +130,17 @@ AFRAME.registerComponent("camera-tool", {
       mesh.scale.set(2, 2, 2);
       mesh.matrixNeedsUpdate = true;
       this.el.setObject3D("mesh", mesh);
+
+      this.el.object3D.visible = true;
+      this.el.object3D.scale.set(0.75, 0.75, 0.75);
+
+      this.el.setAttribute("animation__scale", {
+        property: "scale",
+        dur: 200,
+        from: { x: 0.75, y: 0.75, z: 0.75 },
+        to: { x: 1, y: 1, z: 1 },
+        easing: "easeOutQuad"
+      });
 
       const width = 0.28;
       const geometry = new THREE.PlaneBufferGeometry(width, width / this.camera.aspect);

--- a/src/hub.html
+++ b/src/hub.html
@@ -397,7 +397,6 @@
                     is-remote-hover-target
                     tags="isHandCollisionTarget: true; isHoldable: true; offersHandConstraint: true; offersRemoteConstraint: true;"
                     matrix-auto-update
-                    animation__spawn="property: scale; delay: 50; dur: 200; from: 0.5 0.5 0.5; to: 1 1 1; easing: easeOutQuad"
                     shape-helper="type: box; fit: manual; halfExtents: 0.22 0.14 0.1; offset: 0 0.02 0;"
                     floaty-object="autoLockOnRelease: true; autoLockOnLoad: true;"
                     owned-object-limiter="counter: #camera-counter"


### PR DESCRIPTION
This attempts to fix the hard-to-repro issue around the spawn animation not running or running too late on the camera (leaving the scale at 0.5) -- it defers running the animation until the model has been loaded, etc.