### PR TITLE
Re-enable on-screen joysticks

### DIFF
--- a/src/components/pitch-yaw-rotator.js
+++ b/src/components/pitch-yaw-rotator.js
@@ -28,7 +28,7 @@ AFRAME.registerComponent("pitch-yaw-rotator", {
   init() {
     this.pendingXRotation = 0;
     this.el.sceneEl.addEventListener("rotateX", e => {
-      this.pendingXRotation += e.detail.value;
+      this.pendingXRotation += e.detail.value * 0.03;
     });
     this.on = true;
   },

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -3,7 +3,7 @@ import nextTick from "./utils/next-tick";
 import pinnedEntityToGltf from "./utils/pinned-entity-to-gltf";
 
 const isBotMode = qsTruthy("bot");
-//const isMobile = AFRAME.utils.device.isMobile();
+const isMobile = AFRAME.utils.device.isMobile();
 const isDebug = qsTruthy("debug");
 const qs = new URLSearchParams(location.search);
 
@@ -65,9 +65,9 @@ export default class SceneEntryManager {
       exit2DInterstitialAndEnterVR(true);
     }
 
-    //    if (isMobile || qsTruthy("mobile")) {
-    //      this.avatarRig.setAttribute("virtual-gamepad-controls", {});
-    //    }
+       if (isMobile || qsTruthy("mobile")) {
+         this.avatarRig.setAttribute("virtual-gamepad-controls", {});
+       }
 
     this._setupPlayerRig();
     this._setupBlocking();

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -65,9 +65,9 @@ export default class SceneEntryManager {
       exit2DInterstitialAndEnterVR(true);
     }
 
-       if (isMobile || qsTruthy("mobile")) {
-         this.avatarRig.setAttribute("virtual-gamepad-controls", {});
-       }
+    if (isMobile || qsTruthy("mobile")) {
+      this.avatarRig.setAttribute("virtual-gamepad-controls", {});
+    }
 
     this._setupPlayerRig();
     this._setupBlocking();

--- a/src/systems/userinput/devices/app-aware-touchscreen.js
+++ b/src/systems/userinput/devices/app-aware-touchscreen.js
@@ -139,9 +139,9 @@ export class AppAwareTouchscreenDevice {
 
   move(touch) {
     if (!touchIsAssigned(touch, this.assignments)) {
-      //if (!touch.target.classList[0] || !touch.target.classList[0].startsWith("virtual-gamepad-controls")) {
-      //  console.warn("touch does not have job", touch);
-      //}
+      if (!touch.target.classList[0] || !touch.target.classList[0].startsWith("virtual-gamepad-controls")) {
+        console.warn("touch does not have job", touch);
+      }
       return;
     }
 


### PR DESCRIPTION
This re-enables the on-screen joysticks for mobile devices. I changed the `pitch-yaw-rotator` in #1598 but failed to adjust the sensitivity of the joysticks to match. 