### PR TITLE
Don't exit on scene change failure

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -401,15 +401,6 @@ async function updateEnvironmentForHub(hub, entryManager) {
           { once: true }
         );
 
-        environmentEl.addEventListener(
-          "model-error",
-          () => {
-            remountUI({ roomUnavailableReason: "scene_error" });
-            entryManager.exitScene();
-          },
-          { once: true }
-        );
-
         environmentEl.setAttribute("gltf-model-plus", { src: sceneUrl });
       },
       { once: true }


### PR DESCRIPTION
Amending #1977 to not exit on failure during a scene change. I suspect we run into this often during meetups, especially for lower-spec'd hardware. Since you can recover with a subsequent scene change, we shouldn't exit the room.