### PR TITLE
Remove the loading environment's nav mesh.

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -411,6 +411,7 @@ async function updateEnvironmentForHub(hub, entryManager) {
           { once: true }
         );
 
+        sceneEl.emit("leaving_loading_environment");
         environmentEl.setAttribute("gltf-model-plus", { src: sceneUrl });
       },
       { once: true }

--- a/src/systems/nav.js
+++ b/src/systems/nav.js
@@ -5,6 +5,7 @@ AFRAME.registerSystem("nav", {
     this.pathfinder = new Pathfinding();
     this.mesh = null;
     this.el.addEventListener("reset_scene", this.removeNavMeshData.bind(this));
+    this.el.addEventListener("leaving_loading_environment", this.removeNavMeshData.bind(this));
   },
 
   loadMesh: function(mesh, zone) {


### PR DESCRIPTION
We can probably get rid of the loading environment altogether now that we have the fader fading out before scene transitions and fading in after the new environment loads, but until then, we should fix this bug that leaves the loading environment's mesh around in the scene when transitioning to an environment that does not have a nav mesh. (This also explains why after scene transitions it is normal to see a warning about having multiple nav meshes.)