### PR TITLE
Hacky fix for safari WebRTC audio

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -1266,9 +1266,41 @@ document.addEventListener("DOMContentLoaded", async () => {
       hubChannel.setPermissionsFromToken(permsToken);
 
       scene.addEventListener("adapter-ready", ({ detail: adapter }) => {
+        // HUGE HACK Safari does not like it if the first peer seen does not immediately
+        // send audio over its media stream. Otherwise, the stream doesn't work and stays
+        // silent. (Though subsequent peers work fine.)
+        //
+        // This hooks up a simple audio pipeline to push a short tone over the WebRTC
+        // media stream as its created to mitigate this Safari bug.
+        //
+        // Users will never hear this tone -- the outgoing media track is overwritten
+        // before we spawn our avatar, which is when other users will begin hearing
+        // the audio.
+        //
+        // This only covers the case where a Safari user is in the room and the first
+        // other user joins. If a silent user is in the room and Safari user joins,
+        // then it may still break if that user is silent.
+        const ctx = THREE.AudioContext.getContext();
+        const oscillator = ctx.createOscillator();
+        const gain = ctx.createGain();
+        gain.gain.setValueAtTime(0.01, ctx.currentTime);
+        const dest = ctx.createMediaStreamDestination();
+        oscillator.connect(gain);
+        gain.connect(dest);
+        oscillator.start();
+        const stream = dest.stream;
+        const track = stream.getAudioTracks()[0];
         adapter.setClientId(socket.params().session_id);
         adapter.setJoinToken(data.perms_token);
+        adapter.setLocalMediaStream(stream);
         hubChannel.addEventListener("permissions-refreshed", e => adapter.setJoinToken(e.detail.permsToken));
+
+        // Stop the tone after we've connected, which seems to mitigate the issue without actually
+        // having to keep this playing and using bandwidth.
+        scene.addEventListener("didConnectToNetworkedScene", () => {
+          oscillator.stop();
+          track.enabled = false;
+        });
       });
       subscriptions.setHubChannel(hubChannel);
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -1278,8 +1278,9 @@ document.addEventListener("DOMContentLoaded", async () => {
         // the audio.
         //
         // This only covers the case where a Safari user is in the room and the first
-        // other user joins. If a silent user is in the room and Safari user joins,
-        // then it may still break if that user is silent.
+        // other user joins. If a user is in the room and Safari user joins,
+        // then Safari can fail to receive audio from a single peer (it does not seem
+        // to be related to silence, but may be a factor.)
         const ctx = THREE.AudioContext.getContext();
         const oscillator = ctx.createOscillator();
         const gain = ctx.createGain();


### PR DESCRIPTION
After a full day's worth of investigating, here's what I've uncovered about iOS Safari:

- If you join a room and there are avatars already in the room, there's a non-deterministic chance that you will have one avatar whose audio you will not hear. You will always hear the audio from the other avatars besides that one.

- Additionally, if you are in a room by yourself, the first avatar to join the room will also non-deterministically not be heard.

- When debugging this state, the track and everything is wired up right in the client, but there is just no audio data being received over the track.

- I don't have a solution to the problem seen when joining a room with avatars already present. However, this PR addresses the case when you are in a room by yourself and the first other user joins. It looks like the Safari behavior can be mitigated by ensuring that when a user joins as a peer in Janus, that the Safari peers in the room immediately receive audio over their track. If they do not, then there's a non-deterministic chance the track will die.

This PR mitigates the issue by sending a brief tone over the audio track when joining the lobby (!). This fully mitigates the issue for Safari when you are in a room by yourself. Without this patch, about 80% of the time the first avatar to join you will not be heard. After this patch, they'll be heard 100% of the time!