### PR TITLE
More reliable head handling in camera tool

### DIFF
--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -552,8 +552,6 @@ AFRAME.registerComponent("camera-tool", {
   },
 
   tock: (function() {
-    const tempHeadScale = new THREE.Vector3();
-
     return function tock() {
       const sceneEl = this.el.sceneEl;
       const renderer = this.renderer || sceneEl.renderer;
@@ -578,11 +576,7 @@ AFRAME.registerComponent("camera-tool", {
         this.takeSnapshotNextTick ||
         (this.updateRenderTargetNextTick && (this.viewfinderInViewThisFrame || this.videoRecorder))
       ) {
-        let tempHeadVisible;
         if (playerHead) {
-          tempHeadVisible = playerHead.visible;
-          tempHeadScale.copy(playerHead.scale);
-
           // We want to scale our own head in between frames now that we're taking a video/photo.
           let scale = 1;
           // TODO: The local-audio-analyser has the non-networked media stream, which is active
@@ -595,7 +589,7 @@ AFRAME.registerComponent("camera-tool", {
           }
 
           playerHead.visible = true;
-          playerHead.scale.set(scale, scale, scale);
+          playerHead.el.components["bone-visibility"].tick();
           playerHead.updateMatrices(true, true);
           playerHead.updateMatrixWorld(true, true);
         }
@@ -640,8 +634,8 @@ AFRAME.registerComponent("camera-tool", {
         renderer.vr.enabled = tmpVRFlag;
         sceneEl.object3D.onAfterRender = tmpOnAfterRender;
         if (playerHead) {
-          playerHead.visible = tempHeadVisible;
-          playerHead.scale.copy(tempHeadScale);
+          playerHead.visible = false;
+          playerHead.el.components["bone-visibility"].tick();
           playerHead.updateMatrices(true, true);
           playerHead.updateMatrixWorld(true, true);
         }

--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -589,7 +589,9 @@ AFRAME.registerComponent("camera-tool", {
           }
 
           playerHead.visible = true;
-          playerHead.el.components["bone-visibility"].tick();
+          playerHead.scale.set(scale, scale, scale);
+          playerHead.updateMatrices(true, true);
+          playerHead.updateMatrixWorld(true, true);
         }
 
         let playerHudWasVisible = false;
@@ -633,7 +635,9 @@ AFRAME.registerComponent("camera-tool", {
         sceneEl.object3D.onAfterRender = tmpOnAfterRender;
         if (playerHead) {
           playerHead.visible = false;
-          playerHead.el.components["bone-visibility"].tick();
+          playerHead.scale.set(0.00000001, 0.00000001, 0.00000001);
+          playerHead.updateMatrices(true, true);
+          playerHead.updateMatrixWorld(true, true);
         }
         if (this.playerHud) {
           this.playerHud.visible = playerHudWasVisible;

--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -590,8 +590,6 @@ AFRAME.registerComponent("camera-tool", {
 
           playerHead.visible = true;
           playerHead.el.components["bone-visibility"].tick();
-          playerHead.updateMatrices(true, true);
-          playerHead.updateMatrixWorld(true, true);
         }
 
         let playerHudWasVisible = false;
@@ -636,8 +634,6 @@ AFRAME.registerComponent("camera-tool", {
         if (playerHead) {
           playerHead.visible = false;
           playerHead.el.components["bone-visibility"].tick();
-          playerHead.updateMatrices(true, true);
-          playerHead.updateMatrixWorld(true, true);
         }
         if (this.playerHud) {
           this.playerHud.visible = playerHudWasVisible;


### PR DESCRIPTION
If the avatar's head has an animation (or something else) messing with its scale, its possible for it to get into a broken state where the head is never re-hidden. This fixes it by just always assuming the head state should be invisible rather than trying to restore some previous state. 

The underlying issue still remains, that we need to do something to handle head animations or find a better way of actually hiding the head.