### PR TITLE
Fix some sentry errors

### DIFF
--- a/src/components/clone-media-button.js
+++ b/src/components/clone-media-button.js
@@ -5,6 +5,7 @@ import { guessContentType } from "../utils/media-url-utils";
 AFRAME.registerComponent("clone-media-button", {
   init() {
     this.updateSrc = () => {
+      if (!this.targetEl.components["media-loader"] || !this.targetEl.components["media-loader"].data) return; // If removed
       const src = (this.src = this.targetEl.components["media-loader"].data.src);
       const visible = src && guessContentType(src) !== "video/vnd.hubs-webrtc";
       this.el.object3D.visible = !!visible;

--- a/src/components/open-media-button.js
+++ b/src/components/open-media-button.js
@@ -9,6 +9,7 @@ AFRAME.registerComponent("open-media-button", {
     this.label = this.el.querySelector("[text]");
 
     this.updateSrc = () => {
+      if (!this.targetEl.components["media-loader"] || !this.targetEl.components["media-loader"].data) return; // If removed
       const src = (this.src = this.targetEl.components["media-loader"].data.src);
       const visible = src && guessContentType(src) !== "video/vnd.hubs-webrtc";
       const mayChangeScene = this.el.sceneEl.systems.permissions.canOrWillIfCreator("update_hub");

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -483,7 +483,10 @@ class UIRoot extends Component {
   };
 
   exit = reason => {
-    this.props.exitScene(reason);
+    if (this.props.exitScene) {
+      this.props.exitScene(reason);
+    }
+
     this.setState({ exited: true });
   };
 

--- a/src/systems/userinput/devices/oculus-go-controller.js
+++ b/src/systems/userinput/devices/oculus-go-controller.js
@@ -2,6 +2,7 @@ import { paths } from "../paths";
 import { Pose } from "../pose";
 import { applyArmModel } from "../arm-model.js";
 import { copySittingToStandingTransform } from "./copy-sitting-to-standing-transform";
+import { waitForDOMContentLoaded } from "../../../utils/async-utils";
 
 const ONES = new THREE.Vector3(1, 1, 1);
 
@@ -22,12 +23,17 @@ export class OculusGoControllerDevice {
     // TODO ideally we should just be getting pose from the gamepad
     // TODO if controller is set to left hand, we still use right hand query here
     // because otherwise things break.
-    this.rayObject = document.querySelector("#player-right-controller").object3D;
-    this.headObject3D = document.querySelector("#avatar-pov-node").object3D;
+    waitForDOMContentLoaded().then(() => {
+      this.rayObject = document.querySelector("#player-right-controller").object3D;
+      this.headObject3D = document.querySelector("#avatar-pov-node").object3D;
+    });
+
     navigator.getGamepads();
   }
 
   write(frame) {
+    if (!this.rayObject || !this.headObject3D) return;
+
     // Have to call navigator.getGamepads() in order for the gamepad object to update.
     navigator.getGamepads();
     if (this.gamepad.connected) {


### PR DESCRIPTION
Fixes a few errors in sentry --

Ones I could repro:

- The missing components in clone/open buttons are due to situations where a user removes media before it has completed loading

Ones I couldn't repro or didn't try because it's obvious:

- The scene exit handler being unregistered I think is an early-out situation from Safari if the scene doesn't load and we exit on blur

- The oculus go thing is the usual trap where we expect the DOM to be ready during system init