### PR TITLE
Prevent emojis from being grabbed when hud is closed on FxR

### DIFF
--- a/src/components/emoji-hud.js
+++ b/src/components/emoji-hud.js
@@ -77,7 +77,7 @@ AFRAME.registerComponent("emoji-hud", {
           z: this.data.spawnerScale
         });
         spawnerEntity.setAttribute("is-remote-hover-target", "");
-        spawnerEntity.setAttribute("tags", { isHandCollisionTarget: true });
+        spawnerEntity.setAttribute("tags", { isHandCollisionTarget: false });
         spawnerEntity.setAttribute("visibility-while-frozen", { requireHoverOnNonMobile: false });
         spawnerEntity.setAttribute("css-class", "interactable");
         spawnerEntity.setAttribute("body-helper", {


### PR DESCRIPTION
set default state of emoji-hud to isHandCollisionTarget: false to avoid bug in FxR where emojis can be grabbed when the emoji-hud is not visible.