### PR TITLE
Feature/direct uploads

### DIFF
--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -1,5 +1,5 @@
 import { objectTypeForOriginAndContentType } from "../object-types";
-import { getReticulumFetchUrl } from "./phoenix-utils";
+import { getReticulumFetchUrl, getDirectReticulumFetchUrl } from "./phoenix-utils";
 import { ObjectContentOrigins } from "../object-types";
 import mediaHighlightFrag from "./media-highlight-frag.glsl";
 import { mapMaterials } from "./material-utils";
@@ -15,6 +15,8 @@ const linkify = Linkify();
 linkify.tlds(tlds);
 
 const mediaAPIEndpoint = getReticulumFetchUrl("/api/v1/media");
+const getDirectMediaAPIEndpoint = () => getDirectReticulumFetchUrl("/api/v1/media");
+
 const isMobile = AFRAME.utils.device.isMobile();
 const isMobileVR = AFRAME.utils.device.isMobile();
 
@@ -59,7 +61,9 @@ export const upload = (file, desiredContentType) => {
     formData.append("desired_content_type", desiredContentType);
   }
 
-  return fetch(mediaAPIEndpoint, {
+  // To eliminate the extra hop and avoid proxy timeouts, upload files directly
+  // to a reticulum host.
+  return fetch(getDirectMediaAPIEndpoint(), {
     method: "POST",
     body: formData
   }).then(r => r.json());

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -53,9 +53,9 @@ export async function getReticulumMeta() {
   return reticulumMeta;
 }
 
-let cachedDirectReticulumHostAndPort;
+let directReticulumHostAndPort;
 
-async function refreshCachedDirectReticulumHostAndPort() {
+async function refreshDirectReticulumHostAndPort() {
   const qs = new URLSearchParams(location.search);
   let host = qs.get("phx_host");
   const reticulumMeta = await getReticulumMeta();
@@ -63,16 +63,16 @@ async function refreshCachedDirectReticulumHostAndPort() {
   const port =
     qs.get("phx_port") ||
     (hasReticulumServer() ? new URL(`${document.location.protocol}//${configs.RETICULUM_SERVER}`).port : "443");
-  cachedDirectReticulumHostAndPort = { host, port };
+  directReticulumHostAndPort = { host, port };
 }
 
 export function getDirectReticulumFetchUrl(path, absolute = false) {
-  if (!cachedDirectReticulumHostAndPort) {
+  if (!directReticulumHostAndPort) {
     console.warn("Cannot call getDirectReticulumFetchUrl before connectToReticulum. Returning non-direct url.");
     return getReticulumFetchUrl(path, absolute);
   }
 
-  const { host, port } = cachedDirectReticulumHostAndPort;
+  const { host, port } = directReticulumHostAndPort;
   return getReticulumFetchUrl(path, absolute, host, port);
 }
 
@@ -85,8 +85,8 @@ export async function connectToReticulum(debug = false, params = null, socketCla
   const qs = new URLSearchParams(location.search);
 
   const getNewSocketUrl = async () => {
-    await refreshCachedDirectReticulumHostAndPort();
-    const { host, port } = cachedDirectReticulumHostAndPort;
+    await refreshDirectReticulumHostAndPort();
+    const { host, port } = directReticulumHostAndPort;
     const protocol =
       qs.get("phx_protocol") ||
       configs.RETICULUM_SOCKET_PROTOCOL ||

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -13,23 +13,18 @@ export function isLocalClient() {
 }
 
 const resolverLink = document.createElement("a");
-export function getReticulumFetchUrl(path, absolute = false) {
-  if (hasReticulumServer()) {
-    return `https://${configs.RETICULUM_SERVER}${path}`;
+let reticulumMeta = null;
+let invalidatedReticulumMetaThisSession = false;
+
+export function getReticulumFetchUrl(path, absolute = false, host = null) {
+  if (hasReticulumServer() || host) {
+    return `https://${host || configs.RETICULUM_SERVER}${path}`;
   } else if (absolute) {
     resolverLink.href = path;
     return resolverLink.href;
   } else {
     return path;
   }
-}
-
-let reticulumMeta = null;
-let invalidatedReticulumMetaThisSession = false;
-
-export async function invalidateReticulumMeta() {
-  invalidatedReticulumMetaThisSession = true;
-  reticulumMeta = null;
 }
 
 export async function getReticulumMeta() {
@@ -58,19 +53,48 @@ export async function getReticulumMeta() {
   return reticulumMeta;
 }
 
+async function getDirectReticiulumHost() {
+  const qs = new URLSearchParams(location.search);
+  let host = qs.get("phx_host");
+  const reticulumMeta = await getReticulumMeta();
+  host = host || configs.RETICULUM_SOCKET_SERVER || reticulumMeta.phx_host;
+  return host;
+}
+
+let cachedDirectReticulumHost;
+
+export async function refreshCachedDirectReticulumHost() {
+  cachedDirectReticulumHost = await getDirectReticiulumHost();
+}
+
+export function getDirectReticulumFetchUrl(path, absolute = false) {
+  if (!cachedDirectReticulumHost) {
+    console.warn(
+      "Cannot call getDirectReticulumFetchUrl before refreshCachedDirectReticulumHost. Returning non-direct url."
+    );
+    return getReticulumFetchUrl(path, absolute);
+  }
+
+  return getReticulumFetchUrl(path, absolute, cachedDirectReticulumHost);
+}
+
+export async function invalidateReticulumMeta() {
+  invalidatedReticulumMetaThisSession = true;
+  reticulumMeta = null;
+}
+
 export async function connectToReticulum(debug = false, params = null, socketClass = Socket) {
   const qs = new URLSearchParams(location.search);
 
   const getNewSocketUrl = async () => {
+    await refreshCachedDirectReticulumHost();
+    const socketHost = cachedDirectReticulumHost;
     const socketProtocol =
       qs.get("phx_protocol") ||
       configs.RETICULUM_SOCKET_PROTOCOL ||
       (document.location.protocol === "https:" ? "wss:" : "ws:");
-    let socketHost = qs.get("phx_host");
     let socketPort = qs.get("phx_port");
 
-    const reticulumMeta = await getReticulumMeta();
-    socketHost = socketHost || configs.RETICULUM_SOCKET_SERVER || reticulumMeta.phx_host;
     socketPort =
       socketPort || (hasReticulumServer() ? new URL(`${socketProtocol}//${configs.RETICULUM_SERVER}`).port : "443");
     return `${socketProtocol}//${socketHost}${socketPort ? `:${socketPort}` : ""}`;

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -53,7 +53,9 @@ export async function getReticulumMeta() {
   return reticulumMeta;
 }
 
-async function getDirectReticulumHostAndPort() {
+let cachedDirectReticulumHostAndPort;
+
+async function refreshCachedDirectReticulumHostAndPort() {
   const qs = new URLSearchParams(location.search);
   let host = qs.get("phx_host");
   const reticulumMeta = await getReticulumMeta();
@@ -66,13 +68,7 @@ async function getDirectReticulumHostAndPort() {
     (document.location.protocol === "https:" ? "wss:" : "ws:");
 
   port = port || (hasReticulumServer() ? new URL(`${socketProtocol}//${configs.RETICULUM_SERVER}`).port : "443");
-  return { host, port };
-}
-
-let cachedDirectReticulumHostAndPort;
-
-async function refreshCachedDirectReticulumHostAndPort() {
-  cachedDirectReticulumHostAndPort = await getDirectReticulumHostAndPort();
+  cachedDirectReticulumHostAndPort = { host, port };
 }
 
 export function getDirectReticulumFetchUrl(path, absolute = false) {

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -17,7 +17,7 @@ let reticulumMeta = null;
 let invalidatedReticulumMetaThisSession = false;
 
 export function getReticulumFetchUrl(path, absolute = false, host = null, port = null) {
-  if (hasReticulumServer() || host) {
+  if (host || hasReticulumServer()) {
     return `https://${host || configs.RETICULUM_SERVER}${port ? `:${port}` : ""}${path}`;
   } else if (absolute) {
     resolverLink.href = path;

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -60,22 +60,15 @@ async function refreshCachedDirectReticulumHostAndPort() {
   let host = qs.get("phx_host");
   const reticulumMeta = await getReticulumMeta();
   host = host || configs.RETICULUM_SOCKET_SERVER || reticulumMeta.phx_host;
-  let port = qs.get("phx_port");
-
-  const socketProtocol =
-    qs.get("phx_protocol") ||
-    configs.RETICULUM_SOCKET_PROTOCOL ||
-    (document.location.protocol === "https:" ? "wss:" : "ws:");
-
-  port = port || (hasReticulumServer() ? new URL(`${socketProtocol}//${configs.RETICULUM_SERVER}`).port : "443");
+  const port =
+    qs.get("phx_port") ||
+    (hasReticulumServer() ? new URL(`${document.location.protocol}//${configs.RETICULUM_SERVER}`).port : "443");
   cachedDirectReticulumHostAndPort = { host, port };
 }
 
 export function getDirectReticulumFetchUrl(path, absolute = false) {
   if (!cachedDirectReticulumHostAndPort) {
-    console.warn(
-      "Cannot call getDirectReticulumFetchUrl before refreshCachedDirectReticulumHost. Returning non-direct url."
-    );
+    console.warn("Cannot call getDirectReticulumFetchUrl before connectToReticulum. Returning non-direct url.");
     return getReticulumFetchUrl(path, absolute);
   }
 

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -71,7 +71,7 @@ async function getDirectReticulumHostAndPort() {
 
 let cachedDirectReticulumHostAndPort;
 
-export async function refreshCachedDirectReticulumHostAndPort() {
+async function refreshCachedDirectReticulumHostAndPort() {
   cachedDirectReticulumHostAndPort = await getDirectReticulumHostAndPort();
 }
 


### PR DESCRIPTION
See https://github.com/mozilla/reticulum/pull/319

This updates the client to perform media uploads via direct HTTP request to a reticulum server, instead of via the intermediate proxy (such as Cloudfront.)