### PR TITLE
instruct to run the package script 'login' rather than the npm command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ To run the client, run:
 git clone https://github.com/mozilla/hubs.git
 cd hubs
 npm ci
+npm run login
 npm start
 ```
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -112,7 +112,7 @@ function createDefaultAppConfig() {
 
 async function fetchAppConfigAndEnvironmentVars() {
   if (!fs.existsSync(".ret.credentials")) {
-    throw new Error("Not logged in to Hubs Cloud. Run `npm login` first.");
+    throw new Error("Not logged in to Hubs Cloud. Run `npm run login` first.");
   }
 
   const { host, token } = JSON.parse(fs.readFileSync(".ret.credentials"));


### PR DESCRIPTION
Adds the login command to the instructions and clarifies the command to run in the error message