### PR TITLE
Detect in-app-browser in Facebook on Android

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -666,12 +666,20 @@ document.addEventListener("DOMContentLoaded", async () => {
     return;
   }
 
-  // If we are on iOS but we don't have the mediaDevices API, then we are likely in a Firefox or Chrome WebView,
-  // or a WebView preview used in apps like Twitter and Discord. So we show the dialog that tells users to open
-  // the room in the real Safari.
+  // Some apps like Twitter, Discord and Facebook on Android and iOS open links in
+  // their own embedded preview browsers.
+  //
+  // On iOS this WebView does not have a mediaDevices API at all, but in Android apps
+  // like Facebook, the browser pretends to have a mediaDevices, but never actually
+  // prompts the user for device access. So, we show a dialog that tells users to open
+  // the room in an actual browser like Safari, Chrome or Firefox.
+  //
+  // Facebook Mobile Browser on Android has a userAgent like this:
+  // Mozilla/5.0 (Linux; Android 9; SM-G950U1 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko)
+  // Version/4.0 Chrome/80.0.3987.149 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/262.0.0.34.117;]
   const detectedOS = detectOS(navigator.userAgent);
-  if (detectedOS === "iOS" && !navigator.mediaDevices) {
-    remountUI({ showSafariDialog: true });
+  if ((detectedOS === "iOS" && !navigator.mediaDevices) || /\bfb_iab\b/i.test(navigator.userAgent)) {
+    remountUI({ showInAppBrowserDialog: true });
     return;
   }
 

--- a/src/react-components/in-app-browser-dialog.js
+++ b/src/react-components/in-app-browser-dialog.js
@@ -1,11 +1,12 @@
 import React, { Component } from "react";
 import copy from "copy-to-clipboard";
+import { detectOS } from "detect-browser";
 
 import { messages } from "../utils/i18n";
 import DialogContainer from "./dialog-container.js";
 import { WithHoverSound } from "./wrap-with-audio";
 
-export default class SafariDialog extends Component {
+export default class InAppBrowserDialog extends Component {
   state = {
     copyLinkButtonText: "copy"
   };
@@ -17,12 +18,13 @@ export default class SafariDialog extends Component {
 
   render() {
     const onCopyClicked = this.copyLinkClicked.bind(this, document.location);
+    const detectedOS = detectOS(navigator.userAgent);
     return (
-      <DialogContainer title="Open in Safari" {...this.props}>
+      <DialogContainer title="Open in Browser" {...this.props}>
         <div>
           <div>
-            {messages["app-name"]} does not support your current browser on iOS. Copy and paste this link directly in
-            Safari.
+            {messages["app-name"]} does not support your current browser.<br />
+            Copy and paste this link directly into {detectedOS === "iOS" ? "Safari" : "Chrome or Firefox"}.
           </div>
           <div className="invite-form">
             <input

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -40,7 +40,7 @@ import AvatarUrlDialog from "./avatar-url-dialog.js";
 import InviteDialog from "./invite-dialog.js";
 import InviteTeamDialog from "./invite-team-dialog.js";
 import LinkDialog from "./link-dialog.js";
-import SafariDialog from "./safari-dialog.js";
+import InAppBrowserDialog from "./in-app-browser-dialog.js";
 import SignInDialog from "./sign-in-dialog.js";
 import RoomSettingsDialog from "./room-settings-dialog.js";
 import CloseRoomDialog from "./close-room-dialog.js";
@@ -148,7 +148,7 @@ class UIRoot extends Component {
     signInCompleteMessageId: PropTypes.string,
     signInContinueTextId: PropTypes.string,
     onContinueAfterSignIn: PropTypes.func,
-    showSafariDialog: PropTypes.bool,
+    showInAppBrowserDialog: PropTypes.bool,
     showWebAssemblyDialog: PropTypes.bool,
     showOAuthDialog: PropTypes.bool,
     onCloseOAuthDialog: PropTypes.func,
@@ -219,8 +219,8 @@ class UIRoot extends Component {
   constructor(props) {
     super(props);
 
-    if (props.showSafariDialog) {
-      this.state.dialog = <SafariDialog closable={false} />;
+    if (props.showInAppBrowserDialog) {
+      this.state.dialog = <InAppBrowserDialog closable={false} />;
     }
     if (props.showWebAssemblyDialog) {
       this.state.dialog = <WebAssemblyUnsupportedDialog closable={false} />;
@@ -1424,7 +1424,7 @@ class UIRoot extends Component {
     const isLoading =
       !preload &&
       (!this.state.hideLoader || !this.state.didConnectToNetworkedScene) &&
-      !(this.props.showSafariDialog || this.props.showWebAssemblyDialog);
+      !(this.props.showInAppBrowserDialog || this.props.showWebAssemblyDialog);
 
     const hasPush = navigator.serviceWorker && "PushManager" in window;
 
@@ -2055,7 +2055,7 @@ class UIRoot extends Component {
                   isStreaming={streaming}
                   toggleStreamerMode={this.toggleStreamerMode}
                   hubChannel={this.props.hubChannel}
-                  hubScene={this.props.hub.scene}
+                  hubScene={this.props.hub && this.props.hub.scene}
                   scene={this.props.scene}
                   showAsOverlay={showSettingsAsOverlay}
                   onCloseOverlay={() => exit2DInterstitialAndEnterVR(true)}


### PR DESCRIPTION
Facebook opens links in an in-app-browser based on Chrome. The browser has a `mediaDevices` API, but the API never actually prompts the user for devices, nor does it yield its promise, so we have to just prompt the user to open an actual browser.