### PR TITLE
Fix clicking entries in the favorites menu

### DIFF
--- a/src/react-components/media-tiles.js
+++ b/src/react-components/media-tiles.js
@@ -154,7 +154,7 @@ class MediaTiles extends Component {
     const creator = entry.attributions && entry.attributions.creator;
     const isImage = entry.type.endsWith("_image");
     const isAvatar = ["avatar", "avatar_listing"].includes(entry.type);
-    const isHub = ["hub"].includes(entry.type);
+    const isHub = ["room"].includes(entry.type);
     const imageAspect = entry.images.preview.width / entry.images.preview.height;
 
     const [imageWidth, imageHeight] = this.getTileDimensions(isImage, isAvatar, imageAspect);

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1632,7 +1632,7 @@ class UIRoot extends Component {
                 mediaSearchStore={this.props.mediaSearchStore}
                 hubChannel={this.props.hubChannel}
                 onMediaSearchResultEntrySelected={(entry, selectAction) => {
-                  if (entry.type === "hub") {
+                  if (entry.type === "room") {
                     this.showNonHistoriedDialog(LeaveRoomDialog, {
                       destinationUrl: entry.url,
                       messageType: "join-room"


### PR DESCRIPTION
Hubs searches were changed to return type `room` instead of `hub`. Missed 2 spots that were still checking for `hub` which resulted in entries in the favorites menu being un-clickable 