### PR TITLE
Fix spawner position

### DIFF
--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -1,4 +1,4 @@
-import { getBox, getScaleCoefficient } from "../utils/auto-box-collider";
+import { computeObjectAABB, getBox, getScaleCoefficient } from "../utils/auto-box-collider";
 import {
   resolveUrl,
   getDefaultResolveQuality,
@@ -20,7 +20,7 @@ import qsTruthy from "../utils/qs_truthy";
 import loadingObjectSrc from "../assets/models/LoadingObject_Atom.glb";
 import { SOUND_MEDIA_LOADING, SOUND_MEDIA_LOADED } from "../systems/sound-effects-system";
 import { loadModel } from "./gltf-model-plus";
-import { cloneObject3D } from "../utils/three-utils";
+import { cloneObject3D, setMatrixWorld } from "../utils/three-utils";
 import { waitForDOMContentLoaded } from "../utils/async-utils";
 
 import { SHAPE } from "three-ammo/constants";
@@ -49,7 +49,7 @@ AFRAME.registerComponent("media-loader", {
     src: { type: "string" },
     version: { type: "number", default: 1 }, // Used to force a re-resolution
     fitToBox: { default: false },
-    recenter: { default: true },
+    moveTheParentNotTheMesh: { default: false },
     resolve: { default: false },
     contentType: { default: null },
     contentSubtype: { default: null },
@@ -85,17 +85,46 @@ AFRAME.registerComponent("media-loader", {
 
   updateScale: (function() {
     const center = new THREE.Vector3();
-    return function(fitToBox, recenter) {
+    const originalMeshMatrix = new THREE.Matrix4();
+    const desiredObjectMatrix = new THREE.Matrix4();
+    const position = new THREE.Vector3();
+    const quaternion = new THREE.Quaternion();
+    const scale = new THREE.Vector3();
+    const box = new THREE.Box3();
+    return function(fitToBox, moveTheParentNotTheMesh) {
+      this.el.object3D.updateMatrices();
       const mesh = this.el.getObject3D("mesh");
-      const box = getBox(this.el, mesh);
-      const scaleCoefficient = fitToBox ? getScaleCoefficient(0.5, box) : 1;
-      mesh.scale.multiplyScalar(scaleCoefficient);
-      const { min, max } = box;
-      if (recenter) {
+      mesh.updateMatrices();
+      if (moveTheParentNotTheMesh) {
+        if (fitToBox) {
+          console.warn(
+            "Unexpected combination of inputs. Can fit the mesh to a box OR move the parent to the mesh, but did not expect to do both.",
+            this.el
+          );
+        }
+        // Keep the mesh exactly where it is, but move the parent transform such that it aligns with the center of the mesh's bounding box.
+        originalMeshMatrix.copy(mesh.matrixWorld);
+        computeObjectAABB(mesh, box);
+        center.addVectors(box.min, box.max).multiplyScalar(0.5);
+        this.el.object3D.matrixWorld.decompose(position, quaternion, scale);
+        desiredObjectMatrix.compose(
+          center,
+          quaternion,
+          scale
+        );
+        setMatrixWorld(this.el.object3D, desiredObjectMatrix);
+        mesh.updateMatrices();
+        setMatrixWorld(mesh, originalMeshMatrix);
+      } else {
+        // Move the mesh such that the center of its bounding box is in the same position as the parent matrix position
+        const box = getBox(this.el, mesh);
+        const scaleCoefficient = fitToBox ? getScaleCoefficient(0.5, box) : 1;
+        const { min, max } = box;
         center.addVectors(min, max).multiplyScalar(0.5 * scaleCoefficient);
+        mesh.scale.multiplyScalar(scaleCoefficient);
         mesh.position.sub(center);
+        mesh.matrixNeedsUpdate = true;
       }
-      mesh.matrixNeedsUpdate = true;
     };
   })(),
 
@@ -158,7 +187,7 @@ AFRAME.registerComponent("media-loader", {
       : new THREE.Mesh(new THREE.BoxGeometry(), new THREE.MeshBasicMaterial());
     this.el.setObject3D("mesh", mesh);
 
-    this.updateScale(true, true);
+    this.updateScale(true, false);
 
     if (useFancyLoader) {
       const environmentMapComponent = this.el.sceneEl.components["environment-map"];
@@ -273,7 +302,7 @@ AFRAME.registerComponent("media-loader", {
     if (this.data.animate) {
       if (!this.animating) {
         this.animating = true;
-        if (shouldUpdateScale) this.updateScale(this.data.fitToBox, this.data.recenter);
+        if (shouldUpdateScale) this.updateScale(this.data.fitToBox, this.data.moveTheParentNotTheMesh);
         const mesh = this.el.getObject3D("mesh");
         const scale = { x: 0.001, y: 0.001, z: 0.001 };
         scale.x = mesh.scale.x < scale.x ? mesh.scale.x * 0.001 : scale.x;
@@ -282,7 +311,7 @@ AFRAME.registerComponent("media-loader", {
         addMeshScaleAnimation(mesh, scale, finish);
       }
     } else {
-      if (shouldUpdateScale) this.updateScale(this.data.fitToBox, this.data.recenter);
+      if (shouldUpdateScale) this.updateScale(this.data.fitToBox, this.data.moveTheParentNotTheMesh);
       finish();
     }
   },

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -265,7 +265,8 @@ AFRAME.GLTFModelPlus.registerComponent("spawner", "spawner", (el, componentName,
     src: componentData.src,
     resolve: true,
     fileIsOwned: true,
-    animate: false
+    animate: false,
+    recenter: false
   });
   el.setAttribute("css-class", "interactable");
   el.setAttribute("super-spawner", {

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -266,7 +266,7 @@ AFRAME.GLTFModelPlus.registerComponent("spawner", "spawner", (el, componentName,
     resolve: true,
     fileIsOwned: true,
     animate: false,
-    recenter: false
+    moveTheParentNotTheMesh: true
   });
   el.setAttribute("css-class", "interactable");
   el.setAttribute("super-spawner", {

--- a/src/systems/super-spawner-system.js
+++ b/src/systems/super-spawner-system.js
@@ -1,9 +1,10 @@
 import { addMedia } from "../utils/media-utils";
+import { computeObjectAABB } from "../utils/auto-box-collider";
 import { ObjectContentOrigins } from "../object-types";
 
 // WARNING: This system mutates interaction system state!
 export class SuperSpawnerSystem {
-  maybeSpawn(state, entity, grabPath) {
+  maybeSpawn(state, grabPath) {
     const userinput = AFRAME.scenes[0].systems.userinput;
     const superSpawner = state.hovered && state.hovered.components["super-spawner"];
     if (
@@ -13,71 +14,63 @@ export class SuperSpawnerSystem {
       userinput.get(grabPath) &&
       window.APP.hubChannel.can("spawn_and_move_media")
     ) {
-      this.performSpawn(state, entity, grabPath, userinput, superSpawner);
+      this.performSpawn(state, grabPath, userinput, superSpawner);
     }
   }
 
-  performSpawn(state, entity, grabPath, userinput, superSpawner) {
-    entity.object3D.updateMatrices();
-    entity.object3D.matrix.decompose(entity.object3D.position, entity.object3D.quaternion, entity.object3D.scale);
-    const data = superSpawner.data;
+  performSpawn = (function() {
+    const box = new THREE.Box3();
+    return function performSpawn(state, grabPath, userinput, superSpawner) {
+      const data = superSpawner.data;
 
-    const spawnedEntity = addMedia(
-      data.src,
-      data.template,
-      ObjectContentOrigins.SPAWNER,
-      null,
-      data.resolve,
-      true,
-      false,
-      data.mediaOptions
-    ).entity;
+      const spawnedEntity = addMedia(
+        data.src,
+        data.template,
+        ObjectContentOrigins.SPAWNER,
+        null,
+        data.resolve,
+        true,
+        false,
+        data.mediaOptions
+      ).entity;
 
-    superSpawner.el.object3D.getWorldPosition(spawnedEntity.object3D.position);
-    superSpawner.el.object3D.getWorldQuaternion(spawnedEntity.object3D.quaternion);
-    spawnedEntity.object3D.matrixNeedsUpdate = true;
+      const mesh = superSpawner.el.getObject3D("mesh");
+      if (!mesh) {
+        console.warn("Tried to clone a spawner without a mesh. Will use its position instead of its mesh center.");
+        superSpawner.el.object3D.getWorldPosition(spawnedEntity.object3D.position);
+      } else {
+        computeObjectAABB(mesh, box);
+        spawnedEntity.object3D.position.addVectors(box.min, box.max).multiplyScalar(0.5);
+      }
+      superSpawner.el.object3D.getWorldQuaternion(spawnedEntity.object3D.quaternion);
+      spawnedEntity.object3D.matrixNeedsUpdate = true;
 
-    superSpawner.el.emit("spawned-entity-created", { target: spawnedEntity });
+      superSpawner.el.emit("spawned-entity-created", { target: spawnedEntity });
 
-    state.held = spawnedEntity;
+      state.held = spawnedEntity;
 
-    superSpawner.activateCooldown();
-    state.spawning = true;
+      superSpawner.activateCooldown();
+      state.spawning = true;
 
-    spawnedEntity.addEventListener(
-      "media-loaded",
-      () => {
-        spawnedEntity.object3D.scale.copy(superSpawner.spawnedMediaScale);
-        spawnedEntity.object3D.matrixNeedsUpdate = true;
-        state.spawning = false;
-        superSpawner.el.emit("spawned-entity-loaded", { target: spawnedEntity });
-      },
-      { once: true }
-    );
-  }
+      spawnedEntity.addEventListener(
+        "media-loaded",
+        () => {
+          spawnedEntity.object3D.scale.copy(superSpawner.spawnedMediaScale);
+          spawnedEntity.object3D.matrixNeedsUpdate = true;
+          state.spawning = false;
+          superSpawner.el.emit("spawned-entity-loaded", { target: spawnedEntity });
+        },
+        { once: true }
+      );
+    };
+  })();
 
   tick() {
     const interaction = AFRAME.scenes[0].systems.interaction;
     if (!interaction.ready) return; //DOMContentReady workaround
-    this.maybeSpawn(
-      interaction.state.leftHand,
-      interaction.options.leftHand.entity,
-      interaction.options.leftHand.grabPath
-    );
-    this.maybeSpawn(
-      interaction.state.rightHand,
-      interaction.options.rightHand.entity,
-      interaction.options.rightHand.grabPath
-    );
-    this.maybeSpawn(
-      interaction.state.rightRemote,
-      interaction.options.rightRemote.entity,
-      interaction.options.rightRemote.grabPath
-    );
-    this.maybeSpawn(
-      interaction.state.leftRemote,
-      interaction.options.leftRemote.entity,
-      interaction.options.leftRemote.grabPath
-    );
+    this.maybeSpawn(interaction.state.leftHand, interaction.options.leftHand.grabPath);
+    this.maybeSpawn(interaction.state.rightHand, interaction.options.rightHand.grabPath);
+    this.maybeSpawn(interaction.state.rightRemote, interaction.options.rightRemote.grabPath);
+    this.maybeSpawn(interaction.state.leftRemote, interaction.options.leftRemote.grabPath);
   }
 }

--- a/src/systems/super-spawner-system.js
+++ b/src/systems/super-spawner-system.js
@@ -17,45 +17,42 @@ export class SuperSpawnerSystem {
     }
   }
 
-  performSpawn = (function() {
-    const box = new THREE.Box3();
-    return function performSpawn(state, grabPath, userinput, superSpawner) {
-      const data = superSpawner.data;
+  performSpawn(state, grabPath, userinput, superSpawner) {
+    const data = superSpawner.data;
 
-      const spawnedEntity = addMedia(
-        data.src,
-        data.template,
-        ObjectContentOrigins.SPAWNER,
-        null,
-        data.resolve,
-        true,
-        false,
-        data.mediaOptions
-      ).entity;
+    const spawnedEntity = addMedia(
+      data.src,
+      data.template,
+      ObjectContentOrigins.SPAWNER,
+      null,
+      data.resolve,
+      true,
+      false,
+      data.mediaOptions
+    ).entity;
 
-      superSpawner.el.object3D.getWorldPosition(spawnedEntity.object3D.position);
-      superSpawner.el.object3D.getWorldQuaternion(spawnedEntity.object3D.quaternion);
-      spawnedEntity.object3D.matrixNeedsUpdate = true;
+    superSpawner.el.object3D.getWorldPosition(spawnedEntity.object3D.position);
+    superSpawner.el.object3D.getWorldQuaternion(spawnedEntity.object3D.quaternion);
+    spawnedEntity.object3D.matrixNeedsUpdate = true;
 
-      superSpawner.el.emit("spawned-entity-created", { target: spawnedEntity });
+    superSpawner.el.emit("spawned-entity-created", { target: spawnedEntity });
 
-      state.held = spawnedEntity;
+    state.held = spawnedEntity;
 
-      superSpawner.activateCooldown();
-      state.spawning = true;
+    superSpawner.activateCooldown();
+    state.spawning = true;
 
-      spawnedEntity.addEventListener(
-        "media-loaded",
-        () => {
-          spawnedEntity.object3D.scale.copy(superSpawner.spawnedMediaScale);
-          spawnedEntity.object3D.matrixNeedsUpdate = true;
-          state.spawning = false;
-          superSpawner.el.emit("spawned-entity-loaded", { target: spawnedEntity });
-        },
-        { once: true }
-      );
-    };
-  })();
+    spawnedEntity.addEventListener(
+      "media-loaded",
+      () => {
+        spawnedEntity.object3D.scale.copy(superSpawner.spawnedMediaScale);
+        spawnedEntity.object3D.matrixNeedsUpdate = true;
+        state.spawning = false;
+        superSpawner.el.emit("spawned-entity-loaded", { target: spawnedEntity });
+      },
+      { once: true }
+    );
+  }
 
   tick() {
     const interaction = AFRAME.scenes[0].systems.interaction;

--- a/src/systems/super-spawner-system.js
+++ b/src/systems/super-spawner-system.js
@@ -1,5 +1,4 @@
 import { addMedia } from "../utils/media-utils";
-import { computeObjectAABB } from "../utils/auto-box-collider";
 import { ObjectContentOrigins } from "../object-types";
 
 // WARNING: This system mutates interaction system state!
@@ -34,14 +33,7 @@ export class SuperSpawnerSystem {
         data.mediaOptions
       ).entity;
 
-      const mesh = superSpawner.el.getObject3D("mesh");
-      if (!mesh) {
-        console.warn("Tried to clone a spawner without a mesh. Will use its position instead of its mesh center.");
-        superSpawner.el.object3D.getWorldPosition(spawnedEntity.object3D.position);
-      } else {
-        computeObjectAABB(mesh, box);
-        spawnedEntity.object3D.position.addVectors(box.min, box.max).multiplyScalar(0.5);
-      }
+      superSpawner.el.object3D.getWorldPosition(spawnedEntity.object3D.position);
       superSpawner.el.object3D.getWorldQuaternion(spawnedEntity.object3D.quaternion);
       spawnedEntity.object3D.matrixNeedsUpdate = true;
 

--- a/src/utils/auto-box-collider.js
+++ b/src/utils/auto-box-collider.js
@@ -3,11 +3,12 @@
 // possible AABB -- we could return a tighter one if we examined all of the vertices
 // of the geometry for ourselves, but we don't care enough for what we're using this
 // for to do so much work.
-const computeObjectAABB = (function() {
+export const computeObjectAABB = (function() {
   const bounds = new THREE.Box3();
   return function(root, target) {
     target.makeEmpty();
     root.traverse(node => {
+      node.updateMatrices();
       const geometry = node.geometry;
       if (geometry != null) {
         if (geometry.boundingBox == null) {


### PR DESCRIPTION
Normally, when we load a model with `media-loader`, we reposition the visible mesh so that the center of its AABB is at its parent's position. This way, setting the parent's position to location X feels like putting the center of the mesh at location X. However, when scene authors create spawners, they position parent nodes such that their child mesh nodes (which are not centered) end up in the right position. If we reposition the mesh in this case, it will end up in the wrong place.

This PR fixes the bug by adding a flag on `media-loader` called `moveTheParentNotTheMesh` that will make sure the position of parent node is at the center of the mesh's AABB, but will keep the mesh fixed in place while it does so.