### PR TITLE
Fix a variety of HLS live stream playback issues

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -18,6 +18,10 @@ const ONCE_TRUE = { once: true };
 const TYPE_IMG_PNG = { type: "image/png" };
 const parseGIF = promisifyWorker(new GIFWorker());
 
+const isIOS = AFRAME.utils.device.isIOS();
+const isMobileVR = AFRAME.utils.device.isMobileVR();
+const isFirefoxReality = isMobileVR && navigator.userAgent.match(/Firefox/);
+
 export const VOLUME_LABELS = [];
 for (let i = 0; i <= 20; i++) {
   let s = "|";
@@ -90,8 +94,6 @@ async function createGIFTexture(url) {
       .catch(reject);
   });
 }
-
-const isIOS = AFRAME.utils.device.isIOS();
 
 /**
  * Create video element to be used as a texture.
@@ -333,6 +335,7 @@ AFRAME.registerComponent("media-video", {
     this.videoMutedAt = 0;
     this.localSnapCount = 0;
     this.isSnapping = false;
+    this.videoIsLive = null; // value null until we've determined if the video is live or not.
     this.onSnapImageLoaded = () => (this.isSnapping = false);
 
     this.el.setAttribute("hover-menu__video", { template: "#video-hover-menu", dirs: ["forward", "back"] });
@@ -481,7 +484,8 @@ AFRAME.registerComponent("media-video", {
       this.timeLabel.object3D.visible = !this.data.hidePlaybackControls;
 
       const isPinned = this.el.components.pinnable && this.el.components.pinnable.data.pinned;
-      this.playPauseButton.object3D.visible = !!this.video && (!isPinned || window.APP.hubChannel.can("pin_objects"));
+      this.playPauseButton.object3D.visible =
+        !!this.video && !!this.videoIsLive && (!isPinned || window.APP.hubChannel.can("pin_objects"));
       this.snapButton.object3D.visible = !!this.video && window.APP.hubChannel.can("spawn_and_move_media");
       this.seekForwardButton.object3D.visible = !!this.video && !this.videoIsLive;
       this.seekBackButton.object3D.visible = !!this.video && !this.videoIsLive;
@@ -508,7 +512,9 @@ AFRAME.registerComponent("media-video", {
       delete this._playbackStateChangeTimeout;
     }
 
-    if (!this.videoIsLive && currentTime !== undefined) {
+    // Update current time if we've determined this video is not a live stream, since otherwise we may
+    // update the video to currentTime = 0
+    if (this.videoIsLive === false && currentTime !== undefined) {
       this.video.currentTime = currentTime;
     }
 
@@ -582,9 +588,22 @@ AFRAME.registerComponent("media-video", {
 
       if (texture.hls) {
         const updateLiveState = () => {
-          this.videoIsLive = texture.hls.levels[texture.hls.currentLevel].details.live;
-          this.updateHoverMenuBasedOnLiveState();
+          if (texture.hls.currentLevel >= 0) {
+            const videoWasLive = !!this.videoIsLive;
+            this.videoIsLive = texture.hls.levels[texture.hls.currentLevel].details.live;
+            this.updateHoverMenuBasedOnLiveState();
+
+            if (!videoWasLive && this.videoIsLive) {
+              // We just determined the video is live (there can be a delay due to autoplay issues, etc)
+              // so catch it up to HEAD.
+              if (!isFirefoxReality) {
+                // HACK this causes live streams to freeze in FxR due to https://github.com/MozillaReality/FirefoxReality/issues/1602
+                this.video.currentTime = this.video.duration;
+              }
+            }
+          }
         };
+        texture.hls.on(HLS.Events.LEVEL_LOADED, updateLiveState);
         texture.hls.on(HLS.Events.LEVEL_SWITCHED, updateLiveState);
         if (texture.hls.currentLevel >= 0) {
           updateLiveState();
@@ -688,8 +707,13 @@ AFRAME.registerComponent("media-video", {
       );
     }
 
-    // If a non-live video is currently playing and we own it, send out time updates
-    if (!this.data.videoPaused && !this.videoIsLive && this.networkedEl && NAF.utils.isMine(this.networkedEl)) {
+    // If a known non-live video is currently playing and we own it, send out time updates
+    if (
+      !this.data.videoPaused &&
+      this.videoIsLive === false &&
+      this.networkedEl &&
+      NAF.utils.isMine(this.networkedEl)
+    ) {
       const now = performance.now();
       if (now - this.lastUpdate > this.data.tickRate) {
         this.el.setAttribute("media-video", "time", this.video.currentTime);


### PR DESCRIPTION
This fixes or works around a bunch of gnarly HLS playback issues:

- There can be a delay between the video starting to play back and the time we determine the video is a live stream. For example, in Oculus Browser, we don't actually see the HLS level load until we get a user gesture. As such we should avoid setting `currentTime` (which defaults to 0 because of `this.data.time` defaulting to zero) until we know for sure if the video is live or not.

- Fixes an issue where in Oculus Browser, `LEVEL_SWITCHED` is never fired for live streams, so we do not ever tag the stream as such.

- Avoid flushing time stamps over the network until we've determine that the video is not a live stream. We *never* want time syncing with live streams.

- Disable the pause button for live streams, which leads to all kinds of confusing semantics.

- Partially work around a bug in firefox reality causing HLS seeking to fail.  

- Deal with potential latencies introduced by the need for a user gesture to begin playback by seeking to the end of the stream once we determine that it is a live stream.