### PR TITLE
fix bindings for movement for vive focus plus

### DIFF
--- a/src/systems/userinput/bindings/vive-user.js
+++ b/src/systems/userinput/bindings/vive-user.js
@@ -19,6 +19,7 @@ const lJoyYScaled = v("left/joyY/scaled");
 const lTouch = v("left/touch");
 const lTouchScaled = v("left/touch/scaled");
 const lTouchXScaled = v("left/touchX/scaled");
+const lTouchY = v("left/touchY");
 const lTouchYScaled = v("left/touchY/scaled");
 const lDpadNorth1 = v("left/dpad/north1");
 const lDpadSouth1 = v("left/dpad/south1");
@@ -464,7 +465,7 @@ export const viveUserBindings = addSetsToBindings({
     },
     {
       src: {
-        value: lAxis("touchY")
+        value: lTouchY
       },
       dest: { value: lTouchYScaled },
       xform: xforms.scale(1.5) // vertical character speed modifier
@@ -1492,6 +1493,55 @@ export const viveUserBindings = addSetsToBindings({
 });
 
 export const viveWandUserBindings = addSetsToBindings({
+  [sets.global]: [
+    {
+      src: {
+        value: lAxis("touchY")
+      },
+      dest: { value: lTouchY },
+      xform: xforms.copy
+    }
+  ],
+  [sets.leftHandHoldingPen]: [
+    {
+      src: { value: leftGripPressed2 },
+      dest: { value: paths.actions.leftHand.drop },
+      xform: xforms.rising,
+      priority: 2
+    }
+  ],
+  [sets.rightHandHoldingPen]: [
+    {
+      src: { value: rightGripPressed2 },
+      dest: { value: paths.actions.rightHand.drop },
+      xform: xforms.rising,
+      priority: 2
+    }
+  ]
+});
+
+export const indexUserBindings = addSetsToBindings({
+  [sets.global]: [
+    {
+      src: {
+        value: lAxis("touchY")
+      },
+      dest: { value: lTouchY },
+      xform: xforms.copy
+    }
+  ]
+});
+
+export const viveFocusPlusUserBindings = addSetsToBindings({
+  [sets.global]: [
+    {
+      src: {
+        value: lAxis("touchY")
+      },
+      dest: { value: lTouchY },
+      xform: xforms.negate
+    }
+  ],
   [sets.leftHandHoldingPen]: [
     {
       src: { value: leftGripPressed2 },

--- a/src/systems/userinput/devices/vive-controller.js
+++ b/src/systems/userinput/devices/vive-controller.js
@@ -24,9 +24,6 @@ export class ViveControllerDevice {
         { name: "grip", buttonId: 2 }
       ];
     } else {
-      if (gamepad.axes.length === 2) {
-        this.isViveWand = true;
-      }
       this.buttonMap = [
         { name: "touchpad", buttonId: 0 },
         { name: "trigger", buttonId: 1 },

--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -281,7 +281,6 @@ AFRAME.registerSystem("userinput", {
           mapping && this.registeredMappings.add(mapping);
 
           if (activeDevice instanceof ViveControllerDevice && activeDevice.gamepad) {
-            console.log(activeDevice);
             if (activeDevice.gamepad.id === "HTC Vive Focus Plus Controller") {
               //HTC Vive Focus Plus Controller
               this.registeredMappings.add(viveFocusPlusUserBindings);

--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -20,7 +20,12 @@ import { keyboardMouseUserBindings } from "./bindings/keyboard-mouse-user";
 import { touchscreenUserBindings } from "./bindings/touchscreen-user";
 import { keyboardDebuggingBindings } from "./bindings/keyboard-debugging";
 import { oculusTouchUserBindings } from "./bindings/oculus-touch-user";
-import { viveUserBindings, viveWandUserBindings } from "./bindings/vive-user";
+import {
+  viveUserBindings,
+  viveWandUserBindings,
+  indexUserBindings,
+  viveFocusPlusUserBindings
+} from "./bindings/vive-user";
 import { wmrUserBindings } from "./bindings/windows-mixed-reality-user";
 import { xboxControllerUserBindings } from "./bindings/xbox-controller-user";
 import { daydreamUserBindings } from "./bindings/daydream-user";
@@ -274,8 +279,19 @@ AFRAME.registerSystem("userinput", {
           const activeDevice = this.activeDevices.items[i];
           const mapping = vrGamepadMappings.get(activeDevice.constructor);
           mapping && this.registeredMappings.add(mapping);
-          if (activeDevice instanceof ViveControllerDevice && activeDevice.isViveWand) {
-            this.registeredMappings.add(viveWandUserBindings);
+
+          if (activeDevice instanceof ViveControllerDevice && activeDevice.gamepad) {
+            console.log(activeDevice);
+            if (activeDevice.gamepad.id === "HTC Vive Focus Plus Controller") {
+              //HTC Vive Focus Plus Controller
+              this.registeredMappings.add(viveFocusPlusUserBindings);
+            } else if (activeDevice.gamepad.axes.length === 4) {
+              //Valve Index Controller
+              this.registeredMappings.add(indexUserBindings);
+            } else {
+              //HTC Vive Controller (wands)
+              this.registeredMappings.add(viveWandUserBindings);
+            }
           }
         }
 


### PR DESCRIPTION
We are currently using the same input bindings for the Vive Focus Plus as the Vive and Index, however it has inverted y touchpad axis coordinates. This fixes that. 

There is a separate issue where the pressing on the left touchpad on either controller causes the trigger to also fire (in Hubs this is treated as a teleport)- this appears to be a bug at the gamepad api level, not in Hubs. 