### PR TITLE
Add missing tooltip title to buttons

### DIFF
--- a/src/react-components/2d-hud.js
+++ b/src/react-components/2d-hud.js
@@ -264,6 +264,7 @@ class TopHUD extends Component {
               className={cx(uiStyles.uiInteractive, styles.iconButton, styles.spawn, {
                 [styles.disabled]: this.state.mediaDisabled
               })}
+              title={`Create${this.state.mediaDisabled ? " Disabled" : ""}`}
               onClick={
                 this.state.mediaDisabled ? noop : () => this.props.mediaSearchStore.sourceNavigateToDefaultSource()
               }

--- a/src/react-components/in-world-chat-box.js
+++ b/src/react-components/in-world-chat-box.js
@@ -113,6 +113,7 @@ class InWorldChatBox extends Component {
           />
           {this.props.enableSpawning && (
             <button
+              title={"Create"}
               className={classNames([styles.messageEntrySpawn])}
               onClick={() => {
                 if (this.state.pendingMessage.length > 0) {
@@ -126,6 +127,7 @@ class InWorldChatBox extends Component {
           )}
           <button
             type="submit"
+            title={"Submit"}
             className={classNames([
               styles.messageEntryButton,
               styles.messageEntryButtonInRoom,


### PR DESCRIPTION
This adds an HTML title to the "Create" button in the upper menu, and the "Create" and "Submit" buttons in the chat box. There will now be a tooltip on hover. This is consistent with other menu buttons. Fixes issue #1704

<img width="156" alt="Screen Shot 2019-09-02 at 1 37 58 PM" src="https://user-images.githubusercontent.com/6835324/64132855-8492c100-cd87-11e9-9db7-39eeab13c6de.png">

<img width="205" alt="Screen Shot 2019-09-02 at 1 38 12 PM" src="https://user-images.githubusercontent.com/6835324/64132867-9a07eb00-cd87-11e9-8d31-9cbb2f4bda51.png">

<img width="180" alt="Screen Shot 2019-09-02 at 1 38 07 PM" src="https://user-images.githubusercontent.com/6835324/64132857-89f00b80-cd87-11e9-8906-4055b72e8b84.png">