### PR TITLE
Fix bug when left cursor holds camera

### DIFF
--- a/src/systems/userinput/bindings/oculus-touch-user.js
+++ b/src/systems/userinput/bindings/oculus-touch-user.js
@@ -1134,7 +1134,7 @@ export const oculusTouchUserBindings = addSetsToBindings({
       priority: 4
     }
   ],
-  [sets.rightCursorHoldingCamera]: [
+  [sets.leftCursorHoldingCamera]: [
     {
       src: { value: leftTriggerPressed2 },
       dest: { value: paths.actions.cursor.left.takeSnapshot },


### PR DESCRIPTION
Fixes a typo causing a bug on quest / rift where you can't take a snapshot with the trigger of your left controller when holding the camera with that hand's remote.