### PR TITLE
Fix video failure image

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -580,7 +580,10 @@ AFRAME.registerComponent("media-video", {
     this.mesh.material.needsUpdate = true;
 
     if (projection === "flat" && !this.data.contentType.startsWith("audio/")) {
-      scaleToAspectRatio(this.el, texture.image.videoHeight / texture.image.videoWidth);
+      scaleToAspectRatio(
+        this.el,
+        (texture.image.videoHeight || texture.image.height) / (texture.image.videoWidth || texture.image.width)
+      );
     }
 
     this.updatePlaybackState(true);


### PR DESCRIPTION
This PR fixes the case where we throw an error during video loading -- previously, we were assuming `videoHeight`/`videoWidth` were set, but this isn't true in the error image case. The net effect was error videos would be invisible and cause log spam about 0 determinant matrices.