### PR TITLE
Add external skin editor links to the avatar editor

### DIFF
--- a/src/assets/stylesheets/avatar-editor.scss
+++ b/src/assets/stylesheets/avatar-editor.scss
@@ -30,6 +30,9 @@
     p {
       margin: 0;
       margin-bottom: 0.5em;
+      a {
+        margin-right: 5px;
+      }
     }
 
     a {

--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -105,7 +105,7 @@
     "profile.tabs.url": "Custom Model",
     "avatar-editor.info": "Find more custom avatar resources",
     "avatar-editor.info-link": "here",
-    "avatar-editor.quilt-link": "Create a custom avatar skin with Quilt",
+    "avatar-editor.external-editor-info": "Create a custom skin for this avatar: ",
     "avatar-preview.loading-failed": "Loading failed\nPlease choose another avatar",
     "media-browser.search-placeholder.scenes": "Search Scenes...",
     "media-browser.search-placeholder.avatars": "Search Avatars...",

--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -530,7 +530,7 @@ export default class AvatarEditor extends Component {
                       key={name}
                       target="_blank"
                       rel="noopener noreferrer"
-                      href={url.replace("$AVATAR_GLTF", this.state.previewGltfUrl)}
+                      href={url.replace("$AVATAR_GLTF", encodeURIComponent(this.state.previewGltfUrl))}
                     >
                       {name}
                     </a>

--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -24,6 +24,18 @@ const defaultEditors = [
     url: "https://tryquilt.io/?gltf=$AVATAR_GLTF"
   }
 ];
+const useEditorWhitelist = true;
+const editorWhitelist = [
+  ...defaultEditors,
+  {
+    name: "Skindex Editor",
+    url: "https://www.minecraftskins.com/skin-editor"
+  },
+  {
+    name: "MinecraftSkins.net Editor",
+    url: "https://www.minecraftskins.net/skineditor"
+  }
+];
 
 const fetchAvatar = async avatarId => {
   const { avatars } = await fetchReticulumAuthenticated(`${AVATARS_API}/${avatarId}`);
@@ -416,13 +428,12 @@ export default class AvatarEditor extends Component {
   );
 
   handleGltfLoaded = gltf => {
-    const json = gltf.parser.json;
-    if (json.extensionsUsed && json.extensionsUsed.indexOf("MOZ_hubs_avatar") !== -1) {
-      const hubsAvatarMeta = json.extensions["MOZ_hubs_avatar"];
-      this.setState({ editorLinks: hubsAvatarMeta.editors || defaultEditors });
-    } else {
-      this.setState({ editorLinks: defaultEditors });
+    const ext = gltf.parser.json.extensions && gltf.parser.json.extensions["MOZ_hubs_avatar"];
+    let editorLinks = (ext && ext.editors) || defaultEditors;
+    if (useEditorWhitelist) {
+      editorLinks = editorLinks.filter(e => editorWhitelist.some(w => w.name === e.name && w.url === e.url));
     }
+    this.setState({ editorLinks });
   };
 
   render() {

--- a/src/react-components/avatar-preview.js
+++ b/src/react-components/avatar-preview.js
@@ -62,7 +62,8 @@ function fitBoxInFrustum(camera, box, center, margin = DEFAULT_MARGIN) {
 class AvatarPreview extends Component {
   static propTypes = {
     avatarGltfUrl: PropTypes.string,
-    className: PropTypes.string
+    className: PropTypes.string,
+    onGltfLoaded: PropTypes.func
   };
   constructor(props) {
     super(props);
@@ -187,13 +188,13 @@ class AvatarPreview extends Component {
     this.applyMaps(oldProps, this.props);
   };
 
-  loadCurrentAvatarGltfUrl() {
+  async loadCurrentAvatarGltfUrl() {
     const newLoadId = ++this.loadId;
-    return this.loadPreviewAvatar(this.props.avatarGltfUrl).then(avatar => {
-      // If we had started loading another avatar while we were loading this one, throw this one away
-      if (newLoadId !== this.loadId) return;
-      this.setAvatar(avatar);
-    });
+    const gltf = await this.loadPreviewAvatar(this.props.avatarGltfUrl);
+    // If we had started loading another avatar while we were loading this one, throw this one away
+    if (newLoadId !== this.loadId) return;
+    if (gltf && this.props.onGltfLoaded) this.props.onGltfLoaded(gltf);
+    this.setAvatar(gltf.scene);
   }
 
   applyMaps(oldProps, newProps) {
@@ -267,7 +268,7 @@ class AvatarPreview extends Component {
       this.originalMaps = {};
     }
 
-    return gltf.scene;
+    return gltf;
   };
 
   applyMapToPreview = (name, image) => {

--- a/src/schema.toml
+++ b/src/schema.toml
@@ -20,7 +20,7 @@ features.show_features_link = { category = "features", type = "boolean", name = 
 features.show_community_link = { category = "features", type = "boolean", name = "Show Community Links", description = "Show links to your community." }
 features.show_company_logo = { category = "features", type = "boolean", name = "Show Company Logo", description = "Show the company logo across the app." }
 features.show_issue_report_link = { category = "features", type = "boolean", name = "Show Issue Report Link", description = "Show a link for reporting issues." }
-features.show_avatar_editor_link = { category = "features", type = "boolean", name = "Show Avatar Editor Links", description = "Show links to avatar editors like Quilt." }
+features.show_avatar_editor_link = { category = "features", type = "boolean", name = "Show Avatar Editor Links", description = "Show links to avatar editors like Quilt.", internal = "true" }
 features.show_avatar_pipelines_link = { category = "features", type = "boolean", name = "Show Avatar Pipelines Links", description = "Show links to avatar pipeline info." }
 features.show_model_collection_link = { category = "features", type = "boolean", name = "Show Model Collection Link", description = "Show link to a collection of models." }
 features.hide_powered_by = { category = "features", type = "boolean", name = "Hide Powered By Hubs", description = "Hides the 'Powered by Hubs Cloud' notice on the home page and loading screens." }


### PR DESCRIPTION
Expose links to external skin editors in the avatar edit screen if they are embedded in the selected GLTF. This is done through the `MOZ_hubs_avatar` extension, like:

```json
    "extensionsUsed": [
        "MOZ_hubs_avatar"
    ],
    "extensions":{
        "MOZ_hubs_avatar":{
            "editors":[
                {
                    "name": "Skindex Editor",
                    "url": "https://www.minecraftskins.com/skin-editor"
                },
                {
                    "name": "MinecraftSkins.net Editor",
                    "url": "https://www.minecraftskins.net/skineditor"
                }
            ]
        }
    },
```
Currently the set of editors that will actually be displayed is run through a whitelist and only includes Quilt, minecraftskins.com, and minecraftskins.net. If this proves to be useful we will probably ditch the whitelist and expose it in the admin dashboard as part of the review process.

Urls can also include the placeholder `$AVATAR_GLTF`, which will be replaced with the gltf url for the selected avatar. Quilt has been updated to include this in its url to facilitate more generic editing in quilt.