### PR TITLE
Fix quality query param parsing

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -172,7 +172,7 @@ if (isEmbed && !qs.get("embed_token")) {
 }
 
 THREE.Object3D.DefaultMatrixAutoUpdate = false;
-window.APP.quality = qs.get("quality") || (isMobile || isMobileVR) ? "low" : "high";
+window.APP.quality = qs.get("quality") || (isMobile || isMobileVR ? "low" : "high");
 
 import "./components/owned-object-limiter";
 import "./components/set-unowned-body-kinematic";


### PR DESCRIPTION
Currently, there is an issue with quality query param parsing. When a not empty param is specified, current parsing will set quality to low. 