### PR TITLE
Skip lerping and showing avatar until ik step

### DIFF
--- a/src/components/ik-controller.js
+++ b/src/components/ik-controller.js
@@ -111,6 +111,7 @@ AFRAME.registerComponent("ik-controller", {
     this.playerCamera = document.getElementById("viewing-camera").getObject3D("camera");
 
     this.el.sceneEl.systems["frame-scheduler"].schedule(this._runScheduledWork, "ik");
+    this.forceIkUpdate = true;
   },
 
   remove() {
@@ -220,7 +221,12 @@ AFRAME.registerComponent("ik-controller", {
       cameraYRotation.x = 0;
       cameraYRotation.z = 0;
       cameraYQuaternion.setFromEuler(cameraYRotation);
-      Quaternion.slerp(hips.quaternion, cameraYQuaternion, hips.quaternion, (this.data.rotationSpeed * dt) / 1000);
+
+      if (this._hadFirstTick) {
+        Quaternion.slerp(hips.quaternion, cameraYQuaternion, hips.quaternion, (this.data.rotationSpeed * dt) / 1000);
+      } else {
+        hips.quaternion.copy(cameraYQuaternion);
+      }
 
       this.hasConvergedHips = quaternionAlmostEquals(0.0001, cameraYQuaternion, hips.quaternion);
 
@@ -248,6 +254,12 @@ AFRAME.registerComponent("ik-controller", {
     if (leftHand) this.updateHand(handRotations.left, leftHand, leftController.object3D, true, this.isInView);
     if (rightHand) this.updateHand(handRotations.right, rightHand, rightController.object3D, false, this.isInView);
     this.forceIkUpdate = false;
+
+    if (!this._hadFirstTick) {
+      // Ensure the avatar is not shown until we've done our first IK step, to prevent seeing mis-oriented/t-pose pose or our own avatar at the wrong place.
+      this.ikRoot.el.object3D.visible = true;
+      this._hasFirstTick = true;
+    }
   },
 
   updateHand(handRotation, handObject3D, controllerObject3D, isLeft, isInView) {

--- a/src/hub.html
+++ b/src/hub.html
@@ -77,7 +77,7 @@
             <a-asset-item id="botwoody" response-type="arraybuffer" src="https://asset-bundles-prod.reticulum.io/bots/BotWoody_Avatar-0140485a23.gltf"></a-asset-item>
 
             <template id="remote-avatar">
-                <a-entity networked-avatar ik-root player-info matrix-auto-update>
+                <a-entity networked-avatar ik-root player-info matrix-auto-update visible="false">
                     <a-entity class="camera" matrix-auto-update></a-entity>
 
                     <a-entity class="left-controller" matrix-auto-update></a-entity>
@@ -802,6 +802,7 @@
             ik-root
             player-info
             periodic-full-syncs
+            visible="false"
         >
             <a-entity
                 id="player-hud"


### PR DESCRIPTION
For a while now when an avatar spawns it can be seen in t-pose for a frame, and will also see its body lerp from the neutral orientation. this updates things so the avatar pops in to view in the proper pose in one frame.