### PR TITLE
Fix issue where resuming suspended mobile VR headset causes spinner

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -918,7 +918,6 @@ document.addEventListener("DOMContentLoaded", async () => {
   });
 
   scene.addEventListener("leave_room_requested", () => {
-    scene.exitVR();
     entryManager.exitScene("left");
     remountUI({ roomUnavailableReason: "left" });
   });

--- a/src/hub.js
+++ b/src/hub.js
@@ -814,7 +814,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     // If VR headset is activated, refreshing page will fire vrdisplayactivate
     // which puts A-Frame in VR mode, so exit VR mode whenever it is attempted
     // to be entered and we haven't entered the room yet.
-    if (scene.is("vr-mode") && !scene.is("vr-entered")) {
+    if (scene.is("vr-mode") && !scene.is("vr-entered") && !isMobileVR) {
       console.log("Pre-emptively exiting VR mode.");
       scene.exitVR();
       return true;

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -139,6 +139,7 @@ export default class SceneEntryManager {
   };
 
   exitScene = () => {
+    this.scene.exitVR();
     if (NAF.connection.adapter && NAF.connection.adapter.localMediaStream) {
       NAF.connection.adapter.localMediaStream.getTracks().forEach(t => t.stop());
     }

--- a/src/systems/exit-on-blur.js
+++ b/src/systems/exit-on-blur.js
@@ -33,7 +33,7 @@ AFRAME.registerSystem("exit-on-blur", {
     ) {
       this.lastTimeoutCheck = t;
       clearTimeout(this.exitTimeout);
-      this.exitTimeout = setTimeout(this.onTimeout, 15 * 1000);
+      this.exitTimeout = setTimeout(this.onTimeout, 30 * 1000);
     }
   },
 


### PR DESCRIPTION
Fixes a long standing bug where if you suspend a mobile headset while in hubs and then un-suspend, you get stuck on a spinner since we were re-exiting VR mode.

Also fixes a bug where if you let the headset remain on standby mode long enough, triggering the exit-on-blur behavior, we fail to exit VR mode properly before tearing down the scene so you also get stuck with a spinner when putting the headset on.

Also bumps the blur timeout to 30s, which seems like a better balance between being too fast and mis-triggering, and too long to preserve user privacy.