### PR TITLE
Set gain value directly, skipping setVolume

### DIFF
--- a/src/components/avatar-volume-controls.js
+++ b/src/components/avatar-volume-controls.js
@@ -38,7 +38,7 @@ AFRAME.registerComponent("avatar-volume-controls", {
 
   update() {
     if (this.audio) {
-      this.audio.setVolume(this.data.volume);
+      this.audio.gain.gain.value = this.data.volume;
     }
   },
 


### PR DESCRIPTION
(Maybe) fix issue we saw in standup this week where the audio falloff of other avatars was delayed. I'm not sure how to repro the issue so this is a blind attempt.

In light of the audio issues we were having in the meetup today, I'm not so sure we should expect this change to fix anything after all, since I don't know how this change could have been responsible for the audio degradation we saw in standup.