### PR TITLE
Enable mesh batching by default on mobile.

### DIFF
--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -37,7 +37,7 @@ const fetchContentType = url => {
   return fetch(url, { method: "HEAD" }).then(r => r.headers.get("content-type"));
 };
 
-const batchMeshes = qsTruthy("batchMeshes");
+const forceMeshBatching = qsTruthy("batchMeshes");
 const disableBatching = qsTruthy("disableBatching");
 
 AFRAME.registerComponent("media-loader", {
@@ -458,7 +458,9 @@ AFRAME.registerComponent("media-loader", {
           { once: true }
         );
         this.el.addEventListener("model-error", this.onError, { once: true });
-        let batch = !disableBatching && batchMeshes;
+        let batch =
+          !disableBatching &&
+          (forceMeshBatching || (AFRAME.utils.device.isMobile() && window.APP && window.APP.quality === "low"));
         if (this.data.mediaOptions.hasOwnProperty("batch") && !this.data.mediaOptions.batch) {
           batch = false;
         }

--- a/src/hub.js
+++ b/src/hub.js
@@ -655,9 +655,10 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   const defaultRoomId = configs.feature("default_room_id");
   const hubId =
-    qs.get("hub_id") || (document.location.pathname === "/" && defaultRoomId)
+    qs.get("hub_id") ||
+    (document.location.pathname === "/" && defaultRoomId
       ? defaultRoomId
-      : document.location.pathname.substring(1).split("/")[0];
+      : document.location.pathname.substring(1).split("/")[0]);
   console.log(`Hub ID: ${hubId}`);
 
   const subscriptions = new Subscriptions(hubId);

--- a/src/index.js
+++ b/src/index.js
@@ -87,10 +87,9 @@ async function fetchFeaturedRooms() {
     fetchReticulumAuthenticated("/api/v1/media/search?source=rooms&filter=public")
   ]);
 
-  const ids = publicRoomsResult.entries.map(h => h.id);
-  featuredRooms = [...publicRoomsResult.entries, ...favoriteRoomsResult.entries]
-    .filter((h, i) => ids.lastIndexOf(h.id) === i)
-    .sort((a, b) => b.member_count - a.member_count);
+  const entries = [...publicRoomsResult.entries, ...favoriteRoomsResult.entries];
+  const ids = entries.map(h => h.id);
+  featuredRooms = entries.filter((h, i) => ids.lastIndexOf(h.id) === i).sort((a, b) => b.member_count - a.member_count);
   remountUI();
 }
 

--- a/src/utils/configs.js
+++ b/src/utils/configs.js
@@ -47,7 +47,9 @@ if (window.APP_CONFIG) {
     document.head.prepend(style);
   }
 } else {
-  configs.APP_CONFIG = {};
+  configs.APP_CONFIG = {
+    features: {}
+  };
 }
 
 const isLocalDevelopment = process.env.NODE_ENV === "development";


### PR DESCRIPTION
This PR enables mesh batching for all non-scene objects by default on mobile. Required fixing inspect and emoji menu which were broken when mesh batching was enabled.

Also fixes unrelated issues with favorites on the homepage and loading local hubs introduced in #2059 