### PR TITLE
Bump naf-janus-adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12127,9 +12127,8 @@
       "dev": true
     },
     "naf-janus-adapter": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/naf-janus-adapter/-/naf-janus-adapter-3.0.6.tgz",
-      "integrity": "sha512-fSfuTYQk9lTRLBO9RZKB7mIw8LjbB9LsIn76okiMCdovDUah/hW0KzU+vwrnXvEI6+FHDXx09t3XmD7CNzQIQQ==",
+      "version": "github:mozilla/naf-janus-adapter#bb399723bd2527cb6be0671ec3f6e73bffd28473",
+      "from": "github:mozilla/naf-janus-adapter#master",
       "requires": {
         "debug": "^3.1.0",
         "minijanus": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "jwt-decode": "^2.2.0",
     "markdown-it": "^8.4.2",
     "moving-average": "^1.0.0",
-    "naf-janus-adapter": "^3.0.6",
+    "naf-janus-adapter": "github:mozilla/naf-janus-adapter#master",
     "networked-aframe": "github:mozillareality/networked-aframe#master",
     "nipplejs": "github:mozillareality/nipplejs#mr-social-client/master",
     "node-ensure": "0.0.0",


### PR DESCRIPTION
Want to include fix for mic state: https://github.com/mozilla/naf-janus-adapter/pull/83
To help with issue : https://github.com/mozilla/hubs/issues/1695

(Once I get publish permission to npm, I can instead use a release version of `naf-janus-adapter` again.)