### PR TITLE
Fix interaction issues with static media (e.g. 360 images, video)

### DIFF
--- a/src/systems/userinput/devices/app-aware-mouse.js
+++ b/src/systems/userinput/devices/app-aware-mouse.js
@@ -64,8 +64,18 @@ export class AppAwareMouseDevice {
       const isPinned =
         remoteHoverTarget && remoteHoverTarget.components.pinnable && remoteHoverTarget.components.pinnable.data.pinned;
       const isFrozen = AFRAME.scenes[0].is("frozen");
+      const template =
+        remoteHoverTarget &&
+        remoteHoverTarget.components.networked &&
+        remoteHoverTarget.components.networked.data.template;
+      const isStaticControlledMedia = template && template === "#static-controlled-media";
+      const isStaticMedia = template && template === "#static-media";
       this.clickedOnAnything =
-        (isInteractable && (isFrozen || !isPinned) && (remoteHoverTarget && canMove(remoteHoverTarget))) ||
+        (isInteractable &&
+          (isFrozen || !isPinned) &&
+          (remoteHoverTarget && canMove(remoteHoverTarget)) &&
+          !isStaticControlledMedia &&
+          !isStaticMedia) ||
         userinput.activeSets.includes(sets.rightCursorHoldingPen) ||
         userinput.activeSets.includes(sets.rightCursorHoldingInteractable) ||
         userinput.activeSets.includes(sets.rightCursorHoldingCamera);

--- a/src/systems/userinput/devices/app-aware-touchscreen.js
+++ b/src/systems/userinput/devices/app-aware-touchscreen.js
@@ -59,7 +59,18 @@ function shouldMoveCursor(touch, raycaster) {
   const isPinned =
     remoteHoverTarget && remoteHoverTarget.components.pinnable && remoteHoverTarget.components.pinnable.data.pinned;
   const isFrozen = AFRAME.scenes[0].is("frozen");
-  return isInteractable && (isFrozen || !isPinned) && (remoteHoverTarget && canMove(remoteHoverTarget));
+
+  const template =
+    remoteHoverTarget && remoteHoverTarget.components.networked && remoteHoverTarget.components.networked.data.template;
+  const isStaticControlledMedia = template && template === "#static-controlled-media";
+  const isStaticMedia = template && template === "#static-media";
+  return (
+    isInteractable &&
+    (isFrozen || !isPinned) &&
+    !isStaticControlledMedia &&
+    !isStaticMedia &&
+    (remoteHoverTarget && canMove(remoteHoverTarget))
+  );
 }
 
 export class AppAwareTouchscreenDevice {

--- a/src/utils/media-url-utils.js
+++ b/src/utils/media-url-utils.js
@@ -117,7 +117,7 @@ export const guessContentType = url => {
 };
 const hubsSceneRegex = /https?:\/\/(hubs\.local(:\d+)?|(smoke-)?hubs\.mozilla\.com|(dev\.)?reticulum\.io)\/scenes\/(\w+)\/?\S*/;
 const hubsAvatarRegex = /https?:\/\/(hubs\.local(:\d+)?|(smoke-)?hubs\.mozilla\.com|(dev\.)?reticulum\.io)\/avatars\/(?<id>\w+)\/?\S*/;
-const hubsRoomRegex = /(https?:\/\/)?(hub\.link)|(hubs\.local(:\d+)?|(smoke-)?hubs\.mozilla\.com|(dev\.)?reticulum\.io)\/(\w+)\/?\S*/;
+const hubsRoomRegex = /(https?:\/\/)?(hub\.link)|(hubs\.local(:\d+)?|(smoke-)?hubs\.mozilla\.com|(dev\.)?reticulum\.io)\/([a-zA-Z0-9]{7})\/?\S*/;
 
 export const isHubsSceneUrl = hubsSceneRegex.test.bind(hubsSceneRegex);
 export const isHubsRoomUrl = url => !isHubsSceneUrl(url) && hubsRoomRegex.test(url);


### PR DESCRIPTION
This fixes two bugs related to static media.

First: Our hubs room regex erroneously matched some media urls, for example this image used for a 360 projection: https://uploads-prod.reticulum.io/files/e329adfb-6fe2-40c1-8647-c240ab6a5fca.jpg
This caused the `"#static-controlled-media"` template to load in place of `"#static-media"`, causing the following interaction issue downstream.
I tested this fix for the 360 image in this scene:
https://hubs.mozilla.com/scenes/NwA4yx5 
(on dev: https://dev.reticulum.io/scenes/Yh7Yiyj/rolling-hills) 

Second: The mouse and keyboard devices know to prevent camera movement when the user clicks down on an object they want to move around, but also accidentally prevented camera movement when the user clicks on "#static-controlled-media". These changes should hopefully fix https://github.com/mozilla/hubs/issues/1854

I tested this fix for the the 360 videos in these scenes:
https://hubs.mozilla.com/scenes/Lcb9dNa
(on dev: https://dev.reticulum.io/scenes/iwTXWsR/360-music-video-large)

https://hubs.mozilla.com/scenes/Us7xLh2/malta-boat-tour-dingli-cliffs-360
( on dev: https://dev.reticulum.io/scenes/mY6RhnY/malta-boat-tour-dingli-cliffs-360)


