### PR TITLE
Add soft room capping

### DIFF
--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -67,6 +67,8 @@
     "entry.device-subtitle-desktop": "Standalone VR or Phone",
     "entry.device-subtitle-mobile": "Standalone VR or PC",
     "entry.device-subtitle-vr": "Phone or PC",
+    "entry.entry-disallowed": "Watch from Lobby",
+    "entry.entry-disallowed-subtitle": "Room is Full",
     "entry.cardboard": "Enter on Google Cardboard",
     "entry.daydream-prefix": "Enter on ",
     "entry.daydream-medium": "Daydream",

--- a/src/hub.js
+++ b/src/hub.js
@@ -156,7 +156,7 @@ const NOISY_OCCUPANT_COUNT = 12; // Above this # of occupants, we stop posting j
 
 // Maximum number of people in the room/entering before users are forced to observer mode.
 // Eventually this should be moved to a room setting.
-const MAX_OCCUPIED_ROOM_ENTRY_SLOTS = 1;
+const MAX_OCCUPIED_ROOM_ENTRY_SLOTS = 24;
 
 const qs = new URLSearchParams(location.search);
 const isMobile = AFRAME.utils.device.isMobile();

--- a/src/hub.js
+++ b/src/hub.js
@@ -154,6 +154,10 @@ const mediaSearchStore = window.APP.mediaSearchStore;
 const OAUTH_FLOW_PERMS_TOKEN_KEY = "ret-oauth-flow-perms-token";
 const NOISY_OCCUPANT_COUNT = 12; // Above this # of occupants, we stop posting join/leaves/renames
 
+// Maximum number of people in the room/entering before users are forced to observer mode.
+// Eventually this should be moved to a room setting.
+const MAX_OCCUPIED_ROOM_ENTRY_SLOTS = 1;
+
 const qs = new URLSearchParams(location.search);
 const isMobile = AFRAME.utils.device.isMobile();
 const isMobileVR = AFRAME.utils.device.isMobileVR();
@@ -394,7 +398,7 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data)
     // on re-join. Ideally this would be updated into the channel socket state but this
     // would require significant changes to the hub channel events and socket management.
     if (scene.is("entered")) {
-      hubChannel.sendEntryEvent();
+      hubChannel.sendEnteredEvent();
     }
 
     // Send complete sync on phoenix re-join.
@@ -1106,6 +1110,10 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   let isInitialJoin = true;
 
+  // state used to ensure we only remountUI when entry allowed changes, since otherwise we'd re-render
+  // on every presence sync.
+  let entryDisallowed = false;
+
   // We need to be able to wait for initial presence syncs across reconnects and socket migrations,
   // so we create this object in the outer scope and assign it a new promise on channel join.
   const presenceSync = {
@@ -1141,10 +1149,27 @@ document.addEventListener("DOMContentLoaded", async () => {
           const occupantCount = Object.entries(presence.state).length;
           vrHudPresenceCount.setAttribute("text", "value", occupantCount.toString());
 
+          // A room entry slot is used by people in the room, or those going through the
+          // entry flow.
+          const roomEntrySlotCount = Object.values(presence.state).reduce((acc, { metas }) => {
+            const meta = metas[metas.length - 1];
+            const usingSlot = meta.presence === "room" || (meta.context && meta.context.entering);
+            return acc + (usingSlot ? 1 : 0);
+          }, 0);
+
           if (occupantCount > 1) {
             scene.addState("copresent");
           } else {
             scene.removeState("copresent");
+          }
+
+          const entryNowDisallowed =
+            roomEntrySlotCount >= MAX_OCCUPIED_ROOM_ENTRY_SLOTS && !hubChannel.canOrWillIfCreator("update_hub");
+
+          if (entryDisallowed !== entryNowDisallowed) {
+            // Optimization to prevent re-render unless entry allowed state changes.
+            entryDisallowed = entryNowDisallowed;
+            remountUI({ entryDisallowed });
           }
 
           // HACK - Set a flag on the presence object indicating if the initial sync has completed,

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -103,7 +103,7 @@ export default class SceneEntryManager {
         await nextTick();
       }
 
-      this.hubChannel.sendEntryEvent().then(() => {
+      this.hubChannel.sendEnteredEvent().then(() => {
         this.store.update({ activity: { lastEnteredAt: new Date().toISOString() } });
       });
     })();

--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -91,7 +91,15 @@ export default class HubChannel extends EventTarget {
     }, nextRefresh);
   };
 
-  sendEntryEvent = async () => {
+  sendEnteringEvent = async () => {
+    this.channel.push("events:entering", {});
+  };
+
+  sendEnteringCancelledEvent = async () => {
+    this.channel.push("events:entering_cancelled", {});
+  };
+
+  sendEnteredEvent = async () => {
     if (!this.channel) {
       console.warn("No phoenix channel initialized before room entry.");
       return;


### PR DESCRIPTION
Adds a soft room cap of 24 users who are either in the room or going through the entry flow. This is not server enforced, so could be bypassed somewhat easily by a user, but it should help with reducing the room capacity somewhat until a server-authoritative approach can be incorporated. Goes with: https://github.com/mozilla/reticulum/pull/218

When the room is full, the landing page CTA switches to a "Watch from Lobby" button which has the same effect as the X.