### PR TITLE
Adjust gyro sensitivity

### DIFF
--- a/src/systems/userinput/devices/gyro.js
+++ b/src/systems/userinput/devices/gyro.js
@@ -71,8 +71,8 @@ export class GyroDevice {
     // Don't use gyro values when device is lying flat
     if (hmdEuler.x < -Math.PI * 0.475) return;
 
-    const dX = THREE.Math.RAD2DEG * difference(hmdEuler.x, this.prevX);
-    const dY = THREE.Math.RAD2DEG * difference(hmdEuler.y, this.prevY);
+    const dX = difference(hmdEuler.x, this.prevX);
+    const dY = difference(hmdEuler.y, this.prevY);
 
     this.dXBuffer.push(Math.abs(dX) < 0.001 ? 0 : dX);
     this.dYBuffer.push(Math.abs(dY) < 0.001 ? 0 : dY);

--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -11,7 +11,7 @@ import { OculusTouchControllerDevice } from "./devices/oculus-touch-controller";
 import { DaydreamControllerDevice } from "./devices/daydream-controller";
 import { ViveControllerDevice } from "./devices/vive-controller";
 import { WindowsMixedRealityControllerDevice } from "./devices/windows-mixed-reality-controller";
-//import { GyroDevice } from "./devices/gyro";
+import { GyroDevice } from "./devices/gyro";
 
 import { AppAwareMouseDevice } from "./devices/app-aware-mouse";
 import { AppAwareTouchscreenDevice } from "./devices/app-aware-touchscreen";
@@ -241,7 +241,7 @@ AFRAME.registerSystem("userinput", {
     } else if (!isMobileVR) {
       this.activeDevices.add(new AppAwareTouchscreenDevice());
       this.activeDevices.add(new KeyboardDevice());
-      //      this.activeDevices.add(new GyroDevice());
+      this.activeDevices.add(new GyroDevice());
     }
 
     this.isMobile = isMobile;


### PR DESCRIPTION
This re-enables the gyro for (non-vr) mobile devices. I changed the pitch-yaw-rotator in #1598 but failed to adjust the sensitivity of the gyro to match.

Will push this to dev to test first in order to test in Firefox for android 