### PR TITLE
Perf/lobby camera system query

### DIFF
--- a/src/components/scene-preview-camera.js
+++ b/src/components/scene-preview-camera.js
@@ -31,7 +31,7 @@ AFRAME.registerComponent("scene-preview-camera", {
     const systems = AFRAME.scenes[0].systems["hubs-systems"] || AFRAME.scenes[0].systems["scene-systems"];
 
     if (systems) {
-      systems.lobbyCameraSystem.register(this.el);
+      systems.scenePreviewCameraSystem.register(this.el);
     }
 
     this.startPoint = this.el.object3D.position.clone();
@@ -102,7 +102,7 @@ AFRAME.registerComponent("scene-preview-camera", {
     const systems = AFRAME.scenes[0].systems["hubs-systems"] || AFRAME.scenes[0].systems["scene-systems"];
 
     if (systems) {
-      systems.lobbyCameraSystem.unregister(this.el);
+      systems.scenePreviewCameraSystem.unregister(this.el);
     }
   }
 });

--- a/src/components/scene-preview-camera.js
+++ b/src/components/scene-preview-camera.js
@@ -28,6 +28,12 @@ AFRAME.registerComponent("scene-preview-camera", {
   },
 
   init: function() {
+    const systems = AFRAME.scenes[0].systems["hubs-systems"] || AFRAME.scenes[0].systems["scene-systems"];
+
+    if (systems) {
+      systems.lobbyCameraSystem.register(this.el);
+    }
+
     this.startPoint = this.el.object3D.position.clone();
     this.startRotation = this.el.object3D.quaternion.clone();
 
@@ -89,6 +95,14 @@ AFRAME.registerComponent("scene-preview-camera", {
         this.backwards = !this.backwards;
         this.startTime = performance.now();
       }
+    }
+  },
+
+  remove: function() {
+    const systems = AFRAME.scenes[0].systems["hubs-systems"] || AFRAME.scenes[0].systems["scene-systems"];
+
+    if (systems) {
+      systems.lobbyCameraSystem.unregister(this.el);
     }
   }
 });

--- a/src/systems/hubs-systems.js
+++ b/src/systems/hubs-systems.js
@@ -10,7 +10,7 @@ import { SuperSpawnerSystem } from "./super-spawner-system";
 import { HapticFeedbackSystem } from "./haptic-feedback-system";
 import { SoundEffectsSystem } from "./sound-effects-system";
 import { BatchManagerSystem } from "./render-manager-system";
-import { LobbyCameraSystem } from "./lobby-camera-system";
+import { ScenePreviewCameraSystem } from "./scene-preview-camera-system";
 import { InteractionSfxSystem } from "./interaction-sfx-system";
 import { SpriteSystem } from "./sprites";
 import { CameraSystem } from "./camera-system";
@@ -38,7 +38,7 @@ AFRAME.registerSystem("hubs-systems", {
     this.hoverMenuSystem = new HoverMenuSystem();
     this.hapticFeedbackSystem = new HapticFeedbackSystem();
     this.soundEffectsSystem = new SoundEffectsSystem(this.el);
-    this.lobbyCameraSystem = new LobbyCameraSystem();
+    this.scenePreviewCameraSystem = new ScenePreviewCameraSystem();
     this.spriteSystem = new SpriteSystem(this.el);
     this.batchManagerSystem = new BatchManagerSystem(this.el.object3D, this.el.renderer);
     this.cameraSystem = new CameraSystem(this.batchManagerSystem);
@@ -74,7 +74,7 @@ AFRAME.registerSystem("hubs-systems", {
       this.singleActionButtonSystem.didInteractRightThisFrame
     );
     this.soundEffectsSystem.tick();
-    this.lobbyCameraSystem.tick();
+    this.scenePreviewCameraSystem.tick();
     this.physicsSystem.tick(dt);
     this.spriteSystem.tick(t, dt);
     this.batchManagerSystem.tick(t);

--- a/src/systems/lobby-camera-system.js
+++ b/src/systems/lobby-camera-system.js
@@ -1,11 +1,24 @@
 import { CAMERA_MODE_INSPECT } from "./camera-system.js";
 
 export class LobbyCameraSystem {
+  constructor() {
+    this.entities = [];
+  }
+
+  register(el) {
+    this.entities.push(el);
+  }
+
+  unregister(el) {
+    this.entities.splice(this.entities.indexOf(el, 1));
+  }
+
   tick() {
-    const el = document.querySelector("[scene-preview-camera]");
-    const hubsSystems = AFRAME.scenes[0].systems["hubs-systems"];
-    if (el && (!hubsSystems || hubsSystems.cameraSystem.mode !== CAMERA_MODE_INSPECT)) {
-      el.components["scene-preview-camera"].tick2();
+    for (const el of this.entities) {
+      const hubsSystems = AFRAME.scenes[0].systems["hubs-systems"];
+      if (el && (!hubsSystems || hubsSystems.cameraSystem.mode !== CAMERA_MODE_INSPECT)) {
+        el.components["scene-preview-camera"].tick2();
+      }
     }
   }
 }

--- a/src/systems/scene-preview-camera-system.js
+++ b/src/systems/scene-preview-camera-system.js
@@ -1,6 +1,6 @@
 import { CAMERA_MODE_INSPECT } from "./camera-system.js";
 
-export class LobbyCameraSystem {
+export class ScenePreviewCameraSystem {
   constructor() {
     this.entities = [];
   }

--- a/src/systems/scene-systems.js
+++ b/src/systems/scene-systems.js
@@ -1,4 +1,4 @@
-import { LobbyCameraSystem } from "./lobby-camera-system";
+import { ScenePreviewCameraSystem } from "./scene-preview-camera-system";
 import { waitForDOMContentLoaded } from "../utils/async-utils";
 
 AFRAME.registerSystem("scene-systems", {
@@ -6,11 +6,11 @@ AFRAME.registerSystem("scene-systems", {
     waitForDOMContentLoaded().then(() => {
       this.DOMContentDidLoad = true;
     });
-    this.lobbyCameraSystem = new LobbyCameraSystem();
+    this.scenePreviewCameraSystem = new ScenePreviewCameraSystem();
   },
 
   tick() {
     if (!this.DOMContentDidLoad) return;
-    this.lobbyCameraSystem.tick();
+    this.scenePreviewCameraSystem.tick();
   }
 });


### PR DESCRIPTION
Removes a fairly large `querySelector` we were running each frame, also renames `LobbyCameraSystem` to `ScenePreviewCameraSystem` since that component is used both for the lobby and for the scene landing page.

One thing I wasn't sure about is if this introduces a race condition on `init()` in `scene-preview-camera` and the `init()` in `hubs-systems`/`scene-systems`