### PR TITLE
Wire up canplay handler before setting src

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -124,7 +124,7 @@ function createVideoTexture(url, contentType) {
     texture.minFilter = THREE.LinearFilter;
     texture.encoding = THREE.sRGBEncoding;
 
-    // Wire up event handlers or polling to forward along texture once video can play.
+    // Wire up canplay event handlers to forward along texture once video can play.
     videoEl.addEventListener("canplay", () => resolve(texture), { once: true });
 
     // Set src on video to begin loading.


### PR DESCRIPTION
Fixes issue where `canplay` event handler may be wired up after video fires the `canplay` event (which seems possible, rarely, when a video is cached.)