### PR TITLE
Validate scene url before updating scene

### DIFF
--- a/src/assets/stylesheets/change-scene-dialog.scss
+++ b/src/assets/stylesheets/change-scene-dialog.scss
@@ -15,6 +15,9 @@
   margin-right: 6px;
   width: 128px;
   text-align: center;
+  &:disabled {
+    background-color: $action-color-disabled;
+  }
 }
 
 :local(.buttons) {

--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -333,6 +333,7 @@
     "change-scene-dialog.change-scene": "Change Scene",
     "change-scene-dialog.create-in-spoke": "Or, create a new scene using %editor-name%.",
     "change-scene-dialog.new-spoke-project": "Launch %editor-name%",
+    "invalid-scene-url": "This URL does not point to a scene or valid GLB.",
     "avatar-url-dialog.apply": "Apply",
     "interstitial.prompt": "Continue",
     "feedback.prompt": "🦆 Feedback ",

--- a/src/utils/scene-url-utils.js
+++ b/src/utils/scene-url-utils.js
@@ -1,0 +1,21 @@
+import { isHubsSceneUrl, proxiedUrlFor } from "../utils/media-url-utils";
+
+export async function isValidGLB(url) {
+  return fetch(url).then(r => {
+    const reader = r.body.getReader();
+    return reader.read().then(result => {
+      reader.cancel();
+      return String.fromCharCode.apply(null, result.value.slice(0, 4)) === "glTF";
+    });
+  });
+}
+
+export async function isValidSceneUrl(url) {
+  if (url.trim() === "") return false;
+  if (!url.startsWith("http")) return false;
+  if (await isHubsSceneUrl(url)) {
+    return true;
+  } else {
+    return isValidGLB(proxiedUrlFor(url));
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/1877

- Does a client-side check on the URL, checking if it's a Hubs scene, using our existing isHubsSceneUrl method, or a GLB by downloading the first chunk of the URL and checking its header
- Prevents submission on the Change Scene dialog using html form validation.