### PR TITLE
Fix avatar views not loading in admin and expose tag editing

### DIFF
--- a/src/admin.js
+++ b/src/admin.js
@@ -58,13 +58,18 @@ class AdminUI extends Component {
   }
 }
 
+import { IntlProvider } from "react-intl";
+import { lang, messages } from "./utils/i18n";
+
 const mountUI = async retPhxChannel => {
   const dataProvider = postgrestClient("//" + process.env.POSTGREST_SERVER);
   const authProvider = postgrestAuthenticatior.createAuthProvider(retPhxChannel);
   await postgrestAuthenticatior.refreshToken();
 
   ReactDOM.render(
-    <AdminUI dataProvider={dataProvider} authProvider={authProvider} />,
+    <IntlProvider locale={lang} messages={messages}>
+      <AdminUI dataProvider={dataProvider} authProvider={authProvider} />
+    </IntlProvider>,
     document.getElementById("ui-root")
   );
 };

--- a/src/react-components/admin/avatar-listings.js
+++ b/src/react-components/admin/avatar-listings.js
@@ -14,7 +14,9 @@ import {
   TextField,
   DateField,
   BooleanField,
-  Filter
+  Filter,
+  ArrayInput,
+  SimpleFormIterator
 } from "react-admin";
 
 const AvatarListingFilter = props => (
@@ -30,6 +32,11 @@ export const AvatarListingEdit = props => (
       <TextInput source="name" />
       <TextInput source="description" />
       <TextInput source="attribution" />
+      <ArrayInput source="tags.tags" defaultValue={[]}>
+        <SimpleFormIterator>
+          <TextInput />
+        </SimpleFormIterator>
+      </ArrayInput>
       <NumberInput source="order" />
       <SelectInput source="state" choices={[{ id: "active", name: "active" }, { id: "delisted", name: "delisted" }]} />
     </SimpleForm>

--- a/src/react-components/admin/fields.js
+++ b/src/react-components/admin/fields.js
@@ -80,7 +80,7 @@ SceneLink.propTypes = {
 };
 
 export const AvatarLink = withStyles(styles)(({ source, record = {}, classes }) => {
-  const src = getReticulumFetchUrl(`/api/v1/avatars/${record.avatar_sid || record.avatar_listing_sid}`);
+  const src = getReticulumFetchUrl(`/avatars/${record.avatar_sid || record.avatar_listing_sid}`);
   return (
     <a href={src} className={classes.avatarLink} target="_blank" rel="noopener noreferrer">
       {record[source]}


### PR DESCRIPTION
We started using internationalization stuff in the avatar preview, but didn't update the admin panel for these so the avatar pages in admin fail to load. Also exposes tag editing in the avatar listings edit view and links to the avatar landing pages instead of the API response when opening an avatar.