### PR TITLE
Feature/lobby element focus

### DIFF
--- a/src/assets/stylesheets/avatar-editor.scss
+++ b/src/assets/stylesheets/avatar-editor.scss
@@ -258,10 +258,11 @@
   }
 
   .close-button {
+    @extend %panel-widget;
+
     font-size: 1.6em;
     align-self: flex-start;
-    cursor: pointer;
-    color: var(--panel-widget-color);
+
     @media (max-width: 768px) {
       padding-left: 0.5em;
     }

--- a/src/assets/stylesheets/client-info-dialog.scss
+++ b/src/assets/stylesheets/client-info-dialog.scss
@@ -17,7 +17,7 @@
 
 :local(.collapse-button) {
   @extend %fa-icon-button;
-  color: var(--panel-widget-color);
+  @extend %panel-widget;
   margin: 0 10px;
 
   i {

--- a/src/assets/stylesheets/info-dialog.scss
+++ b/src/assets/stylesheets/info-dialog.scss
@@ -88,16 +88,12 @@
       }
 
       &__close {
+        @extend %panel-widget;
         position: absolute;
         left: 18px;
         top: 18px;
-        color: var(--panel-widget-color);
         font-size: 1.6em;
         font-weight: bold;
-
-        background: none;
-        cursor: pointer;
-        border: none;
       }
     }
 

--- a/src/assets/stylesheets/media-browser.scss
+++ b/src/assets/stylesheets/media-browser.scss
@@ -482,15 +482,15 @@
     margin: 0 0 0 32px;
     display: flex;
     width: 250px;
-    font-size: 1.6em;
 
     @media (max-width: 801px) {
       width: 50px;
       height: 35px;
     }
 
-    a {
-      color: var(--panel-widget-color);
+    button {
+      font-size: 1.6em;
+      @extend %panel-widget;
     }
   }
 

--- a/src/assets/stylesheets/preferences-screen.scss
+++ b/src/assets/stylesheets/preferences-screen.scss
@@ -4,9 +4,7 @@ $smallScreenWidth : 475px;
 $itemHeight : 3.0rem;
 $hoverFontSize: 1.6rem;
 $widescreenControlsWidth: 100%;
-$sectionTitleFontSize: 1.1rem;
-$titleHeight: 3.0rem;
-$sectionTitleFontWeight: bolder;
+$widescreenBreakpoint: 600px;
 $backgroundColor: var(--full-panel-background-color);
 
 :local(.max-resolution-preference-item) {
@@ -33,24 +31,21 @@ input::-webkit-inner-spin-button {
   -webkit-appearance: none;
 }
 
+:local(.preference-list-non-checkbox){
+  @media (max-width: $widescreenBreakpoint) {
+    flex-direction: column;
+  }
+}
+
 :local(.preference-list-item){
   display: flex;
   align-items: center;
-  @media( min-width:$smallScreenWidth+1 ) {
-    flex-flow: row;
-    height: $itemHeight;
-  }
-  @media( max-width:$smallScreenWidth ) {
-    flex-flow: column;
-    height: 2*$itemHeight;
-    margin-bottom: 0.5rem;
-  }
+  margin: 12px 0;
 
   :local(.part) {
     display: flex;
     flex-flow: column;
     justify-content: space-around;
-    height: $itemHeight;
     @media( min-width:$smallScreenWidth+1 ) {
       justify-content: space-around;
     }
@@ -58,8 +53,11 @@ input::-webkit-inner-spin-button {
       text-align: center;
       justify-content: center;
       align-items: center;
-      height: 2*$itemHeight;
     }
+  }
+  :local(.checkbox-margin) {
+    margin-right: 8px;
+    width: 48px;
   }
   :local(.left) {
     flex: 1;
@@ -91,42 +89,53 @@ input::-webkit-inner-spin-button {
   }
 }
 
-:local(.content-container) {
-  @extend %default-font;
-  font-size: 11pt;
-  font-weight: bold;
-  position: absolute;
-  box-sizing: border-box;
+:local(.preferences-panel) {
   top: 0px;
   bottom: 0px;
   width: 100%;
+  height: 100%;
   background: var(--full-panel-background-color);
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+:local(.panel-margin) {
+  margin-top: 18px;
+
+  :local(.close-button) {
+    @extend %panel-widget;
+    top: 32px;
+    left: 24px;
+
+    font-size: 1.6em;
+    position: absolute;
+    z-index: 1;
+  }
+}
+
+:local(.content-container) {
+  @extend %default-font;
+  font-size: 11pt;
   overflow-y: auto;
-  margin-top: $titleHeight;
+  font-weight: bold;
+  box-sizing: border-box;
+  height: calc(100vh - 16px);
+
+  @media (max-width: $widescreenBreakpoint) {
+    margin-top: 0;
+    height: calc(100vh - 48px);
+  }
+
   :local(.scrolling-content) {
     display: flex;
     flex-flow: column;
     max-width: 80%;
     padding-left: 10%;
   }
-  :local(.title-bar) {
-    position: fixed;
-    top: 0px;
-    width: 100%;
-    height: $titleHeight;
-    background: var(--full-panel-background-color);
-  }
-  :local(.title) {
-    @extend %top-title;
-    display: flex;
-    flex-flow: row;
-    justify-content: center;
-    align-items: center;
-    height: $titleHeight;
-  }
   :local(.section-bar) {
     width: 100%;
-    height: $titleHeight;
     display: flex;
     flex-flow: row;
     justify-content: center;
@@ -136,11 +145,17 @@ input::-webkit-inner-spin-button {
     width: 90%;
     display: flex;
     flex-flow: row;
-    justify-content: center;
+    justify-content: flex-start;
+
+    @media (max-width: $widescreenBreakpoint) {
+      justify-content: center;
+    }
+
     align-items: center;
-    height: $titleHeight;
-    font-size: $sectionTitleFontSize;
-    font-weight: $sectionTitleFontWeight;
+    color: var(--menu-header-text-color);
+    font-weight: normal;
+    text-transform: uppercase;
+    margin: 12px 0;
   }
 
   input[type=checkbox] {
@@ -158,25 +173,11 @@ input::-webkit-inner-spin-button {
   justify-content: end;
 }
 
-:local(.close-button) {
-  @extend %panel-widget;
-  top: 0.5em;
-  left: 1em;
-  font-size: 1.6em;
-  position: absolute;
-  z-index: 1;
-}
 :local(.row) {
   width: 90%;
   display: flex;
   flex-flow: row;
   align-items: center;
-  height: $itemHeight;
-  @media( max-width:$smallScreenWidth ) {
-    width: 100%;
-    flex-flow: column;
-    height: 2*$itemHeight;
-  }
 }
 :local(.row-name) {
   display: flex;
@@ -184,14 +185,7 @@ input::-webkit-inner-spin-button {
   flex-wrap: nowrap;
   justify-content: space-around;
   width: 50%;
-  height: $itemHeight;
   text-align: end;
-  @media( max-width:$smallScreenWidth ) {
-    width: 100%;
-    text-align: center;
-    margin-inline-end: 0rem;
-    height: 2*$itemHeight;
-  }
   margin-inline-end: 1rem;
 }
 

--- a/src/assets/stylesheets/preferences-screen.scss
+++ b/src/assets/stylesheets/preferences-screen.scss
@@ -9,7 +9,7 @@ $titleHeight: 3.0rem;
 $sectionTitleFontWeight: bolder;
 $backgroundColor: var(--full-panel-background-color);
 
-:local(.maxResolutionPreferenceItem) {
+:local(.max-resolution-preference-item) {
   display: flex;
   flex-flow: row;
   align-items: center;
@@ -33,7 +33,7 @@ input::-webkit-inner-spin-button {
   -webkit-appearance: none;
 }
 
-:local(.preferenceListItem){
+:local(.preference-list-item){
   display: flex;
   align-items: center;
   @media( min-width:$smallScreenWidth+1 ) {
@@ -91,7 +91,7 @@ input::-webkit-inner-spin-button {
   }
 }
 
-:local(.contentContainer) {
+:local(.content-container) {
   @extend %default-font;
   font-size: 11pt;
   font-weight: bold;
@@ -103,13 +103,13 @@ input::-webkit-inner-spin-button {
   background: var(--full-panel-background-color);
   overflow-y: auto;
   margin-top: $titleHeight;
-  :local(.scrollingContent) {
+  :local(.scrolling-content) {
     display: flex;
     flex-flow: column;
     max-width: 80%;
     padding-left: 10%;
   }
-  :local(.titleBar) {
+  :local(.title-bar) {
     position: fixed;
     top: 0px;
     width: 100%;
@@ -124,7 +124,7 @@ input::-webkit-inner-spin-button {
     align-items: center;
     height: $titleHeight;
   }
-  :local(.sectionBar) {
+  :local(.section-bar) {
     width: 100%;
     height: $titleHeight;
     display: flex;
@@ -132,7 +132,7 @@ input::-webkit-inner-spin-button {
     justify-content: center;
     align-items: center;
   }
-  :local(.sectionTitle) {
+  :local(.section-title) {
     width: 90%;
     display: flex;
     flex-flow: row;
@@ -158,13 +158,12 @@ input::-webkit-inner-spin-button {
   justify-content: end;
 }
 
-:local(.closeButton) {
+:local(.close-button) {
+  @extend %panel-widget;
   top: 0.5em;
   left: 1em;
   font-size: 1.6em;
   position: absolute;
-  cursor: pointer;
-  color: var(--panel-widget-color);
   z-index: 1;
 }
 :local(.row) {
@@ -179,7 +178,7 @@ input::-webkit-inner-spin-button {
     height: 2*$itemHeight;
   }
 }
-:local(.rowName) {
+:local(.row-name) {
   display: flex;
   flex-flow: column;
   flex-wrap: nowrap;
@@ -196,27 +195,27 @@ input::-webkit-inner-spin-button {
   margin-inline-end: 1rem;
 }
 
-:local(.resetToDefaultButton){
+:local(.reset-to-default-button){
   background: transparent;
   border: none;
   font-size: medium;
   padding: 0px 0px 0px 12px;
 }
 
-:local(.prevOptionScale) {
+:local(.prev-option-scale) {
   height: 2rem;
 }
-:local(.nextOptionScale) {
+:local(.next-option-scale) {
   height: 2rem;
 }
 
-:local(.prevOptionHoveredScale) {
+:local(.prev-option-hovered-scale) {
   height: 2.2rem;
 }
-:local(.nextOptionHoveredScale) {
+:local(.next-option-hovered-scale) {
   height: 2.2rem;
 }
-:local(.numberWithRange){
+:local(.number-with-range){
   display: flex;
   flex-flow: row;
   width: $widescreenControlsWidth;
@@ -227,7 +226,7 @@ input::-webkit-inner-spin-button {
   justify-content: flex-start;
   align-items: center;
 
-  :local(.numberInNumberWithRange) {
+  :local(.number-in-number-with-range) {
     display:flex;
     justify-content: center;
     cursor: pointer;
@@ -241,7 +240,7 @@ input::-webkit-inner-spin-button {
       height: 38px;
     }
   }
-  :local(.rangeSlider) {
+  :local(.range-slider) {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/assets/stylesheets/preferences-screen.scss
+++ b/src/assets/stylesheets/preferences-screen.scss
@@ -81,6 +81,7 @@ input::-webkit-inner-spin-button {
       height: 38px;
       padding-left: 1em;
       padding-right: 2.5em;
+      cursor: pointer;
     }
     :local(.dropdownArrow) {
       @extend %dropdown-arrow;
@@ -106,7 +107,7 @@ input::-webkit-inner-spin-button {
 
   :local(.close-button) {
     @extend %panel-widget;
-    top: 32px;
+    top: 24px;
     left: 24px;
 
     font-size: 1.6em;
@@ -194,6 +195,11 @@ input::-webkit-inner-spin-button {
   border: none;
   font-size: medium;
   padding: 0px 0px 0px 12px;
+  cursor: pointer;
+  appearance: none;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  outline-style: none;
 }
 
 :local(.prev-option-scale) {
@@ -302,6 +308,7 @@ $ie-bottom-track-color: $track-color !default;
   background: transparent;
   margin: $thumb-height / 2 0;
   width: $track-width;
+  cursor: pointer;
 
   &::-moz-focus-outer {
     border: 0;
@@ -333,6 +340,7 @@ $ie-bottom-track-color: $track-color !default;
 
   &::-webkit-slider-thumb {
     @include thumb;
+    cursor: pointer;
     -webkit-appearance: none;
     margin-top: ((-$track-border-width * 2 + $track-height) / 2 - $thumb-height / 2);
   }
@@ -348,6 +356,7 @@ $ie-bottom-track-color: $track-color !default;
 
   &::-moz-range-thumb {
     @include thumb;
+    cursor: pointer;
   }
 
   &::-ms-track {
@@ -374,6 +383,7 @@ $ie-bottom-track-color: $track-color !default;
 
   &::-ms-thumb {
     @include thumb;
+    cursor: pointer;
     margin-top: $track-height / 4;
   }
 

--- a/src/assets/stylesheets/profile.scss
+++ b/src/assets/stylesheets/profile.scss
@@ -146,7 +146,10 @@
     left: 24px;
     height: 35px;
     position: absolute;
-    font-size: 1.6em;
-    color: var(--panel-widget-color);
+
+    button {
+      font-size: 1.6em;
+      @extend %panel-widget;
+    }
   }
 }

--- a/src/assets/stylesheets/settings-menu.scss
+++ b/src/assets/stylesheets/settings-menu.scss
@@ -33,15 +33,13 @@
 }
 
 :local(.close-button) {
+  @extend %panel-widget;
+
   position: absolute;
   left: 18px;
   top: 18px;
-  color: var(--panel-widget-color);
   font-size: 1.6em;
   font-weight: bold;
-
-  background: none;
-  cursor: pointer;
   border: none;
 }
 

--- a/src/assets/stylesheets/shared.scss
+++ b/src/assets/stylesheets/shared.scss
@@ -280,6 +280,14 @@ $favorited-color: var(--favorited-color, $duck-yellow);
   margin-left: 16px;
 }
 
+%panel-widget {
+  cursor: pointer;
+  color: var(--panel-widget-color);
+  outline-style: none;
+  background: none;
+  border: none;
+}
+
 %tip-bubble {
   position: absolute;
   left: 50%;

--- a/src/react-components/dialog-container.js
+++ b/src/react-components/dialog-container.js
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
-import { WithHoverSound } from "./wrap-with-audio";
 import { faTimes } from "@fortawesome/free-solid-svg-icons/faTimes";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
@@ -76,13 +75,11 @@ export default class DialogContainer extends Component {
               {this.props.closable &&
                 this.props.onClose &&
                 !this.props.noOverlay && (
-                  <WithHoverSound>
-                    <button className="dialog__box__contents__close" onClick={() => this.props.onClose()}>
-                      <i>
-                        <FontAwesomeIcon icon={faTimes} />
-                      </i>
-                    </button>
-                  </WithHoverSound>
+                  <button autoFocus className="dialog__box__contents__close" onClick={() => this.props.onClose()}>
+                    <i>
+                      <FontAwesomeIcon icon={faTimes} />
+                    </i>
+                  </button>
                 )}
               {this.props.title && <div className="dialog__box__contents__title">{this.props.title}</div>}
               <div className="dialog__box__contents__body">{this.props.children}</div>

--- a/src/react-components/entry-buttons.js
+++ b/src/react-components/entry-buttons.js
@@ -16,6 +16,7 @@ const EntryButton = props => {
   return (
     <WithHoverSound>
       <button
+        autoFocus={props.autoFocus}
         className={cx([{ [styles.entryButton]: true, [styles.entryButtonSecondary]: props.secondary }])}
         onClick={props.onClick}
       >
@@ -42,6 +43,7 @@ const EntryButton = props => {
 
 EntryButton.propTypes = {
   onClick: PropTypes.func,
+  autoFocus: PropTypes.bool,
   iconSrc: PropTypes.string,
   secondary: PropTypes.bool,
   prefixMessageId: PropTypes.string,

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -287,11 +287,11 @@ class MediaBrowser extends Component {
         <div className={classNames([styles.box, styles.darkened])}>
           <div className={classNames(styles.header, { [styles.noSearch]: hideSearch })}>
             <div className={styles.headerLeft}>
-              <a onClick={() => this.close()}>
+              <button onClick={() => this.close()}>
                 <i>
                   <FontAwesomeIcon icon={faTimes} />
                 </i>
-              </a>
+              </button>
             </div>
             <div className={styles.headerCenter}>
               {urlSource === "favorites" && (

--- a/src/react-components/object-info-dialog.js
+++ b/src/react-components/object-info-dialog.js
@@ -112,11 +112,11 @@ export default class ObjectInfoDialog extends Component {
       <DialogContainer noOverlay={true} wide={true} {...this.props}>
         <div className={styles.roomInfo}>
           <div className={styles.titleAndClose}>
-            <a className={entryStyles.collapseButton} onClick={onClose}>
+            <button autoFocus className={entryStyles.collapseButton} onClick={onClose}>
               <i>
                 <FontAwesomeIcon icon={faTimes} />
               </i>
-            </a>
+            </button>
             <a
               className={styles.objectDisplayString}
               href={this.props.objectDisplayString}

--- a/src/react-components/preference-list-item.js
+++ b/src/react-components/preference-list-item.js
@@ -195,9 +195,15 @@ export class PreferenceListItem extends Component {
   }
 
   render() {
+    const isCheckbox = this.props.prefType === PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX;
+
     return (
       <div
-        className={classNames({ [styles.hovered]: this.state.hovered }, styles.preferenceListItem)}
+        className={classNames(
+          { [styles.hovered]: this.state.hovered },
+          styles.preferenceListItem,
+          !isCheckbox && styles.preferenceListNonCheckbox
+        )}
         onMouseEnter={() => {
           this.setState({ hovered: true });
         }}
@@ -205,11 +211,14 @@ export class PreferenceListItem extends Component {
           this.setState({ hovered: false });
         }}
       >
+        <div className={classNames(styles.checkboxMargin)}>
+          {isCheckbox ? this.renderControls() : <span>&nbsp;</span>}
+        </div>
         <div className={classNames(styles.part, styles.left, styles.label)}>
           <FormattedMessage id={`preferences.${this.props.storeKey}`} />
         </div>
         <div className={classNames(styles.part, styles.right)}>
-          {this.renderControls()}
+          {!isCheckbox && this.renderControls()}
           <button
             className={classNames(styles.resetToDefaultButton)}
             onClick={() => {

--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -88,30 +88,28 @@ export default class PreferencesScreen extends Component {
 
     return (
       <IntlProvider locale={lang} messages={messages}>
-        <div className={classNames(styles.root)}>
-          <button autoFocus className={classNames(styles.closeButton)} onClick={e => this.props.onClose(e)}>
-            <i>
-              <FontAwesomeIcon icon={faTimes} />
-            </i>
-          </button>
-          <div className={classNames(styles.contentContainer)}>
-            <div className={classNames(styles.titleBar)}>
-              <div className={classNames(styles.title)}>
-                <span>Preferences</span>
+        <div className={classNames(styles.preferencesPanel)}>
+          <div className={classNames(styles.panelMargin)}>
+            <button autoFocus className={classNames(styles.closeButton)} onClick={e => this.props.onClose(e)}>
+              <i>
+                <FontAwesomeIcon icon={faTimes} />
+              </i>
+            </button>
+
+            <div className={classNames(styles.contentContainer)}>
+              <div className={classNames(styles.sectionBar)}>
+                <div className={classNames(styles.sectionTitle)}>
+                  <span>General</span>
+                </div>
               </div>
-            </div>
-            <div className={classNames(styles.sectionBar)}>
-              <div className={classNames(styles.sectionTitle)}>
-                <span>General</span>
+              <div className={classNames(styles.scrollingContent)}>{general}</div>
+              <div className={classNames(styles.sectionBar)}>
+                <div className={classNames(styles.sectionTitle)}>
+                  <span>Touchscreen</span>
+                </div>
               </div>
+              <div className={classNames(styles.scrollingContent)}>{touchscreen}</div>
             </div>
-            <div className={classNames(styles.scrollingContent)}>{general}</div>
-            <div className={classNames(styles.sectionBar)}>
-              <div className={classNames(styles.sectionTitle)}>
-                <span>Touchscreen</span>
-              </div>
-            </div>
-            <div className={classNames(styles.scrollingContent)}>{touchscreen}</div>
           </div>
         </div>
       </IntlProvider>

--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -89,9 +89,11 @@ export default class PreferencesScreen extends Component {
     return (
       <IntlProvider locale={lang} messages={messages}>
         <div className={classNames(styles.root)}>
-          <i className={classNames(styles.closeButton)} onClick={e => this.props.onClose(e)}>
-            <FontAwesomeIcon icon={faTimes} />
-          </i>
+          <button autoFocus className={classNames(styles.closeButton)} onClick={e => this.props.onClose(e)}>
+            <i>
+              <FontAwesomeIcon icon={faTimes} />
+            </i>
+          </button>
           <div className={classNames(styles.contentContainer)}>
             <div className={classNames(styles.titleBar)}>
               <div className={classNames(styles.title)}>

--- a/src/react-components/profile-entry-panel.js
+++ b/src/react-components/profile-entry-panel.js
@@ -130,11 +130,11 @@ class ProfileEntryPanel extends Component {
     return (
       <div className={styles.profileEntry}>
         <div className={styles.close}>
-          <a onClick={() => this.props.onClose()}>
+          <button autoFocus onClick={() => this.props.onClose()}>
             <i>
               <FontAwesomeIcon icon={faTimes} />
             </i>
-          </a>
+          </button>
         </div>
         <form onSubmit={this.saveStateAndFinish} className={styles.form}>
           <div className={classNames([styles.box])}>

--- a/src/react-components/settings-menu.js
+++ b/src/react-components/settings-menu.js
@@ -92,7 +92,7 @@ export default class SettingsMenu extends Component {
         {!this.props.showAsOverlay && <div className={styles.attachPoint} />}
         <div className={styles.contents}>
           {this.props.showAsOverlay && (
-            <button className={styles.closeButton} onClick={() => this.props.onCloseOverlay()}>
+            <button autoFocus className={styles.closeButton} onClick={() => this.props.onCloseOverlay()}>
               <i>
                 <FontAwesomeIcon icon={faTimes} />
               </i>

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -14,7 +14,7 @@ import { canShare } from "../utils/share";
 import styles from "../assets/stylesheets/ui-root.scss";
 import entryStyles from "../assets/stylesheets/entry.scss";
 import inviteStyles from "../assets/stylesheets/invite-dialog.scss";
-import { ReactAudioContext, WithHoverSound } from "./wrap-with-audio";
+import { ReactAudioContext } from "./wrap-with-audio";
 import {
   pushHistoryState,
   clearHistoryState,
@@ -309,6 +309,7 @@ class UIRoot extends Component {
     this.props.scene.addEventListener("share_video_failed", this.onShareVideoFailed);
     this.props.scene.addEventListener("exit", this.exitEventHandler);
     this.props.scene.addEventListener("action_exit_watch", () => this.setState({ watching: false, hide: false }));
+    this.props.scene.addEventListener("action_advance_lobby", () => this.setState({ watching: false, hide: false }));
 
     const scene = this.props.scene;
 
@@ -976,22 +977,18 @@ class UIRoot extends Component {
       subtitle = (
         <div>
           Your browser does not support{" "}
-          <WithHoverSound>
-            <a
-              href="https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/createDataChannel#Browser_compatibility"
-              rel="noreferrer noopener"
-            >
-              WebRTC Data Channels
-            </a>
-          </WithHoverSound>
+          <a
+            href="https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/createDataChannel#Browser_compatibility"
+            rel="noreferrer noopener"
+          >
+            WebRTC Data Channels
+          </a>
           , which is required to use {messages["app-name"]}.
           <br />
           If you&quot;d like to use {messages["app-name"]} with Oculus or SteamVR, you can{" "}
-          <WithHoverSound>
-            <a href="https://www.mozilla.org/firefox" rel="noreferrer noopener">
-              Download Firefox
-            </a>
-          </WithHoverSound>
+          <a href="https://www.mozilla.org/firefox" rel="noreferrer noopener">
+            Download Firefox
+          </a>
           .
         </div>
       );
@@ -1004,10 +1001,7 @@ class UIRoot extends Component {
           <p />
           {!["left", "disconnected", "scene_error"].includes(this.props.roomUnavailableReason) && (
             <div>
-              You can also{" "}
-              <WithHoverSound>
-                <a href="/">create a new room</a>
-              </WithHoverSound>
+              You can also <a href="/">create a new room</a>
               .
             </div>
           )}
@@ -1094,7 +1088,7 @@ class UIRoot extends Component {
           !this.props.entryDisallowed && (
             <div className={entryStyles.buttonContainer}>
               {!isMobileVR && (
-                <a
+                <button
                   onClick={e => {
                     e.preventDefault();
                     this.attemptLink();
@@ -1107,9 +1101,10 @@ class UIRoot extends Component {
                       id={isMobile ? "entry.device-subtitle-mobile" : "entry.device-subtitle-desktop"}
                     />
                   </div>
-                </a>
+                </button>
               )}
-              <a
+              <button
+                autoFocus
                 onClick={e => {
                   e.preventDefault();
 
@@ -1125,7 +1120,7 @@ class UIRoot extends Component {
                 className={classNames([entryStyles.actionButton, entryStyles.wideButton])}
               >
                 <FormattedMessage id="entry.enter-room" />
-              </a>
+              </button>
             </div>
           )}
         {this.props.entryDisallowed &&
@@ -1192,7 +1187,7 @@ class UIRoot extends Component {
               <DaydreamEntryButton secondary={true} onClick={this.enterDaydream} subtitle={null} />
             )}
             {this.props.availableVREntryTypes.screen === VR_DEVICE_AVAILABILITY.yes && (
-              <TwoDEntryButton onClick={this.enter2D} />
+              <TwoDEntryButton autoFocus={true} onClick={this.enter2D} />
             )}
           </div>
         ) : (
@@ -1227,25 +1222,19 @@ class UIRoot extends Component {
           </div>
           <div className="mic-grant-panel__button-container">
             {granted ? (
-              <WithHoverSound>
-                <button className="mic-grant-panel__button" onClick={this.onMicGrantButton}>
-                  <img src="../assets/images/mic_granted.png" srcSet="../assets/images/mic_granted@2x.png 2x" />
-                </button>
-              </WithHoverSound>
+              <button autoFocus className="mic-grant-panel__button" onClick={this.onMicGrantButton}>
+                <img src="../assets/images/mic_granted.png" srcSet="../assets/images/mic_granted@2x.png 2x" />
+              </button>
             ) : (
-              <WithHoverSound>
-                <button className="mic-grant-panel__button" onClick={this.onMicGrantButton}>
-                  <img src="../assets/images/mic_denied.png" srcSet="../assets/images/mic_denied@2x.png 2x" />
-                </button>
-              </WithHoverSound>
+              <button autoFocus className="mic-grant-panel__button" onClick={this.onMicGrantButton}>
+                <img src="../assets/images/mic_denied.png" srcSet="../assets/images/mic_denied@2x.png 2x" />
+              </button>
             )}
           </div>
           <div className="mic-grant-panel__next-container">
-            <WithHoverSound>
-              <button className={classNames("mic-grant-panel__next")} onClick={this.onMicGrantButton}>
-                <FormattedMessage id="audio.granted-next" />
-              </button>
-            </WithHoverSound>
+            <button autoFocus className={classNames("mic-grant-panel__next")} onClick={this.onMicGrantButton}>
+              <FormattedMessage id="audio.granted-next" />
+            </button>
           </div>
         </div>
       </div>
@@ -1292,20 +1281,18 @@ class UIRoot extends Component {
           </div>
           {this.state.audioTrack && this.state.micDevices.length > 1 ? (
             <div className="audio-setup-panel__device-chooser">
-              <WithHoverSound>
-                <select
-                  className="audio-setup-panel__device-chooser__dropdown"
-                  value={this.selectedMicDeviceId()}
-                  onChange={this.micDeviceChanged}
-                >
-                  {this.state.micDevices.map(d => (
-                    <option key={d.deviceId} value={d.deviceId}>
-                      &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-                      {d.label}
-                    </option>
-                  ))}
-                </select>
-              </WithHoverSound>
+              <select
+                className="audio-setup-panel__device-chooser__dropdown"
+                value={this.selectedMicDeviceId()}
+                onChange={this.micDeviceChanged}
+              >
+                {this.state.micDevices.map(d => (
+                  <option key={d.deviceId} value={d.deviceId}>
+                    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                    {d.label}
+                  </option>
+                ))}
+              </select>
               <img
                 className="audio-setup-panel__device-chooser__mic-icon"
                 src="../assets/images/mic_small.png"
@@ -1349,11 +1336,9 @@ class UIRoot extends Component {
           </label>
         </div>
         <div className="audio-setup-panel__enter-button-container">
-          <WithHoverSound>
-            <button className="audio-setup-panel__enter-button" onClick={this.onAudioReadyButton}>
-              <FormattedMessage id="audio.enter-now" />
-            </button>
-          </WithHoverSound>
+          <button autoFocus className="audio-setup-panel__enter-button" onClick={this.onAudioReadyButton}>
+            <FormattedMessage id="audio.enter-now" />
+          </button>
         </div>
       </div>
     );
@@ -1858,18 +1843,16 @@ class UIRoot extends Component {
                   {!embed &&
                     !hasTopTip &&
                     !streaming && (
-                      <WithHoverSound>
-                        <button
-                          className={classNames({
-                            [inviteStyles.inviteButton]: true,
-                            [inviteStyles.hideSmallScreens]: this.occupantCount() > 1 && entered,
-                            [inviteStyles.inviteButtonLowered]: hasTopTip
-                          })}
-                          onClick={() => this.toggleShareDialog()}
-                        >
-                          <FormattedMessage id="entry.share-button" />
-                        </button>
-                      </WithHoverSound>
+                      <button
+                        className={classNames({
+                          [inviteStyles.inviteButton]: true,
+                          [inviteStyles.hideSmallScreens]: this.occupantCount() > 1 && entered,
+                          [inviteStyles.inviteButtonLowered]: hasTopTip
+                        })}
+                        onClick={() => this.toggleShareDialog()}
+                      >
+                        <FormattedMessage id="entry.share-button" />
+                      </button>
                     )}
                   {showChooseSceneButton && (
                     <button


### PR DESCRIPTION
This PR:

- Addresses https://github.com/mozilla/hubs/issues/1774 by setting `autoFocus` on various elements.
- Adds necessary `autoFocus` so that you can hit the enter key to get through the entry flow
- Does a bunch of restyling on the preferences panel
- Refactors some styling into a new shared style `panel-widget`
- Renames a bunch of CSS styles that were `camelCase`, note @johnshaughnessy that you can do this and webpack does the right thing
- Drops some more `WithHoverSound` elements
