### PR TITLE
Revert "Add support for fog to particle emitter"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2882,9 +2882,9 @@
       "integrity": "sha512-CvyJSEnokog9vkTwPqXkoN6k5vGkyXSKPC7BS1RYZEsWo5TupVmYmMPCY5YNLFNs2+5hL1SEkQ1ufHKCxpM/PQ=="
     },
     "@mozillareality/three-particle-emitter": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@mozillareality/three-particle-emitter/-/three-particle-emitter-0.2.2.tgz",
-      "integrity": "sha512-5f6hVJHyb9ZcookyZZ8/sdzDcL9OzRzfhWo9kGv3OXe2dUxK61B4xa0RFP9bxaenKQt8WQUWlZYLcitDTg9s0Q==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@mozillareality/three-particle-emitter/-/three-particle-emitter-0.2.1.tgz",
+      "integrity": "sha512-KI+iWuJPlFLIO6SHRSJVTpdxYDzWEky62dfTggu/CTmm0cWYbCkPO6Bg3ViYNewmk6vIWVMRzk6+EI0vyehFkA==",
       "requires": {
         "@mozillareality/easing-functions": "^0.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.2.0",
     "@fortawesome/react-fontawesome": "^0.1.0",
     "@mozillareality/three-batch-manager": "^0.1.8",
-    "@mozillareality/three-particle-emitter": "^0.2.2",
+    "@mozillareality/three-particle-emitter": "^0.2.1",
     "aframe": "github:mozillareality/aframe#hubs/master",
     "aframe-rounded": "^1.0.3",
     "aframe-slice9-component": "^1.0.0",


### PR DESCRIPTION
Reverts mozilla/hubs#2103 because build was failing.