### PR TITLE
Fix error that occurs if a body is added and removed in the same frame

### DIFF
--- a/src/systems/interactions.js
+++ b/src/systems/interactions.js
@@ -7,7 +7,7 @@ import { isTagged } from "../components/tags";
 function findHandCollisionTargetForHand(bodyHelper) {
   const physicsSystem = this.el.sceneEl.systems["hubs-systems"].physicsSystem;
 
-  const handCollisions = physicsSystem.collisions[bodyHelper.uuid];
+  const handCollisions = physicsSystem.getCollisions(bodyHelper.uuid);
   if (handCollisions) {
     for (let i = 0; i < handCollisions.length; i++) {
       const object3D = physicsSystem.object3Ds[handCollisions[i]];

--- a/src/systems/physics-system.js
+++ b/src/systems/physics-system.js
@@ -70,9 +70,13 @@ export class PhysicsSystem {
       } else if (event.data.type === MESSAGE_TYPES.BODY_READY) {
         const uuid = event.data.uuid;
         const index = event.data.index;
-        this.bodyUuids.push(uuid);
-        this.uuidToIndex[uuid] = index;
-        this.indexToUuid[index] = uuid;
+        if (this.bodyOptions[uuid]) {
+          this.bodyUuids.push(uuid);
+          this.uuidToIndex[uuid] = index;
+          this.indexToUuid[index] = uuid;
+        } else {
+          console.warn(`Body initialized for uuid: ${uuid} but already removed.`);
+        }
       } else if (event.data.type === MESSAGE_TYPES.SHAPES_READY) {
         const bodyUuid = event.data.bodyUuid;
         const shapesUuid = event.data.shapesUuid;


### PR DESCRIPTION
Normally this won't happen, but if your tab running Hubs is backgrounded, actions to add/remove bodies are queued up and won't run until Hubs regains focus (this is due to `tick` not running the `physics-system` when backgrounded). This adds guard clauses to ensure that if this happens, a body doesn't remain (incorrectly) partially initialized after it has been removed.

This also refactors the code to use a Map to contain all the various state associated with a body uuid to make it easier to read/understand.