### PR TITLE
Allow disabling of fov tracking by hovering over a subelement

### DIFF
--- a/src/components/follow-in-fov.js
+++ b/src/components/follow-in-fov.js
@@ -27,7 +27,8 @@ AFRAME.registerComponent("follow-in-fov", {
 
     let isHovered = false;
     const interaction = AFRAME.scenes[0].systems.interaction;
-    const hoveredEl = interaction.state.rightRemote.hovered;
+
+    const hoveredEl = interaction.state.rightRemote.hovered || interaction.state.leftRemote.hovered;
 
     if (hoveredEl) {
       let el = this.el;
@@ -42,7 +43,7 @@ AFRAME.registerComponent("follow-in-fov", {
       }
     }
 
-    // Stop updating position if hovered over.
+    // Stop updating position if the element or any subelement is hovered.
     if (isHovered) return;
 
     // Compute position + rotation by projecting offset along a downward ray in target space,

--- a/src/components/follow-in-fov.js
+++ b/src/components/follow-in-fov.js
@@ -25,6 +25,26 @@ AFRAME.registerComponent("follow-in-fov", {
     const obj = this.el.object3D;
     const target = this.data.target.object3D;
 
+    let isHovered = false;
+    const interaction = AFRAME.scenes[0].systems.interaction;
+    const hoveredEl = interaction.state.rightRemote.hovered;
+
+    if (hoveredEl) {
+      let el = this.el;
+
+      while (el) {
+        if (hoveredEl === el) {
+          isHovered = true;
+          break;
+        }
+
+        el = el.parentNode;
+      }
+    }
+
+    // Stop updating position if hovered over.
+    if (isHovered) return;
+
     // Compute position + rotation by projecting offset along a downward ray in target space,
     // and mask out Z rotation.
     this._applyMaskedTargetRotation(

--- a/src/react-components/chat-message.js
+++ b/src/react-components/chat-message.js
@@ -153,6 +153,8 @@ export async function createInWorldLogMessage({ name, type, body }) {
   document.querySelector("a-scene").appendChild(entity);
 
   entity.appendChild(meshEntity);
+  entity.setAttribute("class", "ui");
+  entity.setAttribute("is-remote-hover-target", {});
   entity.setAttribute("follow-in-fov", {
     target: "#avatar-pov-node",
     offset: { x: 0, y: 0.0, z: -0.8 }


### PR DESCRIPTION
For wide elements, the current "track the user's head" UX we use has problems since you can't look to the side. This is currently only a problem for in-VR chat bubbles of a wider width, but will become more of a problem once we land the new 'inspect' feature. As such, this PR adjusts that component to stop tracking if the user hovers over the element.

Note that for chat, this still isn't ideal since the message still fades away, but it seems difficult to get out ahead of the animator to stop this so I didn't do that in this PR.