### PR TITLE
Reduce xbox controller vertical look speed

### DIFF
--- a/src/systems/userinput/bindings/xbox-controller-user.js
+++ b/src/systems/userinput/bindings/xbox-controller-user.js
@@ -108,7 +108,7 @@ export const xboxControllerUserBindings = addSetsToBindings({
     {
       src: { value: deadzonedRightJoystickVertical },
       dest: { value: scaledRightJoystickVertical },
-      xform: xforms.scale(-1.25) // vertical look speed modifier
+      xform: xforms.scale(-0.125) // vertical look speed modifier
     },
     {
       src: {},


### PR DESCRIPTION
This fixes a bug where look speed generated by xbox controller inputs is too high. I changed the pitch-yaw-rotator in #1598 but failed to adjust the sensitivity of the xbox controller to match. 