### PR TITLE
Revises bash tip to reflect proper command

### DIFF
--- a/scripts/use-hubs-cloud-stack.sh
+++ b/scripts/use-hubs-cloud-stack.sh
@@ -6,7 +6,7 @@ SHORTLINK_ZONE_NAME=$3
 INTERNAL_ZONE_NAME=$4
 
 if [[ -z "$STACK_NAME" || -z "$EXTERNAL_ZONE_NAME" || -z "$SHORTLINK_ZONE_NAME" || -z "$INTERNAL_ZONE_NAME" ]] ; then 
-  echo -e "Usage: scripts/use-hubs-cloud-stack.sh <stack-name> <domain> <internal-domain>
+  echo -e "Usage: scripts/use-hubs-cloud-stack.sh <stack-name> <domain> <short-link-domain> <internal-domain>
 
 Switches your local client to connect to a remote Hubs Cloud instance by modifying .env.defaults.
 


### PR DESCRIPTION
In the current use-hubs-cloud-stack script, it returns `Usage: scripts/use-hubs-cloud-stack.sh <stack-name> <domain> <internal-domain>` which omits the shortlink domain. Below that tip it gives an example of the command that includes the shortlink domain. 


```
For example if your stack is myhubs at myhubs.com, your short link domain is myhub.link,
and your internal domain is myhubs-internal.com, run:

scripts/use-hubs-cloud-stack.sh myhubs myhubs.com myhub.link myhubs-internal.com
```
This PR changes the tip to include `<short-link-domain>` where it seems to be required per example command. 