### PR TITLE
Ensure reset-pref-to-default button clears local storage

### DIFF
--- a/src/react-components/preference-list-item.js
+++ b/src/react-components/preference-list-item.js
@@ -215,11 +215,15 @@ export class PreferenceListItem extends Component {
             onClick={() => {
               switch (this.props.prefType) {
                 case PREFERENCE_LIST_ITEM_TYPE.MAX_RESOLUTION:
-                  delete this.props.store.state.preferences.maxResolutionWidth;
-                  delete this.props.store.state.preferences.maxResolutionHeight;
+                  this.props.store.update({
+                    preferences: {
+                      maxResolutionWidth: undefined,
+                      maxResolutionHeight: undefined
+                    }
+                  });
                   break;
                 default:
-                  delete this.props.store.state.preferences[this.props.storeKey];
+                  this.props.store.update({ preferences: { [this.props.storeKey]: undefined } });
                   break;
               }
               this.forceUpdate();


### PR DESCRIPTION
The "reset to default" button `delete`d the key from the store's `state`, but this did change did not make it into localStorage. This fixes that.