### PR TITLE
Lower the auto-pixel-ratio threshold. Allow it to increase again.

### DIFF
--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -280,6 +280,7 @@
     "preferences.disableBackwardsMovement": "Disable backwards movement",
     "preferences.disableStrafing": "Disable strafing",
     "preferences.disableTeleporter": "Disable teleporter",
+    "preferences.disableAutoPixelRatio": "Disable automatic pixel ratio adjustments",
     "settings.return-to-vr": "Return to VR",
     "settings.change-avatar": "Set Name & Avatar",
     "settings.change-scene": "Choose a Scene",

--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -50,14 +50,6 @@ export default class PreferencesScreen extends Component {
     const general = [
       { key: "muteMicOnEntry", prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX, defaultBool: false },
       { key: "onlyShowNametagsInFreeze", prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX, defaultBool: false },
-      { key: "allowMultipleHubsInstances", prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX, defaultBool: false },
-      { key: "maxResolution", prefType: PREFERENCE_LIST_ITEM_TYPE.MAX_RESOLUTION },
-      {
-        key: "materialQualitySetting",
-        prefType: PREFERENCE_LIST_ITEM_TYPE.SELECT,
-        options: [{ value: "low", text: "Low" }, { value: "high", text: "High" }],
-        defaultString: isMobile ? "low" : "high"
-      },
       {
         key: "globalVoiceVolume",
         prefType: PREFERENCE_LIST_ITEM_TYPE.NUMBER_WITH_RANGE,
@@ -90,6 +82,18 @@ export default class PreferencesScreen extends Component {
       { key: "enableOnScreenJoystickRight", prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX, defaultBool: false }
     ].map(preferenceListItem);
 
+    const advanced = [
+      { key: "maxResolution", prefType: PREFERENCE_LIST_ITEM_TYPE.MAX_RESOLUTION },
+      {
+        key: "materialQualitySetting",
+        prefType: PREFERENCE_LIST_ITEM_TYPE.SELECT,
+        options: [{ value: "low", text: "Low" }, { value: "high", text: "High" }],
+        defaultString: isMobile ? "low" : "high"
+      },
+      { key: "disableAutoPixelRatio", prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX, defaultBool: false },
+      { key: "allowMultipleHubsInstances", prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX, defaultBool: false }
+    ].map(preferenceListItem);
+
     return (
       <IntlProvider locale={lang} messages={messages}>
         <div className={classNames(styles.preferencesPanel)}>
@@ -113,6 +117,12 @@ export default class PreferencesScreen extends Component {
                 </div>
               </div>
               <div className={classNames(styles.scrollingContent)}>{touchscreen}</div>
+              <div className={classNames(styles.sectionBar)}>
+                <div className={classNames(styles.sectionTitle)}>
+                  <span>Advanced</span>
+                </div>
+              </div>
+              <div className={classNames(styles.scrollingContent)}>{advanced}</div>
             </div>
           </div>
         </div>

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -80,7 +80,8 @@ export const SCHEMA = {
         disableMovement: { type: "bool" },
         disableBackwardsMovement: { type: "bool" },
         disableStrafing: { type: "bool" },
-        disableTeleporter: { type: "bool" }
+        disableTeleporter: { type: "bool" },
+        disableAutoPixelRatio: { type: "bool" }
       }
     },
 

--- a/src/systems/auto-pixel-ratio.js
+++ b/src/systems/auto-pixel-ratio.js
@@ -2,7 +2,7 @@
 // pixelRatio if the FPS drops below a threshold.
 
 const LOW_FPS_THRESHOLD = 30;
-const HIGH_FPS_THRESHOLD = 55;
+const HIGH_FPS_THRESHOLD = 48;
 const SKIP_SECONDS_AFTER_SCENE_VISIBLE = 30;
 const MEASUREMENT_PERIOD_SECONDS = 5;
 const MIN_PIXEL_RATIO = 1;

--- a/src/systems/auto-pixel-ratio.js
+++ b/src/systems/auto-pixel-ratio.js
@@ -17,9 +17,16 @@ AFRAME.registerSystem("auto-pixel-ratio", {
     this.deltas = [];
     this.secondsSinceMeasurementStart = 0;
     this.secondsSinceSceneVisible = 0;
+
+    this.disabledByPref = !!window.APP.store.state.preferences.disableAutoPixelRatio;
+    this.onPreferenceChange = this.onPreferenceChange.bind(this);
+    window.APP.store.addEventListener("statechanged", this.onPreferenceChange);
+  },
+  onPreferenceChange() {
+    this.disabledByPref = !!window.APP.store.state.preferences.disableAutoPixelRatio;
   },
   tick(time, delta) {
-    if (!this.enabled) return;
+    if (!this.enabled || this.disabledByPref) return;
     if (!this.el.is("visible")) return;
     if (this.secondsSinceSceneVisible < SKIP_SECONDS_AFTER_SCENE_VISIBLE) {
       this.secondsSinceSceneVisible += delta / 1000;


### PR DESCRIPTION
- Fixes https://github.com/mozilla/hubs/issues/2141 
- Adds a user preference to disable the auto-pixel-ratio system. (Also separates this into a new section called "advanced" in the preference list.)
- Reduces the "low FPS" threshold at which pixel ratio will decrease. 
- Adds a "high FPS" threshold at which pixel ratio will increase.
- Flip flopping between two pixel ratios repeatedly is prevented: If the system decreases the pixel ratio from `N` to `N-1` more than 3 times (`NUM_TIMES_DECREASED_BEFORE_CHANGING_MAX_PIXEL_RATIO`), then it sets `N-1` as the maximum pixel ratio and will not attempt `N` again.


