### PR TITLE
Add an experimental "fix origin" feature for oculus touch controllers

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -111,6 +111,7 @@ import "./components/periodic-full-syncs";
 import "./components/inspect-button";
 import "./components/set-max-resolution";
 import { sets as userinputSets } from "./systems/userinput/sets";
+import "./utils/pretty-print";
 
 import ReactDOM from "react-dom";
 import React from "react";

--- a/src/systems/character-controller-system.js
+++ b/src/systems/character-controller-system.js
@@ -12,7 +12,6 @@ import {
 } from "../utils/three-utils";
 import { getCurrentPlayerHeight } from "../utils/get-current-player-height";
 import qsTruthy from "../utils/qs_truthy";
-//import { m4String } from "../utils/pretty-print";
 const NAV_ZONE = "character";
 const qsAllowWaypointLerp = qsTruthy("waypointLerp");
 

--- a/src/systems/hubs-systems.js
+++ b/src/systems/hubs-systems.js
@@ -19,6 +19,7 @@ import { CharacterControllerSystem } from "./character-controller-system";
 import { waitForDOMContentLoaded } from "../utils/async-utils";
 import { CursorPoseTrackingSystem } from "./cursor-pose-tracking";
 import { ScaleInScreenSpaceSystem } from "./scale-in-screen-space";
