### PR TITLE
Add support for new nafr message to reduce server load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11925,9 +11925,9 @@
       "dev": true
     },
     "naf-janus-adapter": {
-      "version": "3.0.15",
-      "resolved": "https://registry.npmjs.org/naf-janus-adapter/-/naf-janus-adapter-3.0.15.tgz",
-      "integrity": "sha512-zBAVpnKwNWoCd5wjY4egBRUKjTOKUo51+a43/1KUcIEjeJOV0JJLq2vGaeTkGQmgc7X0FmIdlKgk4aXcctW4cg==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/naf-janus-adapter/-/naf-janus-adapter-3.0.16.tgz",
+      "integrity": "sha512-yiypRF+lCps01qC1qDSvxxUIvwUUYDPbLc0b1QrzKdrpB/OFmYYnHlWES4mW2hYZOhvUGc8DQSQjm4Doc7mCGQ==",
       "requires": {
         "debug": "^3.1.0",
         "minijanus": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "linkify-it": "^2.0.3",
     "markdown-it": "^8.4.2",
     "moving-average": "^1.0.0",
-    "naf-janus-adapter": "^3.0.15",
+    "naf-janus-adapter": "^3.0.16",
     "networked-aframe": "github:mozillareality/networked-aframe#master",
     "nipplejs": "github:mozillareality/nipplejs#mr-social-client/master",
     "node-ensure": "0.0.0",


### PR DESCRIPTION
Goes with https://github.com/mozilla/reticulum/pull/327

The client now will send all non first sync payloads via the `nafr` event type, with the NAF payload as unparsed strings. The client also strips all `isFirstSync` keys from these messages, which is necessary for the server optimization to occur since it checks for the presence of that string to decide if it requires special handling. (Not the cleanest thing, but seems strictly necessary.)

Incoming `nafr` messages are presumed to have a `naf` key which contains the unparsed data, which is then parsed and merged with the `from_session_id` metadata reticulum adds to the payload for processing.

Note this PR also bumps naf-janus-adapter, pending review on https://github.com/mozilla/naf-janus-adapter/pull/93. 