### PR TITLE
Fix bug where it says you loaded n+1 / n objects

### DIFF
--- a/src/react-components/loader.js
+++ b/src/react-components/loader.js
@@ -83,7 +83,10 @@ class Loader extends Component {
         <FormattedMessage id="loader.entering_lobby" />
       </h4>
     );
-    const progress = this.state.loadingNum === 0 ? " " : `${this.state.loadedNum} / ${this.state.loadingNum} `;
+    const progress =
+      this.state.loadingNum === 0
+        ? " "
+        : `${Math.min(this.state.loadedNum, this.state.loadingNum)} / ${this.state.loadingNum} `;
     const usual = (
       <h4 className={loaderStyles.loadingText}>
         <FormattedMessage id="loader.loading" />


### PR DESCRIPTION
There's a bug in calculating # of loaded objects vs # of loading objects. This masks the bug such that you'll never see something like : "Loading 5/4 objects" when joining the room.