### PR TITLE
Feature #1: Video Heads

### DIFF
--- a/src/react-components/2d-hud.js
+++ b/src/react-components/2d-hud.js
@@ -126,7 +126,7 @@ class TopHUD extends Component {
     if (this.props.videoShareMediaSource) {
       this.props.onEndShareVideo();
     } else {
-      this.props.onShareVideo(source);
+      this.props.onShareVideo(source); // note - here is where video is shared
       this.setState({ lastActiveMediaSource: source });
     }
   };
@@ -134,7 +134,7 @@ class TopHUD extends Component {
   buildVideoSharingButtons = () => {
     const isMobile = AFRAME.utils.device.isMobile() || AFRAME.utils.device.isMobileVR();
 
-    const videoShareExtraOptionTypes = [];
+    const videoShareExtraOptionTypes = []; // TODO: Add videohead option
     const primaryVideoShareType =
       this.props.videoShareMediaSource || this.state.lastActiveMediaSource || (isMobile ? "camera" : "screen");
 

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -476,7 +476,7 @@ class UIRoot extends Component {
   };
 
   shareVideo = mediaSource => {
-    this.props.scene.emit(`action_share_${mediaSource}`);
+    this.props.scene.emit(`action_share_${mediaSource}`); // this action sends the state change from react to A-frame
   };
 
   endShareVideo = () => {

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -294,6 +294,29 @@ export default class SceneEntryManager {
       return entity;
     };
 
+    const spawnMediaOnPlayerHead = (src, contentOrigin) => {
+      // TODO: Code this
+      if (!this.hubChannel.can("spawn_and_move_media")) return;
+      const { entity, orientation } = addMedia(
+        src,
+        "#static-media",
+        contentOrigin,
+        null,
+        !(src instanceof MediaStream),
+        true
+      );
+      const headSpawnOffset = { x: 0, y: 1, z: 0 };
+      orientation.then(or => {
+        entity.setAttribute("offset-relative-to", {
+          target: "#avatar-rig",
+          headSpawnOffset,
+          orientation: or
+        });
+      });
+
+      return entity;
+    };
+
     this.scene.addEventListener("add_media", e => {
       const contentOrigin = e.detail instanceof File ? ObjectContentOrigins.FILE : ObjectContentOrigins.URL;
 
@@ -419,8 +442,9 @@ export default class SceneEntryManager {
       if (videoTracks.length > 0) {
         newStream.getVideoTracks().forEach(track => mediaStream.addTrack(track));
         await NAF.connection.adapter.setLocalMediaStream(mediaStream);
-        currentVideoShareEntity = spawnMediaInfrontOfPlayer(mediaStream, undefined);
-
+        // currentVideoShareEntity = spawnMediaInfrontOfPlayer(mediaStream, undefined);
+        // This is where we need to override.
+        currentVideoShareEntity = spawnMediaOnPlayerHead(mediaStream, undefined);
         // Wire up custom removal event which will stop the stream.
         currentVideoShareEntity.setAttribute("emit-scene-event-on-remove", "event:action_end_video_sharing");
       }
@@ -431,6 +455,7 @@ export default class SceneEntryManager {
     };
 
     this.scene.addEventListener("action_share_camera", () => {
+      // This is where A frame receives the event
       shareVideoMediaStream({
         video: {
           mediaSource: "camera",


### PR DESCRIPTION
This commit is very much unfinished - but I've found the location of the code we need to change. It requires a custom NAF template, I've currently changed this to be "static-media" instead of "interactable-media" and it changed the offset, as well as scaffolded a new funciton. Now when pressing "video", a non-interactable version of the video stream is dropped.

Next steps:
Force static media box to be pinned to avatar-rig