### PR TITLE
Stop setting id on media elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12233,7 +12233,7 @@
       "dev": true
     },
     "networked-aframe": {
-      "version": "github:mozillareality/networked-aframe#cd92a49fa4599895412dd71a66340019eaafa1e0",
+      "version": "github:mozillareality/networked-aframe#832285e7bcefd5df0df945e2d5444a8206ed4689",
       "from": "github:mozillareality/networked-aframe#master",
       "requires": {
         "buffered-interpolation": "^0.2.5",

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -89,7 +89,6 @@ function getOrientation(file, callback) {
   reader.readAsArrayBuffer(file);
 }
 
-let interactableId = 0;
 export const addMedia = (
   src,
   template,
@@ -102,7 +101,6 @@ export const addMedia = (
   const scene = AFRAME.scenes[0];
 
   const entity = document.createElement("a-entity");
-  entity.id = "interactable-media-" + interactableId++;
   entity.setAttribute("networked", { template: template });
   const needsToBeUploaded = src instanceof File;
   entity.setAttribute("media-loader", {


### PR DESCRIPTION
Goes with https://github.com/MozillaReality/networked-aframe/pull/35

Stop setting ids on media elements and let NAF deal with it, to ensure consistent/set ids across all clients.