### PR TITLE
Fix race condition with scene-owned networked objects

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -236,7 +236,6 @@ AFRAME.registerComponent("media-video", {
   },
 
   init() {
-    console.log("BPDEBUG video init");
     this.onPauseStateChange = this.onPauseStateChange.bind(this);
     this.tryUpdateVideoPlaybackState = this.tryUpdateVideoPlaybackState.bind(this);
     this.updateSrc = this.updateSrc.bind(this);
@@ -287,7 +286,6 @@ AFRAME.registerComponent("media-video", {
 
     NAF.utils.getNetworkedEntity(this.el).then(networkedEl => {
       this.networkedEl = networkedEl;
-      console.log("BPDEBUG applying video persistent first sync", this.networkedEl.components.networked.data.networkId);
       applyPersistentSync(this.networkedEl.components.networked.data.networkId);
       this.updatePlaybackState();
 

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -11,6 +11,7 @@ import { buildAbsoluteURL } from "url-toolkit";
 import { SOUND_CAMERA_TOOL_TOOK_SNAPSHOT } from "../systems/sound-effects-system";
 import { promisifyWorker } from "../utils/promisify-worker.js";
 import pdfjs from "pdfjs-dist";
+import { applyPersistentSync } from "../utils/permissions-utils";
 
 // Using external CDN to reduce build size
 pdfjs.GlobalWorkerOptions.workerSrc =
@@ -235,6 +236,7 @@ AFRAME.registerComponent("media-video", {
   },
 
   init() {
+    console.log("BPDEBUG video init");
     this.onPauseStateChange = this.onPauseStateChange.bind(this);
     this.tryUpdateVideoPlaybackState = this.tryUpdateVideoPlaybackState.bind(this);
     this.updateSrc = this.updateSrc.bind(this);
@@ -285,7 +287,8 @@ AFRAME.registerComponent("media-video", {
 
     NAF.utils.getNetworkedEntity(this.el).then(networkedEl => {
       this.networkedEl = networkedEl;
-      this.networkedEl.components.networked.applyPersistentFirstSync();
+      console.log("BPDEBUG applying video persistent first sync", this.networkedEl.components.networked.data.networkId);
+      applyPersistentSync(this.networkedEl.components.networked.data.networkId);
       this.updatePlaybackState();
 
       // For scene-owned videos, take ownership after a random delay if nobody

--- a/src/hub.js
+++ b/src/hub.js
@@ -478,6 +478,7 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data)
     while (!scene.components["networked-scene"] || !scene.components["networked-scene"].data) await nextTick();
 
     scene.addEventListener("adapter-ready", ({ detail: adapter }) => {
+
       let newHostPollInterval = null;
 
       // When reconnecting, update the server URL if necessary
@@ -528,7 +529,11 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data)
     });
 
     const loadEnvironmentAndConnect = () => {
-      updateEnvironmentForHub(hub);
+      if (qsTruthy("delay")) {
+        setTimeout(() => updateEnvironmentForHub(hub), 10000);
+      } else {
+        updateEnvironmentForHub(hub);
+      }
 
       scene.components["networked-scene"]
         .connect()
@@ -1314,6 +1319,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         scene.addEventListener(
           "didConnectToNetworkedScene",
           () => {
+            console.log("BPDEBUG clientId", NAF.clientId);
             oscillator.stop();
             track.enabled = false;
           },
@@ -1388,7 +1394,11 @@ document.addEventListener("DOMContentLoaded", async () => {
     updateUIForHub(hub);
 
     if (stale_fields.includes("scene")) {
-      updateEnvironmentForHub(hub);
+      if (qsTruthy("delay")) {
+        setTimeout(() => updateEnvironmentForHub(hub), 10000);
+      } else {
+        updateEnvironmentForHub(hub);
+      }
 
       addToPresenceLog({
         type: "scene_changed",

--- a/src/hub.js
+++ b/src/hub.js
@@ -478,7 +478,6 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data)
     while (!scene.components["networked-scene"] || !scene.components["networked-scene"].data) await nextTick();
 
     scene.addEventListener("adapter-ready", ({ detail: adapter }) => {
-
       let newHostPollInterval = null;
 
       // When reconnecting, update the server URL if necessary

--- a/src/hub.js
+++ b/src/hub.js
@@ -529,11 +529,7 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data)
     });
 
     const loadEnvironmentAndConnect = () => {
-      if (qsTruthy("delay")) {
-        setTimeout(() => updateEnvironmentForHub(hub), 20000);
-      } else {
-        updateEnvironmentForHub(hub);
-      }
+      updateEnvironmentForHub(hub);
 
       scene.components["networked-scene"]
         .connect()
@@ -1393,11 +1389,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     updateUIForHub(hub);
 
     if (stale_fields.includes("scene")) {
-      if (qsTruthy("delay")) {
-        setTimeout(() => updateEnvironmentForHub(hub), 20000);
-      } else {
-        updateEnvironmentForHub(hub);
-      }
+      updateEnvironmentForHub(hub);
 
       addToPresenceLog({
         type: "scene_changed",

--- a/src/hub.js
+++ b/src/hub.js
@@ -530,7 +530,7 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data)
 
     const loadEnvironmentAndConnect = () => {
       if (qsTruthy("delay")) {
-        setTimeout(() => updateEnvironmentForHub(hub), 10000);
+        setTimeout(() => updateEnvironmentForHub(hub), 20000);
       } else {
         updateEnvironmentForHub(hub);
       }
@@ -1319,7 +1319,6 @@ document.addEventListener("DOMContentLoaded", async () => {
         scene.addEventListener(
           "didConnectToNetworkedScene",
           () => {
-            console.log("BPDEBUG clientId", NAF.clientId);
             oscillator.stop();
             track.enabled = false;
           },
@@ -1395,7 +1394,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     if (stale_fields.includes("scene")) {
       if (qsTruthy("delay")) {
-        setTimeout(() => updateEnvironmentForHub(hub), 10000);
+        setTimeout(() => updateEnvironmentForHub(hub), 20000);
       } else {
         updateEnvironmentForHub(hub);
       }

--- a/src/utils/permissions-utils.js
+++ b/src/utils/permissions-utils.js
@@ -96,9 +96,7 @@ function getPendingOrExistingEntityMetadata(networkId) {
   }
 
   const entity = NAF.entities.getEntity(networkId);
-  if (!entity) {
-    return null;
-  }
+  if (!entity) return null;
 
   const { template, creator } = entity.components.networked.data;
   const isPinned = entity.components.pinnable && entity.components.pinnable.data.pinned;

--- a/src/utils/permissions-utils.js
+++ b/src/utils/permissions-utils.js
@@ -138,13 +138,6 @@ function stashPersistentSync(message, entityData) {
   }
 }
 
-const PHOENIX_RELIABLE_NAF = "phx-reliable";
-export function applyPersistentSync(networkId) {
-  if (!persistentSyncs[networkId]) return;
-  NAF.connection.adapter.onData(authorizeOrSanitizeMessage(persistentSyncs[networkId]), PHOENIX_RELIABLE_NAF);
-  delete persistentSyncs[networkId];
-}
-
 const emptyObject = {};
 export function authorizeOrSanitizeMessage(message) {
   const { dataType, from_session_id } = message;
@@ -212,4 +205,11 @@ export function authorizeOrSanitizeMessage(message) {
     // Fall through for other data types. Namely, "drawing-<networkId>" messages at the moment.
     return message;
   }
+}
+
+const PHOENIX_RELIABLE_NAF = "phx-reliable";
+export function applyPersistentSync(networkId) {
+  if (!persistentSyncs[networkId]) return;
+  NAF.connection.adapter.onData(authorizeOrSanitizeMessage(persistentSyncs[networkId]), PHOENIX_RELIABLE_NAF);
+  delete persistentSyncs[networkId];
 }


### PR DESCRIPTION
Scene-owned networked objects can become de-synced if a ClientA receives a sync message from ClientB but ClientA has not yet loaded the scene that contains the networked object. 
For example: ClientA is in a room with a scene-owned video, and they pause that video. ClientB enters the room, but while their scene is loading, they receive a video sync from ClientA. Currently we would just drop that message since ClientB does not have the related entity. A similar issue also occurs during scene changes.

We attempted to solve a related issue with a message stash mechanism introduced in https://github.com/mozilla/hubs/pull/1556 and https://github.com/MozillaReality/networked-aframe/pull/33, but that mechanism was applied too late in the network flow -- after the authorization step that may reject messages. This new mechanism replaces the previous attempt.