### PR TITLE
Avatar Remixing

### DIFF
--- a/src/assets/stylesheets/avatar-editor.scss
+++ b/src/assets/stylesheets/avatar-editor.scss
@@ -50,6 +50,9 @@
     .file-input-row {
       display: flex;
       align-items: center;
+      &.disabled{
+        opacity: 0.5;
+      }
       label {
         display: flex;
         align-items: center;
@@ -86,6 +89,13 @@
       @extend %input-field;
       font-size: 16px;
     }
+
+    .select {
+      @extend %input-field;
+      font-size: 16px;
+      height: 36px;
+    }
+
 
     .checkbox-container {
       display: flex;

--- a/src/assets/stylesheets/avatar-editor.scss
+++ b/src/assets/stylesheets/avatar-editor.scss
@@ -14,6 +14,12 @@
     align-items: center;
   }
 
+  > .loader {
+    position: absolute;
+    left: calc(50% - 4.3em);
+    top: calc(50% - 4.5em);
+  }
+
   .info {
     text-align: center;
     width: 100%;

--- a/src/assets/stylesheets/avatar-editor.scss
+++ b/src/assets/stylesheets/avatar-editor.scss
@@ -96,10 +96,21 @@
       font-size: 16px;
     }
 
+    .select-container {
+      position: relative;
+      .arrow{
+        position: absolute;
+        right: 10px;
+        bottom: 20px;
+      }
+    }
+
     .select {
       @extend %input-field;
       font-size: 16px;
       height: 36px;
+      -webkit-appearance: none;
+      -moz-appearance: none;
     }
 
 

--- a/src/assets/stylesheets/media-browser.scss
+++ b/src/assets/stylesheets/media-browser.scss
@@ -233,6 +233,8 @@
 
     :local(.facet) {
       @extend %action-button;
+      background-color: transparent;
+      color: $action-color;
       border: 0;
       border-radius: 12px;
       font-weight: normal;
@@ -242,6 +244,15 @@
       min-width: auto;
       min-height: 44px;
       white-space: nowrap;
+
+      &:hover{
+        background-color: $action-color-light;
+        color: white;
+      }
+      &.selected{
+        background-color: $action-color;
+        color: white;
+      }
 
       @media(max-width: 801px) {
         font-size: 1.0em;
@@ -387,6 +398,10 @@
           height: 30px;
           text-align: center;
           line-height: 27px;
+          &:hover {
+            background: $action-color;
+            color: white;
+          }
         }
       }
     }

