### PR TITLE
Fix waypoint system startup race condition

### DIFF
--- a/src/systems/waypoint-system.js
+++ b/src/systems/waypoint-system.js
@@ -1,6 +1,7 @@
 import { setMatrixWorld, affixToWorldUp } from "../utils/three-utils";
 import { isTagged } from "../components/tags";
 import { applyPersistentSync } from "../utils/permissions-utils";
+import { waitForDOMContentLoaded } from "../utils/async-utils";
 const calculateIconTransform = (function() {
   const up = new THREE.Vector3();
   const backward = new THREE.Vector3();
@@ -124,9 +125,11 @@ export class WaypointSystem {
     this.elementsFromTemplatesFor = {};
     this.eventHandlers = [];
     this.lostOwnershipOfWaypoint = this.lostOwnershipOfWaypoint.bind(this);
-    loadTemplateAndAddToScene(scene, "waypoint-preview-avatar-template").then(el => {
-      this.waypointPreviewAvatar = el;
-      this.waypointPreviewAvatar.object3D.visible = false;
+    waitForDOMContentLoaded().then(() => {
+      loadTemplateAndAddToScene(scene, "waypoint-preview-avatar-template").then(el => {
+        this.waypointPreviewAvatar = el;
+        this.waypointPreviewAvatar.object3D.visible = false;
+      });
     });
     this.characterController = characterController;
   }


### PR DESCRIPTION
Fixes a race condition on startup in waypoint system, since we are querying the DOM during `init`, which doesn't always work unless you wait for DOM content loaded.