### PR TITLE
Fix mixup between hands and remote constraint checks

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -474,7 +474,7 @@
                     class="interactable"
                     body-helper="type: dynamic; mass: 1; collisionFilterGroup: 1; collisionFilterMask: 15;"
                     is-remote-hover-target
-                    tags="togglesHoveredActionSet: true;"
+                    tags="togglesHoveredActionSet: true; inspectable: true;"
                     set-unowned-body-kinematic
                     set-yxz-order
                     matrix-auto-update

--- a/src/systems/userinput/resolve-action-sets.js
+++ b/src/systems/userinput/resolve-action-sets.js
@@ -102,18 +102,16 @@ export function resolveActionSets() {
   userinput.toggleSet(
     sets.leftHandHoveringOnInteractable,
     !leftHand.held &&
-      (leftHand.hovered &&
-        ((leftHand.hovered.components.tags && leftHand.hovered.components.tags.data.offersRemoteConstraint) ||
-          (leftHand.hovered.components.tags && leftHand.hovered.components.tags.data.togglesHoveredActionSet) ||
-          leftHand.hovered.components["super-spawner"]))
+      leftHand.hovered &&
+      ((leftHand.hovered.components.tags && leftHand.hovered.components.tags.data.offersHandConstraint) ||
+        leftHand.hovered.components["super-spawner"])
   );
   userinput.toggleSet(
     sets.rightHandHoveringOnInteractable,
     !rightHand.held &&
-      (rightHand.hovered &&
-        ((rightHand.hovered.components.tags && rightHand.hovered.components.tags.data.offersRemoteConstraint) ||
-          (rightHand.hovered.components.tags && rightHand.hovered.components.tags.data.togglesHoveredActionSet) ||
-          rightHand.hovered.components["super-spawner"]))
+      rightHand.hovered &&
+      ((rightHand.hovered.components.tags && rightHand.hovered.components.tags.data.offersHandConstraint) ||
+        rightHand.hovered.components["super-spawner"])
   );
   userinput.toggleSet(
     sets.leftCursorHoveringOnInteractable,
@@ -122,6 +120,7 @@ export function resolveActionSets() {
       !leftRemote.held &&
       leftRemote.hovered &&
       ((leftRemote.hovered.components.tags && leftRemote.hovered.components.tags.data.offersRemoteConstraint) ||
+        (leftRemote.hovered.components.tags && leftRemote.hovered.components.tags.data.togglesHoveredActionSet) ||
         leftRemote.hovered.components["super-spawner"])
   );
   userinput.toggleSet(
@@ -131,6 +130,7 @@ export function resolveActionSets() {
       !rightRemote.held &&
       rightRemote.hovered &&
       ((rightRemote.hovered.components.tags && rightRemote.hovered.components.tags.data.offersRemoteConstraint) ||
+        (rightRemote.hovered.components.tags && rightRemote.hovered.components.tags.data.togglesHoveredActionSet) ||
         rightRemote.hovered.components["super-spawner"])
   );
 


### PR DESCRIPTION
Fixes an issue where the `right/leftHandHoveringOnInteractable` action sets were checking for a `remote` tag instead of a `hand` tag.
Also moves the check for the `togglesHoveredActionSet` tag to activate the `right/leftCursorHoveringOnInteractable` action sets (since I think this was gfodor's intention when adding it). 