### PR TITLE
Fix issue with UV tiling not working on mobile

### DIFF
--- a/src/materials/MobileStandardMaterial.js
+++ b/src/materials/MobileStandardMaterial.js
@@ -109,10 +109,42 @@ export default class MobileStandardMaterial extends THREE.ShaderMaterial {
     mobileMaterial.aoMap = material.aoMap;
     mobileMaterial.aoMapIntensity = material.aoMapIntensity;
     mobileMaterial.emissive = material.emissive;
+    mobileMaterial.emissiveIntensity = material.emissiveIntensity;
     mobileMaterial.emissiveMap = material.emissiveMap;
+
+    // TODO this actually needs to get called whenever any of these material properties change
+    mobileMaterial.refreshUniforms();
 
     return mobileMaterial;
   }
+
+  refreshUniforms() {
+    this.uniforms.opacity.value = this.opacity;
+
+    if (this.color) {
+      this.uniforms.diffuse.value.copy(this.color);
+    }
+
+    if (this.emissive) {
+      this.uniforms.emissive.value.copy(this.emissive).multiplyScalar(this.emissiveIntensity);
+    }
+
+    if (this.map) {
+      this.uniforms.map.value = this.map;
+    }
+
+    if (this.aoMap) {
+      this.uniforms.aoMap.value = this.aoMap;
+      this.uniforms.aoMapIntensity.value = this.aoMapIntensity;
+    }
+
+    const uvScaleMap = this.map || this.emissiveMap;
+    if (uvScaleMap && uvScaleMap.matrixAutoUpdate === true) {
+      uvScaleMap.updateMatrix();
+      this.uniforms.uvTransform.value.copy(uvScaleMap.matrix);
+    }
+  }
+
   clone() {
     return MobileStandardMaterial.fromStandardMaterial(this);
   }


### PR DESCRIPTION
fixes #1763 

Note this only updates the uniforms once when the Material is created. We still need to do more work to support updating these properties at runtime, which we currently don't do, but might like to someday