### PR TITLE
Fix getNetworkedEntity exception spam on load

### DIFF
--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -60,9 +60,12 @@ AFRAME.registerComponent("media-loader", {
     this.onMediaLoaded = this.onMediaLoaded.bind(this);
     this.animating = false;
 
-    NAF.utils.getNetworkedEntity(this.el).then(networkedEl => {
-      this.networkedEl = networkedEl;
-    });
+    NAF.utils
+      .getNetworkedEntity(this.el)
+      .then(networkedEl => {
+        this.networkedEl = networkedEl;
+      })
+      .catch(() => {}); //ignore exception, entity might not be networked
   },
 
   updateScale: (function() {
@@ -483,9 +486,12 @@ AFRAME.registerComponent("media-pager", {
     this.onNext = this.onNext.bind(this);
     this.onPrev = this.onPrev.bind(this);
 
-    NAF.utils.getNetworkedEntity(this.el).then(networkedEl => {
-      this.networkedEl = networkedEl;
-    });
+    NAF.utils
+      .getNetworkedEntity(this.el)
+      .then(networkedEl => {
+        this.networkedEl = networkedEl;
+      })
+      .catch(() => {}); //ignore exception, entity might not be networked
 
     this.el.addEventListener("pdf-loaded", async () => {
       await this._ensureUI();
@@ -534,7 +540,7 @@ AFRAME.registerComponent("media-pager", {
   },
 
   onNext() {
-    if (!NAF.utils.isMine(this.networkedEl) && !NAF.utils.takeOwnership(this.networkedEl)) return;
+    if (this.networkedEl && !NAF.utils.isMine(this.networkedEl) && !NAF.utils.takeOwnership(this.networkedEl)) return;
     const newIndex = Math.min(this.data.index + 1, this.data.maxIndex);
     this.el.setAttribute("media-pdf", "index", newIndex);
     this.el.setAttribute("media-pager", "index", newIndex);
@@ -542,7 +548,7 @@ AFRAME.registerComponent("media-pager", {
   },
 
   onPrev() {
-    if (!NAF.utils.isMine(this.networkedEl) && !NAF.utils.takeOwnership(this.networkedEl)) return;
+    if (this.networkedEl && !NAF.utils.isMine(this.networkedEl) && !NAF.utils.takeOwnership(this.networkedEl)) return;
     const newIndex = Math.max(this.data.index - 1, 0);
     this.el.setAttribute("media-pdf", "index", newIndex);
     this.el.setAttribute("media-pager", "index", newIndex);

--- a/src/components/visibility-while-frozen.js
+++ b/src/components/visibility-while-frozen.js
@@ -47,9 +47,14 @@ AFRAME.registerComponent("visibility-while-frozen", {
       console.error("Didn't find a remote hover target.");
     }
 
-    NAF.utils.getNetworkedEntity(this.el).then(networkedEl => {
-      this.networkedEl = networkedEl;
-    });
+    if (!this.data.visibleIfOwned) {
+      NAF.utils
+        .getNetworkedEntity(this.el)
+        .then(networkedEl => {
+          this.networkedEl = networkedEl;
+        })
+        .then(() => {}); //ignore exception, entity might not be networked
+    }
 
     this.onStateChange = evt => {
       if (!evt.detail === "frozen") return;


### PR DESCRIPTION
Add empty catch conditions in the case that `getNetworkedEntity` fails on entities that are not networked.
This prevents `Uncaught (in promise) Entity does not have and is not a child of an entity with the [networked] component` from being spammed on load. 