### PR TITLE
Force WebVR instead of WebXR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3218,7 +3218,7 @@
       "integrity": "sha1-0ME1RB+oAUqBN5BFMQlvZ/KPJjo="
     },
     "aframe": {
-      "version": "github:mozillareality/aframe#1d216f1e179150b5b6db53c85c93125197ccdac7",
+      "version": "github:mozillareality/aframe#d3f8f916897b07c939096e84cc97cbd6a8bab5f4",
       "from": "github:mozillareality/aframe#hubs/master",
       "requires": {
         "animejs": "github:mozillareality/anime#hubs/master",
@@ -5750,13 +5750,13 @@
       "dev": true
     },
     "cardboard-vr-display": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/cardboard-vr-display/-/cardboard-vr-display-1.0.16.tgz",
-      "integrity": "sha512-GFBWPMH/ixy4Ji014BAO1ryddGHphtJlA8gUR6UdKsOpPjUQukCKpgsx2XIJ5oBlqXnDQOcLVRqBWyuvTI32jQ==",
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/cardboard-vr-display/-/cardboard-vr-display-1.0.18.tgz",
+      "integrity": "sha512-G1UEitQBT3pODLnMx37xv9JyZktCBTkwjxS4Vz9KmYL0Ln+Crm/CI7o4WEqAyS6xZjxR3cAvcClou1edX/JUbA==",
       "requires": {
         "gl-preserve-state": "^1.0.0",
         "nosleep.js": "^0.7.0",
-        "webvr-polyfill-dpdb": "^1.0.11"
+        "webvr-polyfill-dpdb": "^1.0.17"
       }
     },
     "caseless": {
@@ -16853,7 +16853,7 @@
       "dev": true
     },
     "three": {
-      "version": "github:mozillareality/three.js#7456c6392ade9815104a0f17188bfd3f940799b3",
+      "version": "github:mozillareality/three.js#8d145082107f0a67580fc617c26b39182b5236cc",
       "from": "github:mozillareality/three.js#hubs/master"
     },
     "three-ammo": {
@@ -18307,17 +18307,17 @@
       "dev": true
     },
     "webvr-polyfill": {
-      "version": "0.10.10",
-      "resolved": "https://registry.npmjs.org/webvr-polyfill/-/webvr-polyfill-0.10.10.tgz",
-      "integrity": "sha512-WdKQ1XR9X2Gj9RUtmr+DajvWBWPva75m1rm0Z7CibR7ZstCm913zHYToxw0p/EK342wAxGfiWKsBmb3Jd5OO0w==",
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/webvr-polyfill/-/webvr-polyfill-0.10.11.tgz",
+      "integrity": "sha512-mzTuMpC3W/aKmm5QxYtTzXAxhVo3tR4c0D5Kihk8Q38GVxiCOvS4Ga4LBN8CsFVpXu1WkGeuf/hMzF75iWYiyA==",
       "requires": {
-        "cardboard-vr-display": "^1.0.16"
+        "cardboard-vr-display": "^1.0.18"
       }
     },
     "webvr-polyfill-dpdb": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/webvr-polyfill-dpdb/-/webvr-polyfill-dpdb-1.0.16.tgz",
