### PR TITLE
Fix spawner scaling issues

### DIFF
--- a/src/components/clone-media-button.js
+++ b/src/components/clone-media-button.js
@@ -19,14 +19,23 @@ AFRAME.registerComponent("clone-media-button", {
 
     this.onClick = () => {
       const src = this.src;
-      const { contentSubtype, fitToBox } = this.targetEl.components["media-loader"].data;
-      const { entity } = addMedia(src, "#interactable-media", ObjectContentOrigins.URL, contentSubtype, true, fitToBox);
-
+      const { contentSubtype, fitToBox, customMeshScale } = this.targetEl.components["media-loader"].data;
+      const { entity } = addMedia(
+        src,
+        "#interactable-media",
+        ObjectContentOrigins.URL,
+        contentSubtype,
+        true,
+        fitToBox,
+        false,
+        customMeshScale
+      );
+      entity.object3D.scale.copy(this.targetEl.object3D.scale);
       entity.object3D.matrixNeedsUpdate = true;
 
       entity.setAttribute("offset-relative-to", {
         target: "#avatar-pov-node",
-        offset: { x: 0, y: 0, z: -1.5 }
+        offset: { x: 0, y: 0, z: -1.5 * this.targetEl.object3D.scale.z }
       });
     };
   },

--- a/src/components/clone-media-button.js
+++ b/src/components/clone-media-button.js
@@ -19,8 +19,8 @@ AFRAME.registerComponent("clone-media-button", {
 
     this.onClick = () => {
       const src = this.src;
-      const { contentSubtype, resize } = this.targetEl.components["media-loader"].data;
-      const { entity } = addMedia(src, "#interactable-media", ObjectContentOrigins.URL, contentSubtype, true, resize);
+      const { contentSubtype, fitToBox } = this.targetEl.components["media-loader"].data;
+      const { entity } = addMedia(src, "#interactable-media", ObjectContentOrigins.URL, contentSubtype, true, fitToBox);
 
       entity.object3D.matrixNeedsUpdate = true;
 

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -512,6 +512,8 @@ AFRAME.registerComponent("gltf-model-plus", {
         this.el.appendChild(this.inflatedEl);
 
         object3DToSet = this.inflatedEl.object3D;
+        object3DToSet.visible = false;
+
         // TODO: Still don't fully understand the lifecycle here and how it differs between browsers, we should dig in more
         // Wait one tick for the appended custom elements to be connected before attaching templates
         await nextTick();
@@ -551,6 +553,7 @@ AFRAME.registerComponent("gltf-model-plus", {
 
       rewires.forEach(f => f());
 
+      object3DToSet.visible = true;
       this.el.emit("model-loaded", { format: "gltf", model: this.model });
     } catch (e) {
       gltfCache.release(src);

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -44,6 +44,8 @@ AFRAME.registerComponent("media-loader", {
     fileIsOwned: { type: "boolean" },
     src: { type: "string" },
     resize: { default: false },
+    useCustomMeshScale: { default: false },
+    customMeshScale: { default: { x: 1, y: 1, z: 1 } },
     resolve: { default: false },
     contentType: { default: null },
     contentSubtype: { default: null },
@@ -71,11 +73,18 @@ AFRAME.registerComponent("media-loader", {
     const center = new THREE.Vector3();
     return function(resize) {
       const mesh = this.el.getObject3D("mesh");
-      const box = getBox(this.el, mesh);
-      const scaleCoefficient = resize ? getScaleCoefficient(0.5, box) : 1;
-      mesh.scale.multiplyScalar(scaleCoefficient);
-      const { min, max } = box;
-      center.addVectors(min, max).multiplyScalar(0.5 * scaleCoefficient);
+      if (this.data.useCustomMeshScale) {
+        mesh.scale.copy(this.data.customMeshScale);
+        const box = getBox(this.el, mesh);
+        const { min, max } = box;
+        center.addVectors(min, max).multiplyScalar(0.5);
+      } else {
+        const box = getBox(this.el, mesh);
+        const scaleCoefficient = resize ? getScaleCoefficient(0.5, box) : 1;
+        mesh.scale.multiplyScalar(scaleCoefficient);
+        const { min, max } = box;
+        center.addVectors(min, max).multiplyScalar(0.5 * scaleCoefficient);
+      }
       mesh.position.sub(center);
       mesh.matrixNeedsUpdate = true;
     };

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -43,9 +43,8 @@ AFRAME.registerComponent("media-loader", {
     fileId: { type: "string" },
     fileIsOwned: { type: "boolean" },
     src: { type: "string" },
-    resize: { default: false },
-    useCustomMeshScale: { default: false },
-    customMeshScale: { default: { x: 1, y: 1, z: 1 } },
+    fitToBox: { default: false },
+    customMeshScale: { type: "vec3", default: { x: 1, y: 1, z: 1 } },
     resolve: { default: false },
     contentType: { default: null },
     contentSubtype: { default: null },
@@ -71,19 +70,19 @@ AFRAME.registerComponent("media-loader", {
 
   updateScale: (function() {
     const center = new THREE.Vector3();
-    return function(resize) {
+    return function(fitToBox) {
       const mesh = this.el.getObject3D("mesh");
-      if (this.data.useCustomMeshScale) {
+      if (fitToBox) {
+        const box = getBox(this.el, mesh);
+        const scaleCoefficient = getScaleCoefficient(0.5, box);
+        mesh.scale.multiplyScalar(scaleCoefficient);
+        const { min, max } = box;
+        center.addVectors(min, max).multiplyScalar(0.5 * scaleCoefficient);
+      } else {
         mesh.scale.copy(this.data.customMeshScale);
         const box = getBox(this.el, mesh);
         const { min, max } = box;
         center.addVectors(min, max).multiplyScalar(0.5);
-      } else {
-        const box = getBox(this.el, mesh);
-        const scaleCoefficient = resize ? getScaleCoefficient(0.5, box) : 1;
-        mesh.scale.multiplyScalar(scaleCoefficient);
-        const { min, max } = box;
-        center.addVectors(min, max).multiplyScalar(0.5 * scaleCoefficient);
       }
       mesh.position.sub(center);
       mesh.matrixNeedsUpdate = true;
@@ -233,7 +232,7 @@ AFRAME.registerComponent("media-loader", {
     if (this.data.animate) {
       if (!this.animating) {
         this.animating = true;
-        if (shouldUpdateScale) this.updateScale(this.data.resize);
+        if (shouldUpdateScale) this.updateScale(this.data.fitToBox);
         const mesh = this.el.getObject3D("mesh");
         const scale = { x: 0.001, y: 0.001, z: 0.001 };
         scale.x = mesh.scale.x < scale.x ? mesh.scale.x * 0.001 : scale.x;
@@ -242,7 +241,7 @@ AFRAME.registerComponent("media-loader", {
         addMeshScaleAnimation(mesh, scale, finish);
       }
     } else {
-      if (shouldUpdateScale) this.updateScale(this.data.resize);
+      if (shouldUpdateScale) this.updateScale(this.data.fitToBox);
       finish();
     }
   },
@@ -397,7 +396,7 @@ AFRAME.registerComponent("media-loader", {
             contentType: contentType,
             inflate: true,
             batch: !disableBatching && batchMeshes,
-            modelToWorldScale: this.data.resize ? 0.0001 : 1.0
+            modelToWorldScale: this.data.fitToBox ? 0.0001 : 1.0
           })
         );
       } else if (contentType.startsWith("text/html")) {

--- a/src/components/super-spawner.js
+++ b/src/components/super-spawner.js
@@ -24,11 +24,6 @@ AFRAME.registerComponent("super-spawner", {
     resolve: { default: false },
 
     /**
-     * Whether to resize the media on load.
-     */
-    resize: { default: false },
-
-    /**
      * The template to use for this object
      */
     template: { default: "" },
@@ -112,7 +107,8 @@ AFRAME.registerComponent("super-spawner", {
       ObjectContentOrigins.SPAWNER,
       null,
       this.data.resolve,
-      false
+      false,
+      this.data.useCustomSpawnScale ? this.data.spawnScale : { x: 1, y: 1, z: 1 }
     ).entity;
 
     const interaction = this.el.sceneEl.systems.interaction;
@@ -124,10 +120,6 @@ AFRAME.registerComponent("super-spawner", {
     cursor.getWorldPosition(entity.object3D.position);
     cursor.getWorldQuaternion(entity.object3D.quaternion);
     entity.object3D.matrixNeedsUpdate = true;
-
-    if (this.data.useCustomSpawnScale) {
-      entity.object3D.scale.copy(this.data.spawnScale);
-    }
 
     const userinput = AFRAME.scenes[0].systems.userinput;
     const willAnimateFromCursor =

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -115,7 +115,7 @@ AFRAME.GLTFModelPlus.registerComponent("media", "media", (el, componentName, com
 
   el.setAttribute("media-loader", {
     src: componentData.src,
-    resize: componentData.contentSubtype ? false : true,
+    fitToBox: componentData.contentSubtype ? false : true,
     resolve: true,
     fileIsOwned: true,
     animate: false,
@@ -185,7 +185,7 @@ function mediaInflator(el, componentName, componentData, components) {
 
   el.setAttribute("media-loader", {
     src,
-    resize: true,
+    fitToBox: true,
     resolve: true,
     fileIsOwned: true,
     animate: false,

--- a/src/systems/super-spawner-system.js
+++ b/src/systems/super-spawner-system.js
@@ -32,9 +32,8 @@ export class SuperSpawnerSystem {
       ObjectContentOrigins.SPAWNER,
       null,
       data.resolve,
-      data.resize,
+      data.fitToBox,
       false,
-      true,
       targetScale
     ).entity;
 

--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -268,7 +268,7 @@ AFRAME.registerSystem("userinput", {
     nonVRGamepadMappings.set(XboxControllerDevice, xboxControllerUserBindings);
     nonVRGamepadMappings.set(GamepadDevice, gamepadBindings);
 
-    const addExtraMappings = (activeDevice) => {
+    const addExtraMappings = activeDevice => {
       if (activeDevice instanceof ViveControllerDevice && activeDevice.gamepad) {
         if (activeDevice.gamepad.id === "OpenVR Cosmos") {
           //HTC Vive Cosmos Controller
@@ -284,16 +284,16 @@ AFRAME.registerSystem("userinput", {
           this.registeredMappings.add(viveWandUserBindings);
         }
       }
-    }
+    };
 
-    const deleteExtraMappings = (activeDevice) => {
+    const deleteExtraMappings = activeDevice => {
       if (activeDevice instanceof ViveControllerDevice && activeDevice.gamepad) {
         this.registeredMappings.delete(viveCosmosUserBindings);
         this.registeredMappings.delete(viveFocusPlusUserBindings);
         this.registeredMappings.delete(indexUserBindings);
         this.registeredMappings.delete(viveWandUserBindings);
       }
-    }
+    };
 
     const updateBindingsForVRMode = () => {
       const inVRMode = this.el.sceneEl.is("vr-mode");

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -97,10 +97,9 @@ export const addMedia = (
   contentOrigin,
   contentSubtype = null,
   resolve = false,
-  resize = false,
+  fitToBox = false,
   animate = true,
-  useCustomMeshScale = false,
-  customMeshScale = null
+  customMeshScale = { x: 1, y: 1, z: 1 }
 ) => {
   const scene = AFRAME.scenes[0];
 
@@ -108,8 +107,7 @@ export const addMedia = (
   entity.setAttribute("networked", { template: template });
   const needsToBeUploaded = src instanceof File;
   entity.setAttribute("media-loader", {
-    resize,
-    useCustomMeshScale,
+    fitToBox,
     customMeshScale,
     resolve,
     animate,

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -128,7 +128,7 @@ export const addMedia = (
 
   const cb = async () => {
     clearTimeout(fireLoadingTimeout);
-    entity.emit("media-loaded", { src: src });
+    entity.emit("media-loaded", { src });
     eventNames.forEach(eventName => {
       entity.removeEventListener(eventName, cb);
     });


### PR DESCRIPTION
Add functionality to set custom mesh scaling on `media-loader` to fix scaling issues with `super-spawners`. The issue is that local clients must update the `mesh` scale of an object to match that of the spawner scale when an object is spawned, but we currently do not network that and as such the spawned entity's scale on remote clients is incorrect. This PR allows for setting of that scale value on `media-loader` (which _is_ networked) so that remote clients can apply the appropriate scale.

Also updates the `media-loaded` event to not leak memory on unused callbacks and updated `super-spawners` to use this event so that other file types can be supported in spawners.

