### PR TITLE
Removes defined `height` to account for images with different aspect ratios

### DIFF
--- a/src/assets/stylesheets/link.scss
+++ b/src/assets/stylesheets/link.scss
@@ -50,7 +50,6 @@ a {
 
   img {
     width: 247px;
-    height: 57px;
   }
 
   @media(max-height: 600px) {


### PR DESCRIPTION
At <hubs-domain>/link the logo has a defined height that causes it to be squished. 
I opened an issue similar to this at: https://github.com/mozilla/hubs/issues/1903#event-2812760998

This PR removes the height of the logo displayed on the `/link` page to allow for other image aspect ratios in custom instances of Hubs.


Here's what it looks like in mine without patch:
 
![Screen Shot 2020-01-15 at 5 41 38 PM](https://user-images.githubusercontent.com/8985705/72480986-a896f200-37be-11ea-8b55-bdb36f6f40f9.png)
