### PR TITLE
Temporarily force WebVR for Firefox Reality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3216,7 +3216,7 @@
       "integrity": "sha1-0ME1RB+oAUqBN5BFMQlvZ/KPJjo="
     },
     "aframe": {
-      "version": "github:mozillareality/aframe#74afe5ad5f2ca6a357ba3f5dfa65fae82f1c2cc2",
+      "version": "github:mozillareality/aframe#3fc6fdfe09cdc6eec381ca70068dbd35270e019e",
       "from": "github:mozillareality/aframe#hubs/master",
       "requires": {
         "custom-event-polyfill": "^1.0.6",
@@ -16399,7 +16399,7 @@
       "dev": true
     },
     "three": {
-      "version": "github:mozillareality/three.js#c0b3d3d9c08406dcbe38ed21618dc09350c0bbbc",
+      "version": "github:mozillareality/three.js#6dc1886802c936054ee5f48e8b39cc1be2e6e45f",
       "from": "github:mozillareality/three.js#hubs/master"
     },
     "three-ammo": {

--- a/src/hub.html
+++ b/src/hub.html
@@ -41,8 +41,7 @@
             physicallyCorrectLights: true;
             alpha: false;
             webgl2: true;
-            multiview: false;
-            forceWebVR: true;"
+            multiview: false;"
         shadow="type: pcfsoft"
         networked-scene="adapter: janus; audio: true; debug: true; connectOnLoad: false;"
         mute-mic="eventSrc: a-scene; toggleEvents: action_mute"

--- a/src/utils/webgl.js
+++ b/src/utils/webgl.js
@@ -1,7 +1,7 @@
 const THREE = AFRAME.THREE;
 
 function checkFloatTextureSupport() {
-  const renderer = new THREE.WebGLRenderer();
+  const renderer = new THREE.WebGLRenderer({ forceWebVR: true });
 
   const scene = new THREE.Scene();
   const size = 2;

--- a/src/webxr-bypass-hacks.js
+++ b/src/webxr-bypass-hacks.js
@@ -7,7 +7,12 @@ window.forceWebVR = true;
 HACK Fix a-frame's device detection in Chrome when WebXR or WebVR flags are enabled in
 chrome://flags. See https://github.com/mozilla/hubs/issues/892
 */
-if (!/mobile vr/i.test(navigator.userAgent) && navigator.xr && !navigator.xr.requestDevice) {
+if (
+  !/mobile vr/i.test(navigator.userAgent) &&
+  /Chrome/.test(navigator.userAgent) &&
+  navigator.xr &&
+  !navigator.xr.requestDevice
+) {
   navigator.xr.requestDevice = () => Promise.reject({ message: "Hubs: requestDevice not supported." });
 }
 /*

--- a/src/webxr-bypass-hacks.js
+++ b/src/webxr-bypass-hacks.js
@@ -1,8 +1,13 @@
 /*
+HACK: Our fork of aframe will read this global in src/utils/device.js to force the WebVR codepaths.
+*/
+window.forceWebVR = true;
+
+/*
 HACK Fix a-frame's device detection in Chrome when WebXR or WebVR flags are enabled in
 chrome://flags. See https://github.com/mozilla/hubs/issues/892
 */
-if (!/Oculus/.test(navigator.userAgent) && navigator.xr && !navigator.xr.requestDevice) {
+if (!/mobile vr/i.test(navigator.userAgent) && navigator.xr && !navigator.xr.requestDevice) {
   navigator.xr.requestDevice = () => Promise.reject({ message: "Hubs: requestDevice not supported." });
 }
 /*


### PR DESCRIPTION
The next version of Firefox Reality (on Quest and other standalone headsets) will have WebXR enabled by default. Since we don't fully support WebXR yet, we need to force WebVR.

Goes with:
https://github.com/MozillaReality/three.js/pull/48
https://github.com/MozillaReality/aframe/pull/26
