### PR TITLE
Unregister extra mappings added to ViveControllerDevice based gamepads when exiting immersive mode.

### DIFF
--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -268,6 +268,33 @@ AFRAME.registerSystem("userinput", {
     nonVRGamepadMappings.set(XboxControllerDevice, xboxControllerUserBindings);
     nonVRGamepadMappings.set(GamepadDevice, gamepadBindings);
 
+    const addExtraMappings = (activeDevice) => {
+      if (activeDevice instanceof ViveControllerDevice && activeDevice.gamepad) {
+        if (activeDevice.gamepad.id === "OpenVR Cosmos") {
+          //HTC Vive Cosmos Controller
+          this.registeredMappings.add(viveCosmosUserBindings);
+        } else if (activeDevice.gamepad.id === "HTC Vive Focus Plus Controller") {
+          //HTC Vive Focus Plus Controller
+          this.registeredMappings.add(viveFocusPlusUserBindings);
+        } else if (activeDevice.gamepad.axes.length === 4) {
+          //Valve Index Controller
+          this.registeredMappings.add(indexUserBindings);
+        } else {
+          //HTC Vive Controller (wands)
+          this.registeredMappings.add(viveWandUserBindings);
+        }
+      }
+    }
+
+    const deleteExtraMappings = (activeDevice) => {
+      if (activeDevice instanceof ViveControllerDevice && activeDevice.gamepad) {
+        this.registeredMappings.delete(viveCosmosUserBindings);
+        this.registeredMappings.delete(viveFocusPlusUserBindings);
+        this.registeredMappings.delete(indexUserBindings);
+        this.registeredMappings.delete(viveWandUserBindings);
+      }
+    }
+
     const updateBindingsForVRMode = () => {
       const inVRMode = this.el.sceneEl.is("vr-mode");
       const isMobile = AFRAME.utils.device.isMobile();
@@ -280,22 +307,7 @@ AFRAME.registerSystem("userinput", {
           const activeDevice = this.activeDevices.items[i];
           const mapping = vrGamepadMappings.get(activeDevice.constructor);
           mapping && this.registeredMappings.add(mapping);
-
-          if (activeDevice instanceof ViveControllerDevice && activeDevice.gamepad) {
-            if (activeDevice.gamepad.id === "OpenVR Cosmos") {
-              //HTC Vive Cosmos Controller
-              this.registeredMappings.add(viveCosmosUserBindings);
-            } else if (activeDevice.gamepad.id === "HTC Vive Focus Plus Controller") {
-              //HTC Vive Focus Plus Controller
-              this.registeredMappings.add(viveFocusPlusUserBindings);
-            } else if (activeDevice.gamepad.axes.length === 4) {
-              //Valve Index Controller
-              this.registeredMappings.add(indexUserBindings);
-            } else {
-              //HTC Vive Controller (wands)
-              this.registeredMappings.add(viveWandUserBindings);
-            }
-          }
+          addExtraMappings(activeDevice);
         }
 
         // Handle cardboard by looking of VR device caps
@@ -312,6 +324,7 @@ AFRAME.registerSystem("userinput", {
         // remove mappings for all active VR input devices
         for (let i = 0; i < this.activeDevices.items.length; i++) {
           const activeDevice = this.activeDevices.items[i];
+          deleteExtraMappings(activeDevice);
           this.registeredMappings.delete(vrGamepadMappings.get(activeDevice.constructor));
         }
         this.registeredMappings.add(isMobile ? touchscreenUserBindings : keyboardMouseUserBindings);


### PR DESCRIPTION
Currently there is a infinite JavaScript loop in `user_input.js` `dependencySort()` function when exiting immersive mode in Vive devices. The problem is that some extra mappins were added in f7908e69c222c650ed3f9e60f86358f83570066f but they are not deleted when the activeDevice is removed. This causes some dependencies never be resolved in `dependencySort()`

fixes https://github.com/MozillaReality/FirefoxReality/issues/1970

