### PR TITLE
Change immersive mode exist behavior to show settings

### DIFF
--- a/src/assets/stylesheets/preferences-screen.scss
+++ b/src/assets/stylesheets/preferences-screen.scss
@@ -1,6 +1,6 @@
 @import 'shared.scss';
 
-$smallScreenWidth : 800px;
+$smallScreenWidth : 475px;
 $itemHeight : 3.0rem;
 $hoverFontSize: 1.6rem;
 $widescreenControlsWidth: 100%;

--- a/src/assets/stylesheets/settings-menu.scss
+++ b/src/assets/stylesheets/settings-menu.scss
@@ -1,7 +1,27 @@
 @import 'shared.scss';
 @import 'drop-menus.scss';
 
-:local(.settings-menu) {
+:local(.settings-menu-overlay-wrap) {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--panel-overlay-background-color);
+}
+
+:local(.settings-menu-overlay) {
+  :local(.contents) {
+    position: relative;
+    min-width: auto;
+    padding: 32px 72px;
+  }
+}
+
+:local(.settings-menu-drop) {
   @extend %drop-menu;
   left: 16px;
 }
@@ -10,6 +30,19 @@
   @extend %attach-point;
   top: -5px;
   left: 16px;
+}
+
+:local(.close-button) {
+  position: absolute;
+  left: 18px;
+  top: 18px;
+  color: var(--panel-widget-color);
+  font-size: 1.6em;
+  font-weight: bold;
+
+  background: none;
+  cursor: pointer;
+  border: none;
 }
 
 :local(.settings-row) {

--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -88,7 +88,6 @@
     "entry.desktop.invite-tip": "Nobody is here yet. Share this room to get together.",
     "entry.mobile.invite-tip": "Share to get together.",
     "entry.return-to-vr": "Return to VR",
-    "entry.enter-in-vr": "Enter in VR",
     "entry.open-in-window": "Open in Tab",
     "entry.lobby": "Lobby",
     "entry.back": "Back",

--- a/src/react-components/settings-menu.js
+++ b/src/react-components/settings-menu.js
@@ -13,6 +13,7 @@ import { faInfoCircle } from "@fortawesome/free-solid-svg-icons/faInfoCircle";
 import { faBars } from "@fortawesome/free-solid-svg-icons/faBars";
 import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus";
 import { faVideo } from "@fortawesome/free-solid-svg-icons/faVideo";
+import { faTimes } from "@fortawesome/free-solid-svg-icons/faTimes";
 
 import configs from "../utils/configs";
 import { messages } from "../utils/i18n";
@@ -32,6 +33,8 @@ export default class SettingsMenu extends Component {
     toggleStreamerMode: PropTypes.func,
     mediaSearchStore: PropTypes.object,
     scene: PropTypes.object,
+    showAsOverlay: PropTypes.bool, // Shows the settings as an overlay menu, instead of a dropdown
+    onCloseOverlay: PropTypes.func, // Shows the settings as an overlay menu, instead of a dropdown
     hubScene: PropTypes.object,
     hubChannel: PropTypes.object,
     performConditionalSignIn: PropTypes.func,
@@ -44,12 +47,14 @@ export default class SettingsMenu extends Component {
     expanded: false
   };
 
+  unexpand() {
+    if (this.state.expanded && !this.props.showAsOverlay) {
+      this.setState({ expanded: false });
+    }
+  }
+
   componentDidMount() {
-    this.onMouseUp = () => {
-      if (this.state.expanded) {
-        this.setState({ expanded: false });
-      }
-    };
+    this.onMouseUp = () => this.unexpand();
     this.acanvas = document.querySelector(".a-canvas");
     this.acanvas.addEventListener("mouseup", this.onMouseUp);
   }
@@ -61,21 +66,44 @@ export default class SettingsMenu extends Component {
   renderExpandedMenu() {
     const rowClasses = classNames([styles.row, styles.settingsRow]);
     const rowHeader = classNames([styles.row, styles.settingsRow, styles.rowHeader]);
+
+    // When showing as overlay, hide some menu items for now since the overlay mode is intended for immersive
+    // mode browsers which have limited vertical screen real estate.
+    //
+    // The reason I didn't do this with CSS is because this changes available functionality, so being more
+    // explicit in code seems like a wise idea.
+    const hideExtranousItems = this.props.showAsOverlay;
+
     const showRoomSettings = !!this.props.hubChannel.canOrWillIfCreator("update_hub");
     const showCloseRoom = !!this.props.hubChannel.canOrWillIfCreator("close_hub");
-    const showRoomInfo = !!this.props.hubScene;
+    const showRoomInfo = !!this.props.hubScene && !hideExtranousItems;
     const showRoomSection = showRoomSettings || showRoomInfo || showCloseRoom;
-    const showStreamerMode = this.props.scene.is("entered") && !!this.props.hubChannel.canOrWillIfCreator("kick_users");
+    const showStreamerMode =
+      this.props.scene.is("entered") && !!this.props.hubChannel.canOrWillIfCreator("kick_users") && !hideExtranousItems;
 
     // Draw self first
     return (
-      <div className={styles.settingsMenu}>
-        <div className={styles.attachPoint} />
+      <div
+        className={classNames({
+          [styles.settingsMenuDrop]: !this.props.showAsOverlay,
+          [styles.settingsMenuOverlay]: this.props.showAsOverlay
+        })}
+      >
+        {!this.props.showAsOverlay && <div className={styles.attachPoint} />}
         <div className={styles.contents}>
+          {this.props.showAsOverlay && (
+            <button className={styles.closeButton} onClick={() => this.props.onCloseOverlay()}>
+              <i>
+                <FontAwesomeIcon icon={faTimes} />
+              </i>
+            </button>
+          )}
           <div className={styles.rows}>
-            <div className={rowHeader}>
-              <FormattedMessage id="settings.row-profile" />
-            </div>
+            {!hideExtranousItems && (
+              <div className={rowHeader}>
+                <FormattedMessage id="settings.row-profile" />
+              </div>
+            )}
             <div className={rowClasses}>
               <div className={styles.icon}>
                 <i>
@@ -87,7 +115,7 @@ export default class SettingsMenu extends Component {
                   stateKey="overlay"
                   stateValue="profile"
                   history={this.props.history}
-                  onClick={() => this.setState({ expanded: false })}
+                  onClick={() => this.unexpand()}
                 >
                   <FormattedMessage id="settings.change-avatar" />
                 </StateLink>
@@ -134,11 +162,12 @@ export default class SettingsMenu extends Component {
                 </div>
               </div>
             </div>
-            {showRoomSection && (
-              <div className={rowHeader}>
-                <FormattedMessage id="settings.row-room" />
-              </div>
-            )}
+            {showRoomSection &&
+              !hideExtranousItems && (
+                <div className={rowHeader}>
+                  <FormattedMessage id="settings.row-room" />
+                </div>
+              )}
             {showRoomSettings && (
               <div className={rowClasses}>
                 <div className={styles.icon}>
@@ -155,7 +184,7 @@ export default class SettingsMenu extends Component {
                         () => {
                           showFullScreenIfAvailable();
                           this.props.mediaSearchStore.sourceNavigateWithNoNav("scenes", "use");
-                          this.setState({ expanded: false });
+                          this.unexpand();
                         },
                         "change-scene"
                       );
@@ -183,7 +212,7 @@ export default class SettingsMenu extends Component {
                         () => this.props.hubChannel.can("update_hub"),
                         () => {
                           this.props.pushHistoryState("modal", "room_settings");
-                          this.setState({ expanded: false });
+                          this.unexpand();
                         },
                         "room-settings"
                       );
@@ -211,7 +240,7 @@ export default class SettingsMenu extends Component {
                         () => this.props.hubChannel.can("update_hub"),
                         () => {
                           this.props.pushHistoryState("modal", "close_room");
-                          this.setState({ expanded: false });
+                          this.unexpand();
                         },
                         "close-room"
                       );
@@ -234,36 +263,38 @@ export default class SettingsMenu extends Component {
                     stateKey="modal"
                     stateValue="room_info"
                     history={this.props.history}
-                    onClick={() => this.setState({ expanded: false })}
+                    onClick={() => this.unexpand()}
                   >
                     <FormattedMessage id="settings.room-info" />
                   </StateLink>
                 </div>
               </div>
             )}
-            <div className={rowClasses}>
-              <div className={styles.icon}>
-                <i>
-                  <FontAwesomeIcon icon={faPlus} />
-                </i>
+            {!hideExtranousItems && (
+              <div className={rowClasses}>
+                <div className={styles.icon}>
+                  <i>
+                    <FontAwesomeIcon icon={faPlus} />
+                  </i>
+                </div>
+                <div className={styles.listItem}>
+                  <a
+                    href="#"
+                    onClick={e => {
+                      e.preventDefault();
+                      this.props.showNonHistoriedDialog(LeaveRoomDialog, {
+                        destinationUrl: "/",
+                        messageType: "create-room"
+                      });
+                      this.unexpand();
+                    }}
+                  >
+                    <FormattedMessage id="settings.create-room" />
+                  </a>
+                </div>
               </div>
-              <div className={styles.listItem}>
-                <a
-                  href="#"
-                  onClick={e => {
-                    e.preventDefault();
-                    this.props.showNonHistoriedDialog(LeaveRoomDialog, {
-                      destinationUrl: "/",
-                      messageType: "create-room"
-                    });
-                    this.setState({ expanded: false });
-                  }}
-                >
-                  <FormattedMessage id="settings.create-room" />
-                </a>
-              </div>
-            </div>
-            {showStreamerMode ? (
+            )}
+            {showStreamerMode && !hideExtranousItems ? (
               <div className={rowHeader}>
                 <FormattedMessage id="settings.row-tools" />
               </div>
@@ -282,7 +313,7 @@ export default class SettingsMenu extends Component {
                     className={styles.listItemLink}
                     onClick={() => {
                       this.props.toggleStreamerMode(true);
-                      this.setState({ expanded: false });
+                      this.unexpand();
                     }}
                   >
                     <FormattedMessage id="settings.enable-streamer-mode" />
@@ -292,91 +323,95 @@ export default class SettingsMenu extends Component {
             ) : (
               <div />
             )}
-            <div className={classNames([styles.bottomLinksMain])}>
-              <IfFeature name="show_whats_new_link">
-                <a href="/whats-new" target="_blank" rel="noreferrer noopener">
-                  <FormattedMessage id="settings.whats-new" />
-                </a>
-              </IfFeature>
-              <button
-                onClick={e => {
-                  e.preventDefault();
-                  resetTips();
-                  this.setState({ expanded: false });
-                }}
-              >
-                <FormattedMessage id="settings.tips" />
-              </button>
-              <IfFeature name="show_controls_link">
-                <a
-                  href={configs.link("controls", "https://github.com/mozilla/hubs/wiki/Hubs-Controls")}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
-                  <FormattedMessage id="settings.controls" />
-                </a>
-              </IfFeature>
-            </div>
-            <div className={classNames([styles.bottomLinks])}>
-              <IfFeature name="show_features_link">
-                <a
-                  href={configs.link("features", messages["help.docs_url"])}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
-                  <FormattedMessage id="settings.features" />
-                </a>
-              </IfFeature>
-              <IfFeature name="show_community_link">
-                <a
-                  href={configs.link("community", "https://discord.gg/wHmY4nd")}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
-                  <FormattedMessage id="settings.community" />
-                </a>
-              </IfFeature>
-              <IfFeature name="show_feedback_ui">
+            {!hideExtranousItems && (
+              <div className={classNames([styles.bottomLinksMain])}>
+                <IfFeature name="show_whats_new_link">
+                  <a href="/whats-new" target="_blank" rel="noreferrer noopener">
+                    <FormattedMessage id="settings.whats-new" />
+                  </a>
+                </IfFeature>
                 <button
                   onClick={e => {
                     e.preventDefault();
-                    this.props.pushHistoryState("modal", "feedback");
+                    resetTips();
+                    this.unexpand();
                   }}
                 >
-                  <FormattedMessage id="settings.send-feedback" />
+                  <FormattedMessage id="settings.tips" />
                 </button>
-              </IfFeature>
-              <IfFeature name="show_issue_report_link">
-                <a
-                  className={styles.bottomLink}
-                  href={configs.link("issue_report", "/?report")}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
-                  <FormattedMessage id="settings.report" />
-                </a>
-              </IfFeature>
-              <IfFeature name="show_terms">
-                <a
-                  className={styles.bottomLink}
-                  href={configs.link("terms_of_use", "https://github.com/mozilla/hubs/blob/master/TERMS.md")}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
-                  <FormattedMessage id="settings.terms" />
-                </a>
-              </IfFeature>
-              <IfFeature name="show_privacy">
-                <a
-                  className={styles.bottomLink}
-                  href={configs.link("privacy_notice", "https://github.com/mozilla/hubs/blob/master/PRIVACY.md")}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
-                  <FormattedMessage id="settings.privacy" />
-                </a>
-              </IfFeature>
-            </div>
+                <IfFeature name="show_controls_link">
+                  <a
+                    href={configs.link("controls", "https://github.com/mozilla/hubs/wiki/Hubs-Controls")}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    <FormattedMessage id="settings.controls" />
+                  </a>
+                </IfFeature>
+              </div>
+            )}
+            {!hideExtranousItems && (
+              <div className={classNames([styles.bottomLinks])}>
+                <IfFeature name="show_features_link">
+                  <a
+                    href={configs.link("features", messages["help.docs_url"])}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    <FormattedMessage id="settings.features" />
+                  </a>
+                </IfFeature>
+                <IfFeature name="show_community_link">
+                  <a
+                    href={configs.link("community", "https://discord.gg/wHmY4nd")}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    <FormattedMessage id="settings.community" />
+                  </a>
+                </IfFeature>
+                <IfFeature name="show_feedback_ui">
+                  <button
+                    onClick={e => {
+                      e.preventDefault();
+                      this.props.pushHistoryState("modal", "feedback");
+                    }}
+                  >
+                    <FormattedMessage id="settings.send-feedback" />
+                  </button>
+                </IfFeature>
+                <IfFeature name="show_issue_report_link">
+                  <a
+                    className={styles.bottomLink}
+                    href={configs.link("issue_report", "/?report")}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    <FormattedMessage id="settings.report" />
+                  </a>
+                </IfFeature>
+                <IfFeature name="show_terms">
+                  <a
+                    className={styles.bottomLink}
+                    href={configs.link("terms_of_use", "https://github.com/mozilla/hubs/blob/master/TERMS.md")}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    <FormattedMessage id="settings.terms" />
+                  </a>
+                </IfFeature>
+                <IfFeature name="show_privacy">
+                  <a
+                    className={styles.bottomLink}
+                    href={configs.link("privacy_notice", "https://github.com/mozilla/hubs/blob/master/PRIVACY.md")}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    <FormattedMessage id="settings.privacy" />
+                  </a>
+                </IfFeature>
+              </div>
+            )}
           </div>
         </div>
       </div>
@@ -386,15 +421,21 @@ export default class SettingsMenu extends Component {
   render() {
     return (
       <div>
-        <FontAwesomeIcon
-          icon={faBars}
-          onClick={() => this.setState({ expanded: !this.state.expanded })}
-          className={classNames({
-            [rootStyles.cornerButton]: true,
-            [rootStyles.cornerButtonSelected]: this.state.expanded
-          })}
-        />
-        {this.state.expanded && this.renderExpandedMenu()}
+        {!this.props.showAsOverlay && (
+          <FontAwesomeIcon
+            icon={faBars}
+            onClick={() => this.setState({ expanded: !this.state.expanded })}
+            className={classNames({
+              [rootStyles.cornerButton]: true,
+              [rootStyles.cornerButtonSelected]: this.state.expanded
+            })}
+          />
+        )}
+        {this.props.showAsOverlay ? (
+          <div className={styles.settingsMenuOverlayWrap}>{this.renderExpandedMenu()}</div>
+        ) : (
+          this.state.expanded && this.renderExpandedMenu()
+        )}
       </div>
     );
   }

--- a/src/react-components/settings-menu.js
+++ b/src/react-components/settings-menu.js
@@ -374,48 +374,6 @@ export default class SettingsMenu extends Component {
                   <button
                     onClick={e => {
                       e.preventDefault();
-                      resetTips();
-                      this.unexpand();
-                    }}
-                  >
-                    <FormattedMessage id="settings.tips" />
-                  </button>
-                  <IfFeature name="show_controls_link">
-                    <a
-                      href={configs.link("controls", "https://github.com/mozilla/hubs/wiki/Hubs-Controls")}
-                      target="_blank"
-                      rel="noreferrer noopener"
-                    >
-                      <FormattedMessage id="settings.controls" />
-                    </a>
-                  </IfFeature>
-                </IfFeature>
-              </div>
-            )}
-            {!hideExtranousItems && (
-              <div className={classNames([styles.bottomLinks])}>
-                <IfFeature name="show_features_link">
-                  <a
-                    href={configs.link("features", messages["help.docs_url"])}
-                    target="_blank"
-                    rel="noreferrer noopener"
-                  >
-                    <FormattedMessage id="settings.features" />
-                  </a>
-                </IfFeature>
-                <IfFeature name="show_community_link">
-                  <a
-                    href={configs.link("community", "https://discord.gg/wHmY4nd")}
-                    target="_blank"
-                    rel="noreferrer noopener"
-                  >
-                    <FormattedMessage id="settings.community" />
-                  </a>
-                </IfFeature>
-                <IfFeature name="show_feedback_ui">
-                  <button
-                    onClick={e => {
-                      e.preventDefault();
                       this.props.pushHistoryState("modal", "feedback");
                     }}
                   >

--- a/src/react-components/settings-menu.js
+++ b/src/react-components/settings-menu.js
@@ -34,7 +34,7 @@ export default class SettingsMenu extends Component {
     mediaSearchStore: PropTypes.object,
     scene: PropTypes.object,
     showAsOverlay: PropTypes.bool, // Shows the settings as an overlay menu, instead of a dropdown
-    onCloseOverlay: PropTypes.func, // Shows the settings as an overlay menu, instead of a dropdown
+    onCloseOverlay: PropTypes.func,
     hubScene: PropTypes.object,
     hubChannel: PropTypes.object,
     performConditionalSignIn: PropTypes.func,

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1506,7 +1506,8 @@ class UIRoot extends Component {
       [styles.backgrounded]: this.isInModalOrOverlay()
     });
 
-    const showVREntryButton = entered && isMobileVR;
+    // MobileVR browsers always show settings panel as an overlay when exiting immersive mode.
+    const showSettingsAsOverlay = entered && isMobileVR;
 
     const presenceLogEntries = this.props.presenceLogEntries || [];
 
@@ -1529,7 +1530,6 @@ class UIRoot extends Component {
       (hasDiscordBridges || (hasEmbedPresence && !this.props.embed)) && !this.state.broadcastTipDismissed;
 
     const showInviteTip =
-      !showVREntryButton &&
       !hasTopTip &&
       !entered &&
       !embed &&
@@ -1541,7 +1541,6 @@ class UIRoot extends Component {
       this.occupantCount() <= 1;
 
     const showChooseSceneButton =
-      !showVREntryButton &&
       !entered &&
       !embed &&
       !preload &&
@@ -1841,18 +1840,11 @@ class UIRoot extends Component {
                   history={this.props.history}
                 />
               )}
-            {this.state.frozen &&
-              !showVREntryButton && (
-                <button className={styles.leaveButton} onClick={() => this.exit("left")}>
-                  <FormattedMessage id="entry.leave-room" />
-                </button>
-              )}
-            {this.state.frozen /* Case when we exit immersive mode while frozen */ &&
-              showVREntryButton && (
-                <button className={styles.leaveButton} onClick={() => exit2DInterstitialAndEnterVR(true)}>
-                  <FormattedMessage id="entry.enter-in-vr" />
-                </button>
-              )}
+            {this.state.frozen && (
+              <button className={styles.leaveButton} onClick={() => this.exit("left")}>
+                <FormattedMessage id="entry.leave-room" />
+              </button>
+            )}
             {!this.state.frozen &&
               !watching &&
               !preload && (
@@ -1864,7 +1856,6 @@ class UIRoot extends Component {
                   })}
                 >
                   {!embed &&
-                    !showVREntryButton &&
                     !hasTopTip &&
                     !streaming && (
                       <WithHoverSound>
@@ -1904,7 +1895,6 @@ class UIRoot extends Component {
                     </div>
                   )}
                   {!embed &&
-                    !showVREntryButton &&
                     this.occupantCount() > 1 &&
                     !hasTopTip &&
                     entered &&
@@ -1919,11 +1909,6 @@ class UIRoot extends Component {
                         </span>
                       </button>
                     )}
-                  {showVREntryButton && (
-                    <button className={inviteStyles.enterButton} onClick={() => exit2DInterstitialAndEnterVR(true)}>
-                      <FormattedMessage id="entry.enter-in-vr" />
-                    </button>
-                  )}
                   {embed && (
                     <a href={baseUrl} className={inviteStyles.enterButton} target="_blank" rel="noopener noreferrer">
                       <FormattedMessage id="entry.open-in-window" />
@@ -2040,6 +2025,8 @@ class UIRoot extends Component {
                   hubChannel={this.props.hubChannel}
                   hubScene={this.props.hubScene}
                   scene={this.props.scene}
+                  showAsOverlay={showSettingsAsOverlay}
+                  onCloseOverlay={() => exit2DInterstitialAndEnterVR(true)}
                   performConditionalSignIn={this.props.performConditionalSignIn}
                   showNonHistoriedDialog={this.showNonHistoriedDialog}
                   showPreferencesScreen={() => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -110,7 +110,7 @@ module.exports = (env, argv) => ({
   devtool: argv.mode === "production" ? "source-map" : "inline-source-map",
   devServer: {
     https: createHTTPSConfig(),
-    host: process.env.HOST_IP || "0.0.0.0",
+    host: "0.0.0.0",
     public: `${host}:8080`,
     useLocalIp: true,
     allowedHosts: [host],


### PR DESCRIPTION
Currently when using an immersive browser on mobile VR, clicking the menu button exits immersive mode and lands you on the 2d mode version of hubs, with an "Enter in VR" button to return. This PR changes that behavior so the menu button actually shows the settings menu, and closing the settings menu returns to VR mode. There doesn't seem to be much value in showing the 2d viewport (which no longer is visible because the menu is shown), and it seems better to not force the user to fish out the menu in the top left corner if they actually want to access settings.

One challenge is vertical real estate is at a premium, and we also want to leave room for the chat and HUD, so this PR truncates some of the less-relevant menu items in this context, such as the various help links and actions which are unlikely to be needed in an immersive context.

![image](https://user-images.githubusercontent.com/220020/71926142-7b579d80-3147-11ea-86bf-72d8804b53d7.png)
