### PR TITLE
Feature/admin import table

### DIFF
--- a/admin/src/admin.html
+++ b/admin/src/admin.html
@@ -25,6 +25,9 @@
   body {
     margin: 0;
   }
+  a {
+    color: #FF3464;
+  }
     </style>
 </head>
 

--- a/admin/src/react-components/import-content.js
+++ b/admin/src/react-components/import-content.js
@@ -265,16 +265,7 @@ class ImportContentComponent extends Component {
 
       await exec(() => {
         const d = approve(objectRes.data[0]);
-
-        if (!d.payload.data.tags) {
-          d.payload.data.tags = { tags };
-        } else {
-          for (const t of tags) {
-            if (d.payload.data.tags.tags.indexOf(t) < 0) {
-              d.payload.data.tags.tags.push(t);
-            }
-          }
-        }
+        d.payload.data.tags = { tags };
 
         return d;
       });

--- a/admin/src/react-components/import-content.js
+++ b/admin/src/react-components/import-content.js
@@ -384,13 +384,28 @@ class ImportContentComponent extends Component {
       );
     };
 
+    const numSelected = imports ? imports.filter(i => i.isEnabled && !i.isImported).length : 0;
+    const rowCount = imports ? imports.length : 0;
+
     return (
       <CardContent>
         <Paper>
           <Table>
             <TableHead>
               <TableRow>
-                <TableCell>Import?</TableCell>
+                <TableCell>
+                  <Checkbox
+                    indeterminate={numSelected > 0 && numSelected < rowCount}
+                    checked={numSelected === rowCount}
+                    onChange={e => {
+                      for (const { isImported, url } of imports) {
+                        if (!isImported) {
+                          this.setImportIsEnabled(url, e.target.checked);
+                        }
+                      }
+                    }}
+                  />
+                </TableCell>
                 <TableCell>Info</TableCell>
                 <TableCell>Preview</TableCell>
                 <TableCell align="right">Name</TableCell>

--- a/admin/src/react-components/import-content.js
+++ b/admin/src/react-components/import-content.js
@@ -283,6 +283,7 @@ class ImportContentComponent extends Component {
   renderImportTable() {
     const { imports } = this.state;
     const isImportingAny = imports ? !!imports.find(i => i.result === RESULTS.importing) : false;
+    const hasNonImported = imports ? !!imports.find(i => !i.isImported) : false;
 
     const rowForImportRecord = r => {
       let icon = null;
@@ -394,17 +395,19 @@ class ImportContentComponent extends Component {
             <TableHead>
               <TableRow>
                 <TableCell>
-                  <Checkbox
-                    indeterminate={numSelected > 0 && numSelected < rowCount}
-                    checked={numSelected === rowCount}
-                    onChange={e => {
-                      for (const { isImported, url } of imports) {
-                        if (!isImported) {
-                          this.setImportIsEnabled(url, e.target.checked);
+                  {hasNonImported && !isImportingAny && (
+                    <Checkbox
+                      indeterminate={numSelected > 0 && numSelected < rowCount}
+                      checked={numSelected === rowCount}
+                      onChange={e => {
+                        for (const { isImported, url } of imports) {
+                          if (!isImported) {
+                            this.setImportIsEnabled(url, e.target.checked);
+                          }
                         }
-                      }
-                    }}
-                  />
+                      }}
+                    />
+                  )}
                 </TableCell>
                 <TableCell>Info</TableCell>
                 <TableCell>Preview</TableCell>
@@ -547,6 +550,7 @@ class ImportContentComponent extends Component {
               Import {readyToImportCount} Item{readyToImportCount > 1 && "s"}
             </Button>
           )}
+          {isImportingAny && <CircularProgress />}
           <Snackbar
             anchorOrigin={{ horizontal: "center", vertical: "bottom" }}
             open={!!loadFailed}

--- a/admin/src/react-components/import-content.js
+++ b/admin/src/react-components/import-content.js
@@ -166,9 +166,10 @@ class ImportContentComponent extends Component {
       }
     }
 
+    let first = true;
+
     for (let i = 0; i < importableUrls.length; i++) {
       const url = importableUrls[i];
-      console.log(url);
       const apiInfo = this.apiInfoForSubmittedUrl(url);
       if (!apiInfo) continue;
 
@@ -181,8 +182,9 @@ class ImportContentComponent extends Component {
       const type = isScene ? "scenes" : "avatars";
       const asset = (await res.json())[type][0];
       const isDefault = (isScene && needsDefaultScene) || (isAvatar && needsDefaultAvatar);
-      const isBase = isAvatar && needsBaseAvatar && i === 0;
+      const isBase = isAvatar && needsBaseAvatar && first; // Only set first avatar to be base by default
       this.addImport(url, importUrl, type, asset, isDefault, isBase, true /* isFeatured */);
+      first = false;
       hadUrl = true;
     }
 

--- a/admin/webpack.config.js
+++ b/admin/webpack.config.js
@@ -184,6 +184,7 @@ module.exports = (env, argv) => ({
         CONFIGURABLE_SERVICES: process.env.CONFIGURABLE_SERVICES,
         ITA_SERVER: process.env.ITA_SERVER,
         RETICULUM_SERVER: process.env.RETICULUM_SERVER,
+        CORS_PROXY_SERVER: process.env.CORS_PROXY_SERVER,
         POSTGREST_SERVER: process.env.POSTGREST_SERVER
       })
     })


### PR DESCRIPTION
This completely updates the content import tool in the admin console:

- Specify multiple URLs separated by commas
- Allow use of "asset pack" files which are just text files ending in `.pack` that are a list of URLs. See examples: https://github.com/mozilla/hubs-cloud/tree/master/asset-packs
- Give the user a visual preview of what is to be imported, allow them to de-select items, and select flags.
- Show visual feedback of each import.

Also fixes the link colors on the admin pages.