### PR TITLE
Better Avatar Thumbnails

### DIFF
--- a/src/react-components/avatar-preview.js
+++ b/src/react-components/avatar-preview.js
@@ -77,7 +77,8 @@ class AvatarPreview extends Component {
 
     this.camera = new THREE.PerspectiveCamera(55, this.canvas.clientWidth / this.canvas.clientHeight, 0.1, 1000);
     this.controls = new THREE.OrbitControls(this.camera, this.canvas);
-    this.controls.enablePan = false;
+    this.controls.screenSpacePanning = true;
+    this.controls.enableKeys = true;
 
     const light = new THREE.DirectionalLight(0xf7f6ef, 1);
     light.position.set(0, 10, 10);
@@ -296,6 +297,8 @@ class AvatarPreview extends Component {
   snapshot = () => {
     return new Promise(resolve => {
       if (this.idleAnimationAction) this.idleAnimationAction.stop();
+      this.snapshotCamera.position.copy(this.camera.position);
+      this.snapshotCamera.rotation.copy(this.camera.rotation);
       this.snapshotRenderer.render(this.scene, this.snapshotCamera);
       this.snapshotCanvas.toBlob(blob => {
         if (this.idleAnimationAction) this.idleAnimationAction.play();


### PR DESCRIPTION
- Allows panning in the avatar preview with right click
- Uses the preview camera angle for taking the thumbnail on save, so the user can better frame their custom avatars
- Fixed a bug that caused meshes other than the first one that had textures to not render in the generated thumbnail (they were being thrown away after being uploaded to the GPU, and the thumbnail generator uses its own renderer, which then failed to upload the textures to the GPU)

![image](https://user-images.githubusercontent.com/130735/79815853-9afd8500-8336-11ea-958b-751a1bd06d61.png)
