### PR TITLE
three-ammo fixes, attempt 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17308,7 +17308,7 @@
       "from": "github:mozillareality/three.js#hubs/master"
     },
     "three-ammo": {
-      "version": "github:infinitelee/three-ammo#b19d326b02ff197b6b1198ad29555765c07c0da9",
+      "version": "github:infinitelee/three-ammo#c613987b7ae126fdb570f10477399a5cac4d70f6",
       "from": "github:infinitelee/three-ammo#master"
     },
     "three-bmfont-text": {

--- a/src/components/body-helper.js
+++ b/src/components/body-helper.js
@@ -33,6 +33,7 @@ AFRAME.registerComponent("body-helper", {
 
   init: function() {
     this.system = this.el.sceneEl.systems["hubs-systems"].physicsSystem;
+    this.alive = true;
     this.system.registerBodyHelper(this);
   },
 
@@ -53,5 +54,6 @@ AFRAME.registerComponent("body-helper", {
       this.body.destroy();
       this.body = null;
     }
+    this.alive = false;
   }
 });

--- a/src/components/body-helper.js
+++ b/src/components/body-helper.js
@@ -51,6 +51,7 @@ AFRAME.registerComponent("body-helper", {
     if (this.body) {
       this.system.removeBody(this.body);
       this.body.destroy();
+      this.body = null;
     }
   }
 });

--- a/src/components/shape-helper.js
+++ b/src/components/shape-helper.js
@@ -1,3 +1,4 @@
+/* global Ammo */
 import * as threeToAmmo from "three-to-ammo";
 import { SHAPE, FIT } from "three-ammo/constants";
 

--- a/src/components/shape-helper.js
+++ b/src/components/shape-helper.js
@@ -75,7 +75,10 @@ AFRAME.registerComponent("shape-helper", {
         if (this.bodyHelper.body) {
           this.bodyHelper.body.removeShape(this.shapes[i]);
         }
+        this.shapes[i].destroy();
+        Ammo.destroy(this.shapes[i].localTransform);
       }
     }
+    this.shapes = null;
   }
 });

--- a/src/components/shape-helper.js
+++ b/src/components/shape-helper.js
@@ -51,7 +51,7 @@ AFRAME.registerComponent("shape-helper", {
         this.bodyHelper = bodyEl.components["body-helper"];
       }
     }
-    if (!this.bodyHelper) {
+    if (!this.bodyHelper || !this.bodyHelper.body) {
       console.warn("body not found");
       return;
     }

--- a/src/components/shape-helper.js
+++ b/src/components/shape-helper.js
@@ -37,6 +37,7 @@ AFRAME.registerComponent("shape-helper", {
 
   init: function() {
     this.system = this.el.sceneEl.systems["hubs-systems"].physicsSystem;
+    this.alive = true;
     this.system.registerShapeHelper(this);
   },
 
@@ -81,5 +82,6 @@ AFRAME.registerComponent("shape-helper", {
       }
     }
     this.shapes = null;
+    this.alive = false;
   }
 });

--- a/src/systems/constraints-system.js
+++ b/src/systems/constraints-system.js
@@ -43,11 +43,13 @@ export class ConstraintsSystem {
         const body = state.held.components["body-helper"].body;
         const targetEl = document.querySelector(`#${entityId}`);
         const targetBody = targetEl.components["body-helper"].body;
-        this.constraints[entityId] = new Constraint({}, body, targetBody, this.physicsSystem.world);
-        if (!this.constraintPairs[heldEntityId]) {
-          this.constraintPairs[heldEntityId] = [];
+        if (targetBody && targetBody.physicsBody) {
+          this.constraints[entityId] = new Constraint({}, body, targetBody, this.physicsSystem.world);
+          if (!this.constraintPairs[heldEntityId]) {
+            this.constraintPairs[heldEntityId] = [];
+          }
+          this.constraintPairs[heldEntityId].push(entityId);
         }
-        this.constraintPairs[heldEntityId].push(entityId);
       }
       return;
     }
