### PR TITLE
fix spawn_emoji permission if spawn_and_move_media permission is not enabled

### DIFF
--- a/src/systems/super-spawner-system.js
+++ b/src/systems/super-spawner-system.js
@@ -6,12 +6,18 @@ export class SuperSpawnerSystem {
   maybeSpawn(state, grabPath) {
     const userinput = AFRAME.scenes[0].systems.userinput;
     const superSpawner = state.hovered && state.hovered.components["super-spawner"];
+
+    const isPermitted =
+      superSpawner && superSpawner.data.template === "#interactable-emoji"
+        ? window.APP.hubChannel.can("spawn_emoji")
+        : window.APP.hubChannel.can("spawn_and_move_media");
+
     if (
       superSpawner &&
       superSpawner.spawnedMediaScale &&
       !superSpawner.cooldownTimeout &&
       userinput.get(grabPath) &&
-      window.APP.hubChannel.can("spawn_and_move_media")
+      isPermitted
     ) {
       this.performSpawn(state, grabPath, userinput, superSpawner);
     }

--- a/src/utils/permissions-utils.js
+++ b/src/utils/permissions-utils.js
@@ -4,8 +4,11 @@ export function showHoverEffect(el) {
   const isFrozen = el.sceneEl.is("frozen");
   const isPinned = el.components.pinnable && el.components.pinnable.data.pinned;
   const isSpawner = !!el.components["super-spawner"];
+  const isEmoji =
+    el.components["super-spawner"] && el.components["super-spawner"].data.template === "#interactable-emoji";
   const canMove =
-    window.APP.hubChannel.can("spawn_and_move_media") && (!isPinned || window.APP.hubChannel.can("pin_objects"));
+    (isEmoji ? window.APP.hubChannel.can("spawn_emoji") : window.APP.hubChannel.can("spawn_and_move_media")) &&
+    (!isPinned || window.APP.hubChannel.can("pin_objects"));
   return (isSpawner || !isPinned || isFrozen) && canMove;
 }
 
@@ -14,15 +17,16 @@ export function canMove(entity) {
   const networkedTemplate = entity && entity.components.networked && entity.components.networked.data.template;
   const isCamera = networkedTemplate === "#interactable-camera";
   const isPen = networkedTemplate === "#interactable-pen";
-  const isEmoji = networkedTemplate === "#interactable-emoji";
+  const spawnerTemplate =
+    entity && entity.components["super-spawner"] && entity.components["super-spawner"].data.template;
+  const isEmoji = spawnerTemplate === "#interactable-emoji";
   const isHoldableButton = entity.components.tags && entity.components.tags.data.holdableButton;
   return (
     isHoldableButton ||
-    (window.APP.hubChannel.can("spawn_and_move_media") &&
+    ((isEmoji ? window.APP.hubChannel.can("spawn_emoji") : window.APP.hubChannel.can("spawn_and_move_media")) &&
       (!isPinned || window.APP.hubChannel.can("pin_objects")) &&
       (!isCamera || window.APP.hubChannel.can("spawn_camera")) &&
-      (!isPen || window.APP.hubChannel.can("spawn_drawing")) &&
-      (!isEmoji || window.APP.hubChannel.can("spawn_emoji")))
+      (!isPen || window.APP.hubChannel.can("spawn_drawing")))
   );
 }
 

--- a/src/utils/permissions-utils.js
+++ b/src/utils/permissions-utils.js
@@ -4,10 +4,12 @@ export function showHoverEffect(el) {
   const isFrozen = el.sceneEl.is("frozen");
   const isPinned = el.components.pinnable && el.components.pinnable.data.pinned;
   const isSpawner = !!el.components["super-spawner"];
-  const isEmoji =
-    el.components["super-spawner"] && el.components["super-spawner"].data.template === "#interactable-emoji";
+  const isEmojiSpawner = isSpawner && el.components["super-spawner"].data.template === "#interactable-emoji";
+  const isEmoji = !!el.components.emoji;
   const canMove =
-    (isEmoji ? window.APP.hubChannel.can("spawn_emoji") : window.APP.hubChannel.can("spawn_and_move_media")) &&
+    (isEmoji || isEmojiSpawner
+      ? window.APP.hubChannel.can("spawn_emoji")
+      : window.APP.hubChannel.can("spawn_and_move_media")) &&
     (!isPinned || window.APP.hubChannel.can("pin_objects"));
   return (isSpawner || !isPinned || isFrozen) && canMove;
 }
@@ -19,11 +21,14 @@ export function canMove(entity) {
   const isPen = networkedTemplate === "#interactable-pen";
   const spawnerTemplate =
     entity && entity.components["super-spawner"] && entity.components["super-spawner"].data.template;
-  const isEmoji = spawnerTemplate === "#interactable-emoji";
+  const isEmojiSpawner = spawnerTemplate === "#interactable-emoji";
+  const isEmoji = !!entity.components.emoji;
   const isHoldableButton = entity.components.tags && entity.components.tags.data.holdableButton;
   return (
     isHoldableButton ||
-    ((isEmoji ? window.APP.hubChannel.can("spawn_emoji") : window.APP.hubChannel.can("spawn_and_move_media")) &&
+    ((isEmoji || isEmojiSpawner
+      ? window.APP.hubChannel.can("spawn_emoji")
+      : window.APP.hubChannel.can("spawn_and_move_media")) &&
       (!isPinned || window.APP.hubChannel.can("pin_objects")) &&
       (!isCamera || window.APP.hubChannel.can("spawn_camera")) &&
       (!isPen || window.APP.hubChannel.can("spawn_drawing")))


### PR DESCRIPTION
There are a handful of issues that occur if the `spawn_emoji` permission is enabled but the `spawn_and_move_media` permission is not. This fixes them so that the permission works by itself as intended.