### PR TITLE
Fixes for link spawning

### DIFF
--- a/admin/src/react-components/content-cdn.js
+++ b/admin/src/react-components/content-cdn.js
@@ -86,7 +86,7 @@ const workerScript = (workerDomain, assetsDomain) => {
         responseHeaders.set("Access-Control-Allow-Origin", origin);
         responseHeaders.set("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS");
         responseHeaders.set("Access-Control-Allow-Headers", "Range");
-        responseHeaders.set("Access-Control-Expose-Headers", "Accept-Ranges, Content-Encoding, Content-Length, Content-Range, hub-name, hub-entity-type");
+        responseHeaders.set("Access-Control-Expose-Headers", "Accept-Ranges, Content-Encoding, Content-Length, Content-Range, Hub-Name, Hub-Entity-Type");
       }
   
       responseHeaders.set("Vary", "Origin");

--- a/admin/src/react-components/content-cdn.js
+++ b/admin/src/react-components/content-cdn.js
@@ -86,7 +86,7 @@ const workerScript = (workerDomain, assetsDomain) => {
         responseHeaders.set("Access-Control-Allow-Origin", origin);
         responseHeaders.set("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS");
         responseHeaders.set("Access-Control-Allow-Headers", "Range");
-        responseHeaders.set("Access-Control-Expose-Headers", "Accept-Ranges, Content-Encoding, Content-Length, Content-Range");
+        responseHeaders.set("Access-Control-Expose-Headers", "Accept-Ranges, Content-Encoding, Content-Length, Content-Range, hub-name, hub-entity-type");
       }
   
       responseHeaders.set("Vary", "Origin");

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "js-cookie": "^2.2.0",
     "jsonschema": "^1.2.2",
     "jwt-decode": "^2.2.0",
+    "linkify-it": "^2.0.3",
     "markdown-it": "^8.4.2",
     "moving-average": "^1.0.0",
     "naf-janus-adapter": "^3.0.15",

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -10,8 +10,8 @@ import {
   guessContentType,
   proxiedUrlFor,
   isHubsRoomUrl,
-  isHubsSceneUrl,
-  isHubsAvatarUrl
+  isLocalHubsSceneUrl,
+  isLocalHubsAvatarUrl
 } from "../utils/media-url-utils";
 import { addAnimationComponents } from "../utils/animation";
 import qsTruthy from "../utils/qs_truthy";
