### PR TITLE
Remove duplicate translation `tips.mobile.object_pin`

### DIFF
--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -329,7 +329,6 @@
     "tips.mobile.object_recenter_button-pre": "Tap ",
     "tips.mobile.object_recenter_button-post": " to have the object face you.",
     "tips.mobile.object_pin": "Pin an object to save it to the room.",
-    "tips.mobile.object_pin": "Pin an object to save it to the room.",
     "tips.mobile.video_share_failed": "No permission granted.",
     "tips.mobile.invite": "Use the Share button to share this room.",
     "tips.mobile.feedback": "🦆 Quack! Want to help Hubs?",


### PR DESCRIPTION
Was digging around in my editor and got a warning about this duplicate translation. Might get confusing for folks so here's a PR that removes it. :) 