### PR TITLE
Fix issues with scene landing page not loading scenes

### DIFF
--- a/src/components/floaty-object.js
+++ b/src/components/floaty-object.js
@@ -34,7 +34,7 @@ AFRAME.registerComponent("floaty-object", {
     }
 
     const interaction = AFRAME.scenes[0].systems.interaction;
-    const isHeld = interaction.isHeld(this.el);
+    const isHeld = interaction && interaction.isHeld(this.el);
     if (isHeld && !this.wasHeld) {
       this.onGrab();
     }

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -60,12 +60,16 @@ AFRAME.registerComponent("media-loader", {
     this.onMediaLoaded = this.onMediaLoaded.bind(this);
     this.animating = false;
 
-    NAF.utils
-      .getNetworkedEntity(this.el)
-      .then(networkedEl => {
-        this.networkedEl = networkedEl;
-      })
-      .catch(() => {}); //ignore exception, entity might not be networked
+    try {
+      NAF.utils
+        .getNetworkedEntity(this.el)
+        .then(networkedEl => {
+          this.networkedEl = networkedEl;
+        })
+        .catch(() => {}); //ignore exception, entity might not be networked
+    } catch (e) {
+      // NAF may not exist on scene landing page
+    }
   },
 
   updateScale: (function() {

--- a/src/components/scene-preview-camera.js
+++ b/src/components/scene-preview-camera.js
@@ -46,8 +46,14 @@ AFRAME.registerComponent("scene-preview-camera", {
   },
 
   tick2: function() {
-    this.el.sceneEl.systems["hubs-systems"].cameraSystem.mode = CAMERA_MODE_SCENE_PREVIEW;
-    const streamerCamera = getStreamerCamera();
+    const hubsSystems = this.el.sceneEl.systems["hubs-systems"];
+
+    let streamerCamera;
+    if (hubsSystems) {
+      this.el.sceneEl.systems["hubs-systems"].cameraSystem.mode = CAMERA_MODE_SCENE_PREVIEW;
+      streamerCamera = getStreamerCamera();
+    }
+
     if (streamerCamera) {
       setMatrixWorld(this.el.object3D, streamerCamera.matrixWorld);
       // Move camera forward just a bit so that we don't see the avatar's eye cylinders.

--- a/src/scene.js
+++ b/src/scene.js
@@ -25,6 +25,7 @@ import React from "react";
 import SceneUI from "./react-components/scene-ui";
 import { disableiOSZoom } from "./utils/disable-ios-zoom";
 
+import "./systems/scene-systems";
 import "./gltf-component-mappings";
 
 import { App } from "./App";

--- a/src/systems/lobby-camera-system.js
+++ b/src/systems/lobby-camera-system.js
@@ -3,7 +3,8 @@ import { CAMERA_MODE_INSPECT } from "./camera-system.js";
 export class LobbyCameraSystem {
   tick() {
     const el = document.querySelector("[scene-preview-camera]");
-    if (el && AFRAME.scenes[0].systems["hubs-systems"].cameraSystem.mode !== CAMERA_MODE_INSPECT) {
+    const hubsSystems = AFRAME.scenes[0].systems["hubs-systems"];
+    if (el && (!hubsSystems || hubsSystems.cameraSystem.mode !== CAMERA_MODE_INSPECT)) {
       el.components["scene-preview-camera"].tick2();
     }
   }

--- a/src/systems/scene-systems.js
+++ b/src/systems/scene-systems.js
@@ -1,0 +1,16 @@
+import { LobbyCameraSystem } from "./lobby-camera-system";
+import { waitForDOMContentLoaded } from "../utils/async-utils";
+
+AFRAME.registerSystem("scene-systems", {
+  init() {
+    waitForDOMContentLoaded().then(() => {
+      this.DOMContentDidLoad = true;
+    });
+    this.lobbyCameraSystem = new LobbyCameraSystem();
+  },
+
+  tick() {
+    if (!this.DOMContentDidLoad) return;
+    this.lobbyCameraSystem.tick();
+  }
+});


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/1948

- `media-loader`'s `init` assumed NAF was accessible, but we load media on the scene landing page where networking is disabled. I couldn't think of a better fix to this -- unclear if having a more clear "Offline" flag somewhere would be better.

- The lobby camera behavior was previously used on both the lobby and scene landing page. Once it was converted to a system, this change was not propagated to the scene page. This PR creates a new systems loop for the scene pages, and adds just the lobby camera.

- Fixes an additional edge case in `floaty-object` that causes a crash on the scene page if the scene has media objects.