### PR TITLE
Rework text bubbles to always use 1024 textures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10204,7 +10204,7 @@
     },
     "indent-string": {
       "version": "2.1.0",
-      "resolved": "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
@@ -10349,7 +10349,7 @@
     },
     "invert-kv": {
       "version": "1.0.0",
-      "resolved": "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
@@ -10543,7 +10543,7 @@
     },
     "is-finite": {
       "version": "1.0.2",
-      "resolved": "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
@@ -11103,7 +11103,7 @@
     },
     "lcid": {
       "version": "1.0.0",
-      "resolved": "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
@@ -12188,9 +12188,9 @@
       }
     },
     "node-sass": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz",
-      "integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.0.tgz",
+      "integrity": "sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -12200,7 +12200,7 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
         "nan": "^2.13.2",
@@ -12240,6 +12240,12 @@
             "lru-cache": "^4.0.1",
             "which": "^1.2.9"
           }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
         },
         "nan": {
           "version": "2.14.0",
@@ -14582,7 +14588,7 @@
     },
     "repeating": {
       "version": "2.0.1",
-      "resolved": "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
@@ -15777,7 +15783,7 @@
     },
     "strip-bom": {
       "version": "2.0.0",
-      "resolved": "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "mini-css-extract-plugin": "^0.8.0",
     "ncp": "^2.0.0",
     "node-fetch": "^2.6.0",
-    "node-sass": "^4.12.0",
+    "node-sass": "^4.13.0",
     "ora": "^4.0.2",
     "phoenix-channels": "^1.0.0",
     "prettier": "^1.7.0",

--- a/src/react-components/chat-message.js
+++ b/src/react-components/chat-message.js
@@ -9,7 +9,6 @@ import serializeElement from "../utils/serialize-element";
 import { navigateToClientInfo } from "./presence-list";
 
 const messageCanvas = document.createElement("canvas");
-messageCanvas.width = messageCanvas.height = 1024;
 
 const emojiRegex = /(?:[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff]|[\u0023-\u0039]\ufe0f?\u20e3|\u3299|\u3297|\u303d|\u3030|\u24c2|\ud83c[\udd70-\udd71]|\ud83c[\udd7e-\udd7f]|\ud83c\udd8e|\ud83c[\udd91-\udd9a]|\ud83c[\udde6-\uddff]|[\ud83c[\ude01-\ude02]|\ud83c\ude1a|\ud83c\ude2f|[\ud83c[\ude32-\ude3a]|[\ud83c[\ude50-\ude51]|\u203c|\u2049|[\u25aa-\u25ab]|\u25b6|\u25c0|[\u25fb-\u25fe]|\u00a9|\u00ae|\u2122|\u2139|\ud83c\udc04|[\u2600-\u26FF]|\u2b05|\u2b06|\u2b07|\u2b1b|\u2b1c|\u2b50|\u2b55|\u231a|\u231b|\u2328|\u23cf|[\u23e9-\u23f3]|[\u23f8-\u23fa]|\ud83c\udccf|\u2934|\u2935|[\u2190-\u21ff])/;
 const urlRegex = /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)$/;
@@ -112,8 +111,12 @@ function renderChatMessage(body, from, allowEmojiRender, lowResolution) {
 
   return new Promise(resolve => {
     ReactDOM.render(entryDom, el, () => {
+      const textureSize = 1024;
+
       const ratio = el.offsetHeight / el.offsetWidth;
-      const scale = (messageCanvas.height * Math.min(1.0, ratio)) / el.offsetHeight;
+      const scale = (textureSize * Math.min(1.0, 1.0 / ratio)) / el.offsetWidth;
+      messageCanvas.width = el.offsetWidth * scale;
+      messageCanvas.height = el.offsetHeight * scale;
 
       const xhtml = encodeURIComponent(`
           <svg xmlns="http://www.w3.org/2000/svg" width="${messageCanvas.width}px" height="${messageCanvas.height}px">
@@ -125,7 +128,6 @@ function renderChatMessage(body, from, allowEmojiRender, lowResolution) {
       const img = new Image();
 
       img.onload = () => {
-        context.clearRect(0, 0, messageCanvas.width, messageCanvas.height);
         context.drawImage(img, 0, 0);
         ReactDOM.unmountComponentAtNode(el);
         el.remove();

--- a/src/react-components/chat-message.js
+++ b/src/react-components/chat-message.js
@@ -9,6 +9,8 @@ import serializeElement from "../utils/serialize-element";
 import { navigateToClientInfo } from "./presence-list";
 
 const messageCanvas = document.createElement("canvas");
+messageCanvas.width = messageCanvas.height = 1024;
+
 const emojiRegex = /(?:[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff]|[\u0023-\u0039]\ufe0f?\u20e3|\u3299|\u3297|\u303d|\u3030|\u24c2|\ud83c[\udd70-\udd71]|\ud83c[\udd7e-\udd7f]|\ud83c\udd8e|\ud83c[\udd91-\udd9a]|\ud83c[\udde6-\uddff]|[\ud83c[\ude01-\ude02]|\ud83c\ude1a|\ud83c\ude2f|[\ud83c[\ude32-\ude3a]|[\ud83c[\ude50-\ude51]|\u203c|\u2049|[\u25aa-\u25ab]|\u25b6|\u25c0|[\u25fb-\u25fe]|\u00a9|\u00ae|\u2122|\u2139|\ud83c\udc04|[\u2600-\u26FF]|\u2b05|\u2b06|\u2b07|\u2b1b|\u2b1c|\u2b50|\u2b55|\u231a|\u231b|\u2328|\u23cf|[\u23e9-\u23f3]|[\u23f8-\u23fa]|\ud83c\udccf|\u2934|\u2935|[\u2190-\u21ff])/;
 const urlRegex = /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)$/;
 const textureLoader = new THREE.TextureLoader();
@@ -110,34 +112,26 @@ function renderChatMessage(body, from, allowEmojiRender, lowResolution) {
 
   return new Promise(resolve => {
     ReactDOM.render(entryDom, el, () => {
-      // Scale by 12x
-      let objectScale = "8.33%";
-      let scale = 12;
-
-      if (lowResolution) {
-        // In low res, scale by 4x
-        objectScale = "25%";
-        scale = 4;
-      }
-
-      messageCanvas.width = el.offsetWidth * (scale + 0.1);
-      messageCanvas.height = el.offsetHeight * (scale + 0.1);
+      const ratio = el.offsetHeight / el.offsetWidth;
+      const scale = (messageCanvas.height * Math.min(1.0, ratio)) / el.offsetHeight;
 
       const xhtml = encodeURIComponent(`
-          <svg xmlns="http://www.w3.org/2000/svg" width="${messageCanvas.width}" height="${messageCanvas.height}">
-            <foreignObject width="${objectScale}" height="${objectScale}" style="transform: scale(${scale});">
+          <svg xmlns="http://www.w3.org/2000/svg" width="${messageCanvas.width}px" height="${messageCanvas.height}px">
+            <foreignObject width="100%" height="100%" style="transform: scale(${scale});">
               ${serializeElement(el)}
             </foreignObject>
           </svg>
     `);
       const img = new Image();
 
-      img.onload = async () => {
+      img.onload = () => {
+        context.clearRect(0, 0, messageCanvas.width, messageCanvas.height);
         context.drawImage(img, 0, 0);
-        const blob = await new Promise(resolve => messageCanvas.toBlob(resolve));
         ReactDOM.unmountComponentAtNode(el);
         el.remove();
-        resolve(blob);
+        img.onload = null;
+        img.src = "";
+        messageCanvas.toBlob(resolve);
       };
 
       img.src = "data:image/svg+xml," + xhtml;


### PR DESCRIPTION
Rework scaling of text bubbles to be a bit more sane. Text bubbles will now always fit into a 1024x1024 texture (with the longer dimension being 1024 and the shorter side preserving aspect ratio). This seems to strike a reasonable compromise between text clarity for the common case of fairly short labels, while also batching neatly and not blowing up texture memory.

Completely unrelated, bumps node-sass dependency since I was having an issue building on my system with a newer version of node.