### PR TITLE
Fix regression in nav mesh performance

### DIFF
--- a/src/systems/character-controller-system.js
+++ b/src/systems/character-controller-system.js
@@ -350,8 +350,15 @@ export class CharacterControllerSystem {
       shouldRecomputeGroupAndNode || this.navGroup === null
         ? pathfinder.getGroup(NAV_ZONE, end, true, true)
         : this.navGroup;
-    this.navNode = shouldRecomputeGroupAndNode || this.navNode === null ? this.getClosestNode(end) : this.navNode;
+    this.navNode =
+      shouldRecomputeGroupAndNode || this.navNode === null || this.navNode === undefined
+        ? this.getClosestNode(end)
+        : this.navNode;
     if (this.navNode === null || this.navNode === undefined) {
+      // this.navNode can be null if it has never been set or if getClosestNode fails,
+      // and it can be undefined if clampStep fails, so we have to check both. We do not
+      // simply check if it is falsey (!this.navNode), because 0 (zero) is a valid value,
+      // and 0 is falsey.
       outPos.copy(end);
     } else {
       this.navNode = pathfinder.clampStep(start, end, this.navNode, NAV_ZONE, this.navGroup, outPos);


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/2052 by saving the `navGroup` and `navNode` of the previous frame, and only recomputes them from scratch if the user teleports, travels by waypoint, stops flying, or `shouldLandWhenPossible`.

Also fixes a bug where if you happen to be on the zeroth node in the nav mesh, you don't actually travel along the nav mesh. (`this.navNode === 0` is a valid node, which we need to treat differently than `this.navNode === null`)