### PR TITLE
Enter the scene in bot mode

### DIFF
--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -90,6 +90,7 @@ export default class SceneEntryManager {
 
     if (isBotMode) {
       this._runBot(mediaStream);
+      this.scene.addState("entered");
       return;
     }
 


### PR DESCRIPTION
This PR fixes a bug where bots are spawning at the origin. The cause of this bug is that in bot mode, we are not adding the `entered` state to the scene, so even though the waypoint system enqueues travel to the spawn point, the `character-controller-system` exits early and never actually travels to the spawn point.

This bug was introduced by the waypoints feature branch. Previously, the `spawn-controller` was attached to the `avatar-rig` and the bot would move to the desired location.

Adding the `entered` state to the scene seems like the most correct fix, but may cause the bots to run slower, since anything else gated on scene entry is now allowed to run. If we find that this is a problem, an alternative solution is to allow waypoint travel in the `character-controller-system` even if the scene is not `entered`, when you are in bot mode.

Relevant line: https://github.com/mozilla/hubs/blob/master/src/systems/character-controller-system.js#L151