### PR TITLE
Fix some HLS playback issues (and upgrade HLS-light.js to HLS.js latest)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11180,9 +11180,9 @@
       }
     },
     "hls.js": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-0.12.2.tgz",
-      "integrity": "sha512-lQBSXggw9OzEuaUllUBoSxPcf7neFgnEiDRfCdCNdIPtUeV7vXZ0OeASx6EWtZTBiqSSPigoOX1Y+AR5dA1Feg==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-0.13.2.tgz",
+      "integrity": "sha512-sIg2t4uGpWQLzuK1Iid9614WOKqxj4OYg+EbFbhhTDCsxpENBN+Du3yBFnoi+a83DuOOHdiQd1ydnti9loSGXw==",
       "requires": {
         "eventemitter3": "3.1.0",
         "url-toolkit": "^2.1.6"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "form-data": "^3.0.0",
     "form-urlencoded": "^2.0.4",
     "history": "^4.7.2",
-    "hls.js": "^0.12.2",
+    "hls.js": "^0.13.2",
     "js-cookie": "^2.2.0",
     "jsonschema": "^1.2.2",
     "jwt-decode": "^2.2.0",

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -396,6 +396,11 @@ AFRAME.registerComponent("media-loader", {
       // we don't think we can infer it from the extension, we need to make a HEAD request to find it out
       contentType = contentType || guessContentType(canonicalUrl) || (await fetchContentType(accessibleUrl));
 
+      // Some servers treat m3u8 playlists as "audio/x-mpegurl", we always want to treat them as HLS videos
+      if (contentType === "audio/x-mpegurl") {
+        contentType = "application/vnd.apple.mpegurl";
+      }
+
       // We don't want to emit media_resolved for index updates.
       if (forceLocalRefresh || srcChanged) {
         this.el.emit("media_resolved", { src, raw: accessibleUrl, contentType });

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -4,7 +4,7 @@ import GIFWorker from "../workers/gifparsing.worker.js";
 import errorImageSrc from "!!url-loader!../assets/images/media-error.gif";
 import audioIcon from "../assets/images/audio.png";
 import { paths } from "../systems/userinput/paths";
-import HLS from "hls.js/dist/hls.light.js";
+import HLS from "hls.js";
 import { addAndArrangeMedia, createImageTexture, createBasisTexture } from "../utils/media-utils";
 import { proxiedUrlFor } from "../utils/media-url-utils";
 import { buildAbsoluteURL } from "url-toolkit";

--- a/src/utils/media-url-utils.js
+++ b/src/utils/media-url-utils.js
@@ -16,7 +16,8 @@ const commonKnownContentTypes = {
   pdf: "application/pdf",
   mp4: "video/mp4",
   mp3: "audio/mpeg",
-  basis: "image/basis"
+  basis: "image/basis",
+  m3u8: "application/vnd.apple.mpegurl"
 };
 
 // thanks to https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding


### PR DESCRIPTION
Fixes a few issues that probably are causing lots of HLS videos to fail, several are linked in #2430.
- Switches to HLS.js, off of HLS-light.js, it seems worth using the full version as videos with independent audio tracks are not supported otherwise (which is likely the primary thing breaking those videos linked in the bug above). The only other thing it seems to add is subtitle support, which we don't need right now but doesn't seem worth trying to strip out.
- Some servers seem to return m3u8 files with the content type `audio/x-mpegurl`, not super surprising since these can also be used for mp3 playlists (I believe its actually the same file format repurposed). In any case we don't support audio playlists so for us, these should always be treated as HLS playlists.
- Upgrades to the latest HLS.js. No particular need for this, but was one of the first things I tried and it hasn't seemed to break anything, so it seems like it is worth keeping up to date.

fixes #2430