### PR TITLE
initialize inspect button in tick

### DIFF
--- a/src/components/inspect-button.js
+++ b/src/components/inspect-button.js
@@ -8,17 +8,22 @@ function getInspectable(child) {
 }
 
 AFRAME.registerComponent("inspect-button", {
-  init() {
-    this.inspectable = getInspectable(this.el);
-    if (!this.inspectable) {
-      console.error("You put an inspect button but I could not find what you want to inspect.", this.el);
-      return;
+  tick() {
+    if (!this.initializedInTick) {
+      // initialize in tick so that parent's `tags` component has been initialized
+      this.initializedInTick = true;
+
+      this.inspectable = getInspectable(this.el);
+      if (!this.inspectable) {
+        console.error("You put an inspect button but I could not find what you want to inspect.", this.el);
+        return;
+      }
+      this.el.object3D.addEventListener("holdable-button-down", () => {
+        this.el.sceneEl.systems["hubs-systems"].cameraSystem.inspect(this.inspectable.object3D);
+      });
+      this.el.object3D.addEventListener("holdable-button-up", () => {
+        this.el.sceneEl.systems["hubs-systems"].cameraSystem.uninspect();
+      });
     }
-    this.el.object3D.addEventListener("holdable-button-down", () => {
-      this.el.sceneEl.systems["hubs-systems"].cameraSystem.inspect(this.inspectable.object3D);
-    });
-    this.el.object3D.addEventListener("holdable-button-up", () => {
-      this.el.sceneEl.systems["hubs-systems"].cameraSystem.uninspect();
-    });
   }
 });


### PR DESCRIPTION
The `inspect-button` wants to find `tags` components in its parent hierarchy, which may be created and attached to the parent elements after the `inspect-button`. Delay looking for the `tags` components until the first `tick`, by which time the parents will have been created. 