### PR TITLE
Use previews for base models in the Avatar Editor instead of a dropdown

### DIFF
--- a/src/assets/stylesheets/avatar-editor.scss
+++ b/src/assets/stylesheets/avatar-editor.scss
@@ -145,7 +145,6 @@
       .item {
         box-sizing: border-box;
         border-radius: 15px;
-        padding: 5px;
         display: flex;
         justify-content: center;
         align-items: center;
@@ -154,6 +153,7 @@
         cursor: pointer;
         margin-bottom: 5px;
         width: calc(1 / 3 * 100% - (1 - 1 / 3) * 10px);
+        position: relative;
 
         &.selected{
           background: #eaeaea;
@@ -163,7 +163,11 @@
           height: 40px;
         }
         img {
-          width: 100%;
+          position: absolute;
+          top: 5px;
+          left: 5px;
+          width: calc(100% - 10px);
+          height: calc(100% - 10px);
         }
       }
     }
@@ -234,7 +238,6 @@
   canvas {
     width: 100%;
     height: 100%;
-    border-radius: 20px;
   }
 
   .delete-avatar {

--- a/src/assets/stylesheets/avatar-editor.scss
+++ b/src/assets/stylesheets/avatar-editor.scss
@@ -105,6 +105,32 @@
       }
     }
 
+    .select-grid {
+      display: flex;
+      .item {
+        flex: 1;
+        box-sizing: border-box;
+        background: #eaeaea;
+        border-radius: 15px;
+        margin: 2px 5px;
+        padding: 5px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        color: $darker-grey;
+        text-align: center;
+        &.selected{
+          border: 4px solid $action-color;
+        }
+        &.custom{
+          flex: 3;
+        }
+        img {
+          width: 100%;
+        }
+      }
+    }
+
     .select {
       @extend %input-field;
       font-size: 16px;

--- a/src/assets/stylesheets/avatar-editor.scss
+++ b/src/assets/stylesheets/avatar-editor.scss
@@ -49,9 +49,25 @@
     }
   }
 
