### PR TITLE
Fix bounding box generation for scaled objects (many avatar previews)

### DIFF
--- a/src/utils/threejs-world-update.js
+++ b/src/utils/threejs-world-update.js
@@ -92,6 +92,19 @@ THREE.Object3D.prototype.applyMatrix = function() {
   handleMatrixModification(this);
 };
 
+// Updates this function to use updateMatrices(). In general our code should prefer calling updateMatrices() directly,
+// patching this for compatability upstream, namely with Box3.expandToObject and Object3D.attach
+THREE.Object3D.prototype.updateWorldMatrix = function(updateParents, updateChildren) {
+  this.updateMatrices(false, false, !updateParents);
+  if (updateChildren) {
+    const children = this.children;
+    for (let i = 0, l = children.length; i < l; i++) {
+      children[i].updateMatrixWorld(false, false);
+    }
+    if (this.childrenNeedMatrixWorldUpdate) this.childrenNeedMatrixWorldUpdate = false;
+  }
+};
+
 // By the end of this function this.matrix reflects the updated local matrix
 // and this.matrixWorld reflects the updated world matrix, taking into account
 // parent matrices.
@@ -123,6 +136,7 @@ THREE.Object3D.prototype.updateMatrices = function(forceLocalUpdate, forceWorldU
     this.matrixWorldNeedsUpdate = true;
     this.cachedMatrixWorld = this.matrixWorld;
   } else if (this.matrixNeedsUpdate || this.matrixAutoUpdate || forceLocalUpdate) {
+    // updateMatrix() sets matrixWorldNeedsUpdate = true
     this.updateMatrix();
     if (this.matrixNeedsUpdate) this.matrixNeedsUpdate = false;
   }

--- a/src/utils/threejs-world-update.js
+++ b/src/utils/threejs-world-update.js
@@ -93,7 +93,7 @@ THREE.Object3D.prototype.applyMatrix = function() {
 };
 
 // Updates this function to use updateMatrices(). In general our code should prefer calling updateMatrices() directly,
-// patching this for compatability upstream, namely with Box3.expandToObject and Object3D.attach
+// patching this for compatibility upstream, namely with Box3.expandToObject and Object3D.attach
 THREE.Object3D.prototype.updateWorldMatrix = function(updateParents, updateChildren) {
   this.updateMatrices(false, false, !updateParents);
   if (updateChildren) {


### PR DESCRIPTION
Patches `updateWorldMatrix()` (which is different from `updateMatrixWorld()`) to be aware of our matrix update flags. An update in three started using this function in `Box3.expandToObject` which caused some avatar previews to start rendering incorrectly. It likely manifested in other ways as well like broken frustum culling and incorrect physics shape generation for some objects.