-      "integrity": "sha512-FCciTtPhwkYYHGL0K67G8k7ZnNVqnEx3u4NVHLJ0+Ya6f2VTZUl/GJpaEo1Id2pBP/2l0RYZ3IGZE4Pe8fRalg=="
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/webvr-polyfill-dpdb/-/webvr-polyfill-dpdb-1.0.17.tgz",
+      "integrity": "sha512-WOd4s0gSrb0fOlOtIpqFbwLBATax/ka7DFAB/u+C9KJBBJk1/x/FZlFynOqsNrUxMJniOdO7ViFJwVdMScMQzA=="
     },
     "well-known-symbols": {
       "version": "2.0.0",

--- a/src/hub.html
+++ b/src/hub.html
@@ -52,7 +52,15 @@
         capture-system
         local-audio-analyser
         class="grab-cursor"
-        renderer="antialias: true; colorManagement: true; sortObjects: true; physicallyCorrectLights: true; alpha: false; webgl2: true; multiview: false; forceWebVR: true;"
+        renderer="
+            antialias: true;
+            colorManagement: true;
+            sortObjects: true;
+            physicallyCorrectLights: true;
+            alpha: false;
+            webgl2: true;
+            multiview: false;
+            forceWebVR: true;"
         shadow="type: pcfsoft"
         networked-scene="adapter: janus; audio: true; debug: true; connectOnLoad: false;"
         mute-mic="eventSrc: a-scene; toggleEvents: action_mute"

--- a/src/hub.html
+++ b/src/hub.html
@@ -24,8 +24,12 @@
         HACK Another hack to fix a-frame's device detection in Chrome when WebXR or WebVR flags are enabled in
         chrome://flags. See https://github.com/mozilla/hubs/issues/892
         */
-        if (navigator.xr && !navigator.xr.requestDevice) {
+        if (!/Oculus/.test(navigator.userAgent) && navigator.xr && !navigator.xr.requestDevice) {
             navigator.xr.requestDevice = () => Promise.reject({message: "Hubs: requestDevice not supported."});
+        }
+        // Call getVRDisplays to force Oculus Browser to use WebVR, which in turn disables the WebXR API.
+        if (/Oculus/.test(navigator.userAgent)) {
+            navigator.getVRDisplays();
         }
     </script>
     <!-- Google Analytics -->
@@ -48,7 +52,7 @@
         capture-system
         local-audio-analyser
         class="grab-cursor"
-        renderer="antialias: true; colorManagement: true; sortObjects: true; physicallyCorrectLights: true; alpha: false; webgl2: true; multiview: false;"
+        renderer="antialias: true; colorManagement: true; sortObjects: true; physicallyCorrectLights: true; alpha: false; webgl2: true; multiview: false; forceWebVR: true;"
         shadow="type: pcfsoft"
         networked-scene="adapter: janus; audio: true; debug: true; connectOnLoad: false;"
         mute-mic="eventSrc: a-scene; toggleEvents: action_mute"

--- a/src/hub.js
+++ b/src/hub.js
@@ -927,7 +927,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     remountUI({ availableVREntryTypes, forcedVREntryType: "vr" });
 
     if (/Oculus/.test(navigator.userAgent)) {
-      // HACK - The polyfill reports Cardboard as the primary VR display on startup out ahead of Oculus Go on Oculus Browser 5.5.0 beta. This display is cached by A-Frame,
+      // HACK - The polyfill reports Cardboard as the primary VR display on startup out ahead of
+      // Oculus Go on Oculus Browser 5.5.0 beta. This display is cached by A-Frame,
       // so we need to resolve that and get the real VRDisplay before entering as well.
       const displays = await navigator.getVRDisplays();
       const vrDisplay = displays.length && displays[0];

--- a/src/scene.html
+++ b/src/scene.html
@@ -20,8 +20,12 @@
         HACK Another hack to fix a-frame's device detection in Chrome when WebXR or WebVR flags are enabled in
         chrome://flags. See https://github.com/mozilla/hubs/issues/892
         */
-        if (navigator.xr && !navigator.xr.requestDevice) {
+        if (!/Oculus/.test(navigator.userAgent) && navigator.xr && !navigator.xr.requestDevice) {
             navigator.xr.requestDevice = () => Promise.reject({message: "Hubs: requestDevice not supported."});
+        }
+        // Call getVRDisplays to force Oculus Browser to use WebVR, which in turn disables the WebXR API.
+        if (/Oculus/.test(navigator.userAgent)) {
+            navigator.getVRDisplays();
         }
     </script>
     <!-- Google Analytics -->
@@ -39,7 +43,13 @@
 <body>
     <a-scene
         loading-screen="enabled: false"
-        renderer="antialias: true; gammaOutput: true; sortObjects: true; physicallyCorrectLights: true; colorManagement: true; alpha: false;"
+        renderer="
+            antialias: true;
+            gammaOutput: true;
+            sortObjects: true;
+            physicallyCorrectLights: true;
+            colorManagement: true;
+            alpha: false;"
         shadow="type: pcfsoft"
         environment-map
     >


### PR DESCRIPTION
We need to be able to force WebVR on the Oculus Browser for the time being since they might release a version of the browser with WebXR enabled by default. This is a temporary fix until we support WebXR fully.

Goes with: 
- https://github.com/MozillaReality/three.js/pull/44
- https://github.com/MozillaReality/aframe/pull/23