### PR TITLE
Disable motion and add willDisableTeleporting

### DIFF
--- a/src/components/teleporter.js
+++ b/src/components/teleporter.js
@@ -188,7 +188,7 @@ AFRAME.registerComponent("teleporter", {
     const { start, confirm, speed } = this.data;
     const object3D = this.el.object3D;
 
-    if (!this.isTeleporting && userinput.get(start)) {
+    if (!this.isTeleporting && userinput.get(start) && !this.characterController.isTeleportingDisabled) {
       this.isTeleporting = true;
       this.timeTeleporting = 0;
       this.hit = false;
@@ -266,6 +266,9 @@ AFRAME.registerComponent("teleporter", {
         collidedIndex = i;
         break;
       }
+    }
+    if (this.characterController.isTeleportingDisabled) {
+      this.hit = false;
     }
 
     const percentToDraw = this.timeTeleporting > DRAW_TIME_MS ? 1 : this.timeTeleporting / DRAW_TIME_MS;

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -90,6 +90,7 @@ AFRAME.GLTFModelPlus.registerComponent("spawn-point", "spawn-point", el => {
     canBeOccupied: false,
     canBeClicked: false,
     willDisableMotion: false,
+    willDisableTeleporting: false,
     willMaintainWorldUp: true
   });
 });

--- a/src/react-components/object-info-dialog.js
+++ b/src/react-components/object-info-dialog.js
@@ -77,6 +77,7 @@ export default class ObjectInfoDialog extends Component {
 
       this.props.scene.systems["hubs-systems"].characterController.enqueueWaypointTravelTo(targetMatrix, true, {
         willDisableMotion: false,
+        willDisableTeleporting: false,
         snapToNavMesh: false,
         willMaintainInitialOrientation: false
       });

--- a/src/systems/character-controller-system.js
+++ b/src/systems/character-controller-system.js
@@ -156,7 +156,7 @@ export class CharacterControllerSystem {
       if (!this.activeWaypoint && this.waypoints.length) {
         this.activeWaypoint = this.waypoints.splice(0, 1)[0];
         this.isMotionDisabled = this.activeWaypoint.waypointComponentData.willDisableMotion;
-        this.triedToMoveCount = 0;
+        this.isTeleportingDisabled = this.activeWaypoint.waypointComponentData.willDisableTeleporting;
         this.avatarPOV.object3D.updateMatrices();
         this.waypointTravelTime =
           (vrMode && !qsAllowWaypointLerp) || this.activeWaypoint.isInstant
@@ -259,11 +259,6 @@ export class CharacterControllerSystem {
       );
       const triedToMove = displacementToDesiredPOV.lengthSq() > 0.001;
       const squareDistanceToNavSnappedPOVPosition = desiredPOVPosition.distanceToSquared(navMeshSnappedPOVPosition);
-      this.triedToMoveCount += triedToMove ? 1 : 0;
-      if (this.triedToMoveCount > 20) {
-        // TODO: Show tip indicating that you are stuck and will get unstuck if you keep trying.
-        this.isMotionDisabled = false;
-      }
 
       if (this.isMotionDisabled) {
         childMatch(this.avatarRig.object3D, this.avatarPOV.object3D, snapRotatedPOV);

--- a/src/systems/waypoint-system.js
+++ b/src/systems/waypoint-system.js
@@ -342,6 +342,7 @@ AFRAME.registerComponent("waypoint", {
     canBeOccupied: { default: false },
     canBeClicked: { default: false },
     willDisableMotion: { default: false },
+    willDisableTeleporting: { default: false },
     snapToNavMesh: { default: false },
     willMaintainInitialOrientation: { default: false },
     willMaintainWorldUp: { default: true },


### PR DESCRIPTION
This PR enforces the `willDisableMotion` flag on waypoints in the obvious way, and adds the `willDisableTeleporting` flag.

Accompanies https://github.com/mozilla/Spoke/pull/855