@@ -482,12 +482,12 @@ AFRAME.registerComponent("media-loader", {
           async () => {
             const mayChangeScene = this.el.sceneEl.systems.permissions.can("update_hub");
 
-            if (await isHubsAvatarUrl(src)) {
+            if (await isLocalHubsAvatarUrl(src)) {
               this.el.setAttribute("hover-menu__hubs-item", {
                 template: "#avatar-link-hover-menu",
                 dirs: ["forward", "back"]
               });
-            } else if ((await isHubsRoomUrl(src)) || ((await isHubsSceneUrl(src)) && mayChangeScene)) {
+            } else if ((await isHubsRoomUrl(src)) || ((await isLocalHubsSceneUrl(src)) && mayChangeScene)) {
               this.el.setAttribute("hover-menu__hubs-item", {
                 template: "#hubs-destination-hover-menu",
                 dirs: ["forward", "back"]

--- a/src/components/open-media-button.js
+++ b/src/components/open-media-button.js
@@ -1,4 +1,4 @@
-import { isHubsSceneUrl, isHubsRoomUrl, isHubsAvatarUrl } from "../utils/media-url-utils";
+import { isLocalHubsSceneUrl, isHubsRoomUrl, isLocalHubsAvatarUrl } from "../utils/media-url-utils";
 import { guessContentType } from "../utils/media-url-utils";
 import { handleExitTo2DInterstitial } from "../utils/vr-interstitial";
 
@@ -20,9 +20,9 @@ AFRAME.registerComponent("open-media-button", {
       if (visible) {
         let label = "open link";
         if (!this.data.onlyOpenLink) {
-          if (await isHubsAvatarUrl(src)) {
+          if (await isLocalHubsAvatarUrl(src)) {
             label = "use avatar";
-          } else if ((await isHubsSceneUrl(src)) && mayChangeScene) {
+          } else if ((await isLocalHubsSceneUrl(src)) && mayChangeScene) {
             label = "use scene";
           } else if (await isHubsRoomUrl(src)) {
             label = "visit room";
@@ -40,10 +40,10 @@ AFRAME.registerComponent("open-media-button", {
       if (this.data.onlyOpenLink) {
         await exitImmersive();
         window.open(this.src);
-      } else if (await isHubsAvatarUrl(this.src)) {
+      } else if (await isLocalHubsAvatarUrl(this.src)) {
         const avatarId = new URL(this.src).pathname.split("/").pop();
         window.APP.store.update({ profile: { avatarId } });
-      } else if ((await isHubsSceneUrl(this.src)) && mayChangeScene) {
+      } else if ((await isLocalHubsSceneUrl(this.src)) && mayChangeScene) {
         this.el.sceneEl.emit("scene_media_selected", this.src);
       } else if (await isHubsRoomUrl(this.src)) {
         await exitImmersive();

--- a/src/react-components/chat-message.js
+++ b/src/react-components/chat-message.js
@@ -209,10 +209,8 @@ export async function createInWorldLogMessage({ name, type, body }) {
 export async function spawnChatMessage(body, from) {
   if (body.length === 0) return;
 
-  const urlOrText = coerceToUrl(body);
-
   try {
-    new URL(urlOrText);
+    new URL(coerceToUrl(body));
     document.querySelector("a-scene").emit("add_media", body);
     return;
   } catch (e) {

--- a/src/react-components/chat-message.js
+++ b/src/react-components/chat-message.js
@@ -7,11 +7,11 @@ import Linkify from "react-linkify";
 import { toArray as toEmojis } from "react-emoji-render";
 import serializeElement from "../utils/serialize-element";
 import { navigateToClientInfo } from "./presence-list";
+import { coerceToUrl } from "../utils/media-utils";
 
 const messageCanvas = document.createElement("canvas");
 
 const emojiRegex = /(?:[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff]|[\u0023-\u0039]\ufe0f?\u20e3|\u3299|\u3297|\u303d|\u3030|\u24c2|\ud83c[\udd70-\udd71]|\ud83c[\udd7e-\udd7f]|\ud83c\udd8e|\ud83c[\udd91-\udd9a]|\ud83c[\udde6-\uddff]|[\ud83c[\ude01-\ude02]|\ud83c\ude1a|\ud83c\ude2f|[\ud83c[\ude32-\ude3a]|[\ud83c[\ude50-\ude51]|\u203c|\u2049|[\u25aa-\u25ab]|\u25b6|\u25c0|[\u25fb-\u25fe]|\u00a9|\u00ae|\u2122|\u2139|\ud83c\udc04|[\u2600-\u26FF]|\u2b05|\u2b06|\u2b07|\u2b1b|\u2b1c|\u2b50|\u2b55|\u231a|\u231b|\u2328|\u23cf|[\u23e9-\u23f3]|[\u23f8-\u23fa]|\ud83c\udccf|\u2934|\u2935|[\u2190-\u21ff])/;
-const urlRegex = /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)$/;
 const textureLoader = new THREE.TextureLoader();
 
 const CHAT_MESSAGE_TEXTURE_SIZE = 1024;
@@ -209,10 +209,17 @@ export async function createInWorldLogMessage({ name, type, body }) {
 export async function spawnChatMessage(body, from) {
   if (body.length === 0) return;
 
-  if (body.match(urlRegex)) {
+  const urlOrText = coerceToUrl(body);
+
+  try {
+    new URL(urlOrText);
     document.querySelector("a-scene").emit("add_media", body);
     return;
+  } catch (e) {
+    // Ignore parse error
   }
+
+  // If not a URL, spawn as a text bubble
 
   const [blob] = await renderChatMessage(body, from, true);
   document.querySelector("a-scene").emit("add_media", new File([blob], "message.png", { type: "image/png" }));

--- a/src/utils/media-url-utils.js
+++ b/src/utils/media-url-utils.js
@@ -159,15 +159,20 @@ const hubsSceneRegex = /https?:\/\/[^/]+\/scenes\/(\w+)\/?\S*/;
 const hubsAvatarRegex = /https?:\/\/[^/]+\/avatars\/(?<id>\w+)\/?\S*/;
 const hubsRoomRegex = /(https?:\/\/)?[^/]+\/([a-zA-Z0-9]{7})\/?\S*/;
 
+export const isLocalHubsUrl = async url =>
+  (await isHubsServer(url)) && new URL(url).origin === document.location.origin;
+
 export const isHubsSceneUrl = async url => (await isHubsServer(url)) && hubsSceneRegex.test(url);
+export const isLocalHubsSceneUrl = async url => (await isHubsSceneUrl(url)) && (await isLocalHubsUrl(url));
+
+export const isHubsAvatarUrl = async url => (await isHubsServer(url)) && hubsAvatarRegex.test(url);
+export const isLocalHubsAvatarUrl = async url => (await isHubsAvatarUrl(url)) && (await isLocalHubsUrl(url));
 
 export const isHubsRoomUrl = async url =>
-  (await isHubsServer(url)) && !(await isHubsSceneUrl(url)) && hubsRoomRegex.test(url);
+  (await isHubsServer(url)) && !(await isHubsAvatarUrl(url)) && !(await isHubsSceneUrl(url)) && hubsRoomRegex.test(url);
 
 export const isHubsDestinationUrl = async url =>
   (await isHubsServer(url)) && ((await isHubsSceneUrl(url)) || (await isHubsRoomUrl(url)));
-
-export const isHubsAvatarUrl = async url => (await isHubsServer(url)) && hubsAvatarRegex.test(url);
 
 export const idForAvatarUrl = url => {
   const match = url.match(hubsAvatarRegex);

--- a/src/utils/media-url-utils.js
+++ b/src/utils/media-url-utils.js
@@ -147,7 +147,7 @@ async function isHubsServer(url) {
 
   let isHubsServer;
   try {
-    isHubsServer = (await fetch(origin, { method: "HEAD" })).headers.has("hub-name");
+    isHubsServer = (await fetch(proxiedUrlFor(origin), { method: "HEAD" })).headers.has("hub-name");
   } catch (e) {
     isHubsServer = false;
   }

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -5,9 +5,13 @@ import { mapMaterials } from "./material-utils";
 import HubsTextureLoader from "../loaders/HubsTextureLoader";
 import { validMaterials } from "../components/hoverable-visuals";
 import { proxiedUrlFor } from "../utils/media-url-utils";
-import { test as testStringForLink } from "linkifyjs";
+import Linkify from "linkify-it";
+import tlds from "tlds";
 
 import anime from "animejs";
+
+const linkify = Linkify();
+linkify.tlds(tlds);
 
 const mediaAPIEndpoint = getReticulumFetchUrl("/api/v1/media");
 const isMobile = AFRAME.utils.device.isMobile();
@@ -115,7 +119,7 @@ function getLatestMediaVersionOfSrc(src) {
 }
 
 export function coerceToUrl(urlOrText) {
-  if (!testStringForLink(urlOrText)) return urlOrText;
+  if (!linkify.test(urlOrText)) return urlOrText;
 
   // See: https://github.com/Soapbox/linkifyjs/blob/master/src/linkify.js#L52
   return urlOrText.indexOf("://") >= 0 ? urlOrText : `https://${urlOrText}`;

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -5,6 +5,7 @@ import { mapMaterials } from "./material-utils";
 import HubsTextureLoader from "../loaders/HubsTextureLoader";
 import { validMaterials } from "../components/hoverable-visuals";
 import { proxiedUrlFor } from "../utils/media-url-utils";
+import { test as testStringForLink } from "linkifyjs";
 
 import anime from "animejs";
 
@@ -113,6 +114,13 @@ function getLatestMediaVersionOfSrc(src) {
   return version;
 }
 
+export function coerceToUrl(urlOrText) {
+  if (!testStringForLink(urlOrText)) return urlOrText;
+
+  // See: https://github.com/Soapbox/linkifyjs/blob/master/src/linkify.js#L52
+  return urlOrText.indexOf("://") >= 0 ? urlOrText : `https://${urlOrText}`;
+}
+
 export const addMedia = (
   src,
   template,
@@ -137,7 +145,7 @@ export const addMedia = (
     fitToBox,
     resolve,
     animate,
-    src: typeof src === "string" ? src : "",
+    src: typeof src === "string" ? coerceToUrl(src) || src : "",
     version,
     contentSubtype,
     fileIsOwned: !needsToBeUploaded,

--- a/src/utils/scene-url-utils.js
+++ b/src/utils/scene-url-utils.js
@@ -1,4 +1,4 @@
-import { isHubsSceneUrl, proxiedUrlFor } from "../utils/media-url-utils";
+import { isLocalHubsSceneUrl, proxiedUrlFor } from "../utils/media-url-utils";
 
 export async function isValidGLB(url) {
   return fetch(url).then(async r => {
@@ -20,7 +20,7 @@ export async function isValidGLB(url) {
 export async function isValidSceneUrl(url) {
   if (url.trim() === "") return false;
   if (!url.startsWith("http")) return false;
-  if (await isHubsSceneUrl(url)) {
+  if (await isLocalHubsSceneUrl(url)) {
     return true;
   } else {
     return isValidGLB(proxiedUrlFor(url));


### PR DESCRIPTION
Fixes issues with spawning links:

- Fixes issue where if you linked to hubs rooms/scenes/avatars on another site, the HEAD request failed bc of CSP. We now CORS proxy these requests
- Adds the necessary headers to the access control headers on the CORS worker to allow external crawling of hubs links
- Properly deals with local vs non-local URLs to rooms, scenes, and avatars
- Now uses `linkifyjs`'s parser to determine if a piece of text is a URL or not, for use when spawning from chatbox and the paste command. (Eg, now URLs without a scheme will spawn properly, like hub.link URLs)

Fixes https://github.com/mozilla/hubs/issues/1246 