### PR TITLE
Fix race condition in tar step of deploy

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -5,6 +5,7 @@ import ncp from "ncp";
 import tar from "tar";
 import ora from "ora";
 import FormData from "form-data";
+import path from "path";
 
 if (!existsSync(".ret.credentials")) {
   console.log("Not logged in, so cannot deploy. To log in, run npm run login.");
@@ -100,7 +101,7 @@ const getTs = (() => {
   step.text = "Preparing Deploy.";
 
   step.text = "Packaging Build.";
-  await tar.c({ gzip: true, C: "dist", file: "_build.tar.gz" }, ["."]);
+  await tar.c({ sync: true, gzip: true, C: path.join(__dirname, "..", "dist"), file: "_build.tar.gz" }, ["."]);
   step.text = `Uploading Build ${buildEnv.BUILD_VERSION}.`;
 
   let uploadedUrl;

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -101,7 +101,7 @@ const getTs = (() => {
   step.text = "Preparing Deploy.";
 
   step.text = "Packaging Build.";
-  await tar.c({ sync: true, gzip: true, C: path.join(__dirname, "..", "dist"), file: "_build.tar.gz" }, ["."]);
+  tar.c({ sync: true, gzip: true, C: path.join(__dirname, "..", "dist"), file: "_build.tar.gz" }, ["."]);
   step.text = `Uploading Build ${buildEnv.BUILD_VERSION}.`;
 
   let uploadedUrl;


### PR DESCRIPTION
This bug seems to only happen on Mac. Making the tar step synchronous seems to fix it. The absolute path may not be necessary, but is a good practice anyway.