### PR TITLE
Adjust move speed with mouse wheel

### DIFF
--- a/src/components/character-controller.js
+++ b/src/components/character-controller.js
@@ -140,9 +140,9 @@ AFRAME.registerComponent("character-controller", {
       if (userinputAngularVelocity !== null && userinputAngularVelocity !== undefined) {
         this.angularVelocity = userinputAngularVelocity;
       }
-      const dCharSpeed = userinput.get(paths.actions.dCharSpeed) || 0;
-      if (enableWheelSpeed && dCharSpeed) {
-        this.charSpeed = Math.min(Math.max(this.charSpeed + this.charSpeed * dCharSpeed, 0.1), 5);
+      if (enableWheelSpeed) {
+        const dCharSpeed = userinput.get(paths.actions.dCharSpeed) || 0;
+        this.charSpeed = THREE.Math.clamp(this.charSpeed + this.charSpeed * dCharSpeed, 0.1, 5);
       }
       const rotationDelta = this.data.rotationSpeed * this.angularVelocity * deltaSeconds;
 

--- a/src/components/character-controller.js
+++ b/src/components/character-controller.js
@@ -179,11 +179,10 @@ AFRAME.registerComponent("character-controller", {
       this.accelerationInput.set(0, 0, 0);
 
       const boost = userinput.get(paths.actions.boost) ? 2 : 1;
-      const slowmo = userinput.get(paths.actions.slowmo) ? 0.5 : 1;
       move.makeTranslation(
-        this.velocity.x * distance * boost * slowmo * this.charSpeed,
-        this.velocity.y * distance * boost * slowmo * this.charSpeed,
-        this.velocity.z * distance * boost * slowmo * this.charSpeed
+        this.velocity.x * distance * boost * this.charSpeed,
+        this.velocity.y * distance * boost * this.charSpeed,
+        this.velocity.z * distance * boost * this.charSpeed
       );
       yawMatrix.makeRotationAxis(rotationAxis, rotationDelta);
 

--- a/src/systems/userinput/bindings/keyboard-mouse-user.js
+++ b/src/systems/userinput/bindings/keyboard-mouse-user.js
@@ -71,13 +71,8 @@ export const keyboardMouseUserBindings = addSetsToBindings({
     },
     {
       src: { value: paths.device.mouse.wheel },
-      dest: { value: dCharSpeed },
-      xform: xforms.scale(-0.3)
-    },
-    {
-      src: { value: dCharSpeed },
       dest: { value: paths.actions.dCharSpeed },
-      xform: xforms.copy
+      xform: xforms.scale(-0.3)
     },
     {
       src: { value: paths.device.keyboard.key("shift") },

--- a/src/systems/userinput/bindings/keyboard-mouse-user.js
+++ b/src/systems/userinput/bindings/keyboard-mouse-user.js
@@ -7,7 +7,6 @@ import { addSetsToBindings } from "./utils";
 
 const wasd_vec2 = "/var/mouse-and-keyboard/wasd_vec2";
 const keyboardCharacterAcceleration = "/var/mouse-and-keyboard/keyboardCharacterAcceleration";
-const dCharSpeed = "/var/mouse-and-keyboard/dCharSpeed";
 const arrows_vec2 = "/var/mouse-and-keyboard/arrows_vec2";
 const togglePenWithRMB = "/vars/mouse-and-keyboard/drop_pen_with_RMB";
 const togglePenWithEsc = "/vars/mouse-and-keyboard/drop_pen_with_esc";

--- a/src/systems/userinput/bindings/keyboard-mouse-user.js
+++ b/src/systems/userinput/bindings/keyboard-mouse-user.js
@@ -7,6 +7,7 @@ import { addSetsToBindings } from "./utils";
 
 const wasd_vec2 = "/var/mouse-and-keyboard/wasd_vec2";
 const keyboardCharacterAcceleration = "/var/mouse-and-keyboard/keyboardCharacterAcceleration";
+const dCharSpeed = "/var/mouse-and-keyboard/dCharSpeed";
 const arrows_vec2 = "/var/mouse-and-keyboard/arrows_vec2";
 const togglePenWithRMB = "/vars/mouse-and-keyboard/drop_pen_with_RMB";
 const togglePenWithEsc = "/vars/mouse-and-keyboard/drop_pen_with_esc";
@@ -67,6 +68,16 @@ export const keyboardMouseUserBindings = addSetsToBindings({
       src: { value: keyboardCharacterAcceleration },
       dest: { value: paths.actions.characterAcceleration },
       xform: xforms.normalize_vec2
+    },
+    {
+      src: { value: paths.device.mouse.wheel },
+      dest: { value: dCharSpeed },
+      xform: xforms.scale(-0.3)
+    },
+    {
+      src: { value: dCharSpeed },
+      dest: { value: paths.actions.dCharSpeed },
+      xform: xforms.copy
     },
     {
       src: { value: paths.device.keyboard.key("shift") },
@@ -527,7 +538,8 @@ export const keyboardMouseUserBindings = addSetsToBindings({
       dest: {
         value: k("wheelWithShift")
       },
-      xform: xforms.copyIfTrue
+      xform: xforms.copyIfTrue,
+      priority: 1
     },
     {
       src: {
@@ -537,7 +549,8 @@ export const keyboardMouseUserBindings = addSetsToBindings({
       dest: {
         value: k("wheelWithoutShift")
       },
-      xform: xforms.copyIfFalse
+      xform: xforms.copyIfFalse,
+      priority: 1
     },
     {
       src: {
@@ -585,7 +598,8 @@ export const keyboardMouseUserBindings = addSetsToBindings({
     {
       src: { value: paths.device.mouse.wheel },
       dest: { value: paths.actions.cursor.right.mediaVolumeMod },
-      xform: xforms.scale(-0.3)
+      xform: xforms.scale(-0.3),
+      priority: 1
     }
   ],
   [sets.inputFocused]: [
@@ -626,7 +640,8 @@ export const keyboardMouseUserBindings = addSetsToBindings({
     {
       src: { value: paths.device.mouse.wheel },
       dest: { value: paths.actions.inspectZoom },
-      xform: xforms.scale(-5.0)
+      xform: xforms.scale(-5.0),
+      priority: 1
     },
     {
       src: {

--- a/src/systems/userinput/paths.js
+++ b/src/systems/userinput/paths.js
@@ -11,6 +11,7 @@ paths.actions.logInteractionState = "/actions/logInteractionState";
 paths.actions.cameraDelta = "/actions/cameraDelta";
 paths.actions.lobbyCameraDelta = "/actions/lobbyCameraDelta";
 paths.actions.characterAcceleration = "/actions/characterAcceleration";
+paths.actions.dCharSpeed = "/actions/dCharSpeed";
 paths.actions.boost = "/actions/boost";
 paths.actions.startGazeTeleport = "/actions/startTeleport";
 paths.actions.stopGazeTeleport = "/actions/stopTeleport";


### PR DESCRIPTION
Allows you to adjust your move speed with the mouse wheel when you add the `wheelspeed` (or `wheelSpeed` or `ws`) URL query string parameter.

Resolves https://github.com/mozilla/hubs/issues/1740