### PR TITLE
Update static-media and static-controlled-media collision behavior

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -211,7 +211,7 @@
 
             <template id="static-media">
                 <a-entity
-                    body-helper="type: static; mass: 1; collisionFilterGroup: 1; collisionFilterMask: 11;"
+                    body-helper="type: static; mass: 1; collisionFilterGroup: 1; collisionFilterMask: 1;"
                 >
                 </a-entity>
             </template>
@@ -219,7 +219,7 @@
             <template id="static-controlled-media">
                 <a-entity
                     class="interactable"
-                    body-helper="type: static; mass: 1; collisionFilterGroup: 1; collisionFilterMask: 11;"
+                    body-helper="type: static; mass: 1; collisionFilterGroup: 1; collisionFilterMask: 1;"
                     is-remote-hover-target
                     position-at-box-shape-border__freeze="target:.freeze-menu;"
                     tags="isStatic: true; togglesHoveredActionSet: true; inspectable: true;"


### PR DESCRIPTION
Updates static-media and static-controlled-media so that they only collide with interactables, and not the environment and avatar hands.
This prevents physics from being calculated between the environment mesh and `static-media` in scenes that export both. 