### PR TITLE
three ammo fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17317,7 +17317,7 @@
       "from": "github:mozillareality/three.js#hubs/master"
     },
     "three-ammo": {
-      "version": "github:infinitelee/three-ammo#b19d326b02ff197b6b1198ad29555765c07c0da9",
+      "version": "github:infinitelee/three-ammo#c613987b7ae126fdb570f10477399a5cac4d70f6",
       "from": "github:infinitelee/three-ammo#master"
     },
     "three-bmfont-text": {

--- a/src/components/body-helper.js
+++ b/src/components/body-helper.js
@@ -51,6 +51,7 @@ AFRAME.registerComponent("body-helper", {
     if (this.body) {
       this.system.removeBody(this.body);
       this.body.destroy();
+      this.body = null;
     }
   }
 });

--- a/src/components/shape-helper.js
+++ b/src/components/shape-helper.js
@@ -1,3 +1,4 @@
+/* global Ammo */
 import * as threeToAmmo from "three-to-ammo";
 import { SHAPE, FIT } from "three-ammo/constants";
 

--- a/src/components/shape-helper.js
+++ b/src/components/shape-helper.js
@@ -75,7 +75,10 @@ AFRAME.registerComponent("shape-helper", {
         if (this.bodyHelper.body) {
           this.bodyHelper.body.removeShape(this.shapes[i]);
         }
+        this.shapes[i].destroy();
+        Ammo.destroy(this.shapes[i].localTransform);
       }
     }
+    this.shapes = null;
   }
 });

--- a/src/systems/interactions.js
+++ b/src/systems/interactions.js
@@ -8,10 +8,13 @@ function findHandCollisionTargetForHand(body) {
   const world = this.el.sceneEl.systems["hubs-systems"].physicsSystem.world;
   const handPtr = Ammo.getPointer(body.physicsBody);
 
-  if (world.collisions.has(handPtr) && world.collisions.get(handPtr).length > 0) {
-    const object3D = world.object3Ds.get(world.collisions.get(handPtr)[0]);
-    if (object3D.el && object3D.el.components.tags && object3D.el.components.tags.data.isHandCollisionTarget) {
-      return object3D.el;
+  const handCollisions = world.collisions.get(handPtr);
+  if (handCollisions !== null) {
+    for (let i = 0; i < handCollisions.length; i++) {
+      const object3D = world.object3Ds.get(handCollisions[i]);
+      if (object3D.el && object3D.el.components.tags && object3D.el.components.tags.data.isHandCollisionTarget) {
+        return object3D.el;
+      }
     }
   }
 

--- a/src/systems/physics-system.js
+++ b/src/systems/physics-system.js
@@ -30,6 +30,15 @@ export class PhysicsSystem {
 
     AmmoModule().then(() => {
       this.world = new World(WORLD_CONFIG);
+
+      for (const bodyHelper of this.bodyHelpers) {
+        if (bodyHelper.isPlaying) bodyHelper.init2();
+      }
+      for (const shapeHelper of this.shapeHelpers) {
+        if (shapeHelper.isPlaying) shapeHelper.init2();
+      }
+      this.shapeHelpers.length = 0;
+      this.bodyHelpers.length = 0;
     });
   }
 
@@ -46,13 +55,6 @@ export class PhysicsSystem {
         } else {
           this.world.getDebugDrawer(this.scene).disable();
         }
-      }
-
-      while (this.bodyHelpers.length > 0) {
-        this.bodyHelpers.shift().init2();
-      }
-      while (this.shapeHelpers.length > 0) {
-        this.shapeHelpers.shift().init2();
       }
 
       for (let i = 0; i < this.bodies.length; i++) {


### PR DESCRIPTION
various fixes for new three-ammo update:
handle possible error case where body-helper and shape-helper components are removed before world is initialized; improve initialization flow of body-helpers and shape-helpers; fix interactions.js to do a better search of valid handCollisionTargets; update to latest three-ammo.