### PR TITLE
Add permission checks for spawning emojis

### DIFF
--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -55,6 +55,7 @@
     "room-settings.spawn_camera": "Create cameras",
     "room-settings.spawn_drawing": "Create drawings",
     "room-settings.pin_objects": "Pin objects",
+    "room-settings.spawn_emoji": "Create emoji",
     "room-settings.access-private": "Private",
     "room-settings.access-private-subtitle": "Only those with the link can join",
     "room-settings.access-public": "Public",

--- a/src/components/emoji-hud.js
+++ b/src/components/emoji-hud.js
@@ -64,11 +64,14 @@ AFRAME.registerComponent("emoji-hud", {
       const width = this.data.spawnerPlatformWidth;
       const spacing = this.data.spawnerPlatformSpacing;
 
+      this.emojiUrls = [];
+
       this.spawnerEntities = [];
 
       for (let i = 0; i < emojis.length; i++) {
         const spawnerEntity = document.createElement("a-entity");
         const url = new URL(emojis[i], window.location.href).href;
+        this.emojiUrls.push(url);
         spawnerEntity.setAttribute("media-loader", { src: url });
         spawnerEntity.setAttribute("hoverable-visuals", "");
         spawnerEntity.setAttribute("scale", {
@@ -78,7 +81,10 @@ AFRAME.registerComponent("emoji-hud", {
         });
         spawnerEntity.setAttribute("is-remote-hover-target", "");
         spawnerEntity.setAttribute("tags", { isHandCollisionTarget: false });
-        spawnerEntity.setAttribute("visibility-while-frozen", { requireHoverOnNonMobile: false });
+        spawnerEntity.setAttribute("visibility-while-frozen", {
+          requireHoverOnNonMobile: false,
+          withPermission: "spawn_emoji"
+        });
         spawnerEntity.setAttribute("css-class", "interactable");
         spawnerEntity.setAttribute("body-helper", {
           mass: 0,
@@ -124,12 +130,15 @@ AFRAME.registerComponent("emoji-hud", {
 
         spawnerEntity.setAttribute("super-spawner", {
           src: url,
-          template: "#interactable-emoji-media",
+          template: "#interactable-emoji",
           spawnScale: { x: this.data.spawnedScale, y: this.data.spawnedScale, z: this.data.spawnedScale }
         });
 
         const cylinder = document.createElement("a-cylinder");
-        cylinder.setAttribute("visibility-while-frozen", { requireHoverOnNonMobile: false });
+        cylinder.setAttribute("visibility-while-frozen", {
+          requireHoverOnNonMobile: false,
+          withPermission: "spawn_emoji"
+        });
         cylinder.setAttribute("material", { opacity: 0.2, color: "#2f7fee" });
         cylinder.setAttribute("segments-height", 1);
         cylinder.setAttribute("segments-radial", 16);

--- a/src/components/emoji.js
+++ b/src/components/emoji.js
@@ -17,9 +17,17 @@ AFRAME.registerComponent("emoji", {
   init() {
     this.data.emitEndTime = performance.now() + this.data.emitDecayTime * 1000;
     this.physicsSystem = this.el.sceneEl.systems["hubs-systems"].physicsSystem;
+
+    this.emojiHud = document.querySelector("[emoji-hud]").components["emoji-hud"];
   },
 
   play() {
+    const mediaLoader = this.el.components["media-loader"];
+    if (this.emojiHud.emojiUrls.indexOf(mediaLoader.data.src) === -1) {
+      this.el.parentNode.removeChild(this.el);
+      return;
+    }
+
     const uuid = this.el.components["body-helper"].uuid;
     this.lastLinearVelocity = this.physicsSystem.getLinearVelocity(uuid);
     this.lastAngularVelocity = this.physicsSystem.getAngularVelocity(uuid);

--- a/src/hub.html
+++ b/src/hub.html
@@ -475,7 +475,7 @@
                 </a-entity>
             </template>
 
-            <template id="interactable-emoji-media">
+            <template id="interactable-emoji">
                 <a-entity
                     class="interactable"
                     emoji

--- a/src/network-schemas.js
+++ b/src/network-schemas.js
@@ -130,7 +130,7 @@ function registerNetworkSchemas() {
   });
 
   NAF.schemas.add({
-    template: "#interactable-emoji-media",
+    template: "#interactable-emoji",
     components: [
       {
         component: "position",

--- a/src/react-components/room-settings-dialog.js
+++ b/src/react-components/room-settings-dialog.js
@@ -164,6 +164,7 @@ export default class RoomSettingsDialog extends Component {
               {this.renderCheckbox("pin_objects", !this.state.member_permissions.spawn_and_move_media)}
             </div>
             {this.renderCheckbox("spawn_drawing")}
+            {this.renderCheckbox("spawn_emoji")}
           </div>
           <button type="submit" className={styles.nextButton}>
             <FormattedMessage id="room-settings.apply" />

--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -25,7 +25,8 @@ const HUB_CREATOR_PERMISSIONS = [
   "kick_users"
 ];
 const VALID_PERMISSIONS =
-  HUB_CREATOR_PERMISSIONS + ["tweet", "spawn_camera", "spawn_drawing", "spawn_and_move_media", "pin_objects"];
+  HUB_CREATOR_PERMISSIONS +
+  ["tweet", "spawn_camera", "spawn_drawing", "spawn_and_move_media", "pin_objects", "spawn_emoji"];
 
 export default class HubChannel extends EventTarget {
   constructor(store, hubId) {

--- a/src/utils/permissions-utils.js
+++ b/src/utils/permissions-utils.js
@@ -14,13 +14,15 @@ export function canMove(entity) {
   const networkedTemplate = entity && entity.components.networked && entity.components.networked.data.template;
   const isCamera = networkedTemplate === "#interactable-camera";
   const isPen = networkedTemplate === "#interactable-pen";
+  const isEmoji = networkedTemplate === "#interactable-emoji";
   const isHoldableButton = entity.components.tags && entity.components.tags.data.holdableButton;
   return (
     isHoldableButton ||
     (window.APP.hubChannel.can("spawn_and_move_media") &&
       (!isPinned || window.APP.hubChannel.can("pin_objects")) &&
       (!isCamera || window.APP.hubChannel.can("spawn_camera")) &&
-      (!isPen || window.APP.hubChannel.can("spawn_drawing")))
+      (!isPen || window.APP.hubChannel.can("spawn_drawing")) &&
+      (!isEmoji || window.APP.hubChannel.can("spawn_emoji")))
   );
 }
 
@@ -85,6 +87,8 @@ function authorizeEntityManipulation(entityMetadata, sender, senderPermissions) 
     return isCreator || senderPermissions.spawn_camera;
   } else if (template.endsWith("-pen") || template.endsWith("-drawing")) {
     return isCreator || senderPermissions.spawn_drawing;
+  } else if (template.endsWith("-emoji")) {
+    return isCreator || senderPermissions.spawn_emoji;
   } else {
     return false;
   }


### PR DESCRIPTION
Also adds a check in the `emoji` component that the `media-loader`'s `src` being used matches one of the emoji urls as defined in `emoji-hud`. 

See: https://github.com/mozilla/reticulum/pull/335

fixes #2154 and #2065