### PR TITLE
Catch more errors as scene load time

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -415,7 +415,10 @@ async function updateEnvironmentForHub(hub, entryManager) {
       },
       { once: true }
     );
-    environmentEl.addEventListener("model-error", sceneErrorHandler, { once: true });
+
+    if (!sceneEl.is("entered")) {
+      environmentEl.addEventListener("model-error", sceneErrorHandler, { once: true });
+    }
 
     environmentEl.setAttribute("gltf-model-plus", { src: loadingEnvironment });
   }

--- a/src/hub.js
+++ b/src/hub.js
@@ -325,6 +325,11 @@ async function updateEnvironmentForHub(hub, entryManager) {
   let sceneUrl;
   let isLegacyBundle; // Deprecated
 
+  const sceneErrorHandler = () => {
+    remountUI({ roomUnavailableReason: "scene_error" });
+    entryManager.exitScene();
+  };
+
   const environmentScene = document.querySelector("#environment-scene");
   const sceneEl = document.querySelector("a-scene");
 
@@ -359,11 +364,6 @@ async function updateEnvironmentForHub(hub, entryManager) {
 
   if (environmentScene.childNodes.length === 0) {
     const environmentEl = document.createElement("a-entity");
-
-    const sceneErrorHandler = () => {
-      remountUI({ roomUnavailableReason: "scene_error" });
-      entryManager.exitScene();
-    };
 
     environmentEl.addEventListener(
       "model-loaded",
@@ -400,6 +400,7 @@ async function updateEnvironmentForHub(hub, entryManager) {
         environmentEl.addEventListener(
           "model-loaded",
           () => {
+            environmentEl.removeEventListener("model-error", sceneErrorHandler);
             traverseMeshesAndAddShapes(environmentEl);
 
             // We've already entered, so move to new spawn point once new environment is loaded
@@ -414,6 +415,7 @@ async function updateEnvironmentForHub(hub, entryManager) {
       },
       { once: true }
     );
+    environmentEl.addEventListener("model-error", sceneErrorHandler, { once: true });
 
     environmentEl.setAttribute("gltf-model-plus", { src: loadingEnvironment });
   }

--- a/src/react-components/loader.js
+++ b/src/react-components/loader.js
@@ -11,7 +11,6 @@ class Loader extends Component {
   static propTypes = {
     scene: PropTypes.object,
     finished: PropTypes.bool,
-    connected: PropTypes.bool,
     onLoaded: PropTypes.func
   };
 
@@ -99,16 +98,6 @@ class Loader extends Component {
         ...
       </h4>
     );
-    const connected = (
-      <h4 className={loaderStyles.loadingText}>
-        <FormattedMessage id="loader.connected" />
-      </h4>
-    );
-    const connecting = (
-      <h4 className={loaderStyles.loadingText}>
-        <FormattedMessage id="loader.connecting" />
-      </h4>
-    );
     return (
       <IntlProvider locale={lang} messages={messages}>
         <div className="loading-panel">
@@ -125,7 +114,6 @@ class Loader extends Component {
           </UnlessFeature>
 
           {this.props.finished ? nomore : usual}
-          {this.props.connected ? connected : connecting}
 
           <div className="loader-wrap loader-bottom">
             <div className="loader">

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1414,7 +1414,6 @@ class UIRoot extends Component {
             scene={this.props.scene}
             finished={this.state.noMoreLoadingUpdates}
             onLoaded={this.onLoadingFinished}
-            connected={this.state.didConnectToNetworkedScene}
           />
           <PreferencesScreen
             onClose={() => {
@@ -1427,12 +1426,7 @@ class UIRoot extends Component {
     }
     if (isLoading) {
       return (
-        <Loader
-          scene={this.props.scene}
-          finished={this.state.noMoreLoadingUpdates}
-          onLoaded={this.onLoadingFinished}
-          connected={this.state.didConnectToNetworkedScene}
-        />
+        <Loader scene={this.props.scene} finished={this.state.noMoreLoadingUpdates} onLoaded={this.onLoadingFinished} />
       );
     }
     if (this.state.showPrefs) {

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -254,7 +254,11 @@ class UIRoot extends Component {
       window.requestAnimationFrame(() => {
         window.setTimeout(() => {
           if (!this.props.isBotMode) {
-            this.props.scene.renderer.compileAndUploadMaterials(this.props.scene.object3D, this.props.scene.camera);
+            try {
+              this.props.scene.renderer.compileAndUploadMaterials(this.props.scene.object3D, this.props.scene.camera);
+            } catch {
+              this.exit("scene_error"); // https://github.com/mozilla/hubs/issues/1950
+            }
           }
 
           if (!this.state.hideLoader) {


### PR DESCRIPTION
This removes the `"connecting"` and `"connected"` strings from the loading screen.

This increases robustness against certain categories of failure at scene load time:
- Listens for `model-error` during scene changes if you are still in the lobby
- Wraps `compileAndUploadMaterial` in a try/catch block in case browser is incapable of rendering the scene (as in #1950 ) 
- Adds a 30s timeout to the connection outside of the normal error handling to catch rare cases where connecting to the networked scene fails but the `catch` block does not run. (I have not been able to diagnose why this happens, but do occasionally see this.)