### PR TITLE
Set max length on fields in admin console

### DIFF
--- a/admin/src/react-components/service-editor.js
+++ b/admin/src/react-components/service-editor.js
@@ -211,6 +211,7 @@ class ConfigurationEditor extends Component {
         key={displayPath}
         id={displayPath}
         label={descriptor.name || displayPath}
+        inputProps={{ maxLength: 4096 }}
         value={currentValue || ""}
         onChange={ev => this.onChange(path, ev.target.value)}
         helperText={descriptor.description}


### PR DESCRIPTION
We can only set max 4096 chars on string fields in parameter store.