### PR TITLE
Add location.hostname to nonCorsProxyDomains

### DIFF
--- a/src/utils/media-url-utils.js
+++ b/src/utils/media-url-utils.js
@@ -5,6 +5,7 @@ const nonCorsProxyDomains = (configs.NON_CORS_PROXY_DOMAINS || "").split(",");
 if (configs.CORS_PROXY_SERVER) {
   nonCorsProxyDomains.push(configs.CORS_PROXY_SERVER);
 }
+nonCorsProxyDomains.push(document.location.hostname);
 
 const commonKnownContentTypes = {
   gltf: "model/gltf",


### PR DESCRIPTION
Adds one line to `media-url-utils.js`:

```js
nonCorsProxyDomains.push(document.location.hostname)
```

This change allows for the hubs client to work out of the box in LAN scenarios, e.g., Oculus Quest, after simply running `npm run start`; in other words, it eliminates the need to add a local IP address or hostname to .env file, or to configure hubs.local. Also, a proxied CORS request is pointless when making a request to the same origin :) 