### PR TITLE
Wait for DOMContentLoaded

### DIFF
--- a/src/components/hoverable-visuals.js
+++ b/src/components/hoverable-visuals.js
@@ -56,6 +56,7 @@ AFRAME.registerComponent("hoverable-visuals", {
 
     let interactorOne, interactorTwo;
     const interaction = AFRAME.scenes[0].systems.interaction;
+    if (!interaction.options.leftHand.entity) return; //DOMContentReady workaround
     if (interaction.state.leftHand.hovered === this.el && !interaction.state.leftHand.held) {
       interactorOne = interaction.options.leftHand.entity.object3D;
     }

--- a/src/components/hoverable-visuals.js
+++ b/src/components/hoverable-visuals.js
@@ -56,7 +56,7 @@ AFRAME.registerComponent("hoverable-visuals", {
 
     let interactorOne, interactorTwo;
     const interaction = AFRAME.scenes[0].systems.interaction;
-    if (!interaction.options.leftHand.entity) return; //DOMContentReady workaround
+    if (!interaction.ready) return; //DOMContentReady workaround
     if (interaction.state.leftHand.hovered === this.el && !interaction.state.leftHand.held) {
       interactorOne = interaction.options.leftHand.entity.object3D;
     }

--- a/src/components/super-spawner.js
+++ b/src/components/super-spawner.js
@@ -116,7 +116,7 @@ AFRAME.registerComponent("super-spawner", {
     ).entity;
 
     const interaction = this.el.sceneEl.systems.interaction;
-    if (!interaction.options.leftHand.entity) return; //DOMContentReady workaround
+    if (!interaction.ready) return; //DOMContentReady workaround
     const cursor = (e.detail && e.detail.object3D) || interaction.options.rightRemote.entity.object3D;
 
     const left = cursor.el.id.indexOf("right") === -1;

--- a/src/components/super-spawner.js
+++ b/src/components/super-spawner.js
@@ -115,12 +115,12 @@ AFRAME.registerComponent("super-spawner", {
       false
     ).entity;
 
-    const cursor =
-      (e.detail && e.detail.object3D) || this.el.sceneEl.systems.interaction.options.rightRemote.entity.object3D;
+    const interaction = this.el.sceneEl.systems.interaction;
+    if (!interaction.options.leftHand.entity) return; //DOMContentReady workaround
+    const cursor = (e.detail && e.detail.object3D) || interaction.options.rightRemote.entity.object3D;
+
     const left = cursor.el.id.indexOf("right") === -1;
-    const hand = left
-      ? this.el.sceneEl.systems.interaction.options.leftHand.entity.object3D
-      : this.el.sceneEl.systems.interaction.options.rightHand.entity.object3D;
+    const hand = left ? interaction.options.leftHand.entity.object3D : interaction.options.rightHand.entity.object3D;
     cursor.getWorldPosition(entity.object3D.position);
     cursor.getWorldQuaternion(entity.object3D.quaternion);
     entity.object3D.matrixNeedsUpdate = true;
@@ -130,7 +130,6 @@ AFRAME.registerComponent("super-spawner", {
     }
 
     const userinput = AFRAME.scenes[0].systems.userinput;
-    const interaction = AFRAME.scenes[0].systems.interaction;
     const willAnimateFromCursor =
       this.data.animateFromCursor &&
       (userinput.get(paths.actions.rightHand.matrix) || userinput.get(paths.actions.leftHand.matrix));

--- a/src/hub.js
+++ b/src/hub.js
@@ -1,5 +1,4 @@
 import "@babel/polyfill";
-import configs from "./utils/configs";
 import "./utils/debug-log";
 
 console.log(`Hubs version: ${process.env.BUILD_VERSION || "?"}`);

--- a/src/systems/constraints-system.js
+++ b/src/systems/constraints-system.js
@@ -97,7 +97,7 @@ export class ConstraintsSystem {
 
   tick() {
     const interaction = AFRAME.scenes[0].systems.interaction;
-    if (!interaction.options.leftHand.entity) return; //DOMContentReady workaround
+    if (!interaction.ready) return; //DOMContentReady workaround
 
     this.tickInteractor(
       "offersHandConstraint",

--- a/src/systems/constraints-system.js
+++ b/src/systems/constraints-system.js
@@ -97,6 +97,7 @@ export class ConstraintsSystem {
 
   tick() {
     const interaction = AFRAME.scenes[0].systems.interaction;
+    if (!interaction.options.leftHand.entity) return; //DOMContentReady workaround
 
     this.tickInteractor(
       "offersHandConstraint",

--- a/src/systems/hubs-systems.js
+++ b/src/systems/hubs-systems.js
@@ -9,12 +9,12 @@ import { HoverMenuSystem } from "./hover-menu-system";
 import { SuperSpawnerSystem } from "./super-spawner-system";
 import { HapticFeedbackSystem } from "./haptic-feedback-system";
 import { SoundEffectsSystem } from "./sound-effects-system";
-
 import { BatchManagerSystem } from "./render-manager-system";
 import { LobbyCameraSystem } from "./lobby-camera-system";
 import { InteractionSfxSystem } from "./interaction-sfx-system";
 import { SpriteSystem } from "./sprites";
 import { CameraSystem } from "./camera-system";
+import { waitForDOMContentLoaded } from "../utils/async-utils";
 
 AFRAME.registerSystem("hubs-systems", {
   init() {
@@ -37,9 +37,13 @@ AFRAME.registerSystem("hubs-systems", {
     this.spriteSystem = new SpriteSystem(this.el);
     this.cameraSystem = new CameraSystem(this.batchManagerSystem);
     this.drawingMenuSystem = new DrawingMenuSystem(this.el.sceneEl);
+    waitForDOMContentLoaded().then(() => {
+      this.DOMContentDidLoad = true;
+    });
   },
 
   tick(t, dt) {
+    if (!this.DOMContentDidLoad) return;
     const systems = AFRAME.scenes[0].systems;
     systems.userinput.tick2();
     systems.interaction.tick2();

--- a/src/systems/interactions.js
+++ b/src/systems/interactions.js
@@ -183,6 +183,7 @@ AFRAME.registerSystem("interaction", {
       this.options.rightHand.entity = document.getElementById("player-right-controller");
       this.options.rightRemote.entity = document.getElementById("right-cursor");
       this.options.leftRemote.entity = document.getElementById("left-cursor");
+      this.ready = true;
     });
   },
 

--- a/src/systems/render-manager/hubs-batch-raw-uniform-group.js
+++ b/src/systems/render-manager/hubs-batch-raw-uniform-group.js
@@ -50,6 +50,7 @@ export default class HubsBatchRawUniformGroup extends BatchRawUniformGroup {
 
   update(time) {
     const interaction = AFRAME.scenes[0].systems.interaction;
+    if (!interaction.options.leftHand.entity) return; //DOMContentReady workaround
     const cameraSystem = AFRAME.scenes[0].systems["hubs-systems"].cameraSystem;
     const inspecting = cameraSystem.mode === CAMERA_MODE_INSPECT && !cameraSystem.enableLights;
     const inspectedMeshesFromBatch = cameraSystem.inspectedMeshesFromBatch;

--- a/src/systems/render-manager/hubs-batch-raw-uniform-group.js
+++ b/src/systems/render-manager/hubs-batch-raw-uniform-group.js
@@ -50,7 +50,7 @@ export default class HubsBatchRawUniformGroup extends BatchRawUniformGroup {
 
   update(time) {
     const interaction = AFRAME.scenes[0].systems.interaction;
-    if (!interaction.options.leftHand.entity) return; //DOMContentReady workaround
+    if (!interaction.ready) return; //DOMContentReady workaround
     const cameraSystem = AFRAME.scenes[0].systems["hubs-systems"].cameraSystem;
     const inspecting = cameraSystem.mode === CAMERA_MODE_INSPECT && !cameraSystem.enableLights;
     const inspectedMeshesFromBatch = cameraSystem.inspectedMeshesFromBatch;

--- a/src/systems/super-spawner-system.js
+++ b/src/systems/super-spawner-system.js
@@ -60,6 +60,7 @@ export class SuperSpawnerSystem {
 
   tick() {
     const interaction = AFRAME.scenes[0].systems.interaction;
+    if (!interaction.options.leftHand.entity) return; //DOMContentReady workaround
     this.maybeSpawn(
       interaction.state.leftHand,
       interaction.options.leftHand.entity,

--- a/src/systems/super-spawner-system.js
+++ b/src/systems/super-spawner-system.js
@@ -60,7 +60,7 @@ export class SuperSpawnerSystem {
 
   tick() {
     const interaction = AFRAME.scenes[0].systems.interaction;
-    if (!interaction.options.leftHand.entity) return; //DOMContentReady workaround
+    if (!interaction.ready) return; //DOMContentReady workaround
     this.maybeSpawn(
       interaction.state.leftHand,
       interaction.options.leftHand.entity,

--- a/src/systems/two-point-stretching-system.js
+++ b/src/systems/two-point-stretching-system.js
@@ -22,7 +22,7 @@ export class TwoPointStretchingSystem {
 
   tick() {
     const interaction = AFRAME.scenes[0].systems.interaction;
-    if (!interaction.options.leftHand.entity) return; //DOMContentReady workaround
+    if (!interaction.ready) return; //DOMContentReady workaround
     const { leftHand, rightHand, rightRemote, leftRemote } = interaction.state;
 
     const stretching =

--- a/src/systems/two-point-stretching-system.js
+++ b/src/systems/two-point-stretching-system.js
@@ -22,6 +22,7 @@ export class TwoPointStretchingSystem {
 
   tick() {
     const interaction = AFRAME.scenes[0].systems.interaction;
+    if (!interaction.options.leftHand.entity) return; //DOMContentReady workaround
     const { leftHand, rightHand, rightRemote, leftRemote } = interaction.state;
 
     const stretching =


### PR DESCRIPTION
Fix for the issue seen in the following screenshot:

![image](https://user-images.githubusercontent.com/4072106/66959787-f49b9480-f01f-11e9-8a1c-bb9619b21fc2.png)

The first commit should (indirectly) fix this particular issue. The second should fix any potential issues with the interaction system. If we revisit initialization and find a better way to handle this class of issues, we can remove the workaround. For now, I added a guard to the sites that make use of those entities:
```
8 candidates:
./src/systems/constraints-system.js:103:      interaction.options.leftHand.entity.id,
./src/systems/two-point-stretching-system.js:34:        ? interaction.options.leftHand.entity.object3D
./src/systems/interactions.js:182:      this.options.leftHand.entity = document.getElementById("player-left-controller");
./src/systems/interactions.js:230:    if (this.options.leftHand.entity.object3D.visible && !this.state.leftRemote.held) {
./src/systems/super-spawner-system.js:65:      interaction.options.leftHand.entity,
./src/components/super-spawner.js:122:      ? this.el.sceneEl.systems.interaction.options.leftHand.entity.object3D
./src/components/hoverable-visuals.js:60:      interactorOne = interaction.options.leftHand.entity.object3D;
./src/systems/render-manager/hubs-batch-raw-uniform-group.js:93:            interactorOne = interaction.options.leftHand.entity.object3D;
```
