### PR TITLE
Support for morph based animations and multiple looping animations

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -195,6 +195,10 @@ const inflateEntities = function(indexToEntityMap, node, templates, isRoot, mode
     node.parent.animations = node.animations;
   }
 
+  if (node.morphTargetInfluences) {
+    node.parent.morphTargetInfluences = node.morphTargetInfluences;
+  }
+
   const gltfIndex = node.userData.gltfIndex;
   if (gltfIndex !== undefined) {
     indexToEntityMap[gltfIndex] = el;


### PR DESCRIPTION
- Fixes morph based animations not playing back correctly when inflated
- Adds support for playing multiple clips to `loop-animation` component. It is only added to the "deprecated" string based `clip` property for now since this is what we use in the blender addon. We should expand this into the numeric one as well, but making a numeric array property is a bit of a pain and trying to keep this as low risk as possible.