### PR TITLE
initialize videos with correct audio/pannernode as per preferences

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -554,6 +554,9 @@ AFRAME.registerComponent("media-video", {
           this.mediaElementAudioSource =
             linkedMediaElementAudioSource ||
             this.el.sceneEl.audioListener.context.createMediaElementSource(audioSourceEl);
+
+          const audioOutputMode = window.APP.store.state.preferences.audioOutputMode === "audio" ? "audio" : "panner";
+          this.data.audioType = audioOutputMode === "panner" ? "pannernode" : "audionode";
           this.setupAudio();
         }
       }

--- a/src/systems/audio-settings-system.js
+++ b/src/systems/audio-settings-system.js
@@ -1,11 +1,15 @@
 function updateMediaAudioSettings(audio, settings) {
-  audio.setDistanceModel(settings.mediaDistanceModel);
-  audio.setRolloffFactor(settings.mediaRolloffFactor);
-  audio.setRefDistance(settings.mediaRefDistance);
-  audio.setMaxDistance(settings.mediaMaxDistance);
-  audio.panner.coneInnerAngle = settings.mediaConeInnerAngle;
-  audio.panner.coneOuterAngle = settings.mediaConeOuterAngle;
-  audio.panner.coneOuterGain = settings.mediaConeOuterGain;
+  if (audio.setDistanceModel) {
+    audio.setDistanceModel(settings.mediaDistanceModel);
+    audio.setRolloffFactor(settings.mediaRolloffFactor);
+    audio.setRefDistance(settings.mediaRefDistance);
+    audio.setMaxDistance(settings.mediaMaxDistance);
+  }
+  if (audio.panner) {
+    audio.panner.coneInnerAngle = settings.mediaConeInnerAngle;
+    audio.panner.coneOuterAngle = settings.mediaConeOuterAngle;
+    audio.panner.coneOuterGain = settings.mediaConeOuterGain;
+  }
 }
 
 function updateAvatarAudioSettings(audio, settings) {


### PR DESCRIPTION
Ensures that videos are initialized with `audionode` not `pannernode` if that is what mode is selected in preferences.