### PR TITLE
Add support for using morph targets for audio feedback

### DIFF
--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -61,6 +61,7 @@ AFRAME.GLTFModelPlus.registerComponent("layers", "layers");
 AFRAME.GLTFModelPlus.registerComponent("shadow", "shadow");
 AFRAME.GLTFModelPlus.registerComponent("water", "water");
 AFRAME.GLTFModelPlus.registerComponent("scale-audio-feedback", "scale-audio-feedback");
+AFRAME.GLTFModelPlus.registerComponent("morph-audio-feedback", "morph-audio-feedback");
 AFRAME.GLTFModelPlus.registerComponent("animation-mixer", "animation-mixer");
 AFRAME.GLTFModelPlus.registerComponent("loop-animation", "loop-animation");
 AFRAME.GLTFModelPlus.registerComponent(

--- a/src/hub.html
+++ b/src/hub.html
@@ -77,7 +77,13 @@
 
                     <a-entity class="model" gltf-model-plus="inflate: true">
                         <template data-name="AvatarRoot">
-                            <a-entity ik-controller hand-pose__left hand-pose__right space-invader-mesh="meshName: AvatarMesh"></a-entity>
+                            <a-entity
+                                ik-controller
+                                hand-pose__left
+                                hand-pose__right
+                                space-invader-mesh="meshName: AvatarMesh"
+                                networked-audio-analyser
+                            ></a-entity>
                         </template>
 
                         <template data-name="Neck">
@@ -163,7 +169,6 @@
                         <template data-name="Head">
                             <a-entity
                                 networked-audio-source="rolloffFactor: 2.0;"
-                                networked-audio-analyser
                                 personal-space-invader="radius: 0.15; useMaterial: true;"
                                 bone-visibility
                                 body-helper="type: kinematic; collisionFilterGroup: 4; collisionFilterMask: 1;"


### PR DESCRIPTION
Adds a `morph-audio-feedback` component that can be added to a mesh with morph targets. It will look for a `network-audio-analyser` in its parent and animate a morph target with `name` between `minValue` and `maxValue` based on the audio volume. This also attempts to consolidate all the different methods we had for trying to normalize the analyser output. We can further refine how we normalize, but at least we can do it in one spot.