### PR TITLE
Allow remxing from avatar_listing landing pages and hover menues

### DIFF
--- a/src/assets/stylesheets/avatar.scss
+++ b/src/assets/stylesheets/avatar.scss
@@ -81,4 +81,33 @@ body {
     position: relative;
     max-width: 300px;
   }
+
+  :local(.copy-tip) {
+    position: absolute;
+    padding: 5px 20px;
+    background: $darker-grey;
+    top: 5px;
+    right: 10px;
+    border-radius: 20px;
+    height: 20px;
+    line-height: 20px;
+    color: $light-text;
+  }
+
+  :local(.edit-avatar) {
+    position: absolute;
+    top: 6px;
+    right: 7px;
+    color: black;
+    background: #ffffffde;
+    border-radius: 30px;
+    width: 30px;
+    height: 30px;
+    text-align: center;
+    line-height: 27px;
+    &:hover {
+      background: $action-color;
+      color: white;
+    }
+  }
 }

--- a/src/avatar.js
+++ b/src/avatar.js
@@ -72,7 +72,7 @@ class AvatarUI extends React.Component {
     const { avatar } = this.state;
     this.setState({ copyMessage: "copying..." });
     await remixAvatar(avatar.avatar_id, avatar.name);
-    this.setState({ copyMessage: "Coppied!" });
+    this.setState({ copyMessage: "Copied!" });
     setTimeout(() => this.setState({ copyMessage: false }), 2000);
   };
 

