### PR TITLE
Fix FF audio camera issues

### DIFF
--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -376,11 +376,15 @@ AFRAME.registerComponent("camera-tool", {
     const track = this.videoCanvas.captureStream(VIDEO_FPS).getVideoTracks()[0];
 
     // HACK: FF 73+ seems to fail to decode videos with no audio track, so we always include a silent track.
-    // Note that chrome won't generate the video without some data flowing to the track, hence the silence.
+    // Note that chrome won't generate the video without some data flowing to the track, hence the oscillator.
     const attachBlankAudio = () => {
       const context = THREE.AudioContext.getContext();
+      const oscillator = context.createOscillator();
+      const gain = context.createGain();
       const destination = context.createMediaStreamDestination();
-      context.createOscillator().connect(destination);
+      gain.gain.setValueAtTime(0.0001, context.currentTime);
+      oscillator.connect(destination);
+      gain.connect(destination);
       stream.addTrack(destination.stream.getAudioTracks()[0]);
     };
 


### PR DESCRIPTION
This fixes two issues with firefox with the camera tool:

- It seems like firefox fails to load mp4 files without audio tracks upon their first load after being created with the camera tool. The browser gives the error: `Media resource https://uploads-prod.reticulum.io/files/2b196e65-4564-4341-8965-5011c05dc9eb.mp4?token=4247fa8700733f31f0bf3865635d9e0b could not be decoded`. As best I could tell, this looked like a browser bug. What's strange is the videos loaded after the second time, or after a fresh page refresh -- the videos only failed to load after being created with the camera. I added a delay to see if it was some server-side race condition, but that did not resolve the problem. Any ideas?

- With FF 71, we need to set a new codec to include audio properly.

Fixes https://github.com/mozilla/hubs/issues/2024 