### PR TITLE
Increase max volume of avatars

### DIFF
--- a/src/components/avatar-volume-controls.js
+++ b/src/components/avatar-volume-controls.js
@@ -1,5 +1,5 @@
 import { VOLUME_LABELS } from "./media-views";
-const MAX_VOLUME = 4;
+const MAX_VOLUME = 2;
 const STEP = MAX_VOLUME / VOLUME_LABELS.length;
 
 AFRAME.registerComponent("avatar-volume-controls", {
@@ -26,11 +26,11 @@ AFRAME.registerComponent("avatar-volume-controls", {
   },
 
   volumeUp() {
-    this.changeVolumeBy(STEP * (this.data.volume < 1 ? 0.5 : 1));
+    this.changeVolumeBy(STEP);
   },
 
   volumeDown() {
-    this.changeVolumeBy(-1 * STEP * (this.data.volume < 1 ? 0.5 : 1));
+    this.changeVolumeBy(-1 * STEP);
   },
 
   update() {

--- a/src/components/avatar-volume-controls.js
+++ b/src/components/avatar-volume-controls.js
@@ -1,4 +1,6 @@
 import { VOLUME_LABELS } from "./media-views";
+const MAX_VOLUME = 4;
+const STEP = MAX_VOLUME / VOLUME_LABELS.length;
 
 AFRAME.registerComponent("avatar-volume-controls", {
   schema: {
@@ -19,21 +21,21 @@ AFRAME.registerComponent("avatar-volume-controls", {
   },
 
   changeVolumeBy(v) {
-    this.el.setAttribute("avatar-volume-controls", "volume", THREE.Math.clamp(this.data.volume + v, 0, 1));
+    this.el.setAttribute("avatar-volume-controls", "volume", THREE.Math.clamp(this.data.volume + v, 0, MAX_VOLUME));
     this.updateVolumeLabel();
   },
 
   volumeUp() {
-    this.changeVolumeBy(0.1);
+    this.changeVolumeBy(STEP * (this.data.volume < 1 ? 0.5 : 1));
   },
 
   volumeDown() {
-    this.changeVolumeBy(-0.1);
+    this.changeVolumeBy(-1 * STEP * (this.data.volume < 1 ? 0.5 : 1));
   },
 
   update() {
     if (this.audio) {
-      this.audio.gain.gain.value = this.data.volume;
+      this.audio.setVolume(this.data.volume);
     }
   },
 
@@ -41,7 +43,7 @@ AFRAME.registerComponent("avatar-volume-controls", {
     this.volumeLabel.setAttribute(
       "text",
       "value",
-      this.data.volume === 0 ? "Muted" : VOLUME_LABELS[Math.floor(this.data.volume / 0.05)]
+      this.data.volume === 0 ? "Muted" : VOLUME_LABELS[Math.floor(this.data.volume / STEP)]
     );
   },
 

--- a/src/components/avatar-volume-controls.js
+++ b/src/components/avatar-volume-controls.js
@@ -1,6 +1,7 @@
 import { VOLUME_LABELS } from "./media-views";
-const MAX_VOLUME = 2;
-const STEP = MAX_VOLUME / VOLUME_LABELS.length;
+const MAX_VOLUME = 8;
+const SMALL_STEP = 1 / (VOLUME_LABELS.length / 2);
+const BIG_STEP = (MAX_VOLUME - 1) / (VOLUME_LABELS.length / 2);
 
 AFRAME.registerComponent("avatar-volume-controls", {
   schema: {
@@ -26,11 +27,13 @@ AFRAME.registerComponent("avatar-volume-controls", {
   },
 
   volumeUp() {
-    this.changeVolumeBy(STEP);
+    const step = this.data.volume > 1 - SMALL_STEP ? BIG_STEP : SMALL_STEP;
+    this.changeVolumeBy(step);
   },
 
   volumeDown() {
-    this.changeVolumeBy(-1 * STEP);
+    const step = this.data.volume > 1 + SMALL_STEP ? BIG_STEP : SMALL_STEP;
+    this.changeVolumeBy(-1 * step);
   },
 
   update() {
@@ -40,11 +43,13 @@ AFRAME.registerComponent("avatar-volume-controls", {
   },
 
   updateVolumeLabel() {
-    this.volumeLabel.setAttribute(
-      "text",
-      "value",
-      this.data.volume === 0 ? "Muted" : VOLUME_LABELS[Math.floor(this.data.volume / STEP)]
+    const numBars = Math.min(
+      VOLUME_LABELS.length - 1,
+      this.data.volume <= 1.001
+        ? Math.floor(this.data.volume / SMALL_STEP)
+        : Math.floor(VOLUME_LABELS.length / 2 + (this.data.volume - 1) / BIG_STEP)
     );
+    this.volumeLabel.setAttribute("text", "value", this.data.volume === 0 ? "Muted" : VOLUME_LABELS[numBars]);
   },
 
   tick() {

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -24,11 +24,11 @@ const isFirefoxReality = isMobileVR && navigator.userAgent.match(/Firefox/);
 
 export const VOLUME_LABELS = [];
 for (let i = 0; i <= 20; i++) {
-  let s = "|";
+  let s = "[";
   for (let j = 0; j <= 20; j++) {
     s += i >= j ? "|" : " ";
   }
-  s += "|";
+  s += "]";
   VOLUME_LABELS[i] = s;
 }
 

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -25,7 +25,7 @@ const isFirefoxReality = isMobileVR && navigator.userAgent.match(/Firefox/);
 export const VOLUME_LABELS = [];
 for (let i = 0; i <= 20; i++) {
   let s = "[";
-  for (let j = 0; j <= 20; j++) {
+  for (let j = 1; j <= 20; j++) {
     s += i >= j ? "|" : " ";
   }
   s += "]";


### PR DESCRIPTION
This changes the avatar volume buttons such that:
 - The max volume is higher
 - When `0 <= volume <= 1`, the buttons change the volume by a `SMALL_STEP`
 - When `1 < volume < MAX`, the buttons change the volume by a `BIG_STEP`
 - The label does not correspond with the volume exactly. Instead, half of the bars are reserved for the "small steps" from 0 to 1, and the other half of the bars are reserved for the "big steps" from 1 to `MAX`.
