### PR TITLE
Fix mis-named var given toml file having the wrong name

### DIFF
--- a/src/assets/stylesheets/entry.scss
+++ b/src/assets/stylesheets/entry.scss
@@ -81,7 +81,7 @@
   :local(.subtitle) {
     font-size: 0.8em;
     font-weight: normal;
-    color: $action-subtitle-text-color;
+    color: $action-subtitle-color;
   }
 }
 

--- a/src/assets/stylesheets/shared.scss
+++ b/src/assets/stylesheets/shared.scss
@@ -7,7 +7,7 @@ $action-label-color: var(--action-label-color, $default-action-color);
 $action-color-disabled: var(--action-color-disabled, $default-action-color-light);
 $action-color-highlight: var(--action-color-highlight, $default-action-color-light);
 $action-text-color: var(--action-text-color, white);
-$action-subtitle-text-color: var(--action-subtitle-text-color, $light-text);
+$action-subtitle-color: var(--action-subtitle-color, $light-text);
 $notice-background-color: var(--notice-background-color, $bright-blue);
 $notice-text-color: var(--notice-text-color, white);
 $notice-widget-color: var(--notice-widget-color, $light-blue);

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -11,7 +11,7 @@ const DEFAULT_COLORS = {
   "action-color-disabled": DEFAULT_ACTION_COLOR_LIGHT,
   "action-color-highlight": DEFAULT_ACTION_COLOR_LIGHT,
   "action-text-color": "#FFFFFF",
-  "action-subtitle-text-color": "#F0F0F0",
+  "action-subtitle-color": "#F0F0F0",
   "notice-background-color": "#2F80ED",
   "notice-text-color": "#FFFFFF",
   "favorited-color": "#FFC000"


### PR DESCRIPTION
There was a mismatch between `schema.toml` for the primary action subtitle text color and what we were using in the code. Given that the toml file may have caused that name to be stored in the db, this PR updates the client to use the name from the toml file. 

Note this color is currently 'dark' and not used anywhere, though it makes sense to offer it since it has a place in the styling hierarchy if we ever add action buttons with subtitles.