### PR TITLE
Fix issue with teleport getting stuck when over interactable

### DIFF
--- a/src/systems/userinput/bindings/oculus-touch-user.js
+++ b/src/systems/userinput/bindings/oculus-touch-user.js
@@ -793,11 +793,6 @@ export const oculusTouchUserBindings = addSetsToBindings({
     {
       src: { value: leftGripPressed2 },
       dest: { value: leftGripRisingGrab },
-      xform: xforms.rising
-    },
-    {
-      src: { value: leftTriggerPressed2 },
-      dest: { value: leftTriggerRisingGrab },
       xform: xforms.rising,
       priority: 2
     },
@@ -805,6 +800,12 @@ export const oculusTouchUserBindings = addSetsToBindings({
       src: [leftGripRisingGrab],
       dest: { value: paths.actions.leftHand.grab },
       xform: xforms.any,
+      priority: 2
+    },
+    {
+      src: { value: leftTriggerPressed2 },
+      dest: { value: paths.actions.leftHand.stopTeleport },
+      xform: xforms.falling,
       priority: 2
     }
   ],
@@ -1041,15 +1042,15 @@ export const oculusTouchUserBindings = addSetsToBindings({
       priority: 2
     },
     {
-      src: { value: rightTriggerPressed2 },
-      dest: { value: rightTriggerRisingGrab },
-      xform: xforms.rising,
-      priority: 2
-    },
-    {
       src: [rightGripRisingGrab],
       dest: { value: paths.actions.rightHand.grab },
       xform: xforms.any,
+      priority: 2
+    },
+    {
+      src: { value: rightTriggerPressed2 },
+      dest: { value: paths.actions.rightHand.stopTeleport },
+      xform: xforms.falling,
       priority: 2
     }
   ],

--- a/src/systems/userinput/bindings/vive-user.js
+++ b/src/systems/userinput/bindings/vive-user.js
@@ -957,9 +957,9 @@ export const viveUserBindings = addSetsToBindings({
     },
     {
       src: { value: leftTriggerPressed2 },
-      dest: { value: lTriggerRisingGrab },
-      xform: xforms.rising,
-      priority: 1
+      dest: { value: paths.actions.leftHand.stopTeleport },
+      xform: xforms.falling,
+      priority: 2
     },
     {
       src: [lGripRisingGrab],
@@ -1402,8 +1402,8 @@ export const viveUserBindings = addSetsToBindings({
     },
     {
       src: { value: rightTriggerPressed2 },
-      dest: { value: rTriggerRisingGrab },
-      xform: xforms.rising,
+      dest: { value: paths.actions.rightHand.stopTeleport },
+      xform: xforms.falling,
       priority: 2
     },
     {


### PR DESCRIPTION
Partially fixes https://github.com/mozilla/hubs/issues/1809

Need to test on vive. Skipped windows mixed reality controllers for now, since the binding changes looked non-trivial. So we should leave the issue open and update it properly to note it is fixed on oculus + vive.