### PR TITLE
Fix GC pauses on Oculus Quest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16403,7 +16403,7 @@
       "from": "github:mozillareality/three.js#hubs/master"
     },
     "three-ammo": {
-      "version": "github:infinitelee/three-ammo#92e8faa025fefd9385a1174f8c5c538b5f65c7f2",
+      "version": "github:infinitelee/three-ammo#e00920e8a618b13df04eaf93f397296015f4671e",
       "from": "github:infinitelee/three-ammo#master"
     },
     "three-bmfont-text": {

--- a/src/systems/physics-system.js
+++ b/src/systems/physics-system.js
@@ -12,6 +12,8 @@ const WORLD_CONFIG = {
   gravity: { x: 0, y: -9.8, z: 0 }
 };
 
+const MAX_BODIES = 512;
+
 export class PhysicsSystem {
   constructor(scene) {
     this.ammoWorker = new AmmoWorker();
@@ -32,7 +34,7 @@ export class PhysicsSystem {
     this.nextBodyUuid = 0;
     this.nextShapeUuid = 0;
 
-    const arrayBuffer = new ArrayBuffer(4 * BUFFER_CONFIG.BODY_DATA_SIZE * BUFFER_CONFIG.MAX_BODIES);
+    const arrayBuffer = new ArrayBuffer(4 * BUFFER_CONFIG.BODY_DATA_SIZE * MAX_BODIES);
     this.objectMatricesFloatArray = new Float32Array(arrayBuffer);
     this.objectMatricesIntArray = new Int32Array(arrayBuffer);
 
@@ -41,6 +43,7 @@ export class PhysicsSystem {
         type: MESSAGE_TYPES.INIT,
         worldConfig: WORLD_CONFIG,
         arrayBuffer,
+        maxBodies: MAX_BODIES,
         wasmUrl: new URL(ammoWasmUrl, configs.BASE_ASSETS_PATH || window.location).href
       },
       [arrayBuffer]


### PR DESCRIPTION
Reduce the size of the arrayBuffer used for three-ammo to reduce GC pauses occurring due to postmessaging between the physics worker and the main thread.