### PR TITLE
Fix coloring of several links in overlay panels

### DIFF
--- a/src/assets/stylesheets/avatar-editor.scss
+++ b/src/assets/stylesheets/avatar-editor.scss
@@ -107,7 +107,7 @@
       }
       a {
         margin-left: 10px;
-        color: $action-label-color;
+        color: var(--panel-subtext-link-color);
       }
     }
 
@@ -199,6 +199,10 @@
 
     .license {
       font-size: 8pt;
+      color: var(--panel-subtext-color);
+      a {
+        color: var(--panel-subtext-link-color)
+      }
     }
 
     hr {
@@ -242,7 +246,7 @@
   }
 
   .delete-avatar {
-    color: var(--panel-subtext-link-color);
+    color: var(--panel-subtext-color);
     a {
       cursor: pointer;
       text-decoration: underline;
@@ -254,6 +258,7 @@
     font-size: 1.6em;
     align-self: flex-start;
     cursor: pointer;
+    color: var(--panel-widget-color);
     @media (max-width: 768px) {
       padding-left: 0.5em;
     }

--- a/src/assets/stylesheets/profile.scss
+++ b/src/assets/stylesheets/profile.scss
@@ -57,7 +57,7 @@
 
       a {
         margin: 0px 12px;
-        color: var(--tile-inset-text);
+        color: var(--panel-subtext-link-color);
       }
     }
   }
@@ -143,5 +143,6 @@
     height: 35px;
     position: absolute;
     font-size: 1.6em;
+    color: var(--panel-widget-color);
   }
 }

--- a/src/assets/stylesheets/root-vars.scss
+++ b/src/assets/stylesheets/root-vars.scss
@@ -70,7 +70,7 @@
   --panel-widget-disabled-color: #{$dark-grey};
   --panel-title-underline-color: #{$dark-grey};
   --panel-subtitle-color: #{$dark-grey};
-  --panel-subtext-color: #{$off-white};
+  --panel-subtext-color: #{$grey-text};
   --panel-subtext-link-color: #{$dark-grey};
   --panel-subtext-disabled-color: #{$light-grey};
   --panel-icon-color: #{$darker-grey};
@@ -160,7 +160,7 @@
   --panel-widget-disabled-color: #{$dark-grey};
   --panel-title-underline-color: #{$dark-grey};
   --panel-subtitle-color: #{$light-grey};
-  --panel-subtext-color: #{$grey-text};
+  --panel-subtext-color: #{$off-white};
   --panel-subtext-link-color: #{$dark-grey};
   --panel-subtext-disabled-color: #{$darker-grey};
   --panel-icon-color: #{$dark-grey};


### PR DESCRIPTION
Fixed text color for a few things in the overlay panels like the avatar editor, media browser, and scene info panel. Also fixed the close button color in these panels so it is consistent.

Fixes #1907