### PR TITLE
Fix "waypoint ghost" bug on android

### DIFF
--- a/src/systems/waypoint-system.js
+++ b/src/systems/waypoint-system.js
@@ -54,7 +54,11 @@ function loadTemplateAndAddToScene(scene, templateId) {
   return new Promise(resolve => {
     const content = document.importNode(document.getElementById(templateId).content.children[0]);
     scene.appendChild(content, true);
-    resolve(content);
+    setTimeout(() => {
+      // Without this timeout, this resolves too early in Firefox for Android
+      // we have to wait a tick for the attach callbacks to get fired for the elements in a template
+      resolve(content);
+    }, 0);
   });
 }
 function templatesToLoadForWaypointData(data) {


### PR DESCRIPTION
Add timeout after adding template content to the scene so that firefox for android (and other browsers (?) that require a one frame delay) finish instantiating the waypoint preview element.

![image](https://user-images.githubusercontent.com/4072106/70488724-7a7f0d80-1aae-11ea-97ea-60a7f5c241a0.png)
