### PR TITLE
Move the stopInspecting binding to generic vive user bindings.

### DIFF
--- a/src/systems/userinput/bindings/vive-user.js
+++ b/src/systems/userinput/bindings/vive-user.js
@@ -1559,6 +1559,13 @@ export const viveUserBindings = addSetsToBindings({
       xform: xforms.noop,
       priority: 1000
     }
+  ],
+  [sets.inspecting]: [
+    {
+      src: { value: inspectButtons },
+      dest: { value: paths.actions.stopInspecting },
+      xform: xforms.falling
+    }
   ]
 });
 
@@ -1739,13 +1746,6 @@ export const viveCosmosUserBindings = addSetsToBindings({
       dest: { value: paths.actions.rightHand.scalePenTip },
       xform: xforms.scaleExp(-0.005, 5),
       priority: 1
-    }
-  ],
-  [sets.inspecting]: [
-    {
-      src: { value: inspectButtons },
-      dest: { value: paths.actions.stopInspecting },
-      xform: xforms.falling
     }
   ]
 });


### PR DESCRIPTION
The `stopInspecting` binding was only in the `viveFocusPlusUserBindings`. This moves it to the `viveUserBindings`, which is used by all the vive-type controllers.

Fixes https://github.com/mozilla/hubs/issues/2266