### PR TITLE
Use a larger key size when generating a self-signed cert.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,7 @@ function createHTTPSConfig() {
       ],
       {
         days: 365,
+        keySize: 2048,
         algorithm: "sha256",
         extensions: [
           {


### PR DESCRIPTION
This allows browsers with more restrictive SSL settings (such as Servo) to reach the local dev server.