### PR TITLE
Feature/retry hls

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -167,13 +167,6 @@ function createVideoTexture(url, contentType) {
           hls.attachMedia(videoEl);
 
           hls.on(HLS.Events.ERROR, function(event, data) {
-            console.log("error");
-            console.log(data);
-            if (data.details === "levelLoadTimeOut") {
-              console.log("Level load timeout, try again");
-              return;
-            }
-
             if (data.fatal) {
               switch (data.type) {
                 case HLS.ErrorTypes.NETWORK_ERROR:
@@ -195,7 +188,10 @@ function createVideoTexture(url, contentType) {
 
         // Sometimes for weird streams HLS fails to initialize.
         const setupInterval = setInterval(() => {
-          if (isReady()) {
+          // Stop retrying if the src changed.
+          const isNoLongerSrc = this.data.src !== url;
+
+          if (isReady() || isNoLongerSrc) {
             clearInterval(setupInterval);
           } else {
             console.warn("HLS failed to read video, trying again");

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -118,112 +118,6 @@ async function createVideoEl() {
   return videoEl;
 }
 
-function createVideoTexture(url, contentType) {
-  return new Promise(async (resolve, reject) => {
-    const videoEl = await createVideoEl();
-
-    const texture = new THREE.VideoTexture(videoEl);
-    texture.minFilter = THREE.LinearFilter;
-    texture.encoding = THREE.sRGBEncoding;
-    const isReady = () =>
-      (texture.image.videoHeight || texture.image.height) && (texture.image.videoWidth || texture.image.width);
-
-    // Set src on video to begin loading.
-    if (url.startsWith("hubs://")) {
-      const streamClientId = url.substring(7).split("/")[1]; // /clients/<client id>/video is only URL for now
-      const stream = await NAF.connection.adapter.getMediaStream(streamClientId, "video");
-      videoEl.srcObject = new MediaStream(stream.getVideoTracks());
-      // If hls.js is supported we always use it as it gives us better events
-    } else if (AFRAME.utils.material.isHLS(url, contentType)) {
-      if (HLS.isSupported()) {
-        const corsProxyPrefix = `https://${configs.CORS_PROXY_SERVER}/`;
-        const baseUrl = url.startsWith(corsProxyPrefix) ? url.substring(corsProxyPrefix.length) : url;
-        const setupHls = () => {
-          if (texture.hls) {
-            texture.hls.stopLoad();
-            texture.hls.detachMedia();
-            texture.hls.destroy();
-            texture.hls = null;
-          }
-
-          const hls = new HLS({
-            xhrSetup: (xhr, u) => {
-              if (u.startsWith(corsProxyPrefix)) {
-                u = u.substring(corsProxyPrefix.length);
-              }
-
-              // HACK HLS.js resolves relative urls internally, but our CORS proxying screws it up. Resolve relative to the original unproxied url.
-              // TODO extend HLS.js to allow overriding of its internal resolving instead
-              if (!u.startsWith("http")) {
-                u = buildAbsoluteURL(baseUrl, u.startsWith("/") ? u : `/${u}`);
-              }
-
-              xhr.open("GET", proxiedUrlFor(u));
-            }
-          });
-
-          texture.hls = hls;
-          hls.loadSource(url);
-          hls.attachMedia(videoEl);
-
-          hls.on(HLS.Events.ERROR, function(event, data) {
-            if (data.fatal) {
-              switch (data.type) {
-                case HLS.ErrorTypes.NETWORK_ERROR:
-                  // try to recover network error
-                  hls.startLoad();
-                  break;
-                case HLS.ErrorTypes.MEDIA_ERROR:
-                  hls.recoverMediaError();
-                  break;
-                default:
-                  reject(event);
-                  return;
-              }
-            }
-          });
-        };
-
-        setupHls();
-
-        // Sometimes for weird streams HLS fails to initialize.
-        const setupInterval = setInterval(() => {
-          // Stop retrying if the src changed.
-          const isNoLongerSrc = this.data.src !== url;
-
-          if (isReady() || isNoLongerSrc) {
-            clearInterval(setupInterval);
-          } else {
-            console.warn("HLS failed to read video, trying again");
-            setupHls();
-          }
-        }, HLS_TIMEOUT);
-        // If not, see if native support will work
-      } else if (videoEl.canPlayType(contentType)) {
-        videoEl.src = url;
-        videoEl.onerror = reject;
-      } else {
-        reject("HLS unsupported");
-      }
-    } else {
-      videoEl.src = url;
-      videoEl.onerror = reject;
-    }
-
-    // NOTE: We used to use the canplay event here to yield the texture, but that fails to fire on iOS Safari
-    // and also sometimes in Chrome it seems.
-    const poll = () => {
-      if (isReady()) {
-        resolve(texture);
-      } else {
-        setTimeout(poll, 500);
-      }
-    };
-
-    poll();
-  });
-}
-
 function scaleToAspectRatio(el, ratio) {
   const width = Math.min(1.0, 1.0 / ratio);
   const height = Math.min(1.0, ratio);
@@ -572,7 +466,7 @@ AFRAME.registerComponent("media-video", {
 
     let texture;
     try {
-      texture = await createVideoTexture(src, this.data.contentType);
+      texture = await this.createVideoTexture();
 
       // No way to cancel promises, so if src has changed while we were creating the texture just throw it away.
       if (this.data.src !== src) {
@@ -680,6 +574,115 @@ AFRAME.registerComponent("media-video", {
     }
 
     this.el.emit("video-loaded", { projection: projection });
+  },
+
+  async createVideoTexture() {
+    const url = this.data.src;
+    const contentType = this.data.contentType;
+
+    return new Promise(async (resolve, reject) => {
+      const videoEl = await createVideoEl();
+
+      const texture = new THREE.VideoTexture(videoEl);
+      texture.minFilter = THREE.LinearFilter;
+      texture.encoding = THREE.sRGBEncoding;
+      const isReady = () =>
+        (texture.image.videoHeight || texture.image.height) && (texture.image.videoWidth || texture.image.width);
+
+      // Set src on video to begin loading.
+      if (url.startsWith("hubs://")) {
+        const streamClientId = url.substring(7).split("/")[1]; // /clients/<client id>/video is only URL for now
+        const stream = await NAF.connection.adapter.getMediaStream(streamClientId, "video");
+        videoEl.srcObject = new MediaStream(stream.getVideoTracks());
+        // If hls.js is supported we always use it as it gives us better events
+      } else if (AFRAME.utils.material.isHLS(url, contentType)) {
+        if (HLS.isSupported()) {
+          const corsProxyPrefix = `https://${configs.CORS_PROXY_SERVER}/`;
+          const baseUrl = url.startsWith(corsProxyPrefix) ? url.substring(corsProxyPrefix.length) : url;
+          const setupHls = () => {
+            if (texture.hls) {
+              texture.hls.stopLoad();
+              texture.hls.detachMedia();
+              texture.hls.destroy();
+              texture.hls = null;
+            }
+
+            const hls = new HLS({
+              xhrSetup: (xhr, u) => {
+                if (u.startsWith(corsProxyPrefix)) {
+                  u = u.substring(corsProxyPrefix.length);
+                }
+
+                // HACK HLS.js resolves relative urls internally, but our CORS proxying screws it up. Resolve relative to the original unproxied url.
+                // TODO extend HLS.js to allow overriding of its internal resolving instead
+                if (!u.startsWith("http")) {
+                  u = buildAbsoluteURL(baseUrl, u.startsWith("/") ? u : `/${u}`);
+                }
+
+                xhr.open("GET", proxiedUrlFor(u));
+              }
+            });
+
+            texture.hls = hls;
+            hls.loadSource(url);
+            hls.attachMedia(videoEl);
+
+            hls.on(HLS.Events.ERROR, function(event, data) {
+              if (data.fatal) {
+                switch (data.type) {
+                  case HLS.ErrorTypes.NETWORK_ERROR:
+                    // try to recover network error
+                    hls.startLoad();
+                    break;
+                  case HLS.ErrorTypes.MEDIA_ERROR:
+                    hls.recoverMediaError();
+                    break;
+                  default:
+                    reject(event);
+                    return;
+                }
+              }
+            });
+          };
+
+          setupHls();
+
+          // Sometimes for weird streams HLS fails to initialize.
+          const setupInterval = setInterval(() => {
+            // Stop retrying if the src changed.
+            const isNoLongerSrc = this.data.src !== url;
+
+            if (isReady() || isNoLongerSrc) {
+              clearInterval(setupInterval);
+            } else {
+              console.warn("HLS failed to read video, trying again");
+              setupHls();
+            }
+          }, HLS_TIMEOUT);
+          // If not, see if native support will work
+        } else if (videoEl.canPlayType(contentType)) {
+          videoEl.src = url;
+          videoEl.onerror = reject;
+        } else {
+          reject("HLS unsupported");
+        }
+      } else {
+        videoEl.src = url;
+        videoEl.onerror = reject;
+      }
+
+      // NOTE: We used to use the canplay event here to yield the texture, but that fails to fire on iOS Safari
+      // and also sometimes in Chrome it seems.
+      const poll = () => {
+        if (isReady()) {
+          resolve(texture);
+        } else {
+          setTimeout(poll, 500);
+        }
+      };
+
+      poll();
+    });
   },
 
   updateHoverMenuBasedOnLiveState() {

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -139,6 +139,13 @@ function createVideoTexture(url, contentType) {
         const corsProxyPrefix = `https://${configs.CORS_PROXY_SERVER}/`;
         const baseUrl = url.startsWith(corsProxyPrefix) ? url.substring(corsProxyPrefix.length) : url;
         const setupHls = () => {
+          if (texture.hls) {
+            texture.hls.stopLoad();
+            texture.hls.detachMedia();
+            texture.hls.destroy();
+            texture.hls = null;
+          }
+
           const hls = new HLS({
             xhrSetup: (xhr, u) => {
               if (u.startsWith(corsProxyPrefix)) {

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -22,6 +22,7 @@ const parseGIF = promisifyWorker(new GIFWorker());
 const isIOS = AFRAME.utils.device.isIOS();
 const isMobileVR = AFRAME.utils.device.isMobileVR();
 const isFirefoxReality = isMobileVR && navigator.userAgent.match(/Firefox/);
+const HLS_TIMEOUT = 10000; // HLS can sometimes fail, we re-try after this duration
 
 export const VOLUME_LABELS = [];
 for (let i = 0; i <= 20; i++) {
@@ -124,6 +125,8 @@ function createVideoTexture(url, contentType) {
     const texture = new THREE.VideoTexture(videoEl);
     texture.minFilter = THREE.LinearFilter;
     texture.encoding = THREE.sRGBEncoding;
+    const isReady = () =>
+      (texture.image.videoHeight || texture.image.height) && (texture.image.videoWidth || texture.image.width);
 
     // Set src on video to begin loading.
     if (url.startsWith("hubs://")) {
@@ -135,40 +138,63 @@ function createVideoTexture(url, contentType) {
       if (HLS.isSupported()) {
         const corsProxyPrefix = `https://${configs.CORS_PROXY_SERVER}/`;
         const baseUrl = url.startsWith(corsProxyPrefix) ? url.substring(corsProxyPrefix.length) : url;
-        const hls = new HLS({
-          xhrSetup: (xhr, u) => {
-            if (u.startsWith(corsProxyPrefix)) {
-              u = u.substring(corsProxyPrefix.length);
+        const setupHls = () => {
+          const hls = new HLS({
+            xhrSetup: (xhr, u) => {
+              if (u.startsWith(corsProxyPrefix)) {
+                u = u.substring(corsProxyPrefix.length);
+              }
+
+              // HACK HLS.js resolves relative urls internally, but our CORS proxying screws it up. Resolve relative to the original unproxied url.
+              // TODO extend HLS.js to allow overriding of its internal resolving instead
+              if (!u.startsWith("http")) {
+                u = buildAbsoluteURL(baseUrl, u.startsWith("/") ? u : `/${u}`);
+              }
+
+              xhr.open("GET", proxiedUrlFor(u));
+            }
+          });
+
+          texture.hls = hls;
+          hls.loadSource(url);
+          hls.attachMedia(videoEl);
+
+          hls.on(HLS.Events.ERROR, function(event, data) {
+            console.log("error");
+            console.log(data);
+            if (data.details === "levelLoadTimeOut") {
+              console.log("Level load timeout, try again");
+              return;
             }
 
-            // HACK HLS.js resolves relative urls internally, but our CORS proxying screws it up. Resolve relative to the original unproxied url.
-            // TODO extend HLS.js to allow overriding of its internal resolving instead
-            if (!u.startsWith("http")) {
-              u = buildAbsoluteURL(baseUrl, u.startsWith("/") ? u : `/${u}`);
+            if (data.fatal) {
+              switch (data.type) {
+                case HLS.ErrorTypes.NETWORK_ERROR:
+                  // try to recover network error
+                  hls.startLoad();
+                  break;
+                case HLS.ErrorTypes.MEDIA_ERROR:
+                  hls.recoverMediaError();
+                  break;
+                default:
+                  reject(event);
+                  return;
+              }
             }
+          });
+        };
 
-            xhr.open("GET", proxiedUrlFor(u));
+        setupHls();
+
+        // Sometimes for weird streams HLS fails to initialize.
+        const setupInterval = setInterval(() => {
+          if (isReady()) {
+            clearInterval(setupInterval);
+          } else {
+            console.warn("HLS failed to read video, trying again");
+            setupHls();
           }
-        });
-        texture.hls = hls;
-        hls.loadSource(url);
-        hls.attachMedia(videoEl);
-        hls.on(HLS.Events.ERROR, function(event, data) {
-          if (data.fatal) {
-            switch (data.type) {
-              case HLS.ErrorTypes.NETWORK_ERROR:
-                // try to recover network error
-                hls.startLoad();
-                break;
-              case HLS.ErrorTypes.MEDIA_ERROR:
-                hls.recoverMediaError();
-                break;
-              default:
-                reject(event);
-                return;
-            }
-          }
-        });
+        }, HLS_TIMEOUT);
         // If not, see if native support will work
       } else if (videoEl.canPlayType(contentType)) {
         videoEl.src = url;
@@ -184,7 +210,7 @@ function createVideoTexture(url, contentType) {
     // NOTE: We used to use the canplay event here to yield the texture, but that fails to fire on iOS Safari
     // and also sometimes in Chrome it seems.
     const poll = () => {
-      if ((texture.image.videoHeight || texture.image.height) && (texture.image.videoWidth || texture.image.width)) {
+      if (isReady()) {
         resolve(texture);
       } else {
         setTimeout(poll, 500);


### PR DESCRIPTION
During the UIST event, we experienced streams not loading via HLS.js. The stream seems to have level loading timeouts and buffer stalls. This hack forces us to retry setting up HLS until it works if we fail to decode the video.

Note that since we are retrying, I had to push `createVideoTexture` into the class so it can avoid retrying if the `this.data.src` has changed as well.
