### PR TITLE
Disable batching by default

### DIFF
--- a/src/components/hoverable-visuals.js
+++ b/src/components/hoverable-visuals.js
@@ -38,7 +38,9 @@ AFRAME.registerComponent("hoverable-visuals", {
         )
           return;
 
-        batchManagerSystem.meshToEl.delete(object);
+        if (batchManagerSystem.batchingEnabled) {
+          batchManagerSystem.meshToEl.delete(object);
+        }
       });
     });
 

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -519,9 +519,7 @@ AFRAME.registerComponent("media-loader", {
           { once: true }
         );
         this.el.addEventListener("model-error", this.onError, { once: true });
-        let batch =
-          !disableBatching &&
-          (forceMeshBatching || (AFRAME.utils.device.isMobile() && window.APP && window.APP.quality === "low"));
+        let batch = !disableBatching && forceMeshBatching;
         if (this.data.mediaOptions.hasOwnProperty("batch") && !this.data.mediaOptions.batch) {
           batch = false;
         }

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -39,6 +39,7 @@ const fetchContentType = url => {
 };
 
 const forceMeshBatching = qsTruthy("batchMeshes");
+const forceImageBatching = qsTruthy("batchImages");
 const disableBatching = qsTruthy("disableBatching");
 
 AFRAME.registerComponent("media-loader", {
@@ -457,7 +458,7 @@ AFRAME.registerComponent("media-loader", {
           { once: true }
         );
         this.el.setAttribute("floaty-object", { reduceAngularFloat: true, releaseGravity: -1 });
-        let batch = !disableBatching;
+        let batch = !disableBatching && forceImageBatching;
         if (this.data.mediaOptions.hasOwnProperty("batch") && !this.data.mediaOptions.batch) {
           batch = false;
         }

--- a/src/systems/camera-system.js
+++ b/src/systems/camera-system.js
@@ -138,7 +138,7 @@ const ensureLightsAreSeenByCamera = function(o) {
 };
 const enableInspectLayer = function(o) {
   const batchManagerSystem = AFRAME.scenes[0].systems["hubs-systems"].batchManagerSystem;
-  const batch = batchManagerSystem.batchManager.batchForMesh.get(o);
+  const batch = batchManagerSystem.batchingEnabled && batchManagerSystem.batchManager.batchForMesh.get(o);
   if (batch) {
     batch.layers.enable(CAMERA_LAYER_INSPECT);
     o.layers.enable(CAMERA_LAYER_BATCH_INSPECT);
@@ -148,7 +148,7 @@ const enableInspectLayer = function(o) {
 };
 const disableInspectLayer = function(o) {
   const batchManagerSystem = AFRAME.scenes[0].systems["hubs-systems"].batchManagerSystem;
-  const batch = batchManagerSystem.batchManager.batchForMesh.get(o);
+  const batch = batchManagerSystem.batchingEnabled && batchManagerSystem.batchManager.batchForMesh.get(o);
   if (batch) {
     batch.layers.disable(CAMERA_LAYER_INSPECT);
     o.layers.disable(CAMERA_LAYER_BATCH_INSPECT);
@@ -169,12 +169,11 @@ function getAudio(o) {
 
 const FALLOFF = 0.9;
 export class CameraSystem {
-  constructor(batchManagerSystem, scene) {
+  constructor(scene) {
     this.enableLights = localStorage.getItem("show-background-while-inspecting") === "true";
     this.verticalDelta = 0;
     this.horizontalDelta = 0;
     this.inspectZoom = 0;
-    this.batchManagerSystem = batchManagerSystem;
     this.mode = CAMERA_MODE_SCENE_PREVIEW;
     this.snapshot = { audioTransform: new THREE.Matrix4(), matrixWorld: new THREE.Matrix4() };
     this.audioListenerTargetTransform = new THREE.Matrix4();

--- a/src/systems/hubs-systems.js
+++ b/src/systems/hubs-systems.js
@@ -43,7 +43,7 @@ AFRAME.registerSystem("hubs-systems", {
     this.scenePreviewCameraSystem = new ScenePreviewCameraSystem();
     this.spriteSystem = new SpriteSystem(this.el);
     this.batchManagerSystem = new BatchManagerSystem(this.el.object3D, this.el.renderer);
-    this.cameraSystem = new CameraSystem(this.batchManagerSystem, this.el);
+    this.cameraSystem = new CameraSystem(this.el);
     this.drawingMenuSystem = new DrawingMenuSystem(this.el);
     this.characterController = new CharacterControllerSystem(this.el);
     this.waypointSystem = new WaypointSystem(this.el, this.characterController);

--- a/src/systems/render-manager-system.js
+++ b/src/systems/render-manager-system.js
@@ -25,11 +25,16 @@ export class BatchManagerSystem {
     }
 
     if (UBO_BYTE_LENGTH > gl.getParameter(gl.MAX_UNIFORM_BLOCK_SIZE)) {
-      console.warn("Insufficient MAX_UNIFORM_BLOCK_SIZE, Disabling batching");
+      console.warn("Insufficient MAX_UNIFORM_BLOCK_SIZE, Disabling batching.");
       return;
     }
 
-    this.batchingEnabled = true;
+    this.batchingEnabled = qsTruthy("forceMeshBatching") || qsTruthy("forceImageBatching");
+
+    if (!this.batchingEnabled) {
+      console.warn("Batching must be forced on with forceMeshBatching or forceImageBatching. Disabling batching.");
+      return;
+    }
 
     this.ubo = new HubsBatchRawUniformGroup(MAX_INSTANCES, this.meshToEl);
     this.batchManager = new BatchManager(scene, renderer, {

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -278,7 +278,9 @@ export function injectCustomShaderChunks(obj) {
         return material;
 
       // Used when the object is batched
-      batchManagerSystem.meshToEl.set(object, obj.el);
+      if (batchManagerSystem.batchingEnabled) {
+        batchManagerSystem.meshToEl.set(object, obj.el);
+      }
 
       const newMaterial = material.clone();
       // This will not run if the object is never rendered unbatched, since its unbatched shader will never be compiled


### PR DESCRIPTION
Since it still seems to be causing stability and rendering issues on various platforms, the negatives seem to outweigh the potential benefits. We should likely still work on getting this back enabled by default, but it makes sense to disable it for now.

Also discovered that we were crashing the render loop in when exiting inspect mode if batching was disabled (which was already the case on platforms that don't support WebGL2 like iOS).

Batching can still be enabled via `forceMeshBatching` or `forceImageBatching`.