### PR TITLE
Increase near clipping plane distance

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -1099,7 +1099,7 @@
         <a-entity id="viewing-rig" set-yxz-order matrix-auto-update>
             <a-entity
                 id="viewing-camera"
-                camera
+                camera="near: 0.05"
                 set-active-camera
                 rotation
                 set-yxz-order

--- a/src/scene.html
+++ b/src/scene.html
@@ -48,7 +48,7 @@
             static-body="shape: none;"
         ></a-entity>
 
-        <a-camera id="camera" fov="80" look-controls="enabled: false" wasd-controls="enabled: false"></a-camera>
+        <a-camera id="camera" fov="80" near="0.05" look-controls="enabled: false" wasd-controls="enabled: false"></a-camera>
     </a-scene>
 
     <div id="ui-root"></div>


### PR DESCRIPTION
I think we should increase the near clipping plane distance from AFrame's default `0.005` to `0.05` in order to improve floating point precision in large scenes. The result should be fewer jittery objects in large scenes. The downside is clipping at very close distances, however in my testing the difference between the two clipping plane distances was not noticeable.