### PR TITLE
Add missing matrixNeedsUpdate flag flip

### DIFF
--- a/src/components/hubs-text.js
+++ b/src/components/hubs-text.js
@@ -273,6 +273,7 @@ AFRAME.registerComponent("text", {
     // Place text slightly in front to avoid Z-fighting.
     mesh.position.z = data.zOffset;
     mesh.scale.set(textScale, -1 * textScale, textScale);
+    mesh.matrixNeedsUpdate = true;
   },
 
   /**


### PR DESCRIPTION
the text component was not invalidating the matrix when performing layout. this seems to have caused the issue with the missing nametags. (not sure why layout is now being run later)