### PR TITLE
added z-index to .top-tip in 2d-hud.scss

### DIFF
--- a/src/assets/stylesheets/2d-hud.scss
+++ b/src/assets/stylesheets/2d-hud.scss
@@ -40,6 +40,7 @@
   :local(.top-tip) {
     @extend %tip-bubble;
     top: 60px;
+    z-index: 0;
 
     width: 350px;
 


### PR DESCRIPTION
Fix to issue #1519 

Added z-index: 0 to .top-tip.

Below are screenshots of fix on desktop version in Chrome:

![chrome_qMk0qyVwkB](https://user-images.githubusercontent.com/29560735/66684031-e7506580-ec2d-11e9-92c9-7570f17a2898.png)
![F6EQmQNc1G](https://user-images.githubusercontent.com/29560735/66684033-e91a2900-ec2d-11e9-8052-ec5e6f68ec80.png)
![chrome_PUNyfqp8ZQ](https://user-images.githubusercontent.com/29560735/66684037-ecadb000-ec2d-11e9-9649-17b2e9e358ee.png)

