### PR TITLE
Disable aframe's default lights

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -53,6 +53,7 @@
         rotate-selected-object
         environment-map
         set-max-resolution
+        light="defaultLightsEnabled: false"
     >
         <a-assets>
             <img id="presence-count" crossorigin="anonymous" src="./assets/hud/presence-count.png">


### PR DESCRIPTION
AFrame registers its `light` system whether you put it on your `a-scene` or not. This explicitly adds the system to the `a-scene` in order to prevent it from from adding default lights: https://github.com/MozillaReality/aframe/blob/hubs/master/src/systems/light.js#L18