### PR TITLE
Bump naf back to release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12127,8 +12127,9 @@
       "dev": true
     },
     "naf-janus-adapter": {
-      "version": "github:mozilla/naf-janus-adapter#bb399723bd2527cb6be0671ec3f6e73bffd28473",
-      "from": "github:mozilla/naf-janus-adapter#master",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/naf-janus-adapter/-/naf-janus-adapter-3.0.10.tgz",
+      "integrity": "sha512-ohc/U8atNze93AU81KyibOrpVEwyBttxER7YQog5uvIiojdQWEcDHf9T88yKvfi+DTNNxVxVbccSJTauf7HUcg==",
       "requires": {
         "debug": "^3.1.0",
         "minijanus": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "jwt-decode": "^2.2.0",
     "markdown-it": "^8.4.2",
     "moving-average": "^1.0.0",
-    "naf-janus-adapter": "github:mozilla/naf-janus-adapter#master",
+    "naf-janus-adapter": "^3.0.10",
     "networked-aframe": "github:mozillareality/networked-aframe#master",
     "nipplejs": "github:mozillareality/nipplejs#mr-social-client/master",
     "node-ensure": "0.0.0",


### PR DESCRIPTION
Got perms for publishing to npm, so can point back at a release.