### PR TITLE
Add qs param for setting a custom field of view for the camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ This will allow the CSP checks to pass that are served up by Reticulum so you ca
 - `allow_idle` - Disable the idle detector timeout
 - `idle_timeout` - Idle timeout in seconds
 - `avatar_scale` - Scale your self!
-- `quality` - Either "low" or "high". Force assets to a certain quality level
 - `mobile` - Force mobile mode
 - `no_stats` - Disable performance stats
 - `vr_entry_type` - Either "2d", "vr", or "daydream". Used internally to force a VR entry type. Add "_now" to the end of the value to skip the audio check.
@@ -69,6 +68,7 @@ This will allow the CSP checks to pass that are served up by Reticulum so you ca
 - `debug_log` - If `true`, enables an on-screen debug log and console. Useful for debugging on mobile devices.
 - `userinput_debug` - If `true`, enables an on-screen userinput debug status panel. Press "L" on your keyboard to show the panel.
 - `thirdPerson` - Enables experimental third person mode.
+- `fov` - Set a custom field of view in degrees (between 1 and 179) for the camera. (2D only)
 
 ## Additional Resources
 

--- a/src/systems/camera-system.js
+++ b/src/systems/camera-system.js
@@ -3,6 +3,8 @@ import { childMatch, setMatrixWorld, calculateViewingDistance } from "../utils/t
 import { paths } from "./userinput/paths";
 import { getBox } from "../utils/auto-box-collider";
 import qsTruthy from "../utils/qs_truthy";
+import { qsGet } from "../utils/qs_truthy";
+const customFOV = qsGet("fov");
 const enableThirdPersonMode = qsTruthy("thirdPerson");
 
 export function getInspectable(child) {
@@ -167,7 +169,7 @@ function getAudio(o) {
 
 const FALLOFF = 0.9;
 export class CameraSystem {
-  constructor(batchManagerSystem) {
+  constructor(batchManagerSystem, scene) {
     this.enableLights = localStorage.getItem("show-background-while-inspecting") === "true";
     this.verticalDelta = 0;
     this.horizontalDelta = 0;
@@ -188,6 +190,15 @@ export class CameraSystem {
       );
       bg.layers.set(CAMERA_LAYER_INSPECT);
       this.viewingRig.object3D.add(bg);
+      if (customFOV) {
+        if (this.viewingCamera.components.camera) {
+          this.viewingCamera.setAttribute("camera", { fov: customFOV });
+        } else {
+          scene.addEventListener("camera-set-active", () => {
+            this.viewingCamera.setAttribute("camera", { fov: customFOV });
+          });
+        }
+      }
     });
   }
 

--- a/src/systems/hubs-systems.js
+++ b/src/systems/hubs-systems.js
@@ -42,7 +42,7 @@ AFRAME.registerSystem("hubs-systems", {
     this.scenePreviewCameraSystem = new ScenePreviewCameraSystem();
     this.spriteSystem = new SpriteSystem(this.el);
     this.batchManagerSystem = new BatchManagerSystem(this.el.object3D, this.el.renderer);
-    this.cameraSystem = new CameraSystem(this.batchManagerSystem);
+    this.cameraSystem = new CameraSystem(this.batchManagerSystem, this.el);
     this.drawingMenuSystem = new DrawingMenuSystem(this.el);
     this.characterController = new CharacterControllerSystem(this.el);
     this.waypointSystem = new WaypointSystem(this.el, this.characterController);

--- a/src/utils/qs_truthy.js
+++ b/src/utils/qs_truthy.js
@@ -5,3 +5,7 @@ export default function qsTruthy(param) {
   // if the param exists but is not set (e.g. "?foo&bar"), its value is the empty string.
   return val === "" || /1|on|true|yes/i.test(val);
 }
+
+export function qsGet(param) {
+  return qs.get(param);
+}


### PR DESCRIPTION
Someone in our discord asked for a way to customize the FOV of the camera. They can open a debugger and enter a command to do this, but I thought we might like to provide this functionality as a query string parameter to save them the trouble.