### PR TITLE
Disables the scene link in the room info dialog

### DIFF
--- a/src/react-components/room-info-dialog.js
+++ b/src/react-components/room-info-dialog.js
@@ -7,10 +7,17 @@ import { scaledThumbnailUrlFor } from "../utils/media-url-utils";
 export default class RoomInfoDialog extends Component {
   static propTypes = {
     hubName: PropTypes.string,
-    scene: PropTypes.object
+    scene: PropTypes.object,
+    store: PropTypes.object
   };
 
   render() {
+    const showSceneLink =
+      (this.props.store.credentialsAccountId &&
+        this.props.scene.account_id === this.props.store.credentialsAccountId) ||
+      this.props.scene.allow_promotion ||
+      this.props.scene.allow_remixing;
+
     const toAttributionDiv = (a, i) => {
       if (a.url) {
         const source = a.url.includes("sketchfab.com")
@@ -59,16 +66,24 @@ export default class RoomInfoDialog extends Component {
       <DialogContainer title={title} wide={true} {...this.props}>
         <div className={styles.roomInfo}>
           <div className={styles.sceneScreenshot}>
-            <a href={this.props.scene.url} target="_blank" rel="noopener noreferrer">
+            {showSceneLink ? (
+              <a href={this.props.scene.url} target="_blank" rel="noopener noreferrer">
+                <img src={scaledThumbnailUrlFor(this.props.scene.screenshot_url, 400, 480)} />
+              </a>
+            ) : (
               <img src={scaledThumbnailUrlFor(this.props.scene.screenshot_url, 400, 480)} />
-            </a>
+            )}
           </div>
           <div className={styles.sceneDetails}>
             <div className={styles.sceneMain}>
               <div className={styles.sceneName}>
-                <a href={this.props.scene.url} target="_blank" rel="noopener noreferrer">
-                  {this.props.scene.name}
-                </a>
+                {showSceneLink ? (
+                  <a href={this.props.scene.url} target="_blank" rel="noopener noreferrer">
+                    {this.props.scene.name}
+                  </a>
+                ) : (
+                  <span>{this.props.scene.name}</span>
+                )}
               </div>
               <div className={styles.sceneCreator}>{creator}</div>
             </div>

--- a/src/react-components/room-info-dialog.js
+++ b/src/react-components/room-info-dialog.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import DialogContainer from "./dialog-container.js";
 import styles from "../assets/stylesheets/room-info-dialog.scss";
 import { scaledThumbnailUrlFor } from "../utils/media-url-utils";
+import { allowDisplayOfSceneLink } from "../utils/scene-url-utils";
 
 export default class RoomInfoDialog extends Component {
   static propTypes = {
@@ -12,11 +13,7 @@ export default class RoomInfoDialog extends Component {
   };
 
   render() {
-    const showSceneLink =
-      (this.props.store.credentialsAccountId &&
-        this.props.scene.account_id === this.props.store.credentialsAccountId) ||
-      this.props.scene.allow_promotion ||
-      this.props.scene.allow_remixing;
+    const showSceneLink = allowDisplayOfSceneLink(this.props.scene, this.props.store);
 
     const toAttributionDiv = (a, i) => {
       if (a.url) {

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1723,7 +1723,11 @@ class UIRoot extends Component {
               stateValue="room_info"
               history={this.props.history}
               render={() =>
-                this.renderDialog(RoomInfoDialog, { scene: this.props.hubScene, hubName: this.props.hubName })
+                this.renderDialog(RoomInfoDialog, {
+                  store: this.props.store,
+                  scene: this.props.hubScene,
+                  hubName: this.props.hubName
+                })
               }
             />
             <StateRoute

--- a/src/utils/scene-url-utils.js
+++ b/src/utils/scene-url-utils.js
@@ -26,3 +26,13 @@ export async function isValidSceneUrl(url) {
     return isValidGLB(proxiedUrlFor(url));
   }
 }
+
+// To assist with content control, we avoid displaying scene links to users who are not the scene
+// creator, unless the scene is remixable or promotable.
+export function allowDisplayOfSceneLink(scene, store) {
+  return (
+    (store.credentialsAccountId && scene.account_id === store.credentialsAccountId) ||
+    scene.allow_promotion ||
+    scene.allow_remixing
+  );
+}


### PR DESCRIPTION
Previously, the scene URL was linked from the room info dialog in all cases. Now, in the interest of the scene creator's preferences, it is not linked unless the scene is remixable or promotable (or if the scene is owned by the current user.)