### PR TITLE
Fix spawn height

### DIFF
--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -53,8 +53,6 @@ export default class SceneEntryManager {
 
   enterScene = async (mediaStream, enterInVR, muteOnEntry) => {
     document.getElementById("viewing-camera").removeAttribute("scene-preview-camera");
-    const waypointSystem = this.scene.systems["hubs-systems"].waypointSystem;
-    waypointSystem.moveToSpawnPoint();
 
     if (isDebug) {
       NAF.connection.adapter.session.options.verbose = true;
@@ -71,6 +69,9 @@ export default class SceneEntryManager {
 
       await exit2DInterstitialAndEnterVR(true);
     }
+
+    const waypointSystem = this.scene.systems["hubs-systems"].waypointSystem;
+    waypointSystem.moveToSpawnPoint();
 
     if (isMobile || forceEnableTouchscreen || qsTruthy("mobile")) {
       this.avatarRig.setAttribute("virtual-gamepad-controls", {});

--- a/src/systems/character-controller-system.js
+++ b/src/systems/character-controller-system.js
@@ -124,10 +124,8 @@ export class CharacterControllerSystem {
         inPosition.setFromMatrixPosition(inMat4Copy);
         this.findPositionOnNavMesh(inPosition, inPosition, outPosition, true);
         finalPOV.setPosition(outPosition);
-        translation.makeTranslation(0, getCurrentPlayerHeight(), -0.15);
-      } else {
-        translation.makeTranslation(0, 1.6, -0.15);
       }
+      translation.makeTranslation(0, getCurrentPlayerHeight(), -0.15);
       finalPOV.multiply(translation);
       if (willMaintainInitialOrientation) {
         initialOrientation.extractRotation(this.avatarPOV.object3D.matrixWorld);

--- a/src/utils/get-current-player-height.js
+++ b/src/utils/get-current-player-height.js
@@ -4,8 +4,8 @@ export const getCurrentPlayerHeight = (function() {
   return function getCurrentPlayerHeight(world) {
     avatarPOV = avatarPOV || document.getElementById("avatar-pov-node");
     avatarRig = avatarRig || document.getElementById("avatar-rig");
-    avatarPOV.object3D.updateMatrices();
     avatarRig.object3D.updateMatrices();
+    avatarPOV.object3D.updateMatrices();
     if (world) {
       return avatarPOV.object3D.matrixWorld.elements[13] - avatarRig.object3D.matrixWorld.elements[13];
     }


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/2189

This PR addresses two problems. The first was that when we spawned at a waypoint that was not snapped to the nav mesh, we used a default height of 1.6 meters. If the current player height was different than that, we would end up above or below the floor. The second problem is that we are using the delta between `avatar-rig` and `avatar-pov-node` to calculate player height, so we need to delay spawning at the waypoint until after these reflect the reported height of the player. 





