### PR TITLE
Dont get id of null

### DIFF
--- a/src/components/audio-feedback.js
+++ b/src/components/audio-feedback.js
@@ -118,7 +118,8 @@ function connectAnalyser(mediaStream) {
 
 function getAnalyser(el) {
   // Is this the local player
-  if (findAncestorWithComponent(el, "ik-root").id === "avatar-rig") {
+  const ikRootEl = findAncestorWithComponent(el, "ik-root");
+  if (ikRootEl && ikRootEl.id === "avatar-rig") {
     return el.sceneEl.systems["local-audio-analyser"];
   } else {
     const analyserEl = findAncestorWithComponent(el, "networked-audio-analyser");


### PR DESCRIPTION
Fixes a bug where `getAnalyser` fails when called from a component which does not have an `ik-root` on an entity in its parent hierarchy. e.g. An entity with a `scale-audio-feedback` component in its gltf