--- a/src/avatar.js
+++ b/src/avatar.js
@@ -41,7 +41,7 @@ class AvatarUI extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = { copyMessage: false };
+    this.state = { copyMessage: null };
   }
 
   componentDidMount() {
@@ -73,7 +73,7 @@ class AvatarUI extends React.Component {
     this.setState({ copyMessage: "copying..." });
     await remixAvatar(avatar.avatar_id, avatar.name);
     this.setState({ copyMessage: "Copied!" });
-    setTimeout(() => this.setState({ copyMessage: false }), 2000);
+    setTimeout(() => this.setState({ copyMessage: null }), 2000);
   };
 
   render() {

--- a/src/avatar.js
+++ b/src/avatar.js
@@ -104,6 +104,7 @@ class AvatarUI extends React.Component {
               <div className={styles.copyTip}>{copyMessage}</div>
             ) : (
               avatar &&
+              avatar.type === "avatar_listing" &&
               avatar.allow_remixing && (
                 <a className={styles.editAvatar} onClick={this.handleCopyAvatar} title="Copy to my avatars">
                   <FontAwesomeIcon icon={faClone} />

--- a/src/avatar.js
+++ b/src/avatar.js
@@ -21,10 +21,13 @@ import { App } from "./App";
 
 import AvatarPreview from "./react-components/avatar-preview";
 
-import { fetchAvatar } from "./utils/avatar-utils";
+import { fetchAvatar, remixAvatar } from "./utils/avatar-utils";
 
 import styles from "./assets/stylesheets/avatar.scss";
 import hubLogo from "./assets/images/hub-preview-white.png";
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faClone } from "@fortawesome/free-solid-svg-icons/faClone";
 
 const qs = new URLSearchParams(location.search);
 window.APP = new App();
@@ -38,7 +41,7 @@ class AvatarUI extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = { copyMessage: false };
   }
 
   componentDidMount() {
@@ -64,8 +67,17 @@ class AvatarUI extends React.Component {
     });
   };
 
-  render() {
+  handleCopyAvatar = async e => {
+    e.preventDefault();
     const { avatar } = this.state;
+    this.setState({ copyMessage: "copying..." });
+    await remixAvatar(avatar.avatar_id, avatar.name);
+    this.setState({ copyMessage: "Coppied!" });
+    setTimeout(() => this.setState({ copyMessage: false }), 2000);
+  };
+
+  render() {
+    const { avatar, copyMessage } = this.state;
     if (!avatar) {
       return (
         <div className={styles.avatarLanding}>
@@ -86,7 +98,19 @@ class AvatarUI extends React.Component {
           <div className={styles.attributions}>
             {avatar.attributions && avatar.attributions.creator && <span>{`by ${avatar.attributions.creator}`}</span>}
           </div>
-          <div className={styles.preview}>{avatar && <AvatarPreview avatarGltfUrl={avatar.gltf_url} />}</div>
+          <div className={styles.preview}>
+            {avatar && <AvatarPreview avatarGltfUrl={avatar.gltf_url} />}
+            {copyMessage ? (
+              <div className={styles.copyTip}>{copyMessage}</div>
+            ) : (
+              avatar &&
+              avatar.allow_remixing && (
+                <a className={styles.editAvatar} onClick={this.handleCopyAvatar} title="Copy to my avatars">
+                  <FontAwesomeIcon icon={faClone} />
+                </a>
+              )
+            )}
+          </div>
           {isSelected ? (
             <span className={styles.selectedMessage}>
               <FormattedMessage id="avatar-landing.selected" />

--- a/src/components/remix-avatar-button.js
+++ b/src/components/remix-avatar-button.js
@@ -10,7 +10,7 @@ AFRAME.registerComponent("remix-avatar-button", {
       this.src = this.targetEl.components["media-loader"].data.src;
       try {
         this.avatar = await fetchAvatar(idForAvatarUrl(this.src));
-        this.el.object3D.visible = this.avatar && this.avatar.allow_remixing;
+        this.el.object3D.visible = this.avatar && this.avatar.allow_remixing && this.avatar.type === "avatar_listing";
       } catch (e) {
         console.error(e);
         this.el.object3D.visible = false;

--- a/src/components/remix-avatar-button.js
+++ b/src/components/remix-avatar-button.js
@@ -26,7 +26,7 @@ AFRAME.registerComponent("remix-avatar-button", {
 
         await remixAvatar(this.avatar.avatar_id, this.avatar.name);
 
-        this.label.setAttribute("text", "value", "Coppied!");
+        this.label.setAttribute("text", "value", "Copied!");
       } catch (e) {
         this.label.setAttribute("text", "value", "Error");
       }

--- a/src/components/remix-avatar-button.js
+++ b/src/components/remix-avatar-button.js
@@ -1,0 +1,54 @@
+import { idForAvatarUrl } from "../utils/media-url-utils";
+import { fetchAvatar, remixAvatar } from "../utils/avatar-utils";
+
+const REMIX_LABEL = "copy avatar";
+AFRAME.registerComponent("remix-avatar-button", {
+  init() {
+    this.label = this.el.querySelector("[text]");
+    this.label.setAttribute("text", "value", REMIX_LABEL);
+    this.updateSrc = async () => {
+      this.src = this.targetEl.components["media-loader"].data.src;
+      try {
+        this.avatar = await fetchAvatar(idForAvatarUrl(this.src));
+        this.el.object3D.visible = this.avatar && this.avatar.allow_remixing;
+      } catch (e) {
+        console.error(e);
+        this.el.object3D.visible = false;
+      }
+    };
+
+    this.onClick = async () => {
+      if (this.copying || !this.avatar) return;
+
+      try {
+        this.copying = true;
+        this.label.setAttribute("text", "value", "Copying...");
+
+        await remixAvatar(this.avatar.avatar_id, this.avatar.name);
+
+        this.label.setAttribute("text", "value", "Coppied!");
+      } catch (e) {
+        this.label.setAttribute("text", "value", "Error");
+      }
+
+      setTimeout(() => {
+        this.label.setAttribute("text", "value", REMIX_LABEL);
+        this.copying = false;
+      }, 2000);
+    };
+
+    NAF.utils.getNetworkedEntity(this.el).then(networkedEl => {
+      this.targetEl = networkedEl;
+      this.targetEl.addEventListener("media_resolved", this.updateSrc, { once: true });
+      this.updateSrc();
+    });
+  },
+
+  play() {
+    this.el.object3D.addEventListener("interact", this.onClick);
+  },
+
+  pause() {
+    this.el.object3D.removeEventListener("interact", this.onClick);
+  }
+});

--- a/src/hub.html
+++ b/src/hub.html
@@ -634,6 +634,9 @@
                     <a-entity mixin="rounded-text-action-button ui" is-remote-hover-target tags="singleActionButton: true; isHoverMenuChild: true;" open-media-button position="0 -0.125 0.01">
                         <a-entity text="width:1.5; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
                     </a-entity>
+                    <a-entity mixin="rounded-text-action-button ui" is-remote-hover-target tags="singleActionButton: true; isHoverMenuChild: true;" remix-avatar-button position="0 -0.35 0.01" visible="false">
+                        <a-entity text="width:1.5; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
+                    </a-entity>
                 </a-entity>
             </template>
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -89,6 +89,7 @@ import "./components/matrix-auto-update";
 import "./components/clone-media-button";
 import "./components/open-media-button";
 import "./components/tweet-media-button";
+import "./components/remix-avatar-button";
 import "./components/transform-object-button";
 import "./components/hover-menu";
 import "./components/disable-frustum-culling";

--- a/src/react-components/media-tiles.js
+++ b/src/react-components/media-tiles.js
@@ -15,9 +15,8 @@ import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus";
 import styles from "../assets/stylesheets/media-browser.scss";
 import { proxiedUrlFor, scaledThumbnailUrlFor } from "../utils/media-url-utils";
 import StateLink from "./state-link";
-import { fetchReticulumAuthenticated } from "../utils/phoenix-utils";
+import { remixAvatar } from "../utils/avatar-utils";
 
-const AVATARS_API = "/api/v1/avatars";
 dayjs.extend(relativeTime);
 
 const PUBLISHER_FOR_ENTRY_TYPE = {
@@ -38,13 +37,7 @@ class MediaTiles extends Component {
 
   handleCopyAvatar = async (e, entry) => {
     e.preventDefault();
-    const avatar = {
-      parent_avatar_listing_id: entry.id,
-      name: entry.name,
-      files: {}
-    };
-
-    await fetchReticulumAuthenticated(AVATARS_API, "POST", { avatar });
+    await remixAvatar(entry.id, entry.name);
     this.props.onCopyAvatar();
   };
 

--- a/src/utils/avatar-utils.js
+++ b/src/utils/avatar-utils.js
@@ -2,6 +2,8 @@ import { fetchReticulumAuthenticated } from "./phoenix-utils";
 import { proxiedUrlFor } from "./media-url-utils";
 import { avatars } from "../assets/avatars/avatars";
 
+const AVATARS_API = "/api/v1/avatars";
+
 export const AVATAR_TYPES = {
   LEGACY: "legacy",
   SKINNABLE: "skinnable",
@@ -91,4 +93,14 @@ export function ensureAvatarMaterial(gltf) {
   }
 
   return gltf;
+}
+
+export async function remixAvatar(parentId, name) {
+  const avatar = {
+    parent_avatar_listing_id: parentId,
+    name: name,
+    files: {}
+  };
+
+  return fetchReticulumAuthenticated(AVATARS_API, "POST", { avatar });
 }

--- a/src/utils/media-url-utils.js
+++ b/src/utils/media-url-utils.js
@@ -119,9 +119,18 @@ export const guessContentType = url => {
   return commonKnownContentTypes[extension];
 };
 const hubsSceneRegex = /https?:\/\/(hubs.local(:\d+)?|(smoke-)?hubs.mozilla.com|(dev\.)?reticulum.io)\/scenes\/(\w+)\/?\S*/;
-const hubsAvatarRegex = /https?:\/\/(hubs.local(:\d+)?|(smoke-)?hubs.mozilla.com|(dev\.)?reticulum.io)\/avatars\/(\w+)\/?\S*/;
+const hubsAvatarRegex = /https?:\/\/(hubs.local(:\d+)?|(smoke-)?hubs.mozilla.com|(dev\.)?reticulum.io)\/avatars\/(?<id>\w+)\/?\S*/;
 const hubsRoomRegex = /(https?:\/\/)?(hub.link)|(hubs.local(:\d+)?|(smoke-)?hubs.mozilla.com|(dev\.)?reticulum.io)\/(\w+)\/?\S*/;
+
 export const isHubsSceneUrl = hubsSceneRegex.test.bind(hubsSceneRegex);
 export const isHubsRoomUrl = url => !isHubsSceneUrl(url) && hubsRoomRegex.test(url);
 export const isHubsDestinationUrl = url => isHubsSceneUrl(url) || isHubsRoomUrl(url);
 export const isHubsAvatarUrl = hubsAvatarRegex.test.bind(hubsAvatarRegex);
+
+export const idForAvatarUrl = url => {
+  const match = url.match(hubsAvatarRegex);
+  if (match) {
+    return match.groups.id;
+  }
+  return null;
+};


### PR DESCRIPTION
Adds remix buttons to the landing pages and hover menus for avatar listings. 
![image](https://user-images.githubusercontent.com/130735/64302336-d712df80-cf37-11e9-85fa-c996bbbd06b9.png)

We probably want to expand this to avatars as well, but starting with listing to match what we have in other places we surface them.