### PR TITLE
Fix issue with enter VR mode hanging on oculus quest

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -444,8 +444,8 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data)
     remountUI({
       showInterstitialPrompt: true,
       onInterstitialPromptClicked: () => {
-        scene.emit("2d-interstitial-gesture-complete");
         remountUI({ showInterstitialPrompt: false, onInterstitialPromptClicked: null });
+        scene.emit("2d-interstitial-gesture-complete");
       }
     });
   });
@@ -658,7 +658,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     const signInContinueTextId = scene.is("vr-mode") ? "entry.return-to-vr" : "dialog.close";
 
-    handleExitTo2DInterstitial(true, () => remountUI({ showSignInDialog: false }));
+    await handleExitTo2DInterstitial(true, () => remountUI({ showSignInDialog: false }));
 
     remountUI({
       showSignInDialog: true,
@@ -702,7 +702,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     );
   });
 
-  scene.addEventListener("action_media_tweet", e => {
+  scene.addEventListener("action_media_tweet", async e => {
     let isInModal = false;
     let isInOAuth = false;
 
@@ -712,7 +712,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       remountUI({ showOAuthDialog: false, oauthInfo: null });
     };
 
-    handleExitTo2DInterstitial(true, () => {
+    await handleExitTo2DInterstitial(true, () => {
       if (isInModal) history.goBack();
       if (isInOAuth) exitOAuth();
     });

--- a/src/utils/fullscreen.js
+++ b/src/utils/fullscreen.js
@@ -15,15 +15,15 @@ export function willRequireUserGesture() {
   return !screenfull.isFullscreen && shouldShowFullScreen();
 }
 
-export function showFullScreenIfAvailable() {
+export async function showFullScreenIfAvailable() {
   if (shouldShowFullScreen()) {
-    screenfull.request();
     hasEnteredFullScreenThisSession = true;
+    await screenfull.request();
   }
 }
 
-export function showFullScreenIfWasFullScreen() {
+export async function showFullScreenIfWasFullScreen() {
   if (hasEnteredFullScreenThisSession && !screenfull.isFullscreen) {
-    screenfull.request();
+    await screenfull.request();
   }
 }


### PR DESCRIPTION
I'm not 100% sure if this fixes it but I can't repro it after this change. I think the root cause for the spinner was because we were remounting the UI potentially while the VR transition occured, but hard to say why that would matter. this PR changes the code to properly await promises for screen transitions and vr entry/exit. it also tightens up the delay on spawning objects on mobile VR.