### PR TITLE
Set matrixNeedsUpdate flag after physics sync

### DIFF
--- a/src/systems/physics-system.js
+++ b/src/systems/physics-system.js
@@ -69,6 +69,7 @@ export class PhysicsSystem {
       for (let i = 0; i < this.bodies.length; i++) {
         if (this.bodies[i].type === TYPE.DYNAMIC) {
           this.bodies[i].syncFromPhysics();
+          this.bodies[i].object3D.matrixNeedsUpdate = true;
         }
       }
     }


### PR DESCRIPTION
This PR sets the `matrixNeedsUpdate` flag after `syncFromPhysics` alters the `position` and `rotation` of the `Object3D`s :
 https://github.com/InfiniteLee/three-ammo/blob/fe57353506b79627a5b2e9b0feba4a2fe52b745c/src/body.js#L329

This is a prerequisite for removing the `matrix-auto-update` component, which causes more work to be done in `updateMatrices` for this entity, which we call before reading the `matrix` or the `matrixWorld` of its `object3D` :
https://github.com/mozilla/hubs/blob/b6752f3bd1601c8ad668dcd54d40610098c2e096/src/utils/threejs-world-update.js#L125