### PR TITLE
Add hidden slash command to disable/enable positional audio

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -44,6 +44,7 @@ const getTs = (() => {
   buildEnv.BUILD_VERSION = `1.0.0.${version}`;
   buildEnv.ITA_SERVER = "";
   buildEnv.POSTGREST_SERVER = "";
+  buildEnv.CONFIGURABLE_SERVICES = "janus-gateway,reticulum,hubs,spoke";
 
   const env = Object.assign(process.env, buildEnv);
 

--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -267,6 +267,7 @@
     "commands.capture": "Capture a 15 second video.",
     "commands.debug": "Toggle physics debug rendering.",
     "commands.vrstats": "Toggle stats in VR.",
+    "commands.audiomode": "(experimental) Toggle positional audio.",
     "preferences.muteMicOnEntry": "Mute microphone on entry",
     "preferences.enableOnScreenJoystickLeft": "Enable left on-screen joystick for moving around",
     "preferences.enableOnScreenJoystickRight": "Enable right on-screen joystick for looking around",

--- a/src/components/avatar-volume-controls.js
+++ b/src/components/avatar-volume-controls.js
@@ -42,12 +42,12 @@ AFRAME.registerComponent("avatar-volume-controls", {
   },
 
   update() {
-    if (this.audio) {
+    if (this.networkedAudioSource && window.APP.store.state.preferences.audioOutputMode === "panner") {
       const globalVoiceVolume =
         window.APP.store.state.preferences.globalVoiceVolume !== undefined
           ? window.APP.store.state.preferences.globalVoiceVolume
           : 100;
-      this.audio.gain.gain.value = (globalVoiceVolume / 100) * this.data.volume;
+      this.networkedAudioSource.sound.gain.gain.value = (globalVoiceVolume / 100) * this.data.volume;
     }
   },
 
@@ -61,14 +61,27 @@ AFRAME.registerComponent("avatar-volume-controls", {
     this.volumeLabel.setAttribute("text", "value", this.data.volume === 0 ? "Muted" : VOLUME_LABELS[numBars]);
   },
 
-  tick() {
-    if (this.audio) return;
-
-    // Walk up to Spine and then search down.
-    const source = this.el.parentNode.parentNode.querySelector("[networked-audio-source]");
-    if (!source) return;
-
-    this.audio = source.components["networked-audio-source"].sound;
-    this.update();
-  }
+  tick: (() => {
+    const positionA = new THREE.Vector3();
+    const positionB = new THREE.Vector3();
+    return function() {
+      if (this.networkedAudioSource && window.APP.store.state.preferences.audioOutputMode === "audio") {
+        const globalVoiceVolume =
+          window.APP.store.state.preferences.globalVoiceVolume !== undefined
+            ? window.APP.store.state.preferences.globalVoiceVolume
+            : 100;
+        this.networkedAudioSource.el.object3D.getWorldPosition(positionA);
+        this.el.sceneEl.camera.getWorldPosition(positionB);
+        const distance = positionA.distanceTo(positionB);
+        this.networkedAudioSource.sound.gain.gain.value =
+          (globalVoiceVolume / 100) * this.data.volume * Math.min(1, 10 / Math.max(1, distance * distance));
+      } else if (!this.networkedAudioSource) {
+        // Walk up to Spine and then search down.
+        const source = this.el.parentNode.parentNode.querySelector("[networked-audio-source]");
+        if (!source) return;
+        this.networkedAudioSource = source.components["networked-audio-source"];
+        this.update();
+      }
+    };
+  })()
 });

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -262,6 +262,8 @@ AFRAME.registerComponent("media-video", {
     this.changeVolumeBy = this.changeVolumeBy.bind(this);
     this.togglePlaying = this.togglePlaying.bind(this);
 
+    this.distanceBasedAttenuation = 1;
+
     this.lastUpdate = 0;
     this.videoMutedAt = 0;
     this.localSnapCount = 0;
@@ -443,7 +445,7 @@ AFRAME.registerComponent("media-video", {
     }
 
     // Volume is local, always update it
-    if (this.audio) {
+    if (this.audio && this.audioOutputMode === "panner") {
       const globalMediaVolume =
         window.APP.store.state.preferences.globalMediaVolume !== undefined
           ? window.APP.store.state.preferences.globalMediaVolume
@@ -487,6 +489,35 @@ AFRAME.registerComponent("media-video", {
     return this.updateSrc(oldData);
   },
 
+  setupAudio() {
+    if (this.audio) {
+      this.audio.disconnect();
+      this.el.removeObject3D("sound");
+    }
+
+    if (this.data.audioType === "pannernode") {
+      this.audio = new THREE.PositionalAudio(this.el.sceneEl.audioListener);
+      this.setPositionalAudioProperties();
+      this.distanceBasedAttenuation = 1;
+    } else {
+      this.audio = new THREE.Audio(this.el.sceneEl.audioListener);
+    }
+    window.foo = this.audio;
+
+    this.audio.setNodeSource(this.mediaElementAudioSource);
+    this.el.setObject3D("sound", this.audio);
+  },
+
+  setPositionalAudioProperties() {
+    this.audio.setDistanceModel(this.data.distanceModel);
+    this.audio.setRolloffFactor(this.data.rolloffFactor);
+    this.audio.setRefDistance(this.data.refDistance);
+    this.audio.setMaxDistance(this.data.maxDistance);
+    this.audio.panner.coneInnerAngle = this.data.coneInnerAngle;
+    this.audio.panner.coneOuterAngle = this.data.coneOuterAngle;
+    this.audio.panner.coneOuterGain = this.data.coneOuterGain;
+  },
+
   async updateSrc(oldData) {
     const { src, linkedVideoTexture, linkedAudioSource, linkedMediaElementAudioSource } = this.data;
 
@@ -520,26 +551,10 @@ AFRAME.registerComponent("media-video", {
         // iOS video audio is broken, see: https://github.com/mozilla/hubs/issues/1797
         if (!isIOS) {
           // TODO FF error here if binding mediastream: The captured HTMLMediaElement is playing a MediaStream. Applying volume or mute status is not currently supported -- not an issue since we have no audio atm in shared video.
-          const mediaElementAudioSource =
+          this.mediaElementAudioSource =
             linkedMediaElementAudioSource ||
             this.el.sceneEl.audioListener.context.createMediaElementSource(audioSourceEl);
-
-          if (this.data.audioType === "pannernode") {
-            this.audio = new THREE.PositionalAudio(this.el.sceneEl.audioListener);
-            this.audio.setDistanceModel(this.data.distanceModel);
-            this.audio.setRolloffFactor(this.data.rolloffFactor);
-            this.audio.setRefDistance(this.data.refDistance);
-            this.audio.setMaxDistance(this.data.maxDistance);
-            this.audio.panner.coneInnerAngle = this.data.coneInnerAngle;
-            this.audio.panner.coneOuterAngle = this.data.coneOuterAngle;
-            this.audio.panner.coneOuterGain = this.data.coneOuterGain;
-          } else {
-            this.audio = new THREE.Audio(this.el.sceneEl.audioListener);
-          }
-
-          this.mediaElementAudioSource = mediaElementAudioSource;
-          this.audio.setNodeSource(mediaElementAudioSource);
-          this.el.setObject3D("sound", this.audio);
+          this.setupAudio();
         }
       }
 
@@ -810,50 +825,77 @@ AFRAME.registerComponent("media-video", {
     );
   },
 
-  tick() {
-    if (!this.video) return;
+  tick: (() => {
+    const positionA = new THREE.Vector3();
+    const positionB = new THREE.Vector3();
+    return function() {
+      if (!this.video) return;
 
-    const userinput = this.el.sceneEl.systems.userinput;
-    const interaction = this.el.sceneEl.systems.interaction;
-    const volumeModRight = userinput.get(paths.actions.cursor.right.mediaVolumeMod);
-    if (interaction.state.rightRemote.hovered === this.el && volumeModRight) {
-      this.changeVolumeBy(volumeModRight);
-    }
-    const volumeModLeft = userinput.get(paths.actions.cursor.left.mediaVolumeMod);
-    if (interaction.state.leftRemote.hovered === this.el && volumeModLeft) {
-      this.changeVolumeBy(volumeModLeft);
-    }
-
-    const isHeld = interaction.isHeld(this.el);
-
-    if (this.wasHeld && !isHeld) {
-      this.localSnapCount = 0;
-    }
-
-    this.wasHeld = isHeld;
-
-    if (this.hoverMenu && this.hoverMenu.object3D.visible && !this.videoIsLive) {
-      this.timeLabel.setAttribute(
-        "text",
-        "value",
-        `${timeFmt(this.video.currentTime)} / ${timeFmt(this.video.duration)}`
-      );
-    }
-
-    // If a known non-live video is currently playing and we own it, send out time updates
-    if (
-      !this.data.videoPaused &&
-      this.videoIsLive === false &&
-      this.networkedEl &&
-      NAF.utils.isMine(this.networkedEl)
-    ) {
-      const now = performance.now();
-      if (now - this.lastUpdate > this.data.tickRate) {
-        this.el.setAttribute("media-video", "time", this.video.currentTime);
-        this.lastUpdate = now;
+      const userinput = this.el.sceneEl.systems.userinput;
+      const interaction = this.el.sceneEl.systems.interaction;
+      const volumeModRight = userinput.get(paths.actions.cursor.right.mediaVolumeMod);
+      if (interaction.state.rightRemote.hovered === this.el && volumeModRight) {
+        this.changeVolumeBy(volumeModRight);
       }
-    }
-  },
+      const volumeModLeft = userinput.get(paths.actions.cursor.left.mediaVolumeMod);
+      if (interaction.state.leftRemote.hovered === this.el && volumeModLeft) {
+        this.changeVolumeBy(volumeModLeft);
+      }
+
+      const isHeld = interaction.isHeld(this.el);
+
+      if (this.wasHeld && !isHeld) {
+        this.localSnapCount = 0;
+      }
+
+      this.wasHeld = isHeld;
+
+      if (this.hoverMenu && this.hoverMenu.object3D.visible && !this.videoIsLive) {
+        this.timeLabel.setAttribute(
+          "text",
+          "value",
+          `${timeFmt(this.video.currentTime)} / ${timeFmt(this.video.duration)}`
+        );
+      }
+
+      // If a known non-live video is currently playing and we own it, send out time updates
+      if (
+        !this.data.videoPaused &&
+        this.videoIsLive === false &&
+        this.networkedEl &&
+        NAF.utils.isMine(this.networkedEl)
+      ) {
+        const now = performance.now();
+        if (now - this.lastUpdate > this.data.tickRate) {
+          this.el.setAttribute("media-video", "time", this.video.currentTime);
+          this.lastUpdate = now;
+        }
+      }
+
+      if (this.audio) {
+        const audioOutputMode = window.APP.store.state.preferences.audioOutputMode === "audio" ? "audio" : "panner";
+        if (
+          (audioOutputMode === "panner" && this.data.audioType !== "pannernode") ||
+          (audioOutputMode === "audio" && this.data.audioType !== "audionode")
+        ) {
+          this.data.audioType = audioOutputMode === "panner" ? "pannernode" : "audionode";
+          this.setupAudio();
+        }
+
+        if (audioOutputMode === "audio") {
+          this.el.object3D.getWorldPosition(positionA);
+          this.el.sceneEl.camera.getWorldPosition(positionB);
+          const distance = positionA.distanceTo(positionB);
+          this.distanceBasedAttenuation = Math.min(1, 10 / Math.max(1, distance * distance));
+          const globalMediaVolume =
+            window.APP.store.state.preferences.globalMediaVolume !== undefined
+              ? window.APP.store.state.preferences.globalMediaVolume
+              : 100;
+          this.audio.gain.gain.value = (globalMediaVolume / 100) * this.data.volume * this.distanceBasedAttenuation;
+        }
+      }
+    };
+  })(),
 
   cleanUp() {
     if (this.mesh && this.mesh.material) {

--- a/src/message-dispatch.js
+++ b/src/message-dispatch.js
@@ -140,6 +140,14 @@ export default class MessageDispatch {
           }
         }
         break;
+      case "audiomode":
+        if (window.APP.store.state.preferences.audioOutputMode !== "audio") {
+          window.APP.store.state.preferences.audioOutputMode = "audio";
+          this.log("Positional Audio disabled.");
+        } else {
+          window.APP.store.state.preferences.audioOutputMode = "panner";
+          this.log("Positional Audio enabled.");
+        }
     }
   };
 }

--- a/src/react-components/chat-command-help.js
+++ b/src/react-components/chat-command-help.js
@@ -12,7 +12,17 @@ export default class ChatCommandHelp extends Component {
   };
 
   render() {
-    const commands = ["leave", "grow", "shrink", "duck", "debug", "vrstats", "scene <scene url>", "rename <new name>"];
+    const commands = [
+      "leave",
+      "grow",
+      "shrink",
+      "duck",
+      "debug",
+      "vrstats",
+      "scene <scene url>",
+      "rename <new name>",
+      "audiomode"
+    ];
 
     if (window.APP.hubChannel && window.APP.hubChannel.can("fly")) {
       commands.push("fly");

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -67,6 +67,7 @@ export const SCHEMA = {
       additionalProperties: false,
       properties: {
         muteMicOnEntry: { type: "bool" },
+        audioOutputMode: { type: "string" },
         enableOnScreenJoystickLeft: { type: "bool" },
         enableOnScreenJoystickRight: { type: "bool" },
         onlyShowNametagsInFreeze: { type: "bool" },

--- a/src/systems/sound-effects-system.js
+++ b/src/systems/sound-effects-system.js
@@ -132,7 +132,12 @@ export class SoundEffectsSystem {
     const audioBuffer = this.sounds.get(sound);
     if (!audioBuffer) return null;
 
-    const positionalAudio = new THREE.PositionalAudio(this.scene.audioListener).setBuffer(audioBuffer);
+    const audioOutputMode = window.APP.store.state.preferences.audioOutputMode === "audio" ? "audio" : "panner";
+    const positionalAudio =
+      audioOutputMode === "panner"
+        ? new THREE.PositionalAudio(this.scene.audioListener)
+        : new THREE.Audio(this.scene.audioListener);
+    positionalAudio.setBuffer(audioBuffer);
     positionalAudio.loop = loop;
     this.pendingPositionalAudios.push(positionalAudio);
     return positionalAudio;


### PR DESCRIPTION
This adds `/audiomode` which will disable/renable positional audio at runtime (persists only for the session). This is to be used to help debug and diagnose clients where WebRTC noise cancellation is not working. When positional audio is disabled, avatar and video audio will attenuate volume by distance based on inverse square formula. 