### PR TITLE
Improve networked-drawing initialization

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -828,7 +828,7 @@
 
         <a-entity id="camera-counter" networked-counter="max: 1;"></a-entity>
 
-        <a-entity id="drawing-manager" drawing-manager></a-entity>
+        <a-entity id="drawing-manager" drawing-manager="penSpawner: #pen-spawner"></a-entity>
 
         <a-entity
             id="right-cursor-controller"
@@ -1077,6 +1077,7 @@
         </a-entity>
 
         <a-entity
+            id="pen-spawner"
             action-to-event="path: /actions/spawnPen; event: spawn_pen; withPermission: spawn_drawing"
             super-spawner="
                 template: #interactable-pen;


### PR DESCRIPTION
Drawings sometimes fail to "draw" correctly for the first few frames when a drawing is created for the first time due to needing to asynchronously wait for components to initialize. This PR moves the drawing initialization to when a pen is spawned for the first time. It also refactors how promises are being used so that duplicate promises won't be created. 