### PR TITLE
Add ability to find "similar" avatars in the media browser

### DIFF
--- a/src/assets/stylesheets/media-browser.scss
+++ b/src/assets/stylesheets/media-browser.scss
@@ -387,20 +387,25 @@
           }
         }
 
-        :local(.edit-avatar) {
+        :local(.tile-actions) {
           position: absolute;
           top: 6px;
           right: 7px;
-          color: black;
-          background: #ffffffde;
-          border-radius: 30px;
-          width: 30px;
-          height: 30px;
-          text-align: center;
-          line-height: 27px;
-          &:hover {
-            background: $action-color;
-            color: white;
+          a {
+            color: black;
+            background: #ffffffde;
+            border-radius: 30px;
+            width: 30px;
+            height: 30px;
+            text-align: center;
+            line-height: 30px;
+            display: block;
+            margin-bottom: 5px;
+
+            &:hover {
+              background: $action-color;
+              color: white;
+            }
           }
         }
       }

--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -146,6 +146,7 @@
     "media-browser.create-scene": "Create Scene with Spoke",
     "media-browser.hub.joined-prefix": "Joined ",
     "media-browser.hub.joined-prefix": "Visited ",
+    "media-browser.similar-to-facet": "Similar to: \"{name}\"",
     "audio.title": "Audio Setup",
     "audio.talk_to_test": "talk",
     "audio.click_to_test": "click",

--- a/src/react-components/avatar-preview.js
+++ b/src/react-components/avatar-preview.js
@@ -83,6 +83,8 @@ class AvatarPreview extends Component {
     this.scene.add(light);
     this.scene.add(new THREE.HemisphereLight(0xb1e3ff, 0xb1e3ff, 2.5));
 
+    this.loadId = 0;
+
     this.camera.position.set(-0.2, 0.5, 0.5);
     this.camera.matrixAutoUpdate = true;
 
@@ -90,7 +92,7 @@ class AvatarPreview extends Component {
     this.controls.update();
 
     if (this.props.avatarGltfUrl) {
-      this.loadPreviewAvatar(this.props.avatarGltfUrl).then(this.setAvatar);
+      this.loadCurrentAvatarGltfUrl();
     }
 
     const clock = new THREE.Clock();
@@ -179,11 +181,20 @@ class AvatarPreview extends Component {
       }
       if (this.props.avatarGltfUrl) {
         this.setState({ error: null, loading: true });
-        await this.loadPreviewAvatar(this.props.avatarGltfUrl).then(this.setAvatar);
+        await this.loadCurrentAvatarGltfUrl();
       }
     }
     this.applyMaps(oldProps, this.props);
   };
+
+  loadCurrentAvatarGltfUrl() {
+    const newLoadId = ++this.loadId;
+    return this.loadPreviewAvatar(this.props.avatarGltfUrl).then(avatar => {
+      // If we had started loading another avatar while we were loading this one, throw this one away
+      if (newLoadId !== this.loadId) return;
+      this.setAvatar(avatar);
+    });
+  }
 
   applyMaps(oldProps, newProps) {
     return Promise.all(

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -125,11 +125,10 @@ class MediaBrowser extends Component {
     const searchParams = new URLSearchParams(props.history.location.search);
     const result = props.mediaSearchStore.result;
 
-    const newState = { result, query: this.state.query || searchParams.get("q") || "" };
+    const newState = { result, query: searchParams.get("q") || "" };
     const urlSource = this.getUrlSource(searchParams);
     newState.showNav = !!(searchParams.get("media_nav") !== "false");
     newState.selectAction = searchParams.get("selectAction") || "spawn";
-    newState.query = searchParams.get("q") || "";
 
     if (result && result.suggestions && result.suggestions.length > 0) {
       newState.facets = result.suggestions.map(s => {
@@ -411,7 +410,10 @@ class MediaBrowser extends Component {
                 ))}
               {activeFilter === "similar" && (
                 <a className={classNames(styles.facet, "selected")}>
-                  Similar to: &quote;{searchParams.get("similar_name")}&quote;
+                  <FormattedMessage
+                    id="media-browser.similar-to-facet"
+                    values={{ name: searchParams.get("similar_name") }}
+                  />
                 </a>
               )}
             </div>

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -410,7 +410,9 @@ class MediaBrowser extends Component {
                   </a>
                 ))}
               {activeFilter === "similar" && (
-                <a className={classNames(styles.facet, "selected")}>Similar to: "{searchParams.get("similar_name")}"</a>
+                <a className={classNames(styles.facet, "selected")}>
+                  Similar to: &quote;{searchParams.get("similar_name")}&quote;
+                </a>
               )}
             </div>
           )}

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -182,6 +182,10 @@ class MediaBrowser extends Component {
     this.handleFacetClicked({ params: { filter: "my-avatars" } });
   };
 
+  onShowSimilar = (id, name) => {
+    this.handleFacetClicked({ params: { similar_to: id, similar_name: name } });
+  };
+
   selectEntry = entry => {
     if (!this.props.onMediaSearchResultEntrySelected) return;
     this.props.onMediaSearchResultEntrySelected(entry, this.state.selectAction);
@@ -250,6 +254,8 @@ class MediaBrowser extends Component {
     const hideSearch = urlSource === "favorites";
     const showEmptyStringOnNoResult = urlSource !== "avatars" && urlSource !== "scenes";
 
+    const facets = this.state.facets && this.state.facets.length > 0 && this.state.facets;
+
     // Don't render anything if we just did a feeling lucky query and are waiting on result.
     if (this.state.selectNextResult) return <div />;
     const handleCustomClicked = urlSource => {
@@ -265,7 +271,8 @@ class MediaBrowser extends Component {
       }
     };
 
-    const activeFilter = searchParams.get("filter") || (!searchParams.get("q") && "");
+    const activeFilter =
+      searchParams.get("filter") || (searchParams.get("similar_to") && "similar") || (!searchParams.get("q") && "");
 
     return (
       <div className={styles.mediaBrowser} ref={browserDiv => (this.browserDiv = browserDiv)}>
@@ -389,10 +396,10 @@ class MediaBrowser extends Component {
             </div>
           )}
 
-          {this.state.facets &&
-            this.state.facets.length > 0 && (
-              <div className={styles.facets}>
-                {this.state.facets.map((s, i) => (
+          {(facets || activeFilter === "similar") && (
+            <div className={styles.facets}>
+              {facets &&
+                facets.map((s, i) => (
                   <a
                     onClick={() => this.handleFacetClicked(s)}
                     key={i}
@@ -401,8 +408,11 @@ class MediaBrowser extends Component {
                     {s.text}
                   </a>
                 ))}
-              </div>
-            )}
+              {activeFilter === "similar" && (
+                <a className={classNames(styles.facet, "selected")}>Similar to: "{searchParams.get("similar_name")}"</a>
+              )}
+            </div>
+          )}
 
           {this.props.mediaSearchStore.isFetching ||
           this._sendQueryTimeout ||
@@ -414,6 +424,7 @@ class MediaBrowser extends Component {
               urlSource={urlSource}
               handleEntryClicked={this.handleEntryClicked}
               onCopyAvatar={this.onCopyAvatar}
+              onShowSimilar={this.onShowSimilar}
               handlePager={this.handlePager}
             />
           ) : (

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -129,6 +129,7 @@ class MediaBrowser extends Component {
     const urlSource = this.getUrlSource(searchParams);
     newState.showNav = !!(searchParams.get("media_nav") !== "false");
     newState.selectAction = searchParams.get("selectAction") || "spawn";
+    newState.query = searchParams.get("q") || "";
 
     if (result && result.suggestions && result.suggestions.length > 0) {
       newState.facets = result.suggestions.map(s => {

--- a/src/react-components/media-tiles.js
+++ b/src/react-components/media-tiles.js
@@ -187,26 +187,21 @@ class MediaTiles extends Component {
             </StateLink>
           )}
           {entry.type === "avatar_listing" && (
-            <StateLink
+            <a
               onClick={e => {
                 e.preventDefault();
                 this.props.onShowSimilar(entry.id, entry.name);
               }}
-              history={this.props.history}
               title="Show Similar"
             >
               <FontAwesomeIcon icon={faSearch} />
-            </StateLink>
+            </a>
           )}
           {entry.type === "avatar_listing" &&
             entry.allow_remixing && (
-              <StateLink
-                onClick={e => this.handleCopyAvatar(e, entry)}
-                history={this.props.history}
-                title="Copy to my avatars"
-              >
+              <a onClick={e => this.handleCopyAvatar(e, entry)} title="Copy to my avatars">
                 <FontAwesomeIcon icon={faClone} />
-              </StateLink>
+              </a>
             )}
         </div>
         {!entry.type.endsWith("_image") && (

--- a/src/react-components/media-tiles.js
+++ b/src/react-components/media-tiles.js
@@ -186,7 +186,7 @@ class MediaTiles extends Component {
               <FontAwesomeIcon icon={faPencilAlt} />
             </StateLink>
           )}
-          {(entry.type === "avatar" || entry.type === "avatar_listing") && (
+          {entry.type === "avatar_listing" && (
             <StateLink
               onClick={e => {
                 e.preventDefault();

--- a/src/react-components/media-tiles.js
+++ b/src/react-components/media-tiles.js
@@ -11,6 +11,7 @@ import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons/faExternalL
 import { faPencilAlt } from "@fortawesome/free-solid-svg-icons/faPencilAlt";
 import { faClone } from "@fortawesome/free-solid-svg-icons/faClone";
 import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus";
+import { faSearch } from "@fortawesome/free-solid-svg-icons/faSearch";
 
 import styles from "../assets/stylesheets/media-browser.scss";
 import { proxiedUrlFor, scaledThumbnailUrlFor } from "../utils/media-url-utils";
@@ -32,7 +33,8 @@ class MediaTiles extends Component {
     urlSource: PropTypes.string,
     handleEntryClicked: PropTypes.func,
     handlePager: PropTypes.func,
-    onCopyAvatar: PropTypes.func
+    onCopyAvatar: PropTypes.func,
+    onShowSimilar: PropTypes.func
   };
 
   handleCopyAvatar = async (e, entry) => {
@@ -172,28 +174,41 @@ class MediaTiles extends Component {
         >
           {thumbnailElement}
         </a>
-        {entry.type === "avatar" && (
-          <StateLink
-            className={styles.editAvatar}
-            stateKey="overlay"
-            stateValue="avatar-editor"
-            stateDetail={{ avatarId: entry.id }}
-            history={this.props.history}
-          >
-            <FontAwesomeIcon icon={faPencilAlt} />
-          </StateLink>
-        )}
-        {entry.type === "avatar_listing" &&
-          entry.allow_remixing && (
+        <div className={styles.tileActions}>
+          {entry.type === "avatar" && (
             <StateLink
-              className={styles.editAvatar}
-              onClick={e => this.handleCopyAvatar(e, entry)}
+              stateKey="overlay"
+              stateValue="avatar-editor"
+              stateDetail={{ avatarId: entry.id }}
               history={this.props.history}
-              title="Copy to my avatars"
+              title="Edit"
             >
-              <FontAwesomeIcon icon={faClone} />
+              <FontAwesomeIcon icon={faPencilAlt} />
             </StateLink>
           )}
+          {(entry.type === "avatar" || entry.type === "avatar_listing") && (
+            <StateLink
+              onClick={e => {
+                e.preventDefault();
+                this.props.onShowSimilar(entry.id, entry.name);
+              }}
+              history={this.props.history}
+              title="Show Similar"
+            >
+              <FontAwesomeIcon icon={faSearch} />
+            </StateLink>
+          )}
+          {entry.type === "avatar_listing" &&
+            entry.allow_remixing && (
+              <StateLink
+                onClick={e => this.handleCopyAvatar(e, entry)}
+                history={this.props.history}
+                title="Copy to my avatars"
+              >
+                <FontAwesomeIcon icon={faClone} />
+              </StateLink>
+            )}
+        </div>
         {!entry.type.endsWith("_image") && (
           <div className={styles.info}>
             <a

--- a/src/storage/media-search-store.js
+++ b/src/storage/media-search-store.js
@@ -26,7 +26,7 @@ export const MEDIA_SOURCE_DEFAULT_FILTERS = {
   favorites: "my-favorites"
 };
 
-const SEARCH_CONTEXT_PARAMS = ["q", "filter", "cursor"];
+const SEARCH_CONTEXT_PARAMS = ["q", "filter", "cursor", "similar_to"];
 
 // This class is responsible for fetching and storing media search results and provides a
 // convenience API for performing history updates relevant to search navigation.
@@ -128,6 +128,9 @@ export default class MediaSearchStore extends EventTarget {
     const location = this.history.location;
     const searchParams = new URLSearchParams(location.search);
 
+    searchParams.delete("similar_to");
+    searchParams.delete("similar_name");
+
     if (query) {
       searchParams.set("q", query);
     } else {
@@ -156,6 +159,8 @@ export default class MediaSearchStore extends EventTarget {
     searchParams.delete("q");
     searchParams.delete("filter");
     searchParams.delete("cursor");
+    searchParams.delete("similar_to");
+    searchParams.delete("similar_name");
 
     if (!keepNav) {
       searchParams.delete("media_nav");


### PR DESCRIPTION
Adds "find similar" buttons to avatar listing results in the media browsers. Currently this is implemented in the backend to just find avatars that share the same parent avatar, but this can be updated later to actually use a more interesting metric of similarity.

Requires backend changes here: https://github.com/mozilla/reticulum/pull/249