### PR TITLE
Feature/pinning permissions adjustments

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -243,6 +243,7 @@ AFRAME.registerComponent("media-video", {
 
   init() {
     this.onPauseStateChange = this.onPauseStateChange.bind(this);
+    this.updateHoverMenu = this.updateHoverMenu.bind(this);
     this.tryUpdateVideoPlaybackState = this.tryUpdateVideoPlaybackState.bind(this);
     this.updateSrc = this.updateSrc.bind(this);
 
@@ -295,6 +296,9 @@ AFRAME.registerComponent("media-video", {
       applyPersistentSync(this.networkedEl.components.networked.data.networkId);
       this.updateHoverMenu();
       this.updatePlaybackState();
+
+      this.networkedEl.addEventListener("pinned", this.updateHoverMenu);
+      this.networkedEl.addEventListener("unpinned", this.updateHoverMenu);
 
       // For scene-owned videos, take ownership after a random delay if nobody
       // else has so there is a timekeeper. Do not due this on iOS because iOS has an
@@ -794,6 +798,9 @@ AFRAME.registerComponent("media-video", {
       this.audio.disconnect();
       delete this.audio;
     }
+
+    this.networkedEl.removeEventListener("pinned", this.updateHoverMenu);
+    this.networkedEl.removeEventListener("unpinned", this.updateHoverMenu);
 
     if (this.video) {
       this.video.removeEventListener("pause", this.onPauseStateChange);

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -407,9 +407,7 @@ AFRAME.registerComponent("media-video", {
   },
 
   updatePlaybackState(force) {
-    if (this.hoverMenu) {
-      this.updateHoverMenu();
-    }
+    this.updateHoverMenu();
 
     // Only update playback position for videos you don't own
     if (this.video && (force || (this.networkedEl && !NAF.utils.isMine(this.networkedEl)))) {

--- a/src/components/pinnable.js
+++ b/src/components/pinnable.js
@@ -23,7 +23,9 @@ AFRAME.registerComponent("pinnable", {
   _fireEventsAndAnimate(oldData, force) {
     // We need to guard against _fireEventsAndAnimate being called during entity initialization,
     // when the networked component isn't initialized yet.
-    if (this.el.components.networked && this.el.components.networked.data && !NAF.utils.isMine(this.el)) return;
+    if (!this.el.components.networked || !this.el.components.networked.data) return;
+
+    const isMine = NAF.utils.isMine(this.el);
 
     // Avoid firing events during initialization by checking if the pin state has changed before doing so.
     const pinStateChanged = !!oldData.pinned !== this.data.pinned;
@@ -33,29 +35,31 @@ AFRAME.registerComponent("pinnable", {
         this.el.emit("pinned", { el: this.el });
       }
 
-      this.el.removeAttribute("animation__pin-start");
-      this.el.removeAttribute("animation__pin-end");
-      const currentScale = this.el.object3D.scale;
+      if (isMine) {
+        this.el.removeAttribute("animation__pin-start");
+        this.el.removeAttribute("animation__pin-end");
+        const currentScale = this.el.object3D.scale;
 
-      this.el.setAttribute("animation__pin-start", {
-        property: "scale",
-        dur: 200,
-        from: { x: currentScale.x, y: currentScale.y, z: currentScale.z },
-        to: { x: currentScale.x * 1.1, y: currentScale.y * 1.1, z: currentScale.z * 1.1 },
-        easing: "easeOutElastic"
-      });
+        this.el.setAttribute("animation__pin-start", {
+          property: "scale",
+          dur: 200,
+          from: { x: currentScale.x, y: currentScale.y, z: currentScale.z },
+          to: { x: currentScale.x * 1.1, y: currentScale.y * 1.1, z: currentScale.z * 1.1 },
+          easing: "easeOutElastic"
+        });
 
-      this.el.setAttribute("animation__pin-end", {
-        property: "scale",
-        delay: 200,
-        dur: 200,
-        from: { x: currentScale.x * 1.1, y: currentScale.y * 1.1, z: currentScale.z * 1.1 },
-        to: { x: currentScale.x, y: currentScale.y, z: currentScale.z },
-        easing: "easeOutElastic"
-      });
+        this.el.setAttribute("animation__pin-end", {
+          property: "scale",
+          delay: 200,
+          dur: 200,
+          from: { x: currentScale.x * 1.1, y: currentScale.y * 1.1, z: currentScale.z * 1.1 },
+          to: { x: currentScale.x, y: currentScale.y, z: currentScale.z },
+          easing: "easeOutElastic"
+        });
 
-      if (this.el.components["body-helper"] && !this.el.sceneEl.systems.interaction.isHeld(this.el)) {
-        this.el.setAttribute("body-helper", { type: "kinematic" });
+        if (this.el.components["body-helper"] && !this.el.sceneEl.systems.interaction.isHeld(this.el)) {
+          this.el.setAttribute("body-helper", { type: "kinematic" });
+        }
       }
     } else {
       if (pinStateChanged || force) {
@@ -71,9 +75,10 @@ AFRAME.registerComponent("pinnable", {
 
   tick() {
     const held = this.isHeld(this.el);
+    const isMine = this.el.components.networked && this.el.components.networked.data && NAF.utils.isMine(this.el);
 
     let didFireThisFrame = false;
-    if (!held && this.wasHeld) {
+    if (!held && this.wasHeld && isMine) {
       didFireThisFrame = true;
       this._fireEventsAndAnimate(this.data, true);
     }
@@ -82,7 +87,7 @@ AFRAME.registerComponent("pinnable", {
 
     this.transformObjectSystem = this.transformObjectSystem || AFRAME.scenes[0].systems["transform-selected-object"];
     const transforming = this.transformObjectSystem.transforming && this.transformObjectSystem.target.el === this.el;
-    if (!didFireThisFrame && !transforming && this.wasTransforming) {
+    if (!didFireThisFrame && !transforming && this.wasTransforming && isMine) {
       this._fireEventsAndAnimate(this.data, true);
     }
     this.wasTransforming = transforming;

--- a/src/components/visibility-while-frozen.js
+++ b/src/components/visibility-while-frozen.js
@@ -14,6 +14,7 @@ AFRAME.registerComponent("visibility-while-frozen", {
     visible: { type: "boolean", default: true },
     requireHoverOnNonMobile: { type: "boolean", default: true },
     withPermission: { type: "string" },
+    withoutPermission: { type: "string" },
     visibleIfOwned: { type: "boolean", default: true }
   },
 
@@ -90,7 +91,17 @@ AFRAME.registerComponent("visibility-while-frozen", {
 
     const isTransforming = this.el.sceneEl.systems["transform-selected-object"].transforming;
 
-    const allowed = !this.data.withPermission || window.APP.hubChannel.canOrWillIfCreator(this.data.withPermission);
+    if (this.data.withPermission && this.data.withoutPermission) {
+      throw new Error(
+        "only withPermission or withoutPermission can be speciifed on visibility-while-frozen, not both."
+      );
+    }
+
+    const allowed = !!(
+      (!this.data.withPermission && !this.data.withoutPermission) ||
+      (this.data.withPermission && window.APP.hubChannel.canOrWillIfCreator(this.data.withPermission)) ||
+      (this.data.withoutPermission && !window.APP.hubChannel.canOrWillIfCreator(this.data.withoutPermission))
+    );
 
     let shouldBeVisible =
       allowed &&

--- a/src/hub.html
+++ b/src/hub.html
@@ -387,7 +387,7 @@
                             </a-entity>
                         </a-entity>
                         <a-entity class="freeze-unprivileged-menu" visibility-while-frozen="withinDistance: 100; withouttPermission: spawn_and_move_media">
-                            <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" open-media-button="onlyOpenLink: true" position="0 0.125 0.001">
+                            <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" open-media-button="onlyOpenLink: true" position="0 -0.125 0.001">
                                 <a-entity text="value:open link; width:1.75; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
                             </a-entity>
                             <a-entity

--- a/src/hub.html
+++ b/src/hub.html
@@ -239,6 +239,7 @@
                     set-yxz-order
                     matrix-auto-update
                     position-at-box-shape-border__freeze="target:.freeze-menu;"
+                    position-at-box-shape-border__freeze-unprivileged="target:.freeze-unprivileged-menu;"
                     hoverable-visuals
                     listed-media
                 >
@@ -380,6 +381,24 @@
                                 <a-entity
                                     sprite
                                     icon-button="image: scale-action.png; hoverImage: scale-action.png"
+                                    scale="0.165 0.165 0.165"
+                                    position="0 0 0.001"
+                                ></a-entity>
+                            </a-entity>
+                        </a-entity>
+                        <a-entity class="freeze-unprivileged-menu" visibility-while-frozen="withinDistance: 100; withouttPermission: spawn_and_move_media">
+                            <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" open-media-button="onlyOpenLink: true" position="0 -0.375 0.001">
+                                <a-entity text="value:open link; width:1.75; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
+                            </a-entity>
+                            <a-entity
+                                mixin="rounded-action-button"
+                                tags="isHoldable: true; holdableButton: true;"
+                                is-remote-hover-target
+                                inspect-button
+                                position="0 0.125 0.001">
+                                <a-entity
+                                    sprite
+                                    icon-button="image: recenter-action.png; hoverImage: recenter-action.png"
                                     scale="0.165 0.165 0.165"
                                     position="0 0 0.001"
                                 ></a-entity>

--- a/src/hub.html
+++ b/src/hub.html
@@ -386,7 +386,7 @@
                                 ></a-entity>
                             </a-entity>
                         </a-entity>
-                        <a-entity class="freeze-unprivileged-menu" visibility-while-frozen="withinDistance: 100; withouttPermission: spawn_and_move_media">
+                        <a-entity class="freeze-unprivileged-menu" visibility-while-frozen="withinDistance: 100; withoutPermission: spawn_and_move_media;">
                             <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" open-media-button="onlyOpenLink: true" position="0 -0.125 0.001">
                                 <a-entity text="value:open link; width:1.75; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
                             </a-entity>

--- a/src/hub.html
+++ b/src/hub.html
@@ -387,7 +387,7 @@
                             </a-entity>
                         </a-entity>
                         <a-entity class="freeze-unprivileged-menu" visibility-while-frozen="withinDistance: 100; withouttPermission: spawn_and_move_media">
-                            <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" open-media-button="onlyOpenLink: true" position="0 -0.375 0.001">
+                            <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" open-media-button="onlyOpenLink: true" position="0 0.125 0.001">
                                 <a-entity text="value:open link; width:1.75; align:center;" text-raycast-hack position="0 0 0.02"></a-entity>
                             </a-entity>
                             <a-entity

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -290,15 +290,17 @@ export default class SceneEntryManager {
       spawnMediaInfrontOfPlayer(e.detail, contentOrigin);
     });
 
-    this.scene.addEventListener("pinned", e => {
+    const handlePinEvent = (e, pinned) => {
       if (this._disableSignInOnPinAction) return;
-      this._signInAndPinOrUnpinElement(e.detail.el, true);
-    });
+      const el = e.detail.el;
 
-    this.scene.addEventListener("unpinned", e => {
-      if (this._disableSignInOnPinAction) return;
-      this._signInAndPinOrUnpinElement(e.detail.el, false);
-    });
+      if (NAF.utils.isMine(el)) {
+        this._signInAndPinOrUnpinElement(e.detail.el, pinned);
+      }
+    };
+
+    this.scene.addEventListener("pinned", e => handlePinEvent(e, true));
+    this.scene.addEventListener("unpinned", e => handlePinEvent(e, false));
 
     this.scene.addEventListener("object_spawned", e => {
       this.hubChannel.sendObjectSpawnedEvent(e.detail.objectType);

--- a/src/utils/permissions-utils.js
+++ b/src/utils/permissions-utils.js
@@ -14,11 +14,13 @@ export function canMove(entity) {
   const networkedTemplate = entity && entity.components.networked && entity.components.networked.data.template;
   const isCamera = networkedTemplate === "#interactable-camera";
   const isPen = networkedTemplate === "#interactable-pen";
+  const isHoldableButton = entity.components.tags && entity.components.tags.data.holdableButton;
   return (
-    window.APP.hubChannel.can("spawn_and_move_media") &&
-    (!isPinned || window.APP.hubChannel.can("pin_objects")) &&
-    (!isCamera || window.APP.hubChannel.can("spawn_camera")) &&
-    (!isPen || window.APP.hubChannel.can("spawn_drawing"))
+    isHoldableButton ||
+    (window.APP.hubChannel.can("spawn_and_move_media") &&
+      (!isPinned || window.APP.hubChannel.can("pin_objects")) &&
+      (!isCamera || window.APP.hubChannel.can("spawn_camera")) &&
+      (!isPen || window.APP.hubChannel.can("spawn_drawing")))
   );
 }
 

--- a/src/utils/permissions-utils.js
+++ b/src/utils/permissions-utils.js
@@ -1,3 +1,5 @@
+// Brief overview of client authorization can be found in the wiki:
+// https://github.com/mozilla/hubs/wiki/Hubs-authorization
 export function showHoverEffect(el) {
   const isFrozen = el.sceneEl.is("frozen");
   const isPinned = el.components.pinnable && el.components.pinnable.data.pinned;


### PR DESCRIPTION
This PR makes a few semantic changes to authorization and adds a few improvements.

- Previously, the `pinned` and `unpinned` events were not fired except when an object was pinned that the current session owned. This updates the code so these events are fired on all connected clients when the pin state changes on an object, and gates the various places where we previously assumed the user owned the object. This ensures the UI more accurately reflects the pin state. Up until now this worked for incidental reasons, such as time keeping causing `update` events to fire and update the UI eventually after a pinned event.

- We pre-emptively hide the play button on pinned videos if you did not have permission to pin objects, which makes sense since this would cause a the pinned state to change. We also allow any user in the room to broadcast the video time, even for pinned videos, because otherwise timekeeping would not work. Because technically all users are authorized to send the time, we kept the seek buttons enabled for all users as well. However, this is not the ideal UX: typically you do not want non-privileged users to be manually seeking the video even though they have the permissions necessary to set the time. This PR updates the UI conventions so non-privileged users will not be able to seek the video using the UI (but can keep time or also seek it through other means.) This is one of the few places where we expose a mismatch between UI affordances and authorized permissions.

- Previously when a user did not have spawn media permissions they would not get the freeze menu on objects. However the inspect and open link actions should be permissible regardless of a users permissions on an object. This PR adds a new dedicated freeze menu for non-privileged users, who do not have spawn media permission. (And adds a new inversion case for permission checks in `visibility-while-frozen`) This is also intended to prep for the upcoming changes to the inspect/peek features, which similarly should always be allowed.

- Fixes a bug which prevented 'holdable' buttons like the inspect button from working if the user lacked spawn media permissions.

- Also wrote a short doc on authorization in the wiki and linked it from the code
