### PR TITLE
Remove connection status from loader

### DIFF
--- a/src/react-components/loader.js
+++ b/src/react-components/loader.js
@@ -11,7 +11,6 @@ class Loader extends Component {
   static propTypes = {
     scene: PropTypes.object,
     finished: PropTypes.bool,
-    connected: PropTypes.bool,
     onLoaded: PropTypes.func
   };
 
@@ -99,16 +98,6 @@ class Loader extends Component {
         ...
       </h4>
     );
-    const connected = (
-      <h4 className={loaderStyles.loadingText}>
-        <FormattedMessage id="loader.connected" />
-      </h4>
-    );
-    const connecting = (
-      <h4 className={loaderStyles.loadingText}>
-        <FormattedMessage id="loader.connecting" />
-      </h4>
-    );
     return (
       <IntlProvider locale={lang} messages={messages}>
         <div className="loading-panel">
@@ -125,7 +114,6 @@ class Loader extends Component {
           </UnlessFeature>
 
           {this.props.finished ? nomore : usual}
-          {this.props.connected ? connected : connecting}
 
           <div className="loader-wrap loader-bottom">
             <div className="loader">

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1414,7 +1414,6 @@ class UIRoot extends Component {
             scene={this.props.scene}
             finished={this.state.noMoreLoadingUpdates}
             onLoaded={this.onLoadingFinished}
-            connected={this.state.didConnectToNetworkedScene}
           />
           <PreferencesScreen
             onClose={() => {
@@ -1431,7 +1430,6 @@ class UIRoot extends Component {
           scene={this.props.scene}
           finished={this.state.noMoreLoadingUpdates}
           onLoaded={this.onLoadingFinished}
-          connected={this.state.didConnectToNetworkedScene}
         />
       );
     }

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1426,11 +1426,7 @@ class UIRoot extends Component {
     }
     if (isLoading) {
       return (
-        <Loader
-          scene={this.props.scene}
-          finished={this.state.noMoreLoadingUpdates}
-          onLoaded={this.onLoadingFinished}
-        />
+        <Loader scene={this.props.scene} finished={this.state.noMoreLoadingUpdates} onLoaded={this.onLoadingFinished} />
       );
     }
     if (this.state.showPrefs) {


### PR DESCRIPTION
Rather than always expose connection state, we'd prefer to only show connection info if we catch an error. This reverts adding the connection info to the loader (but does not yet replace it with showing something to the user if they fail to connect to janus).