### PR TITLE
Properly switch ret server for hubs cloud

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -150,6 +150,7 @@ async function fetchAppConfigAndEnvironmentVars() {
   process.env.CORS_PROXY_SERVER = cors_proxy_server;
   process.env.THUMBNAIL_SERVER = thumbnail_server;
   process.env.NON_CORS_PROXY_DOMAINS = non_cors_proxy_domains + ",hubs.local";
+  process.env.RETICULUM_SERVER = host;
 
   return appConfig;
 }


### PR DESCRIPTION
It seems that npm run start was not talking to my hubs cloud server. Kind of surprised this was missed given the refactoring was focused on enabling this, so if there was a gap in testing this reveals we should chase down any other potential issues, or maybe I'm doing something wrong.