### PR TITLE
Don't show mock joysticks if disabled

### DIFF
--- a/src/assets/stylesheets/preferences-screen.scss
+++ b/src/assets/stylesheets/preferences-screen.scss
@@ -91,6 +91,7 @@ input::-webkit-inner-spin-button {
 }
 
 :local(.preferences-panel) {
+  z-index: 2;
   top: 0px;
   bottom: 0px;
   width: 100%;

--- a/src/components/virtual-gamepad-controls.css
+++ b/src/components/virtual-gamepad-controls.css
@@ -2,6 +2,7 @@
   position: absolute;
   height: 20vh;
   bottom: 0;
+  z-index: 1;
 
   /* Orientation selector fails here when keyboard pops up on shorter screens */
   @media(min-aspect-ratio: 15/9) {
@@ -46,6 +47,9 @@
   border-top-right-radius: 50%;
   border-bottom-right-radius: 50%;
   border-bottom-left-radius: 50%;
+  &__hidden {
+    background-color: transparent;
+  }
 }
 
 :local(.mockJoystick.inner) {


### PR DESCRIPTION
This fixes an issue where the mock joysticks that suggest to people how to use the joysticks show up even if the joysticks are disabled. Enabling a joystick in the preference menu will also cause the mock joystick(s) to re-appear.