### PR TITLE
Add an auto-pixel-ratio system

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -136,6 +136,7 @@ import "./systems/personal-space-bubble";
 import "./systems/app-mode";
 import "./systems/permissions";
 import "./systems/exit-on-blur";
+import "./systems/auto-pixel-ratio";
 import "./systems/idle-detector";
 import "./systems/camera-tools";
 import "./systems/userinput/userinput";
@@ -371,6 +372,8 @@ async function updateEnvironmentForHub(hub, entryManager) {
 
         // Show the canvas once the model has loaded
         document.querySelector(".a-canvas").classList.remove("a-hidden");
+
+        sceneEl.addState("visible");
 
         //TODO: check if the environment was made with spoke to determine if a shape should be added
         traverseMeshesAndAddShapes(environmentEl);

--- a/src/systems/auto-pixel-ratio.js
+++ b/src/systems/auto-pixel-ratio.js
@@ -18,8 +18,10 @@ AFRAME.registerSystem("auto-pixel-ratio", {
   tick(time, delta) {
     if (!this.enabled) return;
     if (!this.el.is("visible")) return;
-    this.secondsSinceSceneVisible += delta / 1000;
-    if (this.secondsSinceSceneVisible < SKIP_SECONDS_AFTER_SCENE_VISIBLE) return;
+    if (this.secondsSinceSceneVisible < SKIP_SECONDS_AFTER_SCENE_VISIBLE) {
+      this.secondsSinceSceneVisible += delta / 1000;
+      return;
+    }
 
     this.deltas.push(delta);
     this.secondsSinceMeasurementStart += delta / 1000;

--- a/src/systems/auto-pixel-ratio.js
+++ b/src/systems/auto-pixel-ratio.js
@@ -1,0 +1,50 @@
+// On high-DPI displays, measures the median FPS over time and reduces the
+// pixelRatio if the FPS drops below a threshold.
+
+const FPS_THRESHOLD = 50;
+const SKIP_SECONDS_AFTER_SCENE_VISIBLE = 30;
+const MEASUREMENT_PERIOD_SECONDS = 5;
+const MIN_PIXEL_RATIO = 1;
+
+AFRAME.registerSystem("auto-pixel-ratio", {
+  init() {
+    // For now let's only enabled this on macs, since they tend to have retina displays.
+    // Note this test will also include iPads running iPadOS.
+    this.enabled = window.devicePixelRatio > 1 && /macintosh/i.test(navigator.userAgent);
+    this.deltas = [];
+    this.secondsSinceMeasurementStart = 0;
+    this.secondsSinceSceneVisible = 0;
+  },
+  tick(time, delta) {
+    if (!this.enabled) return;
+    if (!this.el.is("visible")) return;
+    this.secondsSinceSceneVisible += delta / 1000;
+    if (this.secondsSinceSceneVisible < SKIP_SECONDS_AFTER_SCENE_VISIBLE) return;
+
+    this.deltas.push(delta);
+    this.secondsSinceMeasurementStart += delta / 1000;
+
+    if (this.secondsSinceMeasurementStart > MEASUREMENT_PERIOD_SECONDS) {
+      this.deltas.sort();
+      const medianDelta = this.deltas[Math.floor(this.deltas.length / 2)];
+      const medianFps = 1000 / medianDelta;
+
+      if (medianFps < FPS_THRESHOLD) {
+        const newPixelRatio = this.el.renderer.getPixelRatio() - 1;
+        console.info(
+          `Hubs auto-pixel-ratio: Median FPS (${medianFps.toFixed()}) was below ${FPS_THRESHOLD}. ` +
+            `Reducing pixel ratio to ${newPixelRatio}.`
+        );
+        this.el.renderer.setPixelRatio(newPixelRatio);
+
+        if (newPixelRatio <= MIN_PIXEL_RATIO) {
+          this.enabled = false;
+        }
+      }
+
+      // Clear deltas so that we start measuring a new median.
+      this.deltas.length = 0;
+      this.secondsSinceMeasurementStart = 0;
+    }
+  }
+});

--- a/src/utils/debug-log.js
+++ b/src/utils/debug-log.js
@@ -84,6 +84,7 @@ if (showLog) {
     debugLog.scrollTop = debugLog.scrollHeight - debugLog.clientHeight;
   };
 
+  const origConsoleInfo = console.info;
   const origConsoleLog = console.log;
   const origConsoleError = console.error;
   const origConsoleWarn = console.warn;
@@ -136,6 +137,11 @@ if (showLog) {
   console.log = function() {
     origConsoleLog.apply(null, arguments);
     log("log", arguments);
+  };
+
+  console.info = function() {
+    origConsoleInfo.apply(null, arguments);
+    log("info", arguments);
   };
 
   window.onunhandledrejection = e => log("error", [e.reason.message, e.reason.code, e.reason.name]);


### PR DESCRIPTION
Add a system that drops the pixel ratio on high-DPI devices (currently limited to Macs). This is particularly helpful on Macbooks that have lower-spec integrated graphics cards.