### PR TITLE
Exit if scene fails to load

### DIFF
--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -172,6 +172,7 @@
     "exit.subtitle.disconnected": "You have disconnected from the room. Refresh the page to try to reconnect.",
     "exit.subtitle.left": "You have left the room.",
     "exit.subtitle.full": "This room is full, please try again later.",
+    "exit.subtitle.scene_error": "The scene failed to load.",
     "exit.subtitle.connect_error": "Unable to connect to this room, please try again later.",
     "exit.subtitle.version_mismatch": "The version you deployed is not available yet. Your browser will refresh in 5 seconds.",
     "autoexit.title": "Auto-ending session in ",

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -982,7 +982,7 @@ class UIRoot extends Component {
         <div>
           <FormattedMessage id={exitSubtitleId} />
           <p />
-          {!["left", "disconnected"].includes(this.props.roomUnavailableReason) && (
+          {!["left", "disconnected", "scene_error"].includes(this.props.roomUnavailableReason) && (
             <div>
               You can also{" "}
               <WithHoverSound>


### PR DESCRIPTION
We ran into this with a particularly large scene, where both Chrome and Firefox would throw an error on Android while uploading textures from the scene after reaching the device's memory limit. This fix at least exits the room instead of spinning on the loading screen forever.