### PR TITLE
Add support for MOZ_lightmap

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -342,17 +342,35 @@ export async function loadGLTF(src, contentType, preferredTechnique, onProgress,
   runMigration(version, parser.json);
 
   const materials = parser.json.materials;
+  const dependencies = [];
+
   if (materials) {
     for (let i = 0; i < materials.length; i++) {
       const material = materials[i];
 
+      if (!material.extensions) {
+        continue;
+      }
+
       if (
-        material.extensions &&
         material.extensions.MOZ_alt_materials &&
         material.extensions.MOZ_alt_materials[preferredTechnique] !== undefined
       ) {
         const altMaterialIndex = material.extensions.MOZ_alt_materials[preferredTechnique];
         materials[i] = materials[altMaterialIndex];
+      } else if (material.extensions.MOZ_lightmap) {
+        const lightmapDef = material.extensions.MOZ_lightmap;
+
+        const loadLightmap = async () => {
+          const [material, lightMap] = await Promise.all([
+            parser.getDependency("material", i),
+            parser.getDependency("texture", lightmapDef.index)
+          ]);
+
+          material.lightMap = lightMap;
+        };
+
+        dependencies.push(loadLightmap);
       }
     }
   }
@@ -371,7 +389,8 @@ export async function loadGLTF(src, contentType, preferredTechnique, onProgress,
     }
   }
 
-  const gltf = await new Promise(parser.parse.bind(parser));
+  // Note: dependency functions need to be called after parser.parse() so that the cache isn't cleared.
+  const [gltf] = await Promise.all([new Promise(parser.parse.bind(parser)), dependencies.map(fn => fn())]);
 
   gltf.scene.traverse(object => {
     // GLTFLoader sets matrixAutoUpdate on animated objects, we want to keep the defaults


### PR DESCRIPTION
This PR adds support for loading materials with lightmaps into Hubs.

Example of a glTF file using `MOZ_lightmap`:
```
{
  "extensionsUsed": ["KHR_materials_unlit", "MOZ_lightmap"]
  "materials": [
    {
      "emissiveFactor": [0, 0, 0],
      "pbrMetallicRoughness": {
        "baseColorTexture": {
          "index": 0,
          "texCoord": 0
        },
        "metallicFactor": 0,
        "roughnessFactor": 1
      },
      "extensions": {
        "KHR_materials_unlit": {},
        "MOZ_lightmap": {
          "index": 1,
          "texCoord": 1
        }
      }
    }
  ],
"meshes": [
    {
      "name": "TheGeometry_m",
      "primitives": [
        {
          "attributes": {
            "POSITION": 0,
            "NORMAL": 1,
            "TEXCOORD_0": 3,
            "TEXCOORD_1": 2
          },
          "indices": 4,
          "material": 0
        }
      ]
    }
  ]
}
```

Note: Because of limitations in ThreeJS, the lightmap should always use `"texCoord": 1`/`TEXCOORD_1` and the base color map should continue using `"texCoord": 0` / `TEXCOORD_0`.

This PR corresponds with a PR for support in Spoke as well: https://github.com/mozilla/Spoke/pull/953