### PR TITLE
Fix environment map generation

### DIFF
--- a/src/components/skybox.js
+++ b/src/components/skybox.js
@@ -238,6 +238,7 @@ AFRAME.registerComponent("skybox", {
     this.el.setObject3D("mesh", this.sky);
     this.skyScene = new THREE.Scene();
     this.cubeCamera = new THREE.CubeCamera(1, 100000, 512);
+    this.cubeCamera.children.forEach(o => (o.matrixNeedsUpdate = true));
     this.skyScene.add(this.cubeCamera);
 
     this.updateEnvironmentMap = this.updateEnvironmentMap.bind(this);


### PR DESCRIPTION
The cameras used to take snapshots of the skybox for the environment map were not being updated correctly (and probably have not been for some time, likely from a three.js update). This resulted in an environment map with incorrect faces.