### PR TITLE
Hide the newsletter if it is not enabled

### DIFF
--- a/src/react-components/auth-dialog.js
+++ b/src/react-components/auth-dialog.js
@@ -38,10 +38,12 @@ class AuthDialog extends Component {
             <div>
               <FormattedMessage className="preformatted" id="auth.verified" />
               <IfFeature name="show_newsletter_signup">
-                Want Hubs news sent to your inbox?{"\n"}
-                <a href="https://eepurl.com/gX_fH9" target="_blank" rel="noopener noreferrer">
-                  Subscribe for updates
-                </a>.
+                <p>
+                  Want Hubs news sent to your inbox?{"\n"}
+                  <a href="https://eepurl.com/gX_fH9" target="_blank" rel="noopener noreferrer">
+                    Subscribe for updates
+                  </a>.
+                </p>
               </IfFeature>
             </div>
           )}

--- a/src/react-components/join-us-dialog.js
+++ b/src/react-components/join-us-dialog.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import DialogContainer from "./dialog-container.js";
+import IfFeature from "./if-feature";
 
 export default class JoinUsDialog extends Component {
   render() {
@@ -19,12 +20,14 @@ export default class JoinUsDialog extends Component {
               @MozillaHubs
             </a>.
           </p>
-          <p>
-            Want Hubs news sent to your inbox?{"\n"}
-            <a href="https://eepurl.com/gX_fH9" target="_blank" rel="noopener noreferrer">
-              Subscribe for updates
-            </a>.
-          </p>
+          <IfFeature name="show_newsletter_signup">
+            <p>
+              Want Hubs news sent to your inbox?{"\n"}
+              <a href="https://eepurl.com/gX_fH9" target="_blank" rel="noopener noreferrer">
+                Subscribe for updates
+              </a>.
+            </p>
+          </IfFeature>
         </span>
       </DialogContainer>
     );

--- a/src/react-components/sign-in-dialog.js
+++ b/src/react-components/sign-in-dialog.js
@@ -42,10 +42,12 @@ export default class SignInDialog extends Component {
             <FormattedMessage className="preformatted" id="sign-in.auth-started" />
           </p>
           <IfFeature name="show_newsletter_signup">
-            Want Hubs news sent to your inbox?{"\n"}
-            <a href="https://eepurl.com/gX_fH9" target="_blank" rel="noopener noreferrer">
-              Subscribe for updates
-            </a>.
+            <p>
+              Want Hubs news sent to your inbox?{"\n"}
+              <a href="https://eepurl.com/gX_fH9" target="_blank" rel="noopener noreferrer">
+                Subscribe for updates
+              </a>.
+            </p>
           </IfFeature>
         </div>
       );


### PR DESCRIPTION
Quick fix. The newsletter link in the "Join Us" dialog should only appear if the feature is enabled by the config.