### PR TITLE
Reintroduce limits for cursor move job in touchscreen

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -128,7 +128,7 @@
                         <template data-name="Spine">
                             <a-entity is-remote-hover-target personal-space-invader="radius: 0.2; useMaterial: true;" bone-visibility>
                                 <a-entity class="chest-image" scale="0.18 0.18 0.18" position="0 -0.025 0.13"></a-entity>
-                                <a-entity class="ui interactable-ui">
+                                <a-entity class="interactable ui interactable-ui">
                                     <a-entity billboard class="freeze-menu" visibility-while-frozen="withinDistance: 100; requireHoverOnNonMobile: false;" avatar-volume-controls>
                                         <a-entity class="avatar-volume-label" text="value: 0%; anchor: center; align: center; color: #ff3464; letterSpacing: 4; width:1.5;" text-raycast-hack position="0.0 0.675 0.35" scale="1.25 1.25 1.25"></a-entity>
                                         <a-entity mixin="rounded-button" is-remote-hover-target tags="singleActionButton: true;" position="-0.45 0.675 0.35" class="avatar-volume-down-button">

--- a/src/systems/userinput/devices/app-aware-mouse.js
+++ b/src/systems/userinput/devices/app-aware-mouse.js
@@ -52,14 +52,12 @@ export class AppAwareMouseDevice {
       const intersection = rawIntersections.find(x => x.object.el);
       const remoteHoverTarget = intersection && findRemoteHoverTarget(intersection.object);
       const userinput = AFRAME.scenes[0].systems.userinput;
-      const isInteractable =
-        intersection &&
-        intersection.object.el.matches(".pen, .pen *, .video, .video *, .interactable, .interactable *");
+      const isInteractable = intersection && intersection.object.el.matches(".interactable, .interactable *");
       const isPinned =
         remoteHoverTarget && remoteHoverTarget.components.pinnable && remoteHoverTarget.components.pinnable.data.pinned;
       const isFrozen = AFRAME.scenes[0].is("frozen");
       this.clickedOnAnything =
-        (isInteractable && (isFrozen || !isPinned) && canMove(remoteHoverTarget)) ||
+        (isInteractable && (isFrozen || !isPinned) && (remoteHoverTarget && canMove(remoteHoverTarget))) ||
         userinput.activeSets.includes(sets.cursorHoldingPen) ||
         userinput.activeSets.includes(sets.cursorHoldingInteractable) ||
         userinput.activeSets.includes(sets.cursorHoldingCamera);

--- a/src/systems/userinput/devices/app-aware-touchscreen.js
+++ b/src/systems/userinput/devices/app-aware-touchscreen.js
@@ -2,6 +2,7 @@ import { paths } from "../paths";
 import { Pose } from "../pose";
 import { touchIsAssigned, jobIsAssigned, assign, unassign, findByJob, findByTouch } from "./touchscreen/assignments";
 import { findRemoteHoverTarget } from "../../interactions";
+import { canMove } from "../../../utils/permissions-utils";
 
 const MOVE_CURSOR_JOB = "MOVE CURSOR";
 const MOVE_CAMERA_JOB = "MOVE CAMERA";
@@ -53,7 +54,12 @@ function shouldMoveCursor(touch, raycaster) {
     rawIntersections
   );
   const intersection = rawIntersections.find(x => x.object.el);
-  return intersection && findRemoteHoverTarget(intersection.object);
+  const remoteHoverTarget = intersection && findRemoteHoverTarget(intersection.object);
+  const isInteractable = intersection && intersection.object.el.matches(".interactable, .interactable *");
+  const isPinned =
+    remoteHoverTarget && remoteHoverTarget.components.pinnable && remoteHoverTarget.components.pinnable.data.pinned;
+  const isFrozen = AFRAME.scenes[0].is("frozen");
+  return isInteractable && (isFrozen || !isPinned) && canMove(remoteHoverTarget);
 }
 
 export class AppAwareTouchscreenDevice {

--- a/src/systems/userinput/devices/app-aware-touchscreen.js
+++ b/src/systems/userinput/devices/app-aware-touchscreen.js
@@ -54,12 +54,12 @@ function shouldMoveCursor(touch, raycaster) {
     rawIntersections
   );
   const intersection = rawIntersections.find(x => x.object.el);
-  const remoteHoverTarget = intersection && findRemoteHoverTarget(intersection.object);
   const isInteractable = intersection && intersection.object.el.matches(".interactable, .interactable *");
+  const remoteHoverTarget = intersection && findRemoteHoverTarget(intersection.object);
   const isPinned =
     remoteHoverTarget && remoteHoverTarget.components.pinnable && remoteHoverTarget.components.pinnable.data.pinned;
   const isFrozen = AFRAME.scenes[0].is("frozen");
-  return isInteractable && (isFrozen || !isPinned) && canMove(remoteHoverTarget);
+  return isInteractable && (isFrozen || !isPinned) && (remoteHoverTarget && canMove(remoteHoverTarget));
 }
 
 export class AppAwareTouchscreenDevice {


### PR DESCRIPTION
This fixes a regression made in #1614 where pinned media gets touch precedence over camera movement. This includes a fix for the driving issue #1421 by adding the `interactable` class to the avatar hover menu. 