### PR TITLE
Properly deal with enable_spoke feature flag

### DIFF
--- a/src/schema.toml
+++ b/src/schema.toml
@@ -30,8 +30,8 @@ features.hide_powered_by = { category = "features", type = "boolean", name = "Hi
 
 features.public_rooms = { category = "features", type = "boolean", name = "Public Rooms", description = "Allow visitors to set rooms to public to feature them on the homepage." }
 features.default_room_id = { category = "features", type = "string", name = "Homepage Room ID", description = "Use the specified room in place of the homepage."}
+features.enable_spoke = { category = "features", type = "boolean", name = "Enable Scene Editor", description = "Enable Scene Editor for all visitors."}
 
-features.enable_spoke = { category = "features", type = "boolean", internal = "true" }
 features.show_join_us_dialog = { category = "features", type = "boolean", internal = "true" }
 features.show_discord_bot_link = { category = "features", type = "boolean", internal = "true" }
 features.show_whats_new_link = { category = "features", type = "boolean", internal = "true" }

--- a/src/utils/configs.js
+++ b/src/utils/configs.js
@@ -60,7 +60,7 @@ const isLocalDevelopment = process.env.NODE_ENV === "development";
 
 configs.feature = featureName => {
   const value = configs.APP_CONFIG.features[featureName];
-  if (typeof value === "boolean") {
+  if (typeof value === "boolean" || featureName === "enable_spoke") {
     const enableAll = isLocalDevelopment && !process.env.USE_FEATURE_CONFIG;
     const forceEnableSpoke = featureName === "enable_spoke" && isAdmin;
     return forceEnableSpoke || enableAll || value;


### PR DESCRIPTION
Fixes the `enable_spoke` feature flag, previously the logic was not properly enabling it for admins when there was no value set, and it was hidden from being configured as well.