### PR TITLE
fix rotations of pens and hands over the network

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -371,7 +371,7 @@
                     scale="0.5 0.5 0.5"
                     action-to-remove__pen="path: /actions/pen/remove;"
                     position-at-box-shape-border="target:.pen-menu"
-
+                    set-yxz-order
                 >
                     <a-entity
                         id="pen"
@@ -954,6 +954,7 @@
                 matrix-auto-update
                 body-helper="type: kinematic; emitCollisionEvents: false; disableCollision: true; collisionFilterGroup: 8; collisionFilterMask: 3; activationState: disable_deactivation; scaleAutoUpdate: false;"
                 shape-helper="type: box; fit: manual; halfExtents: 0.03 0.04 0.05; offset: 0 0 -0.04"
+                set-yxz-order
             >
             </a-entity>
 
@@ -967,6 +968,7 @@
                 matrix-auto-update
                 body-helper="type: kinematic; emitCollisionEvents: false; disableCollision: true; collisionFilterGroup: 8; collisionFilterMask: 3; activationState: disable_deactivation; scaleAutoUpdate: false;"
                 shape-helper="type: box; fit: manual; halfExtents: 0.03 0.04 0.05; offset: 0 0 -0.04"
+                set-yxz-order
             >
             </a-entity>
 


### PR DESCRIPTION
use "set-yxz-order" on pen and hand entities so that their rotations get properly networked.