### PR TITLE
Bug/disappearing avatars

### DIFF
--- a/src/components/billboard.js
+++ b/src/components/billboard.js
@@ -63,6 +63,17 @@ AFRAME.registerComponent("billboard", {
       if (!this.playerCamera) return;
 
       this.isInView = this.el.sceneEl.is("vr-mode") ? true : isInViewOfCamera(this.el.object3D, this.playerCamera);
+
+      if (!this.isInView) {
+        // Check in-game camera if rendering to viewfinder and owned
+        const cameraTools = this.el.sceneEl.systems["camera-tools"];
+
+        if (cameraTools) {
+          cameraTools.ifMyCameraRenderingViewfinder(cameraTool => {
+            this.isInView = this.isInView || isInViewOfCamera(this.el.object3D, cameraTool.camera);
+          });
+        }
+      }
     };
   })(),
 

--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -611,12 +611,6 @@ AFRAME.registerComponent("camera-tool", {
           playerHead.updateMatrixWorld(true, true);
         }
 
-        const bubbleSystem = this.el.sceneEl.systems["personal-space-bubble"];
-
-        for (const invader of bubbleSystem.invaders) {
-          invader.disable();
-        }
-
         let playerHudWasVisible = false;
 
         if (this.playerHud) {
@@ -626,6 +620,14 @@ AFRAME.registerComponent("camera-tool", {
             for (const mesh of Object.values(this.el.sceneEl.systems["hubs-systems"].spriteSystem.meshes)) {
               mesh.visible = false;
             }
+          }
+        }
+
+        const bubbleSystem = this.el.sceneEl.systems["personal-space-bubble"];
+
+        if (bubbleSystem) {
+          for (const invader of bubbleSystem.invaders) {
+            invader.disable();
           }
         }
 
@@ -672,8 +674,10 @@ AFRAME.registerComponent("camera-tool", {
           }
         }
 
-        for (const invader of bubbleSystem.invaders) {
-          invader.enable();
+        if (bubbleSystem) {
+          for (const invader of bubbleSystem.invaders) {
+            invader.enable();
+          }
         }
 
         this.lastUpdate = now;

--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -611,6 +611,12 @@ AFRAME.registerComponent("camera-tool", {
           playerHead.updateMatrixWorld(true, true);
         }
 
+        const bubbleSystem = this.el.sceneEl.systems["personal-space-bubble"];
+
+        for (const invader of bubbleSystem.invaders) {
+          invader.disable();
+        }
+
         let playerHudWasVisible = false;
 
         if (this.playerHud) {
@@ -656,6 +662,7 @@ AFRAME.registerComponent("camera-tool", {
           playerHead.updateMatrices(true, true);
           playerHead.updateMatrixWorld(true, true);
         }
+
         if (this.playerHud) {
           this.playerHud.visible = playerHudWasVisible;
           if (this.el.sceneEl.systems["hubs-systems"]) {
@@ -664,6 +671,11 @@ AFRAME.registerComponent("camera-tool", {
             }
           }
         }
+
+        for (const invader of bubbleSystem.invaders) {
+          invader.enable();
+        }
+
         this.lastUpdate = now;
 
         if (this.videoRecorder) {

--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -626,8 +626,8 @@ AFRAME.registerComponent("camera-tool", {
         const bubbleSystem = this.el.sceneEl.systems["personal-space-bubble"];
 
         if (bubbleSystem) {
-          for (const invader of bubbleSystem.invaders) {
-            invader.disable();
+          for (let i = 0, l = bubbleSystem.invaders.length; i < l; i++) {
+            bubbleSystem.invaders[i].disable();
           }
         }
 
@@ -675,8 +675,8 @@ AFRAME.registerComponent("camera-tool", {
         }
 
         if (bubbleSystem) {
-          for (const invader of bubbleSystem.invaders) {
-            invader.enable();
+          for (let i = 0, l = bubbleSystem.invaders.length; i < l; i++) {
+            bubbleSystem.invaders[i].enable();
           }
         }
 

--- a/src/components/ik-controller.js
+++ b/src/components/ik-controller.js
@@ -67,7 +67,6 @@ AFRAME.registerComponent("ik-controller", {
     leftHand: { type: "string", default: "LeftHand" },
     rightHand: { type: "string", default: "RightHand" },
     chest: { type: "string", default: "Spine" },
-    hips: { type: "string", default: "Hips" },
     rotationSpeed: { default: 5 },
     alwaysUpdate: { type: "boolean", default: false }
   },
@@ -115,6 +114,8 @@ AFRAME.registerComponent("ik-controller", {
   },
 
   update(oldData) {
+    this.avatar = this.el.object3D;
+
     if (this.data.leftEye !== oldData.leftEye) {
       this.leftEye = this.el.object3D.getObjectByName(this.data.leftEye);
     }
@@ -141,10 +142,6 @@ AFRAME.registerComponent("ik-controller", {
 
     if (this.data.chest !== oldData.chest) {
       this.chest = this.el.object3D.getObjectByName(this.data.chest);
-    }
-
-    if (this.data.hips !== oldData.hips) {
-      this.hips = this.el.object3D.getObjectByName(this.data.hips);
     }
 
     // Set middleEye's position to be right in the middle of the left and right eyes.
@@ -186,7 +183,7 @@ AFRAME.registerComponent("ik-controller", {
       }
 
       const {
-        hips,
+        avatar,
         head,
         neck,
         chest,
@@ -208,9 +205,13 @@ AFRAME.registerComponent("ik-controller", {
       // Compute the head position such that the hmd position would be in line with the middleEye
       headTransform.multiplyMatrices(cameraForward, invMiddleEyeToHead);
 
-      // Then position the hips such that the head is aligned with headTransform
+      // Then position the avatar such that the head is aligned with headTransform
       // (which positions middleEye in line with the hmd)
-      hips.position.setFromMatrixPosition(headTransform).add(invHipsToHeadVector);
+      //
+      // Note that we position the avatar itself, *not* the hips, since positioning the
+      // hips will use vertex skinning to do the root displacement, which results in
+      // frustum culling errors.
+      avatar.position.setFromMatrixPosition(headTransform).add(invHipsToHeadVector);
 
       // Animate the hip rotation to follow the Y rotation of the camera with some damping.
       cameraYRotation.setFromRotationMatrix(cameraForward, "YXZ");
@@ -219,20 +220,25 @@ AFRAME.registerComponent("ik-controller", {
       cameraYQuaternion.setFromEuler(cameraYRotation);
 
       if (this._hadFirstTick) {
-        Quaternion.slerp(hips.quaternion, cameraYQuaternion, hips.quaternion, (this.data.rotationSpeed * dt) / 1000);
+        Quaternion.slerp(
+          avatar.quaternion,
+          cameraYQuaternion,
+          avatar.quaternion,
+          (this.data.rotationSpeed * dt) / 1000
+        );
       } else {
-        hips.quaternion.copy(cameraYQuaternion);
+        avatar.quaternion.copy(cameraYQuaternion);
       }
 
-      this.hasConvergedHips = quaternionAlmostEquals(0.0001, cameraYQuaternion, hips.quaternion);
+      this.hasConvergedHips = quaternionAlmostEquals(0.0001, cameraYQuaternion, avatar.quaternion);
 
       // Take the head orientation computed from the hmd, remove the Y rotation already applied to it by the hips,
       // and apply it to the head
-      invHipsQuaternion.copy(hips.quaternion).inverse();
+      invHipsQuaternion.copy(avatar.quaternion).inverse();
       head.quaternion.setFromRotationMatrix(headTransform).premultiply(invHipsQuaternion);
 
-      hips.updateMatrix();
-      rootToChest.multiplyMatrices(hips.matrix, chest.matrix);
+      avatar.updateMatrix();
+      rootToChest.multiplyMatrices(avatar.matrix, chest.matrix);
       invRootToChest.getInverse(rootToChest);
 
       root.matrixNeedsUpdate = true;

--- a/src/components/ik-controller.js
+++ b/src/components/ik-controller.js
@@ -267,9 +267,13 @@ AFRAME.registerComponent("ik-controller", {
     // TODO: This coupling with personal-space-invader is not ideal.
     // There should be some intermediate thing managing multiple opinions about object visibility
     const spaceInvader = handObject3D.el.components["personal-space-invader"];
-    const handHiddenByPersonalSpace = spaceInvader && spaceInvader.invading;
 
-    handObject3D.visible = !handHiddenByPersonalSpace && controllerObject3D.visible;
+    if (spaceInvader) {
+      // If this hand has an invader, defer to it to manage visibility overall but tell it to hide based upon controller state
+      spaceInvader.setAlwaysHidden(!controllerObject3D.visible);
+    } else {
+      handObject3D.visible = controllerObject3D.visible;
+    }
 
     // Optimization: skip IK update if not in view and not forced by frame scheduler
     if (controllerObject3D.visible && (isInView || this.forceIkUpdate || this.data.alwaysUpdate)) {

--- a/src/components/ik-controller.js
+++ b/src/components/ik-controller.js
@@ -210,7 +210,8 @@ AFRAME.registerComponent("ik-controller", {
       //
       // Note that we position the avatar itself, *not* the hips, since positioning the
       // hips will use vertex skinning to do the root displacement, which results in
-      // frustum culling errors.
+      // frustum culling errors since three.js does not take into account skinning when
+      // computing frustum culling sphere bounds.
       avatar.position.setFromMatrixPosition(headTransform).add(invHipsToHeadVector);
 
       // Animate the hip rotation to follow the Y rotation of the camera with some damping.

--- a/src/components/ik-controller.js
+++ b/src/components/ik-controller.js
@@ -308,7 +308,19 @@ AFRAME.registerComponent("ik-controller", {
       const camera = this.ikRoot.camera.object3D;
       camera.getWorldPosition(cameraWorld);
 
+      // Check player camera
       this.isInView = isInViewOfCamera(this.playerCamera, cameraWorld);
+
+      if (!this.isInView) {
+        // Check in-game camera if rendering to viewfinder and owned
+        const cameraTools = this.el.sceneEl.systems["camera-tools"];
+
+        if (cameraTools) {
+          cameraTools.ifMyCameraRenderingViewfinder(cameraTool => {
+            this.isInView = this.isInView || isInViewOfCamera(cameraTool.camera, cameraWorld);
+          });
+        }
+      }
     };
   })()
 });

--- a/src/hub.html
+++ b/src/hub.html
@@ -100,6 +100,7 @@
                     <a-entity class="model" gltf-model-plus="inflate: true">
                         <template data-name="AvatarRoot">
                             <a-entity
+                                disable-frustum-culling
                                 ik-controller
                                 hand-pose__left
                                 hand-pose__right

--- a/src/hub.html
+++ b/src/hub.html
@@ -100,11 +100,9 @@
                     <a-entity class="model" gltf-model-plus="inflate: true">
                         <template data-name="AvatarRoot">
                             <a-entity
-                                disable-frustum-culling
                                 ik-controller
                                 hand-pose__left
                                 hand-pose__right
-                                space-invader-mesh="meshName: AvatarMesh"
                                 networked-audio-analyser
                             ></a-entity>
                         </template>

--- a/src/systems/camera-tools.js
+++ b/src/systems/camera-tools.js
@@ -15,6 +15,7 @@ AFRAME.registerSystem("camera-tools", {
       playerModelEl.addEventListener("model-loading", () => (this.playerHead = null));
       playerModelEl.addEventListener("model-loaded", this.updatePlayerHead.bind(this));
       this.updatePlayerHead();
+      this.updateMyCamera();
     });
   },
 

--- a/src/systems/camera-tools.js
+++ b/src/systems/camera-tools.js
@@ -8,6 +8,7 @@ AFRAME.registerSystem("camera-tools", {
     this.cameraEls = [];
     this.cameraUpdateCount = 0;
     this.ticks = 0;
+    this.updateMyCamera = this.updateMyCamera.bind(this);
 
     waitForDOMContentLoaded().then(() => {
       const playerModelEl = document.querySelector("#avatar-rig .model");
@@ -24,24 +25,36 @@ AFRAME.registerSystem("camera-tools", {
 
   register(el) {
     this.cameraEls.push(el);
-    el.addEventListener("ownership-changed", this._onOwnershipChange);
-    delete this.myCamera;
+    el.addEventListener("ownership-changed", this.updateMyCamera);
+    this.updateMyCamera();
   },
 
   deregister(el) {
     this.cameraEls = this.cameraEls.filter(c => c !== el);
-    el.removeEventListener("ownership-changed", this._onOwnershipChange);
-    delete this.myCamera;
+    el.removeEventListener("ownership-changed", this.updateMyCamera);
+    this.updateMyCamera();
   },
 
   getMyCamera() {
-    if (this.myCamera !== undefined) return this.myCamera;
-    this.myCamera = this.cameraEls.find(NAF.utils.isMine) || null;
     return this.myCamera;
   },
 
-  _onOwnershipChange() {
-    this.myCamera = null;
+  ifMyCameraRenderingViewfinder(f) {
+    if (!this.myCamera) return;
+
+    const myCameraTool = this.myCamera.components["camera-tool"];
+
+    if (myCameraTool && myCameraTool.showCameraViewfinder && myCameraTool.camera) {
+      f(myCameraTool);
+    }
+  },
+
+  updateMyCamera() {
+    if (!this.cameraEls) {
+      this.myCamera = null;
+    } else {
+      this.myCamera = this.cameraEls.find(NAF.utils.isMine);
+    }
   },
 
   tick() {

--- a/src/systems/personal-space-bubble.js
+++ b/src/systems/personal-space-bubble.js
@@ -198,11 +198,18 @@ AFRAME.registerComponent("personal-space-invader", {
       }
     }
     this.invading = false;
+    this.alwaysHidden = false;
   },
 
   update() {
     this.radiusSquared = this.data.radius * this.data.radius;
     this.updateDebug();
+  },
+
+  // Allow external callers to tell this invader to always hide this element, regardless of invasion state
+  setAlwaysHidden(alwaysHidden) {
+    this.alwaysHidden = alwaysHidden;
+    this.applyInvasionToMesh(this.invading);
   },
 
   updateDebug() {
@@ -249,13 +256,13 @@ AFRAME.registerComponent("personal-space-invader", {
   applyInvasionToMesh(invading) {
     if (this.disabled) return;
 
-    if (this.targetMesh && this.targetMesh.material) {
+    if (this.targetMesh && this.targetMesh.material && !this.alwaysHidden) {
       forEachMaterial(this.targetMesh, material => {
         material.opacity = invading ? this.data.invadingOpacity : 1;
         material.transparent = invading;
       });
     } else {
-      this.el.object3D.visible = !invading;
+      this.el.object3D.visible = !invading && !this.alwaysHidden;
     }
   }
 });

--- a/src/systems/personal-space-bubble.js
+++ b/src/systems/personal-space-bubble.js
@@ -221,6 +221,34 @@ AFRAME.registerComponent("personal-space-invader", {
   setInvading(invading) {
     if (this.invading === invading) return;
 
+    this.applyInvasionToMesh(invading);
+    this.invading = invading;
+  },
+
+  disable() {
+    if (this.invading) {
+      this.applyInvasionToMesh(false);
+    }
+
+    this.disabled = true;
+    this.updateBoneVisibility();
+  },
+
+  enable() {
+    this.disabled = false;
+    this.applyInvasionToMesh(this.invading);
+    this.updateBoneVisibility();
+  },
+
+  updateBoneVisibility() {
+    // HACK, bone visibility typically takes a tick to update, but since we want to be able
+    // to have enable() and disable() be reflected this frame, we need to do it immediately.
+    this.el.components["bone-visibility"] && this.el.components["bone-visibility"].tick();
+  },
+
+  applyInvasionToMesh(invading) {
+    if (this.disabled) return;
+
     if (this.targetMesh && this.targetMesh.material) {
       forEachMaterial(this.targetMesh, material => {
         material.opacity = invading ? this.data.invadingOpacity : 1;
@@ -229,7 +257,6 @@ AFRAME.registerComponent("personal-space-invader", {
     } else {
       this.el.object3D.visible = !invading;
     }
-    this.invading = invading;
   }
 });
 


### PR DESCRIPTION
Fixes a wide variety of issues causing avatars to disappear or appear choppy.

Fixes https://github.com/mozilla/hubs/issues/1843

- Previously, we were using vertex skinning to position the hips (updated via `ik-controller`.) The net effect of this is that the displacement made to the hip (for example, the height delta needed to move the head up) was being done on GPU, so was not visible to three.js for accurate frustum culling. Three frustum culling uses the geometry's boundingSphere, and so our boundingSphere for avatars was very far off since the root hip transform was not baked into the matrixWorld of the root avatar geometry. To fix this, `ik-controller` now transforms the `AvatarRoot` entity instead of the hip element with the computed hip transform needed to properly orient the head. The hip joint transform is now fixed at 0,0,0 in local space. I kept the local references to `hips` in the naming, to make it clear that we are still doing the IK math to determine logical hip transform, but are applying it to the root avatar entity.

- Previously, we were not taking into account the camera viewfinder frustum for optimizations which disabled billboarding and IK updates on avatars that were 'not visible'. This led to visible choppiness on avatars, nametags, and other elements when taking a video recording that were in the camera viewfinder frustum but not in the player frustum (eg behind the player.) This PR updates things so that those optimizations will be disabled on entities which are in the view frustum of the currently owned camera when that camera's viewfinder is active. (Note that on mobile the viewfinder is only active when you are holding the camera, so this change will not affect overall frame performance except for when the camera is being held.)

- Previously, space bubble effects were seen in the camera viewfinder. So if you were near someone and taking a picture, they would be invisible in your camera. This updates the camera renderer so that the space bubble behavior is temporarily disabled as we render the viewfinder/recording frame.

- Fixed a bunch of logic in `camera-tools` system that was causing it to misinform callers of the currently owned camera.

Along the way, adds two new facilities to the invader system, the ability to `enable`/`disable` the invader handling explicitly, as well as the ability for an external caller to inform the invader that the element it is managing the visibility for should always be invisible.

Also, I finally tracked down why avatars stopped going translucent during invasion. I think the behavior we have now where they are hidden is better safety-wise so I didn't try to restore translucency, but the problem was that our lookup by name for the avatar mesh started failing for some reason (likely as we worked on the avatar system) and so the invader logic fell back on using visibility instead of material opacity as the invasion response.