### PR TITLE
Fix keyboard inputs for changing pen colors

### DIFF
--- a/src/systems/userinput/bindings/keyboard-mouse-user.js
+++ b/src/systems/userinput/bindings/keyboard-mouse-user.js
@@ -532,8 +532,7 @@ export const keyboardMouseUserBindings = addSetsToBindings({
       dest: {
         value: k("wheelWithShift")
       },
-      xform: xforms.copyIfTrue,
-      priority: 1
+      xform: xforms.copyIfTrue
     },
     {
       src: {
@@ -543,8 +542,7 @@ export const keyboardMouseUserBindings = addSetsToBindings({
       dest: {
         value: k("wheelWithoutShift")
       },
-      xform: xforms.copyIfFalse,
-      priority: 1
+      xform: xforms.copyIfFalse
     },
     {
       src: {


### PR DESCRIPTION
revert these priorities that were added to "wheelWithShift" and "wheelWithoutShift" that are breaking the ability to change pen colors with keyboard