### PR TITLE
Fix env map error on loading cube

### DIFF
--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -126,10 +126,12 @@ AFRAME.registerComponent("media-loader", {
 
     if (useFancyLoader) {
       const environmentMapComponent = this.el.sceneEl.components["environment-map"];
-      const currentEnivronmentMap = environmentMapComponent.environmentMap;
-      if (loadingObjectEnvMap !== currentEnivronmentMap) {
-        environmentMapComponent.applyEnvironmentMap(mesh);
-        loadingObjectEnvMap = currentEnivronmentMap;
+      if (environmentMapComponent) {
+        const currentEnivronmentMap = environmentMapComponent.environmentMap;
+        if (loadingObjectEnvMap !== currentEnivronmentMap) {
+          environmentMapComponent.applyEnvironmentMap(mesh);
+          loadingObjectEnvMap = currentEnivronmentMap;
+        }
       }
 
       this.loaderMixer = new THREE.AnimationMixer(mesh);


### PR DESCRIPTION
Fix for https://sentry.prod.mozaws.net/operations/hubs-prod/issues/6099086/

Couldn't repro this manually, but I imagine it happens if someone in a room spawns something while you're in the middle of initializing your scene.