--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -571,7 +571,9 @@ AFRAME.registerComponent("camera-tool", {
         this.takeSnapshotNextTick ||
         (this.updateRenderTargetNextTick && (this.viewfinderInViewThisFrame || this.videoRecorder))
       ) {
+        let tempHeadVisible;
         if (playerHead) {
+          tempHeadVisible = playerHead.visible;
           tempHeadScale.copy(playerHead.scale);
 
           // We want to scale our own head in between frames now that we're taking a video/photo.
@@ -585,6 +587,7 @@ AFRAME.registerComponent("camera-tool", {
             scale = getAudioFeedbackScale(this.el.object3D, playerHead, 1, 2, analyser.volume);
           }
 
+          playerHead.visible = true;
           playerHead.scale.set(scale, scale, scale);
           playerHead.updateMatrices(true, true);
           playerHead.updateMatrixWorld(true, true);
@@ -628,6 +631,7 @@ AFRAME.registerComponent("camera-tool", {
         renderer.vr.enabled = tmpVRFlag;
         sceneEl.object3D.onAfterRender = tmpOnAfterRender;
         if (playerHead) {
+          playerHead.visible = tempHeadVisible;
           playerHead.scale.copy(tempHeadScale);
           playerHead.updateMatrices(true, true);
           playerHead.updateMatrixWorld(true, true);

--- a/src/hub.js
+++ b/src/hub.js
@@ -425,15 +425,16 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data)
   remountUI({
     onSendMessage: messageDispatch.dispatch,
     onLoaded: () => store.executeOnLoadActions(scene),
-    onMediaSearchResultEntrySelected: entry => scene.emit("action_selected_media_result_entry", entry),
+    onMediaSearchResultEntrySelected: (entry, selectAction) =>
+      scene.emit("action_selected_media_result_entry", { entry, selectAction }),
     onMediaSearchCancelled: entry => scene.emit("action_media_search_cancelled", entry),
     onAvatarSaved: entry => scene.emit("action_avatar_saved", entry),
     embedToken: embedToken
   });
 
   scene.addEventListener("action_selected_media_result_entry", e => {
-    const entry = e.detail;
-    if (entry.type !== "scene_listing" && entry.type !== "scene") return;
+    const { entry, selectAction } = e.detail;
+    if ((entry.type !== "scene_listing" && entry.type !== "scene") || selectAction !== "use") return;
     if (!hubChannel.can("update_hub")) return;
 
     hubChannel.updateScene(entry.url);

--- a/src/materials/MobileStandardMaterial.js
+++ b/src/materials/MobileStandardMaterial.js
@@ -97,7 +97,8 @@ export default class MobileStandardMaterial extends THREE.ShaderMaterial {
       alphaTest: material.alphaTest,
       skinning: material.skinning,
       morphTargets: material.morphTargets,
-      vertexColors: material.vertexColors
+      vertexColors: material.vertexColors,
+      name: material.name
     };
 
     const mobileMaterial = new MobileStandardMaterial(parameters);

--- a/src/message-dispatch.js
+++ b/src/message-dispatch.js
@@ -99,7 +99,7 @@ export default class MessageDispatch {
             this.addToPresenceLog({ type: "log", body: "You do not have permission to change the scene." });
           }
         } else if (this.hubChannel.canOrWillIfCreator("update_hub")) {
-          this.mediaSearchStore.sourceNavigateWithNoNav("scenes");
+          this.mediaSearchStore.sourceNavigateWithNoNav("scenes", "use");
         }
 
         break;

--- a/src/react-components/admin/approve-buttons.js
+++ b/src/react-components/admin/approve-buttons.js
@@ -19,12 +19,12 @@ class ApproveButton extends Component {
   };
 
   render() {
-    const { record } = this.props;
+    const { record, resource } = this.props;
     if (!(record.allow_promotion || record._allow_promotion)) return false;
 
     return (
       <Button label="Approve" onClick={this.handleClick}>
-        Approve
+        {record[`${resource}_listing_id`] ? "Update" : "Approve"}
       </Button>
     );
   }
@@ -48,11 +48,11 @@ const withStaticProps = staticProps => (stateProps, dispatchProps, ownProps) => 
 export const ApproveSceneButton = connect(
   null,
   { approveNew: sceneApproveNew, approveExisting: sceneApproveExisting, reviewed: sceneReviewed },
-  withStaticProps({ resource: "scenes" })
+  withStaticProps({ resource: "scene" })
 )(ApproveButton);
 
 export const ApproveAvatarButton = connect(
   null,
   { approveNew: avatarApproveNew, approveExisting: avatarApproveExisting, reviewed: avatarReviewed },
-  withStaticProps({ resource: "avatars" })
+  withStaticProps({ resource: "avatar" })
 )(ApproveButton);

--- a/src/react-components/admin/avatar-actions.js
+++ b/src/react-components/admin/avatar-actions.js
@@ -18,6 +18,8 @@ export const avatarApproveNew = avatar => ({
       attributions: avatar.attributions,
       tags: { tags: [] },
 
+      account_id: avatar.account,
+
       parent_avatar_listing_id: avatar.parent_avatar_listing_id,
       gltf_owned_file_id: avatar.gltf_owned_file_id,
       bin_owned_file_id: avatar.bin_owned_file_id,
@@ -45,6 +47,8 @@ export const avatarApproveExisting = avatar => ({
       name: avatar.name,
       description: avatar.description,
       attributions: avatar.attributions,
+
+      account_id: avatar.account,
 
       parent_avatar_listing_id: avatar.parent_avatar_listing_id,
       gltf_owned_file_id: avatar.gltf_owned_file_id,

--- a/src/react-components/admin/avatar-listings.js
+++ b/src/react-components/admin/avatar-listings.js
@@ -70,7 +70,6 @@ export const AvatarListingList = props => (
       <TextField source="reviewed_at" />
       <DateField source="inserted_at" />
       <DateField source="updated_at" />
-      <TextField source="state" />
       <FeatureAvatarListingButton />
       <EditButton />
     </Datagrid>

--- a/src/react-components/admin/avatars.js
+++ b/src/react-components/admin/avatars.js
@@ -52,10 +52,10 @@ const styles = {
   }
 };
 
-const Preview = withStyles(styles)(({ record, classes }) => (
+const Preview = withStyles(styles)(({ record, classes, source = "avatar_sid" }) => (
   <AvatarPreview
     className={classes.preview}
-    avatarGltfUrl={getReticulumFetchUrl(`/api/v1/avatars/${record.avatar_sid}/avatar.gltf?v=${record.updated_at}`)}
+    avatarGltfUrl={getReticulumFetchUrl(`/api/v1/avatars/${record[source]}/avatar.gltf?v=${record.updated_at}`)}
   />
 ));
 
@@ -66,18 +66,30 @@ const rowStyle = record => ({
 export const AvatarList = props => (
   <List {...props} filters={<AvatarFilter />} bulkActionButtons={false}>
     <Datagrid rowStyle={rowStyle}>
+      <ConditionalReferenceField label="live thumbnail" reference="avatar_listings" source="avatar_listing_id">
+        <OwnedFileImage
+          source="thumbnail_owned_file_id"
+          aspect="tall"
+          defaultImage="https://asset-bundles-prod.reticulum.io/bots/avatar_unavailable.png"
+        />
+      </ConditionalReferenceField>
+      <ConditionalReferenceField label="live preview" reference="avatar_listings" source="avatar_listing_id">
+        <Preview source="avatar_listing_sid" />
+      </ConditionalReferenceField>
+      <ConditionalReferenceField label="live name" reference="avatar_listings" source="avatar_listing_id">
+        <TextField source="name" />
+      </ConditionalReferenceField>
+      <span> ➡ </span>
       <OwnedFileImage
+        label="thumbnail"
         source="thumbnail_owned_file_id"
         aspect="tall"
         defaultImage="https://asset-bundles-prod.reticulum.io/bots/avatar_unavailable.png"
       />
-      <Preview />
+      <Preview label="preview" />
       <TextField source="name" />
       <TextField source="account_id" />
       <AvatarLink source="avatar_sid" />
-      <ConditionalReferenceField reference="avatars" source="parent_avatar_id">
-        <TextField source="name" />
-      </ConditionalReferenceField>
       <ConditionalReferenceField reference="avatar_listings" source="parent_avatar_listing_id">
         <TextField source="name" />
       </ConditionalReferenceField>
@@ -87,11 +99,9 @@ export const AvatarList = props => (
       <OwnedFileImage source="orm_map_owned_file_id" aspect="square" />
       <TextField source="attributions" />
       <BooleanField source="allow_remixing" />
-      <BooleanField source="allow_promotion" />
       <TextField source="reviewed_at" />
       <DateField source="inserted_at" />
       <DateField source="updated_at" />
-      <TextField source="state" />
       <EditButton />
       <ApproveAvatarButton />
       <DenyAvatarButton />

--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -452,7 +452,16 @@ export default class AvatarEditor extends Component {
                     <a onClick={() => this.setState({ confirmDelete: false })}>no</a>
                   </span>
                 ) : (
-                  <a onClick={() => this.setState({ confirmDelete: true })}>delete avatar</a>
+                  <a
+                    onClick={() => this.setState({ confirmDelete: true })}
+                    title={
+                      avatar.has_listings
+                        ? "Other users already using this avatar will still be able to use it, but it will be removed from 'My Avatars' and search results."
+                        : ""
+                    }
+                  >
+                    {avatar.has_listings ? "delist" : "delete"} avatar
+                  </a>
                 )}
               </div>
             )}

--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -265,6 +265,7 @@ export default class AvatarEditor extends Component {
 
   textField = (name, placeholder, disabled, required) => (
     <div>
+      <label htmlFor={`#avatar-${name}`}>{placeholder}</label>
       <input
         id={`avatar-${name}`}
         type="text"
@@ -289,8 +290,10 @@ export default class AvatarEditor extends Component {
   };
 
   selectListingField = (propName, placeholder) => (
-    <div>
+    <div className="select-container">
+      <label htmlFor={`#avatar-${propName}`}>{placeholder}</label>
       <select
+        id={`avatar-${propName}`}
         value={this.state.avatar[propName] || ""}
         onChange={async e => {
           const sid = e.target.value;
@@ -306,6 +309,11 @@ export default class AvatarEditor extends Component {
         ))}
         <option value="">Custom GLB...</option>
       </select>
+      <img
+        className="arrow"
+        src="../assets/images/dropdown_arrow.png"
+        srcSet="../assets/images/dropdown_arrow@2x.png 2x"
+      />
     </div>
   );
 
@@ -362,7 +370,7 @@ export default class AvatarEditor extends Component {
                 {debug && this.textField("parent_avatar_listing_id", "Parent Avatar Listing ID")}
                 {this.textField("name", "Name", false, true)}
                 {debug && this.textarea("description", "Description")}
-                {!!this.state.baseAvatarResults.length && this.selectListingField("parent_avatar_listing_id")}
+                {!!this.state.baseAvatarResults.length && this.selectListingField("parent_avatar_listing_id", "Model")}
                 {!avatar.parent_avatar_listing_id && this.fileField("glb", "Avatar GLB", "model/gltf+binary,.glb")}
                 {this.mapField("base_map", "Base Map", "image/*")}
                 <details>

--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { FormattedMessage } from "react-intl";
 import { fetchReticulumAuthenticated } from "../utils/phoenix-utils";
 import { upload } from "../utils/media-utils";
+import { ensureAvatarMaterial } from "../utils/avatar-utils";
 import classNames from "classnames";
 import { faTimes } from "@fortawesome/free-solid-svg-icons/faTimes";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -90,8 +91,8 @@ export default class AvatarEditor extends Component {
       );
       URL.revokeObjectURL(gltfUrl);
 
-      const { content, body } = parser.extensions.KHR_binary_glTF;
-
+      const { body } = parser.extensions.KHR_binary_glTF;
+      const content = JSON.stringify(ensureAvatarMaterial(parser.json));
       // Inject hubs components on upload. Used to create base avatar
       // const gltf = parser.json;
       // Object.assign(gltf.scenes[0], {

--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -328,8 +328,8 @@ export default class AvatarEditor extends Component {
     </div>
   );
 
-  checkbox = (name, children, disabled) => (
-    <div className="checkbox-container">
+  checkbox = (name, title, children, disabled) => (
+    <div className="checkbox-container" title={title}>
       <input
         id={`avatar-${name}`}
         type="checkbox"
@@ -379,6 +379,7 @@ export default class AvatarEditor extends Component {
                 </details>
                 {this.checkbox(
                   "allow_promotion",
+                  "Allow Mozilla to promote your avatar, and show it in search results.",
                   <span>
                     Allow{" "}
                     <a
@@ -392,6 +393,7 @@ export default class AvatarEditor extends Component {
                 )}
                 {this.checkbox(
                   "allow_remixing",
+                  "Allow others to edit and re-publish your avatar as long as they give you credit.",
                   <span>
                     Allow{" "}
                     <a

--- a/src/react-components/avatar-preview.js
+++ b/src/react-components/avatar-preview.js
@@ -298,23 +298,23 @@ class AvatarPreview extends Component {
   render() {
     return (
       <div className={classNames(styles.preview, this.props.className)}>
-        {this.state.loading &&
+        {this.props.avatarGltfUrl &&
+          this.state.loading &&
           !this.state.error && (
             <div className="loader">
               <div className="loader-center" />
             </div>
           )}
-        {this.state.error &&
-          !this.state.loading && (
-            <div className="error">
-              <img
-                src="../assets/images/warning_icon.png"
-                srcSet="../assets/images/warning_icon@2x.png 2x"
-                className="error-icon"
-              />
-              <FormattedMessage id="avatar-preview.loading-failed" />
-            </div>
-          )}
+        {(!this.props.avatarGltfUrl || (this.state.error && !this.state.loading)) && (
+          <div className="error">
+            <img
+              src="../assets/images/warning_icon.png"
+              srcSet="../assets/images/warning_icon@2x.png 2x"
+              className="error-icon"
+            />
+            <FormattedMessage id="avatar-preview.loading-failed" />
+          </div>
+        )}
         <canvas ref={c => (this.canvas = c)} />
       </div>
     );

--- a/src/react-components/avatar-preview.js
+++ b/src/react-components/avatar-preview.js
@@ -6,7 +6,8 @@ import "three/examples/js/controls/OrbitControls";
 
 import { createDefaultEnvironmentMap } from "../components/environment-map";
 import { loadGLTF } from "../components/gltf-model-plus";
-import { disposeNode } from "../utils/three-utils";
+import { disposeNode, findNode } from "../utils/three-utils";
+import { ensureAvatarMaterial, MAT_NAME } from "../utils/avatar-utils";
 import { createImageBitmap, disposeImageBitmap } from "../utils/image-bitmap-utils";
 import styles from "../assets/stylesheets/avatar-preview.scss";
 
@@ -204,26 +205,18 @@ class AvatarPreview extends Component {
   loadPreviewAvatar = async avatarGltfUrl => {
     let gltf;
     try {
-      gltf = await loadGLTF(avatarGltfUrl, "model/gltf");
+      const technique = window.APP.quality === "low" ? "KHR_materials_unlit" : "pbrMetallicRoughness";
+      gltf = await loadGLTF(avatarGltfUrl, "model/gltf", technique, null, ensureAvatarMaterial);
     } catch (e) {
       this.setState({ loading: false, error: true });
       return;
     }
 
-    // On the backend we look for a material called Bot_PBS, here we are looking for a mesh called Avatar.
-    // When we "officially" support uploading custom GLTFs we need to decide what we are going to key things on
-    this.previewMesh =
-      gltf.scene.getObjectByName("AvatarMesh") ||
-      gltf.scene.getObjectByName("Avatar") ||
-      gltf.scene.getObjectByName("Bot_Skinned") ||
-      gltf.scene;
+    this.previewMesh = findNode(gltf.scene, n => n.isMesh && n.material && n.material.name === MAT_NAME);
 
-    if (!this.previewMesh.isMesh) {
-      this.previewMesh.traverse(o => {
-        if (!this.previewMesh.isMesh && o.isMesh) {
-          this.previewMesh = o;
-        }
-      });
+    if (!this.previewMesh) {
+      this.setState({ loading: false, error: true });
+      return;
     }
 
     const idleAnimation = gltf.animations && gltf.animations.find(({ name }) => name === "idle_eyes");

--- a/src/react-components/avatar-preview.js
+++ b/src/react-components/avatar-preview.js
@@ -218,6 +218,14 @@ class AvatarPreview extends Component {
       gltf.scene.getObjectByName("Bot_Skinned") ||
       gltf.scene;
 
+    if (!this.previewMesh.isMesh) {
+      this.previewMesh.traverse(o => {
+        if (!this.previewMesh.isMesh && o.isMesh) {
+          this.previewMesh = o;
+        }
+      });
+    }
+
     const idleAnimation = gltf.animations && gltf.animations.find(({ name }) => name === "idle_eyes");
     if (idleAnimation) {
       this.mixer = new THREE.AnimationMixer(gltf.scene);
@@ -230,7 +238,7 @@ class AvatarPreview extends Component {
     const { material } = this.previewMesh;
     if (material) {
       // We delete onUpdate here to opt out of the auto texture cleanup after GPU upload.
-      const getImage = p => delete material[p].onUpdate && material[p].image;
+      const getImage = p => material[p] && delete material[p].onUpdate && material[p].image;
       this.originalMaps = {
         base_map: TEXTURE_PROPS["base_map"].map(getImage),
         emissive_map: TEXTURE_PROPS["emissive_map"].map(getImage),

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -128,6 +128,7 @@ class MediaBrowser extends Component {
     const newState = { result, query: this.state.query || searchParams.get("q") || "" };
     const urlSource = this.getUrlSource(searchParams);
     newState.showNav = !!(searchParams.get("media_nav") !== "false");
+    newState.selectAction = searchParams.get("selectAction") || "spawn";
 
     if (result && result.suggestions && result.suggestions.length > 0) {
       newState.facets = result.suggestions.map(s => {
@@ -179,7 +180,7 @@ class MediaBrowser extends Component {
 
   selectEntry = entry => {
     if (!this.props.onMediaSearchResultEntrySelected) return;
-    this.props.onMediaSearchResultEntrySelected(entry);
+    this.props.onMediaSearchResultEntrySelected(entry, this.state.selectAction);
     this.close();
   };
 
@@ -188,7 +189,7 @@ class MediaBrowser extends Component {
   };
 
   handleFacetClicked = facet => {
-    const searchParams = this.getSearchClearedSearchParams(true, true);
+    const searchParams = this.getSearchClearedSearchParams(true, true, true);
 
     for (const [k, v] of Object.entries(facet.params)) {
       searchParams.set(k, v);
@@ -197,8 +198,13 @@ class MediaBrowser extends Component {
     pushHistoryPath(this.props.history, this.props.history.location.pathname, searchParams.toString());
   };
 
-  getSearchClearedSearchParams = (keepSource, keepNav) => {
-    return this.props.mediaSearchStore.getSearchClearedSearchParams(this.props.history.location, keepSource, keepNav);
+  getSearchClearedSearchParams = (keepSource, keepNav, keepSelectAction) => {
+    return this.props.mediaSearchStore.getSearchClearedSearchParams(
+      this.props.history.location,
+      keepSource,
+      keepNav,
+      keepSelectAction
+    );
   };
 
   pushExitMediaBrowserHistory = (stashLastSearchParams = true) => {

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -234,7 +234,7 @@ class MediaBrowser extends Component {
     const showCustomOption =
       !isFavorites && (!isSceneApiType || this.props.hubChannel.canOrWillIfCreator("update_hub"));
     const entries = (this.state.result && this.state.result.entries) || [];
-    const hideSearch = urlSource === "avatars" || urlSource === "favorites";
+    const hideSearch = urlSource === "favorites";
     const showEmptyStringOnNoResult = urlSource !== "avatars" && urlSource !== "scenes";
 
     // Don't render anything if we just did a feeling lucky query and are waiting on result.

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -67,7 +67,7 @@ const DEFAULT_FACETS = {
   avatars: [
     { text: "Featured", params: { filter: "featured" } },
     { text: "My Avatars", params: { filter: "my-avatars" } },
-    { text: "All Avatars", params: { filter: "" } }
+    { text: "Newest", params: { filter: "" } }
   ],
   favorites: [],
   scenes: [{ text: "Featured", params: { filter: "featured" } }, { text: "My Scenes", params: { filter: "my-scenes" } }]
@@ -176,6 +176,10 @@ class MediaBrowser extends Component {
       this.setState({ clearStashedQueryOnClose: true });
       this.handleQueryUpdated(entry.lucky_query, true);
     }
+  };
+
+  onCopyAvatar = () => {
+    this.handleFacetClicked({ params: { filter: "my-avatars" } });
   };
 
   selectEntry = entry => {
@@ -409,8 +413,8 @@ class MediaBrowser extends Component {
               history={this.props.history}
               urlSource={urlSource}
               handleEntryClicked={this.handleEntryClicked}
+              onCopyAvatar={this.onCopyAvatar}
               handlePager={this.handlePager}
-              mediaBrowser={this}
             />
           ) : (
             <div className={styles.emptyString}>

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -404,6 +404,7 @@ class MediaBrowser extends Component {
               urlSource={urlSource}
               handleEntryClicked={this.handleEntryClicked}
               handlePager={this.handlePager}
+              mediaBrowser={this}
             />
           ) : (
             <div className={styles.emptyString}>

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -32,6 +32,7 @@ const PRIVACY_POLICY_LINKS = {
 
 const DEFAULT_FACETS = {
   sketchfab: [
+    { text: "Featured", params: { filter: "featured" } },
     { text: "Animals", params: { filter: "animals-pets" } },
     { text: "Architecture", params: { filter: "architecture" } },
     { text: "Art", params: { filter: "art-abstract" } },
@@ -52,6 +53,7 @@ const DEFAULT_FACETS = {
     { text: "Weapons", params: { filter: "weapons-military" } }
   ],
   poly: [
+    { text: "Featured", params: { filter: "" } },
     { text: "Animals", params: { filter: "animals" } },
     { text: "Architecture", params: { filter: "architecture" } },
     { text: "Art", params: { filter: "art" } },
@@ -64,7 +66,8 @@ const DEFAULT_FACETS = {
   ],
   avatars: [
     { text: "Featured", params: { filter: "featured" } },
-    { text: "My Avatars", params: { filter: "my-avatars" } }
+    { text: "My Avatars", params: { filter: "my-avatars" } },
+    { text: "All Avatars", params: { filter: "" } }
   ],
   favorites: [],
   scenes: [{ text: "Featured", params: { filter: "featured" } }, { text: "My Scenes", params: { filter: "my-scenes" } }]
@@ -252,6 +255,8 @@ class MediaBrowser extends Component {
       }
     };
 
+    const activeFilter = searchParams.get("filter") || (!searchParams.get("q") && "");
+
     return (
       <div className={styles.mediaBrowser} ref={browserDiv => (this.browserDiv = browserDiv)}>
         <div className={classNames([styles.box, styles.darkened])}>
@@ -378,7 +383,11 @@ class MediaBrowser extends Component {
             this.state.facets.length > 0 && (
               <div className={styles.facets}>
                 {this.state.facets.map((s, i) => (
-                  <a onClick={() => this.handleFacetClicked(s)} key={i} className={styles.facet}>
+                  <a
+                    onClick={() => this.handleFacetClicked(s)}
+                    key={i}
+                    className={classNames(styles.facet, { selected: s.params.filter === activeFilter })}
+                  >
                     {s.text}
                   </a>
                 ))}

--- a/src/react-components/media-tiles.js
+++ b/src/react-components/media-tiles.js
@@ -33,21 +33,19 @@ class MediaTiles extends Component {
     urlSource: PropTypes.string,
     handleEntryClicked: PropTypes.func,
     handlePager: PropTypes.func,
-    mediaBrowser: PropTypes.object
+    onCopyAvatar: PropTypes.func
   };
 
   handleCopyAvatar = async (e, entry) => {
     e.preventDefault();
-    console.log(entry);
     const avatar = {
       parent_avatar_listing_id: entry.id,
       name: entry.name,
       files: {}
     };
 
-    const { avatars } = await fetchReticulumAuthenticated(AVATARS_API, "POST", { avatar });
-    console.log(avatars);
-    this.props.mediaBrowser.handleFacetClicked({ params: { filter: "my-avatars" } });
+    await fetchReticulumAuthenticated(AVATARS_API, "POST", { avatar });
+    this.props.onCopyAvatar();
   };
 
   render() {

--- a/src/react-components/media-tiles.js
+++ b/src/react-components/media-tiles.js
@@ -9,12 +9,15 @@ import { faAngleLeft } from "@fortawesome/free-solid-svg-icons/faAngleLeft";
 import { faAngleRight } from "@fortawesome/free-solid-svg-icons/faAngleRight";
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons/faExternalLinkAlt";
 import { faPencilAlt } from "@fortawesome/free-solid-svg-icons/faPencilAlt";
+import { faClone } from "@fortawesome/free-solid-svg-icons/faClone";
 import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus";
 
 import styles from "../assets/stylesheets/media-browser.scss";
 import { proxiedUrlFor, scaledThumbnailUrlFor } from "../utils/media-url-utils";
 import StateLink from "./state-link";
+import { fetchReticulumAuthenticated } from "../utils/phoenix-utils";
 
+const AVATARS_API = "/api/v1/avatars";
 dayjs.extend(relativeTime);
 
 const PUBLISHER_FOR_ENTRY_TYPE = {
@@ -29,7 +32,22 @@ class MediaTiles extends Component {
     history: PropTypes.object,
     urlSource: PropTypes.string,
     handleEntryClicked: PropTypes.func,
-    handlePager: PropTypes.func
+    handlePager: PropTypes.func,
+    mediaBrowser: PropTypes.object
+  };
+
+  handleCopyAvatar = async (e, entry) => {
+    e.preventDefault();
+    console.log(entry);
+    const avatar = {
+      parent_avatar_listing_id: entry.id,
+      name: entry.name,
+      files: {}
+    };
+
+    const { avatars } = await fetchReticulumAuthenticated(AVATARS_API, "POST", { avatar });
+    console.log(avatars);
+    this.props.mediaBrowser.handleFacetClicked({ params: { filter: "my-avatars" } });
   };
 
   render() {
@@ -171,6 +189,16 @@ class MediaTiles extends Component {
             history={this.props.history}
           >
             <FontAwesomeIcon icon={faPencilAlt} />
+          </StateLink>
+        )}
+        {entry.type === "avatar_listing" && (
+          <StateLink
+            className={styles.editAvatar}
+            onClick={e => this.handleCopyAvatar(e, entry)}
+            history={this.props.history}
+            title="Copy to my avatars"
+          >
+            <FontAwesomeIcon icon={faClone} />
           </StateLink>
         )}
         {!entry.type.endsWith("_image") && (

--- a/src/react-components/media-tiles.js
+++ b/src/react-components/media-tiles.js
@@ -191,16 +191,17 @@ class MediaTiles extends Component {
             <FontAwesomeIcon icon={faPencilAlt} />
           </StateLink>
         )}
-        {entry.type === "avatar_listing" && (
-          <StateLink
-            className={styles.editAvatar}
-            onClick={e => this.handleCopyAvatar(e, entry)}
-            history={this.props.history}
-            title="Copy to my avatars"
-          >
-            <FontAwesomeIcon icon={faClone} />
-          </StateLink>
-        )}
+        {entry.type === "avatar_listing" &&
+          entry.allow_remixing && (
+            <StateLink
+              className={styles.editAvatar}
+              onClick={e => this.handleCopyAvatar(e, entry)}
+              history={this.props.history}
+              title="Copy to my avatars"
+            >
+              <FontAwesomeIcon icon={faClone} />
+            </StateLink>
+          )}
         {!entry.type.endsWith("_image") && (
           <div className={styles.info}>
             <a

--- a/src/react-components/profile-entry-panel.js
+++ b/src/react-components/profile-entry-panel.js
@@ -77,7 +77,9 @@ class ProfileEntryPanel extends Component {
     e.stopPropagation();
   };
 
-  setAvatarFromMediaResult = ({ detail: entry }) => {
+  setAvatarFromMediaResult = ({ detail: { entry, selectAction } }) => {
+    if ((entry.type !== "avatar" && entry.type !== "avatar_listing") || selectAction !== "use") return;
+
     this.setState({ avatarId: entry.id });
     // Replace history state with the current avatar id since this component gets destroyed when we open the
     // avatar editor and we want the back button to work. We read the history state back via the avatarId prop.
@@ -174,7 +176,7 @@ class ProfileEntryPanel extends Component {
                 )}
 
                 <div className={styles.chooseAvatar}>
-                  <a onClick={() => this.props.mediaSearchStore.sourceNavigateWithNoNav("avatars")}>
+                  <a onClick={() => this.props.mediaSearchStore.sourceNavigateWithNoNav("avatars", "use")}>
                     <FormattedMessage id="profile.choose_avatar" />
                   </a>
                 </div>
@@ -182,7 +184,7 @@ class ProfileEntryPanel extends Component {
             ) : (
               <div className={styles.preview}>
                 <div className={styles.chooseAvatar}>
-                  <a onClick={() => this.props.mediaSearchStore.sourceNavigateWithNoNav("avatars")}>
+                  <a onClick={() => this.props.mediaSearchStore.sourceNavigateWithNoNav("avatars", "use")}>
                     <FormattedMessage id="profile.choose_avatar" />
                   </a>
                 </div>

--- a/src/react-components/profile-entry-panel.js
+++ b/src/react-components/profile-entry-panel.js
@@ -183,6 +183,7 @@ class ProfileEntryPanel extends Component {
               </div>
             ) : (
               <div className={styles.preview}>
+                <AvatarPreview />
                 <div className={styles.chooseAvatar}>
                   <a onClick={() => this.props.mediaSearchStore.sourceNavigateWithNoNav("avatars", "use")}>
                     <FormattedMessage id="profile.choose_avatar" />

--- a/src/react-components/settings-menu.js
+++ b/src/react-components/settings-menu.js
@@ -92,7 +92,7 @@ export default class SettingsMenu extends Component {
                       () => this.props.hubChannel.signedIn,
                       () => {
                         showFullScreenIfAvailable();
-                        this.props.mediaSearchStore.sourceNavigateWithNoNav("favorites");
+                        this.props.mediaSearchStore.sourceNavigateWithNoNav("favorites", "use");
                       },
                       "favorite-rooms"
                     );
@@ -122,7 +122,7 @@ export default class SettingsMenu extends Component {
                         () => this.props.hubChannel.can("update_hub"),
                         () => {
                           showFullScreenIfAvailable();
-                          this.props.mediaSearchStore.sourceNavigateWithNoNav("scenes");
+                          this.props.mediaSearchStore.sourceNavigateWithNoNav("scenes", "use");
                           this.setState({ expanded: false });
                         },
                         "change-scene"

--- a/src/react-components/state-link.js
+++ b/src/react-components/state-link.js
@@ -18,6 +18,7 @@ class StateLink extends React.Component {
     stateValue: PropTypes.string,
     stateDetail: PropTypes.object,
     target: PropTypes.string,
+    title: PropTypes.string,
     onClick: PropTypes.func,
     children: PropTypes.node,
     className: PropTypes.string
@@ -39,11 +40,12 @@ class StateLink extends React.Component {
   }
 
   render() {
-    const { innerRef, target, className, children } = this.props;
+    const { innerRef, target, className, title, children } = this.props;
     return (
       <a
         target={target}
         className={className}
+        title={title}
         onClick={event => this.handleClick(event, this.props.history)}
         href="#"
         ref={innerRef}

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1500,7 +1500,7 @@ class UIRoot extends Component {
                       this.props.history.goBack();
                       // We are returning to the media browser. Trigger an update so that the filter switches to
                       // my-avatars, now that we've saved an avatar.
-                      this.props.mediaSearchStore.sourceNavigateWithNoNav("avatars");
+                      this.props.mediaSearchStore.sourceNavigateWithNoNav("avatars", "use");
                     }
                     this.props.onAvatarSaved();
                   }}
@@ -1517,14 +1517,14 @@ class UIRoot extends Component {
                 history={this.props.history}
                 mediaSearchStore={this.props.mediaSearchStore}
                 hubChannel={this.props.hubChannel}
-                onMediaSearchResultEntrySelected={entry => {
+                onMediaSearchResultEntrySelected={(entry, selectAction) => {
                   if (entry.type === "hub") {
                     this.showNonHistoriedDialog(LeaveRoomDialog, {
                       destinationUrl: entry.url,
                       messageType: "join-room"
                     });
                   } else {
-                    this.props.onMediaSearchResultEntrySelected(entry);
+                    this.props.onMediaSearchResultEntrySelected(entry, selectAction);
                   }
                 }}
                 performConditionalSignIn={this.props.performConditionalSignIn}
@@ -1744,7 +1744,7 @@ class UIRoot extends Component {
                           () => this.props.hubChannel.can("update_hub"),
                           () => {
                             showFullScreenIfAvailable();
-                            this.props.mediaSearchStore.sourceNavigateWithNoNav("scenes");
+                            this.props.mediaSearchStore.sourceNavigateWithNoNav("scenes", "use");
                           },
                           "change-scene"
                         );

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -461,9 +461,8 @@ export default class SceneEntryManager {
 
     this.scene.addEventListener("action_selected_media_result_entry", async e => {
       // TODO spawn in space when no rights
-      const entry = e.detail;
-      if (["avatar", "avatar_listing"].includes(entry.type)) return;
-      if ((entry.type === "scene_listing" || entry.type === "scene") && this.hubChannel.can("update_hub")) return;
+      const { entry, selectAction } = e.detail;
+      if (selectAction !== "spawn") return;
 
       const delaySpawn = isIn2DInterstitial() && !isMobileVR;
       await exit2DInterstitialAndEnterVR();

--- a/src/storage/media-search-store.js
+++ b/src/storage/media-search-store.js
@@ -2,7 +2,7 @@ import { EventTarget } from "event-target-shim";
 import { getReticulumFetchUrl, fetchReticulumAuthenticated } from "../utils/phoenix-utils";
 import { pushHistoryPath, sluglessPath, withSlug } from "../utils/history";
 
-export const SOURCES = ["poly", "sketchfab", "videos", "scenes", "gifs", "images", "twitch"];
+export const SOURCES = ["poly", "sketchfab", "videos", "scenes", "avatars", "gifs", "images", "twitch"];
 
 const EMPTY_RESULT = { entries: [], meta: {} };
 
@@ -158,7 +158,7 @@ export default class MediaSearchStore extends EventTarget {
     pushHistoryPath(this.history, location.pathname, searchParams.toString());
   };
 
-  getSearchClearedSearchParams = (location, keepSource, keepNav) => {
+  getSearchClearedSearchParams = (location, keepSource, keepNav, keepSelectAction) => {
     const searchParams = new URLSearchParams(location.search);
 
     // Strip browsing query params
@@ -172,6 +172,10 @@ export default class MediaSearchStore extends EventTarget {
 
     if (!keepSource) {
       searchParams.delete("media_source");
+    }
+
+    if (!keepSelectAction) {
+      searchParams.delete("selectAction");
     }
 
     return searchParams;
@@ -213,11 +217,11 @@ export default class MediaSearchStore extends EventTarget {
     this._sourceNavigate(this._stashedSource ? this._stashedSource : SOURCES[0], false, true);
   };
 
-  sourceNavigateWithNoNav = source => {
-    this._sourceNavigate(source, true, false);
+  sourceNavigateWithNoNav = (source, selectAction) => {
+    this._sourceNavigate(source, true, false, selectAction);
   };
 
-  _sourceNavigate = async (source, hideNav, useLastStashedParams) => {
+  _sourceNavigate = async (source, hideNav, useLastStashedParams, selectAction) => {
     const currentQuery = new URLSearchParams(this.history.location.search).get("q");
     const searchParams = this.getSearchClearedSearchParams(this.history.location);
 
@@ -250,6 +254,10 @@ export default class MediaSearchStore extends EventTarget {
 
     if (hideNav) {
       searchParams.set("media_nav", "false");
+    }
+
+    if (selectAction) {
+      searchParams.set("selectAction", selectAction);
     }
 
     if (process.env.RETICULUM_SERVER && document.location.host !== process.env.RETICULUM_SERVER) {

--- a/src/utils/avatar-utils.js
+++ b/src/utils/avatar-utils.js
@@ -64,3 +64,27 @@ export async function getAvatarThumbnailUrl(avatarId) {
       return "https://asset-bundles-prod.reticulum.io/bots/avatar_unavailable.png";
   }
 }
+
+export const MAT_NAME = "Bot_PBS";
+export function ensureAvatarMaterial(gltf) {
+  if (gltf.materials.find(m => m.name === MAT_NAME)) return gltf;
+
+  function materialForMesh(mesh) {
+    if (!mesh.primitives) return;
+    const primitive = mesh.primitives.find(p => p.material !== undefined);
+    return primitive && gltf.materials[primitive.material];
+  }
+
+  let nodes = gltf.scenes[gltf.scene].nodes.slice(0);
+  while (nodes.length) {
+    const node = gltf.nodes[nodes.shift()];
+    const material = node.mesh !== undefined && materialForMesh(gltf.meshes[node.mesh]);
+    if (material) {
+      material.name = MAT_NAME;
+      break;
+    }
+    if (node.children) nodes = nodes.concat(node.children);
+  }
+
+  return gltf;
+}

--- a/src/utils/avatar-utils.js
+++ b/src/utils/avatar-utils.js
@@ -65,6 +65,10 @@ export async function getAvatarThumbnailUrl(avatarId) {
   }
 }
 
+// Currently the way we do material overrides is with a special named material.
+// We want to migrate eventually to having a GLTF extension that specifies what
+// materials can be overridden, but in the meantime we want to be able to support
+// arbitrary models with some sort of functionality. This provides a fallback
 export const MAT_NAME = "Bot_PBS";
 export function ensureAvatarMaterial(gltf) {
   if (gltf.materials.find(m => m.name === MAT_NAME)) return gltf;

--- a/src/utils/three-utils.js
+++ b/src/utils/three-utils.js
@@ -183,5 +183,5 @@ export function findNode(root, pred) {
     if (pred(node)) return node;
     if (node.children) nodes = nodes.concat(node.children);
   }
-  return undefined;
+  return null;
 }

--- a/src/utils/three-utils.js
+++ b/src/utils/three-utils.js
@@ -175,3 +175,13 @@ export function cloneObject3D(source, preserveUUIDs) {
 
   return clone;
 }
+
+export function findNode(root, pred) {
+  let nodes = [root];
+  while (nodes.length) {
+    const node = nodes.shift();
+    if (pred(node)) return node;
+    if (node.children) nodes = nodes.concat(node.children);
+  }
+  return undefined;
+}


### PR DESCRIPTION
You can now select from multiple base models when creating new avatars. Still
want more? You can now upload custom GLBs directly from the avatar editor and
share them with the community. If you see an avatar you want to reskin, you can
copy it to "My Avatars" and then share the changes back to the community! You
can also now place avatars into the room from the media browser, making it even
easier to share your creations.

![image](https://user-images.githubusercontent.com/130735/63558535-21409d80-c502-11e9-9268-e32013da6b62.png)

In this PR:
- Remove the need for hardcoded `basebot` avatar, instead using avatar listings
tagged with `base` to populate the dropdown of base `parent_avatar_listing`s
when creating new avatars. Users can also select a "Custom Model" option to
expose an additional GLB field, allowing them to upload their own modesl,
creating a new root avatar.
- Avatar listings in the media browser now show a "copy to my avatars" button,
which creates a new avatars using the selected listing as
`parent_avatar_listing`.
- We now hide the non-base maps behind an "advanced" button in the avatar editor
- TODO
   - [x] avatars with listings now show "delist" instead of "delete" as
      deleting them will no longer actually delete the avatar files from our
      servers, instead just removing them from search results.

These PRs should be landed before this one:
- [x] https://github.com/mozilla/hubs/pull/1657
- [x] https://github.com/mozilla/hubs-ops/pull/64
- [x] https://github.com/mozilla/reticulum/pull/215

Also some setup needs to be done in the admin console and DB
- [x] Create a proper base avatar for the alternate bot body type. Making sure to also include the head scaling and animation components
- [x] Create a listing for the alternate bot body.
- [x] Manually in the DB or Ret console, find avatars that have the alternate
      bod body as a hardcoded GLTF and remove these files, changing them instead
      to use the new listing created above as their `parent_avatar_listing`
- [x] Tag the base avatars we want to expose as "base" in the admin console.
      While we are at it we may want to also tag up the avatars we want to
      eventually expose as "default" avatars.