### PR TITLE
Sign out if auth token is expired

### DIFF
--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -176,7 +176,18 @@ export default class Store extends EventTarget {
       this._shouldResetAvatarOnInit = true;
       Cookies.remove(OAUTH_FLOW_CREDENTIALS_KEY);
     }
+
+    this._signOutOnExpiredAuthToken();
   }
+
+  _signOutOnExpiredAuthToken = () => {
+    if (!this.state.credentials.token) return;
+
+    const expiry = jwtDecode(this.state.credentials.token).exp;
+    if (expiry <= Date.now()) {
+      this.update({ credentials: { token: null, email: null } });
+    }
+  };
 
   initProfile = async () => {
     if (this._shouldResetAvatarOnInit) {


### PR DESCRIPTION
If you had an old, expired token in your localstorage, it would prevent you from entering a room since we now attempt to retrieve default avatars when you load a hub. It also breaks favorites on the home page.

This change checks the current token's expiration date and signs you out during Store initialization, in order to ensure that any subsequent requests do not attempt to make a request that would result in a 401