### PR TITLE
Tweak object list button

### DIFF
--- a/src/assets/stylesheets/ui-root.scss
+++ b/src/assets/stylesheets/ui-root.scss
@@ -1,4 +1,5 @@
 @import 'shared';
+@import 'drop-menus.scss';
 
 :local(.streaming-tip) {
   position: absolute;
@@ -158,45 +159,57 @@ body.vr-mode {
   }
 }
 
-:local(.object-list) {
+:local(.object-list-button) {
   @extend %unselectable;
-  text-align: right;
+  pointer-events: auto;
+  cursor: pointer;
   position: absolute;
+  padding: 0px;
   z-index: 1;
-  top: 0;
-  right: 132px;
-  margin: 16px 0;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  font-size: 1.3em;
   background-color: var(--menu-background-color);
   color: var(--menu-icon-color);
   border-radius: 24px;
-  font-weight: bold;
-  padding: 8px 18px;
-  pointer-events: auto;
-  cursor: pointer;
+  border-style: none;
+  border-width: 0px;
+
+  svg {
+    width: 26px !important;
+    height: 26px;
+  }
+  span {
+    font-size: 22px;
+    font-weight: bold;
+    font-family: 'Open Sans', sans-serif;
+  }
 
   @media(min-width: 501px) {
-    :local(.occupant-count) {
-      margin: 0px 8px;
-    }
+    width: 90px;
+    min-width: 90px;
+    height: 44px;
+    top: 16px;
+    right: 132px;
+    justify-content: space-evenly;
   }
 
   @media(max-width: 500px) {
     flex-direction: column;
-    padding: 8px 0px;
     right: 16px;
-    top: 80px;
+    top: 96px;
     width: 52px;
-    :local(.occupant-count) {
-      margin: 0px 0px;
-    }
-    svg {
-      width: 26px !important;
-    }
+    min-width: 52px;
+    height: 72px;
+    justify-content: center;
   }
+}
+
+:local(.object-list) {
+  @extend %drop-menu;
+  @media(max-width: 500px) {
+    top: 184px;
+  }
+  right: 16px;
 }
 
 :local(.presence-info) {

--- a/src/react-components/object-list.js
+++ b/src/react-components/object-list.js
@@ -142,7 +142,7 @@ export default class ObjectList extends Component {
 
   renderExpandedList() {
     return (
-      <div className={styles.presenceList}>
+      <div className={rootStyles.objectList}>
         <div className={styles.contents}>
           <div className={styles.rows}>{this.state.mediaEntities.map(this.domForEntity.bind(this))}</div>
         </div>
@@ -153,7 +153,7 @@ export default class ObjectList extends Component {
   render() {
     return (
       <div>
-        <div
+        <button
           title={"Media"}
           onClick={() => {
             this.props.onExpand(
@@ -162,13 +162,13 @@ export default class ObjectList extends Component {
             );
           }}
           className={classNames({
-            [rootStyles.objectList]: true,
+            [rootStyles.objectListButton]: true,
             [rootStyles.presenceInfoSelected]: this.props.expanded
           })}
         >
-          <FontAwesomeIcon icon={faCubes} />
-          <span className={rootStyles.occupantCount}>{this.state.mediaEntities.length}</span>
-        </div>
+          <FontAwesomeIcon className={classNames(rootStyles.objectListSvg)} icon={faCubes} />
+          <span className={rootStyles.mediaCount}>{this.state.mediaEntities.length}</span>
+        </button>
         {this.props.expanded && this.renderExpandedList()}
       </div>
     );


### PR DESCRIPTION
- Convert object list div into a button. 
- Fix dimensions in widescreen and mobile views to be a known, stable size across browsers. 
- Fix drop-down location so that it does not block the object list button (as it did in the small-screen view).

Work is ongoing, but this commit can be deployed as-is, if desired.