-  .form-body {
+  form {
     display: flex;
     flex-direction: column;
+
+    > label {
+      margin-top: 8px;
+    }
+
+    details {
+      margin-bottom: 10px;
+    }
+
+    > .text-field-container {
+      display: flex;
+      align-items: center;
+      label {
+        margin-right: 5px;
+      }
+    }
 
     .file-input-row {
       display: flex;
@@ -63,6 +79,7 @@
         display: flex;
         align-items: center;
         margin: 5px 0;
+        cursor: pointer;
       }
       input {
         display: none;
@@ -76,6 +93,13 @@
         margin-right: 5px;
         background: #eaeaea;
         overflow: hidden;
+        color: $dark-grey;
+        position: relative;
+        svg {
+          position: absolute;
+          left: 15px;
+          top: 15px;
+        }
       }
       img {
         width: 100%;
@@ -105,25 +129,38 @@
       }
     }
 
-    .select-grid {
-      display: flex;
+    .select-grid-container {
+      .select-grid {
+        display: flex;
+        flex-wrap: wrap;
+        margin-top: 5px;
+        justify-content: space-between;
+        max-width: 355px;
+      }
+
+      input {
+        display: none;
+      }
+
       .item {
-        flex: 1;
         box-sizing: border-box;
-        background: #eaeaea;
         border-radius: 15px;
-        margin: 2px 5px;
         padding: 5px;
         display: flex;
         justify-content: center;
         align-items: center;
         color: $darker-grey;
         text-align: center;
+        cursor: pointer;
+        margin-bottom: 5px;
+        width: calc(1 / 3 * 100% - (1 - 1 / 3) * 10px);
+
         &.selected{
-          border: 4px solid $action-color;
+          background: #eaeaea;
         }
         &.custom{
-          flex: 3;
+          width: 100%;
+          height: 40px;
         }
         img {
           width: 100%;

--- a/src/assets/stylesheets/avatar-preview.scss
+++ b/src/assets/stylesheets/avatar-preview.scss
@@ -4,6 +4,7 @@
   position: relative;
   overflow: hidden;
   background: #eaeaea;
+  border-radius: 20px;
 
   .loader {
     position: absolute;

--- a/src/assets/stylesheets/profile.scss
+++ b/src/assets/stylesheets/profile.scss
@@ -99,8 +99,6 @@
 
   :local(.preview) {
     flex: 1;
-    border-radius: 20px;
-    overflow: hidden;
     display: flex;
     position: relative;
     max-width: 300px;

--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -338,6 +338,7 @@ export default class AvatarEditor extends Component {
             }
             key={a.id}
             className={classNames("item", { selected: a.id === this.state.avatar[propName] })}
+            style={{ paddingBottom: `${(a.images.preview.width / a.images.preview.height) * 100}%` }}
           >
             <img src={a.images.preview.url} />
           </div>
@@ -429,7 +430,6 @@ export default class AvatarEditor extends Component {
                 {debug && this.textField("parent_avatar_listing_id", "Parent Avatar Listing ID")}
                 {debug && this.textarea("description", "Description")}
                 {!!this.state.baseAvatarResults.length && this.selectListingGrid("parent_avatar_listing_id", "Model")}
-                {/* {!avatar.parent_avatar_listing_id && this.fileField("glb", "Avatar GLB", "model/gltf+binary,.glb")} */}
 
                 <label>Skin</label>
                 {this.mapField("base_map", "Base Map", "image/*")}

--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -48,7 +48,7 @@ export default class AvatarEditor extends Component {
       this.setState({ avatar, previewGltfUrl: avatar.base_gltf_url });
     } else {
       const { entries } = await fetchReticulumAuthenticated(`/api/v1/media/search?filter=base&source=avatar_listings`);
-      const baseAvatarResults = entries.map(e => ({ id: e.id, name: e.name, gltfs: e.gltfs }));
+      const baseAvatarResults = entries.map(e => ({ id: e.id, name: e.name, gltfs: e.gltfs, images: e.images }));
       if (baseAvatarResults.length) {
         const randomAvatarResult = baseAvatarResults[Math.floor(Math.random() * baseAvatarResults.length)];
         this.setState({
@@ -317,6 +317,39 @@ export default class AvatarEditor extends Component {
     </div>
   );
 
+  selectListingGrid = (propName, placeholder) => (
+    <div className="select-container">
+      <label htmlFor={`#avatar-${propName}`}>{placeholder}</label>
+      <div className="select-grid">
+        {this.state.baseAvatarResults.map(a => (
+          <div
+            onClick={() =>
+              this.setState({
+                avatar: { ...this.state.avatar, [propName]: a.id },
+                previewGltfUrl: this.getPreviewUrl(a.id)
+              })
+            }
+            key={a.id}
+            className={classNames("item", { selected: a.id === this.state.avatar[propName] })}
+          >
+            <img src={a.images.preview.url} />
+          </div>
+        ))}
+      </div>
+      <div
+        onClick={() =>
+          this.setState({
+            avatar: { ...this.state.avatar, [propName]: "" },
+            previewGltfUrl: this.getPreviewUrl("")
+          })
+        }
+        className={classNames("item", "custom", { selected: "" === this.state.avatar[propName] })}
+      >
+        Custom GLB
+      </div>
+    </div>
+  );
+
   textarea = (name, placeholder, disabled) => (
     <div>
       <textarea
@@ -370,7 +403,7 @@ export default class AvatarEditor extends Component {
                 {debug && this.textField("parent_avatar_listing_id", "Parent Avatar Listing ID")}
                 {this.textField("name", "Name", false, true)}
                 {debug && this.textarea("description", "Description")}
-                {!!this.state.baseAvatarResults.length && this.selectListingField("parent_avatar_listing_id", "Model")}
+                {!!this.state.baseAvatarResults.length && this.selectListingGrid("parent_avatar_listing_id", "Model")}
                 {!avatar.parent_avatar_listing_id && this.fileField("glb", "Avatar GLB", "model/gltf+binary,.glb")}
                 {this.mapField("base_map", "Base Map", "image/*")}
                 <details>


### PR DESCRIPTION
This replaces the base model dropwdown in the Avatar Editor with small thumbnails. This will hopefully help people discover the alternate model types. Also slightly tweaks the layout of the editor in general to better break things up into logical sections.

![image](https://user-images.githubusercontent.com/130735/66445425-9d803900-e9fb-11e9-81d0-396e44048b77.png)
![image](https://user-images.githubusercontent.com/130735/66445435-a83ace00-e9fb-11e9-934b-a8aa00152de4.png)
