### PR TITLE
Only show discord ID when scene is frozen, regardless of prefs

### DIFF
--- a/src/components/player-info.js
+++ b/src/components/player-info.js
@@ -119,7 +119,7 @@ AFRAME.registerComponent("player-info", {
     if (communityIdentifierEl) {
       if (this.communityIdentifier) {
         communityIdentifierEl.setAttribute("text", { value: this.communityIdentifier });
-        communityIdentifierEl.object3D.visible = !infoShouldBeHidden;
+        communityIdentifierEl.object3D.visible = this.el.sceneEl.is("frozen");
       }
     }
     const recordingBadgeEl = this.el.querySelector(".recordingBadge");


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/1995
