### PR TITLE
Improve UI/UX of "Watch from Lobby" button.

### DIFF
--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1117,6 +1117,22 @@ class UIRoot extends Component {
                   </div>
                 </button>
               )}
+              {configs.feature("enable_lobby_ghosts") ? (
+                <button
+                  onClick={e => {
+                    e.preventDefault();
+                    this.setState({ watching: true });
+                  }}
+                  className={classNames([entryStyles.secondaryActionButton, entryStyles.wideButton])}
+                >
+                  <FormattedMessage id="entry.watch-from-lobby" />
+                  <div className={entryStyles.buttonSubtitle}>
+                    <FormattedMessage id="entry.watch-from-lobby-subtitle" />
+                  </div>
+                </button>
+              ) : (
+                <div />
+              )}
               <button
                 autoFocus
                 onClick={e => {
@@ -1136,23 +1152,6 @@ class UIRoot extends Component {
               >
                 <FormattedMessage id="entry.enter-room" />
               </button>
-
-              {configs.feature("enable_lobby_ghosts") ? (
-                <a
-                  onClick={e => {
-                    e.preventDefault();
-                    this.setState({ watching: true });
-                  }}
-                  className={classNames([entryStyles.secondaryActionButton, entryStyles.wideButton])}
-                >
-                  <FormattedMessage id="entry.watch-from-lobby" />
-                  <div className={entryStyles.buttonSubtitle}>
-                    <FormattedMessage id="entry.watch-from-lobby-subtitle" />
-                  </div>
-                </a>
-              ) : (
-                <div />
-              )}
             </div>
           )}
         {this.props.entryDisallowed &&


### PR DESCRIPTION
Reorders the buttons and makes sure the size is correct by using `<button>`, not `<a>`.
Also I confirmed that this works on my mobile device without overflowing.
![image](https://user-images.githubusercontent.com/4072106/77567409-593b0500-6e84-11ea-948f-268a98c4ef55.png)
