### PR TITLE
Minor UI improvements

### DIFF
--- a/src/assets/stylesheets/2d-hud.scss
+++ b/src/assets/stylesheets/2d-hud.scss
@@ -9,8 +9,7 @@
   pointer-events: none;
 
   &:local(.top) {
-    top: 10px;
-    height: 80px;
+    top: 16px;
   }
 
   &:local(.column) {
@@ -108,7 +107,7 @@
   }
 
   :local(.top-tip-no-hud) {
-    top: -30px;
+    top: 0px;
     width: auto;
     white-space: nowrap;
     height: 20px;

--- a/src/assets/stylesheets/invite-dialog.scss
+++ b/src/assets/stylesheets/invite-dialog.scss
@@ -129,7 +129,7 @@
 }
 
 :local(.invite-container-below-hud) {
-  margin-top: 86px;
+  margin-top: 76px;
 }
 
 :local(.attach-point) {

--- a/src/assets/stylesheets/ui-root.scss
+++ b/src/assets/stylesheets/ui-root.scss
@@ -159,7 +159,16 @@ body.vr-mode {
   }
 }
 
-:local(.object-list-button) {
+:local(.object-list) {
+  @extend %drop-menu;
+  @media(max-width: 500px) {
+    top: 184px;
+  }
+  right: 16px;
+}
+
+
+%button-with-count {
   @extend %unselectable;
   pointer-events: auto;
   cursor: pointer;
@@ -173,7 +182,6 @@ body.vr-mode {
   border-radius: 24px;
   border-style: none;
   border-width: 0px;
-
   svg {
     width: 26px !important;
     height: 26px;
@@ -183,69 +191,40 @@ body.vr-mode {
     font-weight: bold;
     font-family: 'Open Sans', sans-serif;
   }
-
   @media(min-width: 501px) {
     width: 90px;
     min-width: 90px;
     height: 44px;
-    top: 16px;
-    right: 132px;
     justify-content: space-evenly;
   }
-
   @media(max-width: 500px) {
     flex-direction: column;
-    right: 16px;
-    top: 96px;
     width: 52px;
     min-width: 52px;
     height: 72px;
     justify-content: center;
   }
 }
+:local(.object-list-button) {
+  @extend %button-with-count;
 
-:local(.object-list) {
-  @extend %drop-menu;
-  @media(max-width: 500px) {
-    top: 184px;
+  @media(min-width: 501px) {
+    top: 16px;
+    right: 122px;
+    justify-content: space-evenly;
   }
-  right: 16px;
+
+  @media(max-width: 500px) {
+    right: 16px;
+    top: 96px;
+  }
 }
 
-:local(.presence-info) {
-  @extend %unselectable;
-  text-align: right;
-  position: absolute;
-  z-index: 1;
-  top: 0;
+:local(.presence-list-button) {
+  @extend %button-with-count;
+
+  top: 16px;
   right: 16px;
-  margin: 16px 0;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  font-size: 1.3em;
-  background-color: var(--menu-background-color);
-  color: var(--menu-icon-color);
-  border-radius: 24px;
-  font-weight: bold;
-  padding: 8px 18px;
-  pointer-events: auto;
-  cursor: pointer;
-
-  @media(max-width: 500px) {
-    width: 52px;
-    flex-direction: column;
-    padding: 8px 0px;
-
-    svg {
-      width: 26px !important;
-    }
-  }
-
-  :local(.occupant-count) {
-    margin: 0 12px;
-  }
-
 }
 
 :local(.presence-info-selected) {
@@ -296,7 +275,12 @@ body.vr-mode {
 :local(.choose-scene-button) {
   @extend %action-button-secondary;
   pointer-events: auto;
-  margin-top: 16px;
+  @media (max-width: 500px) {
+    margin-top: 8px;
+  }
+  @media (min-width: 501px) {
+    margin-top: 16px;
+  }
 }
 
 :local(.invite-tip) {

--- a/src/assets/stylesheets/ui-root.scss
+++ b/src/assets/stylesheets/ui-root.scss
@@ -1,4 +1,5 @@
 @import 'shared';
+@import 'drop-menus.scss';
 
 :local(.streaming-tip) {
   position: absolute;
@@ -158,45 +159,57 @@ body.vr-mode {
   }
 }
 
-:local(.object-list) {
+:local(.object-list-button) {
   @extend %unselectable;
-  text-align: right;
+  pointer-events: auto;
+  cursor: pointer;
   position: absolute;
+  padding: 0px;
   z-index: 1;
-  top: 0;
-  right: 132px;
-  margin: 16px 0;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  font-size: 1.3em;
   background-color: var(--menu-background-color);
   color: var(--menu-icon-color);
   border-radius: 24px;
-  font-weight: bold;
-  padding: 8px 18px;
-  pointer-events: auto;
-  cursor: pointer;
+  border-style: none;
+  border-width: 0px;
+
+  svg {
+    width: 26px !important;
+    height: 26px;
+  }
+  span {
+    font-size: 22px;
+    font-weight: bold;
+    font-family: 'Open Sans', sans-serif;
+  }
 
   @media(min-width: 501px) {
-    :local(.occupant-count) {
-      margin: 0px 8px;
-    }
+    width: 90px;
+    min-width: 90px;
+    height: 44px;
+    top: 16px;
+    right: 132px;
+    justify-content: space-evenly;
   }
 
   @media(max-width: 500px) {
     flex-direction: column;
-    padding: 8px 0px;
     right: 16px;
-    top: 80px;
+    top: 96px;
     width: 52px;
-    :local(.occupant-count) {
-      margin: 0px 0px;
-    }
-    svg {
-      width: 26px !important;
-    }
+    min-width: 52px;
+    height: 72px;
+    justify-content: center;
   }
+}
+
+:local(.object-list) {
+  @extend %drop-menu;
+  @media(max-width: 500px) {
+    top: 184px;
+  }
+  right: 16px;
 }
 
 :local(.presence-info) {

--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -392,6 +392,7 @@
     "client-info.cancel": "Cancel",
     "client-info.add-owner": "Promote",
     "client-info.remove-owner": "Demote",
+    "object-info.no-media": "There is no media in the room yet",
     "object-info.remove-button": "Remove",
     "object-info.open-link": "Open Link",
     "object-info.waypoint": "Go To",

--- a/src/react-components/object-list.js
+++ b/src/react-components/object-list.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import { FormattedMessage } from "react-intl";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import rootStyles from "../assets/stylesheets/ui-root.scss";
@@ -148,9 +149,7 @@ export default class ObjectList extends Component {
             {this.state.mediaEntities.length ? (
               this.state.mediaEntities.map(this.domForEntity.bind(this))
             ) : (
-              <div className={styles.listItem}>
-                <span>There is no media in the scene yet.</span>
-              </div>
+              <FormattedMessage id="object-info.no-media" className={styles.listItem} />
             )}
           </div>
         </div>

--- a/src/react-components/object-list.js
+++ b/src/react-components/object-list.js
@@ -144,7 +144,15 @@ export default class ObjectList extends Component {
     return (
       <div className={rootStyles.objectList}>
         <div className={styles.contents}>
-          <div className={styles.rows}>{this.state.mediaEntities.map(this.domForEntity.bind(this))}</div>
+          <div className={styles.rows}>
+            {this.state.mediaEntities.length ? (
+              this.state.mediaEntities.map(this.domForEntity.bind(this))
+            ) : (
+              <div className={styles.listItem}>
+                <span>There is no media in the scene yet.</span>
+              </div>
+            )}
+          </div>
         </div>
       </div>
     );
@@ -156,10 +164,7 @@ export default class ObjectList extends Component {
         <button
           title={"Media"}
           onClick={() => {
-            this.props.onExpand(
-              !this.props.expanded && this.state.mediaEntities.length > 0,
-              !AFRAME.utils.device.isMobileVR()
-            );
+            this.props.onExpand(!this.props.expanded, !AFRAME.utils.device.isMobileVR());
           }}
           className={classNames({
             [rootStyles.objectListButton]: true,

--- a/src/react-components/object-list.js
+++ b/src/react-components/object-list.js
@@ -142,7 +142,7 @@ export default class ObjectList extends Component {
 
   renderExpandedList() {
     return (
-      <div className={styles.presenceList}>
+      <div className={rootStyles.objectList}>
         <div className={styles.contents}>
           <div className={styles.rows}>{this.state.mediaEntities.map(this.domForEntity.bind(this))}</div>
         </div>
@@ -153,7 +153,7 @@ export default class ObjectList extends Component {
   render() {
     return (
       <div>
-        <div
+        <button
           title={"Media"}
           onClick={() => {
             this.props.onExpand(
@@ -162,13 +162,13 @@ export default class ObjectList extends Component {
             );
           }}
           className={classNames({
-            [rootStyles.objectList]: true,
+            [rootStyles.objectListButton]: true,
             [rootStyles.presenceInfoSelected]: this.props.expanded
           })}
         >
-          <FontAwesomeIcon icon={faCubes} />
-          <span className={rootStyles.occupantCount}>{this.state.mediaEntities.length}</span>
-        </div>
+          <FontAwesomeIcon className={classNames(rootStyles.objectListSvg)} icon={faCubes} />
+          <span className={rootStyles.mediaCount}>{this.state.mediaEntities.length}</span>
+        </button>
         {this.props.expanded && this.renderExpandedList()}
       </div>
     );

--- a/src/react-components/object-list.js
+++ b/src/react-components/object-list.js
@@ -171,7 +171,7 @@ export default class ObjectList extends Component {
             [rootStyles.presenceInfoSelected]: this.props.expanded
           })}
         >
-          <FontAwesomeIcon className={classNames(rootStyles.objectListSvg)} icon={faCubes} />
+          <FontAwesomeIcon icon={faCubes} />
           <span className={rootStyles.mediaCount}>{this.state.mediaEntities.length}</span>
         </button>
         {this.props.expanded && this.renderExpandedList()}

--- a/src/react-components/presence-list.js
+++ b/src/react-components/presence-list.js
@@ -165,19 +165,19 @@ export default class PresenceList extends Component {
     const occupantCount = this.props.presences ? Object.entries(this.props.presences).length : 0;
     return (
       <div>
-        <div
+        <button
           title={"Members"}
           onClick={() => {
             this.props.onExpand(!this.props.expanded);
           }}
           className={classNames({
-            [rootStyles.presenceInfo]: true,
+            [rootStyles.presenceListButton]: true,
             [rootStyles.presenceInfoSelected]: this.props.expanded
           })}
         >
           <FontAwesomeIcon icon={faUsers} />
           <span className={rootStyles.occupantCount}>{occupantCount}</span>
-        </div>
+        </button>
         {this.props.expanded && this.renderExpandedList()}
       </div>
     );


### PR DESCRIPTION
- Converts the object list and presence list `div`s into `button`s to assist screen readers.
- Applies uniform styling to both so that they are the same size as each other
- Fixes object list placement on small screens so that it does not cover the object list button when open.
- Shows (very minimal) info when the object list is empty and the button is clicked, instead of doing nothing.
- Tweaks the `top` values so that all the upper buttons are the same distance from the top of the page.
- Move choose scene button closer to share button on small screens to make better use of limited screen space.