@@ -76,11 +78,13 @@ export class ConstraintsSystem {
         const body = state.held.components["body-helper"].body;
         const targetEl = document.querySelector(`#${entityId}`);
         const targetBody = targetEl.components["body-helper"].body;
-        this.constraints[entityId] = new Constraint(CONSTRAINT_CONFIG, body, targetBody, this.physicsSystem.world);
-        if (!this.constraintPairs[heldEntityId]) {
-          this.constraintPairs[heldEntityId] = [];
+        if (targetBody && targetBody.physicsBody) {
+          this.constraints[entityId] = new Constraint(CONSTRAINT_CONFIG, body, targetBody, this.physicsSystem.world);
+          if (!this.constraintPairs[heldEntityId]) {
+            this.constraintPairs[heldEntityId] = [];
+          }
+          this.constraintPairs[heldEntityId].push(entityId);
         }
-        this.constraintPairs[heldEntityId].push(entityId);
       } else {
         console.log("Failed to obtain ownership while trying to create constraint on networked object.");
       }

--- a/src/systems/interactions.js
+++ b/src/systems/interactions.js
@@ -6,14 +6,16 @@ import { canMove } from "../utils/permissions-utils";
 
 function findHandCollisionTargetForHand(body) {
   const world = this.el.sceneEl.systems["hubs-systems"].physicsSystem.world;
-  const handPtr = Ammo.getPointer(body.physicsBody);
 
-  const handCollisions = world.collisions.get(handPtr);
-  if (handCollisions !== null) {
-    for (let i = 0; i < handCollisions.length; i++) {
-      const object3D = world.object3Ds.get(handCollisions[i]);
-      if (object3D.el && object3D.el.components.tags && object3D.el.components.tags.data.isHandCollisionTarget) {
-        return object3D.el;
+  if (world) {
+    const handPtr = Ammo.getPointer(body.physicsBody);
+    const handCollisions = world.collisions.get(handPtr);
+    if (handCollisions) {
+      for (let i = 0; i < handCollisions.length; i++) {
+        const object3D = world.object3Ds.get(handCollisions[i]);
+        if (object3D.el && object3D.el.components.tags && object3D.el.components.tags.data.isHandCollisionTarget) {
+          return object3D.el;
+        }
       }
     }
   }

--- a/src/systems/interactions.js
+++ b/src/systems/interactions.js
@@ -8,10 +8,13 @@ function findHandCollisionTargetForHand(body) {
   const world = this.el.sceneEl.systems["hubs-systems"].physicsSystem.world;
   const handPtr = Ammo.getPointer(body.physicsBody);
 
-  if (world.collisions.has(handPtr) && world.collisions.get(handPtr).length > 0) {
-    const object3D = world.object3Ds.get(world.collisions.get(handPtr)[0]);
-    if (object3D.el && object3D.el.components.tags && object3D.el.components.tags.data.isHandCollisionTarget) {
-      return object3D.el;
+  const handCollisions = world.collisions.get(handPtr);
+  if (handCollisions !== null) {
+    for (let i = 0; i < handCollisions.length; i++) {
+      const object3D = world.object3Ds.get(handCollisions[i]);
+      if (object3D.el && object3D.el.components.tags && object3D.el.components.tags.data.isHandCollisionTarget) {
+        return object3D.el;
+      }
     }
   }
 

--- a/src/systems/physics-system.js
+++ b/src/systems/physics-system.js
@@ -32,10 +32,10 @@ export class PhysicsSystem {
       this.world = new World(WORLD_CONFIG);
 
       for (const bodyHelper of this.bodyHelpers) {
-        if (bodyHelper.isPlaying) bodyHelper.init2();
+        if (bodyHelper.alive) bodyHelper.init2();
       }
       for (const shapeHelper of this.shapeHelpers) {
-        if (shapeHelper.isPlaying) shapeHelper.init2();
+        if (shapeHelper.alive) shapeHelper.init2();
       }
       this.shapeHelpers.length = 0;
       this.bodyHelpers.length = 0;

--- a/src/systems/physics-system.js
+++ b/src/systems/physics-system.js
@@ -30,6 +30,15 @@ export class PhysicsSystem {
 
     AmmoModule().then(() => {
       this.world = new World(WORLD_CONFIG);
+
+      for (const bodyHelper of this.bodyHelpers) {
+        if (bodyHelper.isPlaying) bodyHelper.init2();
+      }
+      for (const shapeHelper of this.shapeHelpers) {
+        if (shapeHelper.isPlaying) shapeHelper.init2();
+      }
+      this.shapeHelpers.length = 0;
+      this.bodyHelpers.length = 0;
     });
   }
 
@@ -46,13 +55,6 @@ export class PhysicsSystem {
         } else {
           this.world.getDebugDrawer(this.scene).disable();
         }
-      }
-
-      while (this.bodyHelpers.length > 0) {
-        this.bodyHelpers.shift().init2();
-      }
-      while (this.shapeHelpers.length > 0) {
-        this.shapeHelpers.shift().init2();
       }
 
       for (let i = 0; i < this.bodies.length; i++) {


### PR DESCRIPTION
various fixes for new three-ammo update (2nd attempt): 

handle possible error case where body-helper and shape-helper components are removed before world is initialized; improve initialization flow of body-helpers and shape-helpers; fix interactions.js to do a better search of valid handCollisionTargets; update to latest three-ammo.