### PR TITLE
Fix highlight effect on nested objects

### DIFF
--- a/src/components/emoji-hud.js
+++ b/src/components/emoji-hud.js
@@ -23,6 +23,7 @@ AFRAME.registerComponent("emoji-hud", {
     for (let i = 0; i < emojis.length; i++) {
       const spawnerEntity = document.createElement("a-entity");
       const url = new URL(emojis[i], window.location.href).href;
+      spawnerEntity.setAttribute("hoverable-visuals", "");
       spawnerEntity.setAttribute("media-loader", { src: url });
       spawnerEntity.setAttribute("scale", { x: width, y: width, z: width });
       spawnerEntity.setAttribute("is-remote-hover-target", "");

--- a/src/components/hoverable-visuals.js
+++ b/src/components/hoverable-visuals.js
@@ -17,7 +17,7 @@ AFRAME.registerComponent("hoverable-visuals", {
   init() {
     // uniforms and boundingSphere are set from the component responsible for loading the mesh.
     this.uniforms = null;
-    this.boundingSphere = new THREE.Sphere();
+    this.geometryRadius = 0;
     this.scene = AFRAME.scenes[0];
 
     this.sweepParams = [0, 0];
@@ -87,7 +87,11 @@ AFRAME.registerComponent("hoverable-visuals", {
 
     if (interactorOne || interactorTwo || isFrozen) {
       const worldY = this.el.object3D.matrixWorld.elements[13];
-      const scaledRadius = this.el.object3D.scale.y * this.boundingSphere.radius;
+      const ms1 = this.el.object3D.matrixWorld.elements[4];
+      const ms2 = this.el.object3D.matrixWorld.elements[5];
+      const ms3 = this.el.object3D.matrixWorld.elements[6];
+      const worldScale = Math.sqrt(ms1 * ms1 + ms2 * ms2 + ms3 * ms3);
+      const scaledRadius = worldScale * this.geometryRadius;
       this.sweepParams[0] = worldY - scaledRadius;
       this.sweepParams[1] = worldY + scaledRadius;
     }

--- a/src/systems/render-manager/hubs-batch-raw-uniform-group.js
+++ b/src/systems/render-manager/hubs-batch-raw-uniform-group.js
@@ -79,7 +79,11 @@ export default class HubsBatchRawUniformGroup extends BatchRawUniformGroup {
         const hoverableVisuals = el.components["hoverable-visuals"];
         if (hoverableVisuals) {
           const worldY = obj.matrixWorld.elements[13];
-          const scaledRadius = obj.scale.y * hoverableVisuals.boundingSphere.radius;
+          const ms1 = obj.matrixWorld.elements[4];
+          const ms2 = obj.matrixWorld.elements[5];
+          const ms3 = obj.matrixWorld.elements[6];
+          const worldScale = Math.sqrt(ms1 * ms1 + ms2 * ms2 + ms3 * ms3);
+          const scaledRadius = worldScale * hoverableVisuals.geometryRadius;
 
           const isPinned = el.components.pinnable && el.components.pinnable.data.pinned;
           const isSpawner = !!el.components["super-spawner"];

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -189,6 +189,7 @@ export function injectCustomShaderChunks(obj) {
     if (!object.material) return;
 
     object.material = mapMaterials(object, material => {
+      if (material.hubs_InjectedCustomShaderChunks) return material;
       if (!validMaterials.includes(material.type)) {
         return material;
       }
@@ -228,7 +229,7 @@ export function injectCustomShaderChunks(obj) {
           // Used in the fragment shader below.
           hubs_WorldPosition = wt.xyz;
         }
-      `;
+        `;
 
         const vlines = shader.vertexShader.split("\n");
         const vindex = vlines.findIndex(line => vertexRegex.test(line));
@@ -256,6 +257,7 @@ export function injectCustomShaderChunks(obj) {
         shaderUniforms.push(shader.uniforms);
       };
       newMaterial.needsUpdate = true;
+      newMaterial.hubs_InjectedCustomShaderChunks = true;
       return newMaterial;
     });
   });


### PR DESCRIPTION
There were a couple of issues with the highlight effect on nested objects. Firstly, the custom shader chunks were being injected twice, once when the emoji was loaded and again when the avatar model loaded (since we inject shaders recursively). Secondly the highlight math assumed objects were on the root. This was fixed by calculating the world scale on the object manually and un-scaling the calculated geometry radius.