+import { ReorientPlayerOculusTouchSystem } from "./reorient-player-oculus-touch";
 
 AFRAME.registerSystem("hubs-systems", {
   init() {
@@ -47,6 +48,7 @@ AFRAME.registerSystem("hubs-systems", {
     this.waypointSystem = new WaypointSystem(this.el, this.characterController);
     this.cursorPoseTrackingSystem = new CursorPoseTrackingSystem();
     this.scaleInScreenSpaceSystem = new ScaleInScreenSpaceSystem();
+    this.reorientPlayerOculusTouchSystem = new ReorientPlayerOculusTouchSystem();
   },
 
   tick(t, dt) {
@@ -80,6 +82,7 @@ AFRAME.registerSystem("hubs-systems", {
     this.batchManagerSystem.tick(t);
     this.cameraSystem.tick(this.el, dt);
     this.waypointSystem.tick(t, dt);
+    this.reorientPlayerOculusTouchSystem.tick(systems.userinput, this.el);
   },
 
   remove() {

--- a/src/systems/reorient-player-oculus-touch.js
+++ b/src/systems/reorient-player-oculus-touch.js
@@ -1,0 +1,102 @@
+import { v3String } from "../utils/pretty-print";
+import { extractAxisAngle, setMatrixWorld } from "../utils/three-utils";
+import qsTruthy from "../utils/qs_truthy";
+import { paths } from "./userinput/paths";
+const ENABLE_REORIENTATION_FEATURE = qsTruthy("reo");
+
+// This axis is computed as follows:
+// I put the oculus touch controller down on my desk, resting it on the ring.
+// I extracted the rotation (matrix) from the player-right-controller's matrix.
+// I converted this rotation matrix to a quaternion and put it into a collection.
+// I rotated the oculus touch controller and resampled the controller, adding new quaternions to my collection.
+// Now I had a collection of quaternions represented the orientation of the player-right-controller
+// when it was resting on its ring.
+// I took two quaternions from the collection and computed their difference: (qA_inverse * qB).
+// I extracted the axis of the difference using extractAxisAngle.
+// I did this a few more times choosing random pairs of quaternions from the collection, making sure
+// that I got either the same axis or the reverse axis.
+const EXPECTED_AXIS = new THREE.Vector3().set(0.004065492310506375, -0.6425824931271795, 0.766205724174066).normalize();
+// With this axis I can figure out how to re-orient the player.
+// I saved one of the quaternions from the initial collection: CONTROLLER_RESTING_ON_RING_QUATERNION
+const CONTROLLER_RESTING_ON_RING_QUATERNION = new THREE.Quaternion().set(
+  0.26699080915051965,
+  0.39745257336123907,
+  0.8684911690815028,
+  -0.12833724706855257
+);
+const TARGET_CONTROLLER_POSITION = new THREE.Vector3().set(0, 0, 0);
+function reorientPlayer() {
+  const playerRightController = document.getElementById("player-right-controller");
+  playerRightController.object3D.updateMatrices();
+  // Now if the player presses the "reorient" I can compute the difference quaternion:
+  const currentControllerQuaternion = new THREE.Quaternion().setFromRotationMatrix(
+    new THREE.Matrix4().extractRotation(playerRightController.object3D.matrix)
+  );
+  const differenceQuaternion = new THREE.Quaternion().multiplyQuaternions(
+    new THREE.Quaternion().copy(currentControllerQuaternion).inverse(),
+    CONTROLLER_RESTING_ON_RING_QUATERNION
+  );
+  const diffAxis = new THREE.Vector3();
+  const angle = extractAxisAngle(differenceQuaternion, diffAxis);
+  // The diffAxis should be almost the same as the EXPECTED_AXIS
+  function almostEqualVec3(u, v) {
+    const epsilon = 0.05;
+    return Math.abs(u.x - v.x) < epsilon && Math.abs(u.y - v.y) < epsilon && Math.abs(u.z - v.z) < epsilon;
+  }
+  const same = almostEqualVec3(EXPECTED_AXIS, diffAxis);
+  let reverse = false;
+  if (!same) {
+    const reverseDiffAxis = new THREE.Vector3().copy(diffAxis).multiplyScalar(-1);
+    reverse = almostEqualVec3(EXPECTED_AXIS, reverseDiffAxis);
+  }
+  if (!same && !reverse) {
+    console.error(
+      "Can only re-orient the player if the controller is resting with its ring on a flat surface!",
+      `Expected: ${v3String(EXPECTED_AXIS)}, got: ${v3String(diffAxis)}`,
+      "This may happen when the current controller orientation is too similar to the rest orientation, causing the accuracy of the diffAxis to degrade significantly. This may be corrected by rotating the oculus touch controller 90 degrees or so (while keeping its ring on a flat surface)."
+    );
+    // TODO: We can fix the degraded accuracy issue by repeating this process again using an alternative rest quaternion, which is rotated about the expected axis by 90 degrees. We then have to make sure to correct for the 90 degree turn when calculating the final player rig orientation.
+    return;
+  }
+  const angleToUse = reverse ? -1 * angle : angle;
+  const avatarRig = document.getElementById("avatar-rig");
+  avatarRig.object3D.updateMatrices();
+  const avatarRigScale = new THREE.Vector3().setFromMatrixScale(avatarRig.object3D.matrixWorld);
+  const avatarRigPosition = new THREE.Vector3().setFromMatrixPosition(avatarRig.object3D.matrixWorld);
+  const quaternionToUse = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), angleToUse);
+  const desiredAvatarRigQuaternion = new THREE.Quaternion()
+    .setFromRotationMatrix(
+      new THREE.Matrix4().makeBasis(new THREE.Vector3(1, 0, 0), new THREE.Vector3(0, 1, 0), new THREE.Vector3(0, 0, 1))
+    )
+    .premultiply(quaternionToUse);
+  const avatarRigTransform = new THREE.Matrix4().compose(
+    avatarRigPosition,
+    desiredAvatarRigQuaternion,
+    avatarRigScale
+  );
+  setMatrixWorld(avatarRig.object3D, avatarRigTransform);
+
+  // Orientation is set. Now find the offset that will put the controller at the world origin.
+  const rigPos = new THREE.Vector3().setFromMatrixPosition(avatarRig.object3D.matrixWorld);
+  playerRightController.object3D.updateMatrices();
+  const controllerPos = new THREE.Vector3().setFromMatrixPosition(playerRightController.object3D.matrixWorld);
+  const controllerToRig = new THREE.Vector3().subVectors(rigPos, controllerPos);
+  const desiredRigPosition = new THREE.Vector3().addVectors(TARGET_CONTROLLER_POSITION, controllerToRig);
+  avatarRigTransform.compose(
+    desiredRigPosition,
+    desiredAvatarRigQuaternion,
+    avatarRigScale
+  );
+  setMatrixWorld(avatarRig.object3D, avatarRigTransform);
+}
+
+export class ReorientPlayerOculusTouchSystem {
+  constructor() {}
+  tick(userinput, scene) {
+    if (!ENABLE_REORIENTATION_FEATURE) return;
+    if (!scene.is("entered")) return;
+    if (userinput.get(paths.actions.reorientPlayerOculusTouch)) {
+      reorientPlayer(false);
+    }
+  }
+}

--- a/src/systems/userinput/bindings/oculus-touch-user.js
+++ b/src/systems/userinput/bindings/oculus-touch-user.js
@@ -468,6 +468,15 @@ export const oculusTouchUserBindings = addSetsToBindings({
       xform: xforms.rising
     },
     {
+      src: {
+        value: rightButton("b").pressed
+      },
+      dest: {
+        value: paths.actions.reorientPlayerOculusTouch
+      },
+      xform: xforms.rising
+    },
+    {
       src: [keyboardBoost, leftBoost, rightBoost],
       dest: { value: paths.actions.boost },
       xform: xforms.any

--- a/src/systems/userinput/paths.js
+++ b/src/systems/userinput/paths.js
@@ -120,6 +120,7 @@ paths.actions.inspectZoom = "/actions/inspectZoom";
 paths.actions.inspectPanY = "/actions/inspectPanY";
 paths.actions.resetInspectView = "/actions/resetInspectView";
 paths.actions.nextCameraMode = "/actions/nextCameraMode";
+paths.actions.reorientPlayerOculusTouch = "/actions/rightHand/reorientPlayerOculusTouch";
 paths.haptics = {};
 paths.haptics.actuators = {};
 paths.haptics.actuators.left = "/haptics/actuators/left";

--- a/src/utils/pretty-print.js
+++ b/src/utils/pretty-print.js
@@ -13,3 +13,13 @@ export function m4String(mat4) {
     ""
   ].join("\n");
 }
+export function qString(q) {
+  return ["", q.x, q.y, q.z, q.w, ""].join("\n");
+}
+if (new URL(location.href).hostname.indexOf("local") !== -1) {
+  window.prettyPrint = {
+    v3String,
+    m4String,
+    qString
+  };
+}

--- a/src/utils/three-utils.js
+++ b/src/utils/three-utils.js
@@ -328,3 +328,10 @@ export const childMatch = (function() {
     setMatrixWorld(parent, newParentMatrix);
   };
 })();
+
+export function extractAxisAngle(quaternion, outAxis) {
+  const halfAngle = Math.acos(quaternion._w);
+  const axisFactor = Math.sqrt(1 - quaternion._w * quaternion._w);
+  outAxis.set(quaternion._x / axisFactor, quaternion._y / axisFactor, quaternion._z / axisFactor);
+  return 2 * halfAngle;
+}


### PR DESCRIPTION
This PR adds an (experimental) feature that allows people to synchronize the virtual environment with their real environment. 
This feature is enabled with the `reo` query string parameter.
This feature only works with oculus touch controllers.
To perform the synchronization, two people put their right controllers next to each other on the floor in the same orientation, with the controllers resting on the "ring" part. Then they press the "b" button. If the operation succeeds, then their right in-game hands will have been teleported to the TARGET_CONTROLLER_POSITION (the origin). They will still be one-controller's-width out of sync unless the second person slides their controller along the ground to occupy the exact same position (in real life) that the first person's controller did after the first person presses the button.


