### PR TITLE
Fix WebXR support for Oculus Browser

### DIFF
--- a/src/components/audio-feedback.js
+++ b/src/components/audio-feedback.js
@@ -169,7 +169,7 @@ AFRAME.registerComponent("scale-audio-feedback", {
 
   async init() {
     await waitForDOMContentLoaded();
-    this.camera = document.getElementById("viewing-camera").object3D;
+    this.camera = document.getElementById("viewing-camera").object3DMap.camera;
   },
 
   tick() {

--- a/src/components/hud-controller.js
+++ b/src/components/hud-controller.js
@@ -31,7 +31,7 @@ AFRAME.registerComponent("hud-controller", {
 
   tick() {
     const hud = this.el.object3D;
-    const head = this.data.head.object3D;
+    const head = this.data.head.object3DMap.camera;
 
     const { offset, lookCutoff, animRange, yawCutoff } = this.data;
 

--- a/src/components/position-at-border.js
+++ b/src/components/position-at-border.js
@@ -76,7 +76,7 @@ AFRAME.registerComponent("position-at-border", {
 
   doInit() {
     this.didInit = true;
-    this.cam = document.getElementById("viewing-camera").object3D;
+    this.cam = document.getElementById("viewing-camera").object3DMap.camera;
     if (!this.data.target) {
       console.error("No target for position-at-border on element:", this.el);
       return;

--- a/src/components/scale-button.js
+++ b/src/components/scale-button.js
@@ -83,7 +83,7 @@ AFRAME.registerComponent("scale-button", {
         this.viewingCamera = document.getElementById("viewing-camera").object3DMap.camera;
       }
       this.plane = e.object3D === this.leftEventer ? planeForLeftCursor : planeForRightCursor;
-      setMatrixWorld(this.plane, calculatePlaneMatrix(this.viewingCamera.object3DMap.camera, this.el.object3D));
+      setMatrixWorld(this.plane, calculatePlaneMatrix(this.viewingCamera, this.el.object3D));
       this.planeRotation.extractRotation(this.plane.matrixWorld);
       this.planeUp.set(0, 1, 0).applyMatrix4(this.planeRotation);
       this.planeRight.set(1, 0, 0).applyMatrix4(this.planeRotation);
@@ -96,7 +96,7 @@ AFRAME.registerComponent("scale-button", {
       this.initialObjectScale.setFromMatrixScale(this.objectToScale.matrixWorld);
       this.initialDistanceToObject = objectToCam
         .subVectors(
-          camPosition.setFromMatrixPosition(this.viewingCamera.object3DMap.camera.matrixWorld),
+          camPosition.setFromMatrixPosition(this.viewingCamera.matrixWorld),
           objectPosition.setFromMatrixPosition(this.el.object3D.matrixWorld)
         )
         .length();

--- a/src/components/scale-button.js
+++ b/src/components/scale-button.js
@@ -80,10 +80,10 @@ AFRAME.registerComponent("scale-button", {
         this.leftRaycaster = this.leftCursorController.components["cursor-controller"].raycaster;
         this.rightCursorController = document.getElementById("right-cursor-controller");
         this.rightRaycaster = this.rightCursorController.components["cursor-controller"].raycaster;
-        this.viewingCamera = document.getElementById("viewing-camera").object3D;
+        this.viewingCamera = document.getElementById("viewing-camera").object3DMap.camera;
       }
       this.plane = e.object3D === this.leftEventer ? planeForLeftCursor : planeForRightCursor;
-      setMatrixWorld(this.plane, calculatePlaneMatrix(this.viewingCamera, this.el.object3D));
+      setMatrixWorld(this.plane, calculatePlaneMatrix(this.viewingCamera.object3DMap.camera, this.el.object3D));
       this.planeRotation.extractRotation(this.plane.matrixWorld);
       this.planeUp.set(0, 1, 0).applyMatrix4(this.planeRotation);
       this.planeRight.set(1, 0, 0).applyMatrix4(this.planeRotation);
@@ -96,7 +96,7 @@ AFRAME.registerComponent("scale-button", {
       this.initialObjectScale.setFromMatrixScale(this.objectToScale.matrixWorld);
       this.initialDistanceToObject = objectToCam
         .subVectors(
-          camPosition.setFromMatrixPosition(this.viewingCamera.matrixWorld),
+          camPosition.setFromMatrixPosition(this.viewingCamera.object3DMap.camera.matrixWorld),
           objectPosition.setFromMatrixPosition(this.el.object3D.matrixWorld)
         )
         .length();

--- a/src/components/skybox.js
+++ b/src/components/skybox.js
@@ -333,7 +333,7 @@ export default class Sky extends Object3D {
     const theta = Math.PI * (this._inclination - 0.5);
     const phi = 2 * Math.PI * (this._azimuth - 0.5);
 
-    const distance = this._distance;
+    const distance = Math.min(1000, this._distance);
 
     const x = distance * Math.cos(phi);
     const y = distance * Math.sin(phi) * Math.sin(theta);

--- a/src/components/visibility-while-frozen.js
+++ b/src/components/visibility-while-frozen.js
@@ -24,7 +24,7 @@ AFRAME.registerComponent("visibility-while-frozen", {
     this.objWorldPos = new THREE.Vector3();
 
     waitForDOMContentLoaded().then(() => {
-      this.cam = document.getElementById("viewing-camera").object3D;
+      this.cam = document.getElementById("viewing-camera").object3DMap.camera;
       this.updateVisibility();
     });
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -1062,7 +1062,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (isMobileVR) {
       remountUI({ availableVREntryTypes, forcedVREntryType: "vr", checkingForDeviceAvailability: false });
 
-      if (/Oculus/.test(navigator.userAgent)) {
+      if (/Oculus/.test(navigator.userAgent) && "getVRDisplays" in navigator) {
         // HACK - The polyfill reports Cardboard as the primary VR display on startup out ahead of
         // Oculus Go on Oculus Browser 5.5.0 beta. This display is cached by A-Frame,
         // so we need to resolve that and get the real VRDisplay before entering as well.

--- a/src/react-components/object-info-dialog.js
+++ b/src/react-components/object-info-dialog.js
@@ -79,8 +79,8 @@ export default class ObjectInfoDialog extends Component {
     const targetMatrix = new THREE.Matrix4();
     const translation = new THREE.Matrix4();
     return function enqueueWaypointTravel() {
-      this.viewingCamera.object3D.updateMatrices();
-      targetMatrix.copy(this.viewingCamera.object3D.matrixWorld);
+      this.viewingCamera.object3DMap.camera.updateMatrices();
+      targetMatrix.copy(this.viewingCamera.object3DMap.camera.matrixWorld);
       affixToWorldUp(targetMatrix, targetMatrix);
       translation.makeTranslation(0, -1.6, 0.15);
       targetMatrix.multiply(translation);

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -64,7 +64,7 @@ export default class SceneEntryManager {
 
       // HACK - A-Frame calls getVRDisplays at module load, we want to do it here to
       // force gamepads to become live.
-      navigator.getVRDisplays();
+      "getVRDisplays" in navigator && navigator.getVRDisplays();
 
       await exit2DInterstitialAndEnterVR(true);
     }
@@ -107,7 +107,7 @@ export default class SceneEntryManager {
 
     // Delay sending entry event telemetry until VR display is presenting.
     (async () => {
-      while (enterInVR && !(await navigator.getVRDisplays()).find(d => d.isPresenting)) {
+      while (enterInVR && !this.scene.renderer.vr.isPresenting()) {
         await nextTick();
       }
 

--- a/src/systems/camera-system.js
+++ b/src/systems/camera-system.js
@@ -314,6 +314,10 @@ export class CameraSystem {
     const translation = new THREE.Matrix4();
     let uiRoot;
     return function tick(scene, dt) {
+      this.viewingCamera.object3DMap.camera.matrixNeedsUpdate = true;
+      this.viewingCamera.object3DMap.camera.updateMatrix();
+      this.viewingCamera.object3DMap.camera.updateMatrixWorld();
+
       const entered = scene.is("entered");
       uiRoot = uiRoot || document.getElementById("ui-root");
       const isGhost = !entered && uiRoot && uiRoot.firstChild && uiRoot.firstChild.classList.contains("isGhost");
@@ -322,7 +326,6 @@ export class CameraSystem {
         const position = new THREE.Vector3();
         const quat = new THREE.Quaternion();
         const scale = new THREE.Vector3();
-        this.viewingCamera.object3DMap.camera.updateMatrices();
         this.viewingRig.object3D.updateMatrices();
         this.viewingRig.object3D.matrixWorld.decompose(position, quat, scale);
         position.setFromMatrixPosition(this.viewingCamera.object3DMap.camera.matrixWorld);

--- a/src/systems/camera-system.js
+++ b/src/systems/camera-system.js
@@ -211,11 +211,6 @@ export class CameraSystem {
     if (this.mode === CAMERA_MODE_SCENE_PREVIEW) return;
 
     this.mode = NEXT_MODES[this.mode] || 0;
-    if (this.mode === CAMERA_MODE_FIRST_PERSON) {
-      AFRAME.scenes[0].renderer.vr.setPoseTarget(this.avatarPOV.object3D);
-    } else if (this.mode === CAMERA_MODE_THIRD_PERSON_NEAR || this.mode === CAMERA_MODE_THIRD_PERSON_FAR) {
-      AFRAME.scenes[0].renderer.vr.setPoseTarget(this.viewingCamera.object3D);
-    }
   }
 
   inspect(o, distanceMod, temporarilyDisableRegularExit) {
@@ -245,12 +240,12 @@ export class CameraSystem {
       this.hideEverythingButThisObject(o);
     }
 
-    this.viewingCamera.object3D.updateMatrices();
+    this.viewingCamera.object3DMap.camera.updateMatrices();
     this.snapshot.matrixWorld.copy(this.viewingRig.object3D.matrixWorld);
 
     moveRigSoCameraLooksAtObject(
       this.viewingRig.object3D,
-      this.viewingCamera.object3D,
+      this.viewingCamera.object3DMap.camera,
       this.inspected,
       distanceMod || 1
     );
@@ -327,10 +322,10 @@ export class CameraSystem {
         const position = new THREE.Vector3();
         const quat = new THREE.Quaternion();
         const scale = new THREE.Vector3();
-        this.viewingCamera.object3D.updateMatrices();
+        this.viewingCamera.object3DMap.camera.updateMatrices();
         this.viewingRig.object3D.updateMatrices();
         this.viewingRig.object3D.matrixWorld.decompose(position, quat, scale);
-        position.setFromMatrixPosition(this.viewingCamera.object3D.matrixWorld);
+        position.setFromMatrixPosition(this.viewingCamera.object3DMap.camera.matrixWorld);
         position.y = position.y - 1.6;
         setMatrixWorld(
           this.avatarRig.object3D,
@@ -342,7 +337,7 @@ export class CameraSystem {
         );
         scene.systems["hubs-systems"].characterController.fly = true;
         this.avatarPOV.object3D.updateMatrices();
-        setMatrixWorld(this.avatarPOV.object3D, this.viewingCamera.object3D.matrixWorld);
+        setMatrixWorld(this.avatarPOV.object3D, this.viewingCamera.object3DMap.camera.matrixWorld);
       }
       if (!this.enteredScene && entered) {
         this.enteredScene = true;
@@ -393,11 +388,11 @@ export class CameraSystem {
         this.avatarRig.object3D.updateMatrices();
         setMatrixWorld(this.viewingRig.object3D, this.avatarRig.object3D.matrixWorld);
         if (scene.is("vr-mode")) {
-          this.viewingCamera.object3D.updateMatrices();
-          setMatrixWorld(this.avatarPOV.object3D, this.viewingCamera.object3D.matrixWorld);
+          this.viewingCamera.object3DMap.camera.updateMatrices();
+          setMatrixWorld(this.avatarPOV.object3D, this.viewingCamera.object3DMap.camera.matrixWorld);
         } else {
           this.avatarPOV.object3D.updateMatrices();
-          setMatrixWorld(this.viewingCamera.object3D, this.avatarPOV.object3D.matrixWorld);
+          setMatrixWorld(this.viewingCamera.object3DMap.camera, this.avatarPOV.object3D.matrixWorld);
         }
       } else if (this.mode === CAMERA_MODE_THIRD_PERSON_NEAR || this.mode === CAMERA_MODE_THIRD_PERSON_FAR) {
         if (this.mode === CAMERA_MODE_THIRD_PERSON_NEAR) {
@@ -408,7 +403,7 @@ export class CameraSystem {
         this.avatarRig.object3D.updateMatrices();
         this.viewingRig.object3D.matrixWorld.copy(this.avatarRig.object3D.matrixWorld).multiply(translation);
         setMatrixWorld(this.viewingRig.object3D, this.viewingRig.object3D.matrixWorld);
-        this.avatarPOV.object3D.quaternion.copy(this.viewingCamera.object3D.quaternion);
+        this.avatarPOV.object3D.quaternion.copy(this.viewingCamera.object3DMap.camera.quaternion);
         this.avatarPOV.object3D.matrixNeedsUpdate = true;
       } else if (this.mode === CAMERA_MODE_INSPECT) {
         this.avatarPOVRotator.on = false;
@@ -436,7 +431,7 @@ export class CameraSystem {
         }
         const panY = this.userinput.get(paths.actions.inspectPanY) || 0;
         if (this.userinput.get(paths.actions.resetInspectView)) {
-          moveRigSoCameraLooksAtObject(this.viewingRig.object3D, this.viewingCamera.object3D, this.inspected, 1);
+          moveRigSoCameraLooksAtObject(this.viewingRig.object3D, this.viewingCamera.object3DMap.camera, this.inspected, 1);
         }
 
         if (
@@ -448,7 +443,7 @@ export class CameraSystem {
           orbit(
             this.inspected,
             this.viewingRig.object3D,
-            this.viewingCamera.object3D,
+            this.viewingCamera.object3DMap.camera,
             this.horizontalDelta,
             this.verticalDelta,
             this.inspectZoom,
@@ -465,9 +460,9 @@ export class CameraSystem {
           (this.mode === CAMERA_MODE_FIRST_PERSON ||
             this.mode === CAMERA_MODE_THIRD_PERSON_NEAR ||
             this.mode === CAMERA_MODE_THIRD_PERSON_FAR) &&
-          scene.audioListener.parent !== this.viewingCamera.object3D
+          scene.audioListener.parent !== this.viewingCamera.object3DMap.camera
         ) {
-          this.viewingCamera.object3D.add(scene.audioListener);
+          this.viewingCamera.object3DMap.camera.add(scene.audioListener);
         }
       }
     };

--- a/src/systems/camera-system.js
+++ b/src/systems/camera-system.js
@@ -431,7 +431,12 @@ export class CameraSystem {
         }
         const panY = this.userinput.get(paths.actions.inspectPanY) || 0;
         if (this.userinput.get(paths.actions.resetInspectView)) {
-          moveRigSoCameraLooksAtObject(this.viewingRig.object3D, this.viewingCamera.object3DMap.camera, this.inspected, 1);
+          moveRigSoCameraLooksAtObject(
+            this.viewingRig.object3D,
+            this.viewingCamera.object3DMap.camera,
+            this.inspected,
+            1
+          );
         }
 
         if (

--- a/src/systems/menu-animation-system.js
+++ b/src/systems/menu-animation-system.js
@@ -7,7 +7,7 @@ export class MenuAnimationSystem {
     this.data = new Map();
     this.tick = this.tick.bind(this);
     waitForDOMContentLoaded().then(() => {
-      this.viewingCamera = document.getElementById("viewing-camera").object3D;
+      this.viewingCamera = document.getElementById("viewing-camera").object3DMap.camera;
     });
   }
   register(component, menuEl, chooseScale) {

--- a/src/systems/scale-in-screen-space.js
+++ b/src/systems/scale-in-screen-space.js
@@ -19,7 +19,7 @@ export class ScaleInScreenSpaceSystem {
         const component = this.components[i];
         // TODO: This calculates the distance to the viewing camera, the correct distance might be to the viewing plane.
         // This seemed accurate enough in my testing.
-        const distance = Math.sqrt(squareDistanceBetween(component.el.object3D, this.viewingCamera.object3D));
+        const distance = Math.sqrt(squareDistanceBetween(component.el.object3D, this.viewingCamera.object3DMap.camera));
         if (distance < MIN_DISTANCE) {
           component.el.object3D.scale.set(0.00001, 0.000001, 0.00001);
         } else {

--- a/src/systems/scene-preview-camera-system.js
+++ b/src/systems/scene-preview-camera-system.js
@@ -28,7 +28,7 @@ export class ScenePreviewCameraSystem {
         el.components["scene-preview-camera"].tick2();
         if (hubsSystems && viewingCamera) {
           el.object3D.updateMatrices();
-          setMatrixWorld(viewingCamera.object3D, el.object3D.matrixWorld);
+          setMatrixWorld(viewingCamera.object3DMap.camera, el.object3D.matrixWorld);
         }
       }
     }

--- a/src/systems/userinput/bindings/webxr-user.js
+++ b/src/systems/userinput/bindings/webxr-user.js
@@ -1,0 +1,180 @@
+import { paths } from "../paths";
+import { sets } from "../sets";
+import { xforms } from "./xforms";
+import { addSetsToBindings } from "./utils";
+
+function controllerTransformBindings() {
+  return [
+    {
+      src: { value: paths.device.webXR.left.matrix },
+      dest: { value: paths.actions.leftHand.matrix },
+      xform: xforms.copy
+    },
+    {
+      src: { value: paths.device.webXR.right.matrix },
+      dest: { value: paths.actions.rightHand.matrix },
+      xform: xforms.copy
+    },
+    {
+      src: { value: paths.device.webXR.left.pose },
+      dest: { value: paths.actions.leftHand.pose },
+      xform: xforms.copy
+    },
+    {
+      src: { value: paths.device.webXR.right.pose },
+      dest: { value: paths.actions.rightHand.pose },
+      xform: xforms.copy
+    },
+    {
+      src: { value: paths.device.webXR.left.pose },
+      dest: { value: paths.actions.cursor.left.pose },
+      xform: xforms.copy
+    },
+    {
+      src: { value: paths.device.webXR.right.pose },
+      dest: { value: paths.actions.cursor.right.pose },
+      xform: xforms.copy
+    }
+  ];
+}
+
+function characterAccelerationBindings() {
+  const lJoyXDeadzoned = paths.device.webXR.v("left/joy/x/deadzoned");
+  const lJoyYDeadzoned = paths.device.webXR.v("left/joy/y/deadzoned");
+  const lJoyXScaled = paths.device.webXR.v("left/joy/x/scaled");
+  const lJoyYScaled = paths.device.webXR.v("left/joy/y/scaled");
+  return [
+    {
+      src: { value: paths.device.webXR.left.joystick.axisX },
+      dest: { value: lJoyXDeadzoned },
+      xform: xforms.deadzone(0.1)
+    },
+    {
+      src: { value: lJoyXDeadzoned },
+      dest: { value: lJoyXScaled },
+      xform: xforms.scale(1.5) // horizontal character speed modifier
+    },
+    {
+      src: { value: paths.device.webXR.left.joystick.axisY },
+      dest: { value: lJoyYDeadzoned },
+      xform: xforms.deadzone(0.1)
+    },
+    {
+      src: { value: lJoyYDeadzoned },
+      dest: { value: lJoyYScaled },
+      xform: xforms.scale(-1.5) // vertical character speed modifier
+    },
+    {
+      src: { x: lJoyXScaled, y: lJoyYScaled },
+      dest: { value: paths.actions.characterAcceleration },
+      xform: xforms.compose_vec2
+    }
+  ];
+}
+
+function teleportationAndRotationBindings() {
+  const rightJoy = paths.device.webXR.v("right/joy");
+  const rightJoyWest = paths.device.webXR.v("right/joy/west");
+  const rightJoyEast = paths.device.webXR.v("right/joy/east");
+  return [
+    {
+      src: {
+        x: paths.device.webXR.right.joystick.axisX,
+        y: paths.device.webXR.right.joystick.axisY
+      },
+      dest: { value: rightJoy },
+      xform: xforms.compose_vec2
+    },
+    {
+      src: { value: rightJoy },
+      dest: { west: rightJoyWest, east: rightJoyEast },
+      xform: xforms.vec2dpad(0.2)
+    },
+    {
+      src: { value: rightJoyWest },
+      dest: { value: paths.actions.snapRotateLeft },
+      xform: xforms.rising
+    },
+    {
+      src: { value: rightJoyEast },
+      dest: { value: paths.actions.snapRotateRight },
+      xform: xforms.rising
+    },
+    {
+      src: { value: paths.device.webXR.right.trigger.pressed },
+      dest: { value: paths.actions.rightHand.startTeleport },
+      xform: xforms.rising
+    }
+  ];
+}
+
+function handPoseBindings(hand) {
+  const triggerPressed = paths.device.webXR[hand].trigger.pressed;
+  const gripPressed = paths.device.webXR[hand].grip.pressed;
+  const actions = paths.actions[hand + "Hand"];
+  return [
+    {
+      src: { value: triggerPressed },
+      dest: { value: actions.index },
+      xform: xforms.copy
+    },
+    {
+      src: { value: gripPressed },
+      dest: { value: actions.middleRingPinky },
+      xform: xforms.copy
+    }
+  ];
+}
+
+function cursorGrabBindings(hand) {
+  return [
+    {
+      src: { value: paths.device.webXR[hand].trigger.pressed },
+      dest: { value: paths.actions.cursor[hand].grab },
+      xform: xforms.rising
+    }
+  ];
+}
+
+function cursorDropBindings(hand) {
+  return [
+    {
+      src: { value: paths.device.webXR[hand].trigger.pressed },
+      dest: { value: paths.actions.cursor[hand].drop },
+      xform: xforms.falling
+    }
+  ];
+}
+
+export const webXRUserBindings = addSetsToBindings({
+  [sets.global]: [
+    ...controllerTransformBindings(),
+    ...characterAccelerationBindings(),
+    ...teleportationAndRotationBindings(),
+    ...handPoseBindings("left"),
+    ...handPoseBindings("right")
+  ],
+
+  [sets.rightHandTeleporting]: [
+    {
+      src: { value: paths.device.webXR.right.trigger.pressed },
+      dest: { value: paths.actions.rightHand.stopTeleport },
+      xform: xforms.falling
+    }
+  ],
+
+  [sets.leftCursorHoveringOnUI]: [...cursorGrabBindings("left")],
+  [sets.rightCursorHoveringOnUI]: [...cursorGrabBindings("right")],
+  [sets.leftCursorHoldingUI]: [...cursorDropBindings("left")],
+  [sets.rightCursorHoldingUI]: [...cursorDropBindings("right")],
+
+  [sets.leftCursorHoveringOnInteractable]: [...cursorGrabBindings("left")],
+  [sets.rightCursorHoveringOnInteractable]: [...cursorGrabBindings("right")],
+  [sets.leftCursorHoldingInteractable]: [...cursorDropBindings("left")],
+  [sets.rightCursorHoldingInteractable]: [...cursorDropBindings("right")],
+
+  //[sets.leftHandHoveringOnInteractable]: [...handGrabBindings("left")],
+  //[sets.rightHandHoveringOnInteractable]: [...handGrabBindings("right")],
+  //[sets.leftHandHoldingInteractable]: [...handDropBindings("left")],
+  //[sets.rightHandHoldingInteractable]: [...handDropBindings("right")]
+});

--- a/src/systems/userinput/bindings/webxr-user.js
+++ b/src/systems/userinput/bindings/webxr-user.js
@@ -3,178 +3,763 @@ import { sets } from "../sets";
 import { xforms } from "./xforms";
 import { addSetsToBindings } from "./utils";
 
-function controllerTransformBindings() {
-  return [
+const name = "/webxr/var/";
+
+const leftButton = paths.device.webxr.left.button;
+const leftAxis = paths.device.webxr.left.axis;
+const leftPose = paths.device.webxr.left.pose;
+const rightButton = paths.device.webxr.right.button;
+const rightAxis = paths.device.webxr.right.axis;
+const rightPose = paths.device.webxr.right.pose;
+
+const wakeLeft = `${name}left/wake`;
+const wakeRight = `${name}right/wake`;
+const leftJoyXDeadzoned = `${name}left/joy/x/deadzoned`;
+const leftJoyYDeadzoned = `${name}left/joy/y/deadzoned`;
+const scaledLeftJoyX = `${name}left/scaledJoyX`;
+const scaledLeftJoyY = `${name}left/scaledJoyY`;
+const cursorDrop2 = `${name}right/cursorDrop2`;
+const cursorDrop1 = `${name}right/cursorDrop1`;
+const leftCursorDrop2 = `${name}left/cursorDrop2`;
+const leftCursorDrop1 = `${name}left/cursorDrop1`;
+const rightHandDrop2 = `${name}right/rightHandDrop2`;
+const rightGripRisingGrab = `${name}right/grip/RisingGrab`;
+const rightTriggerRisingGrab = `${name}right/trigger/RisingGrab`;
+const leftGripRisingGrab = `${name}left/grip/RisingGrab`;
+const leftTriggerRisingGrab = `${name}left/trigger/RisingGrab`;
+const rightDpadNorth = `${name}rightDpad/north`;
+const rightDpadSouth = `${name}rightDpad/south`;
+const rightDpadEast = `${name}rightDpad/east`;
+const rightDpadWest = `${name}rightDpad/west`;
+const rightDpadCenter = `${name}rightDpad/center`;
+const rightJoy = `${name}right/joy`;
+const rightJoyY1 = `${name}right/joyY1`;
+const rightJoyY2 = `${name}right/joyY2`;
+const rightJoyYDeadzoned = `${name}right/joy/y/deadzoned`;
+const leftDpadNorth = `${name}leftDpad/north`;
+const leftDpadSouth = `${name}leftDpad/south`;
+const leftDpadEast = `${name}leftDpad/east`;
+const leftDpadWest = `${name}leftDpad/west`;
+const leftDpadCenter = `${name}leftDpad/center`;
+const leftJoy = `${name}left/joy`;
+const characterAcceleration = "/var/webxr/nonNormalizedCharacterAcceleration";
+const rightBoost = "/var/right-webxr/boost";
+const leftBoost = "/var/left-webxr/boost";
+
+const lowerButtons = `${name}buttons/lower`;
+const upperButtons = `${name}buttons/upper`;
+
+const v = s => {
+  return "/webxr-user-vars/" + s;
+};
+const leftGripPressed1 = v("leftGripPressed1");
+const leftGripPressed2 = v("leftGripPressed2");
+const rightGripPressed1 = v("rightGripPressed1");
+const rightGripPressed2 = v("rightGripPressed2");
+const leftTriggerPressed1 = v("leftTriggerPressed1");
+const leftTriggerPressed2 = v("leftTriggerPressed2");
+const rightTriggerPressed1 = v("rightTriggerPressed1");
+const rightTriggerPressed2 = v("rightTriggerPressed2");
+
+export const webXRUserBindings = addSetsToBindings({
+  [sets.global]: [
     {
-      src: { value: paths.device.webXR.left.matrix },
+      src: { value: paths.device.webxr.left.matrix },
       dest: { value: paths.actions.leftHand.matrix },
       xform: xforms.copy
     },
     {
-      src: { value: paths.device.webXR.right.matrix },
+      src: { value: paths.device.webxr.right.matrix },
       dest: { value: paths.actions.rightHand.matrix },
       xform: xforms.copy
     },
     {
-      src: { value: paths.device.webXR.left.pose },
-      dest: { value: paths.actions.leftHand.pose },
+      src: { value: leftButton.grip.pressed },
+      dest: { value: leftGripPressed1 },
       xform: xforms.copy
     },
     {
-      src: { value: paths.device.webXR.right.pose },
-      dest: { value: paths.actions.rightHand.pose },
+      src: { value: leftButton.grip.pressed },
+      dest: { value: leftGripPressed2 },
       xform: xforms.copy
     },
     {
-      src: { value: paths.device.webXR.left.pose },
-      dest: { value: paths.actions.cursor.left.pose },
+      src: { value: leftGripPressed1 },
+      dest: { value: paths.actions.leftHand.middleRingPinky },
       xform: xforms.copy
     },
     {
-      src: { value: paths.device.webXR.right.pose },
-      dest: { value: paths.actions.cursor.right.pose },
+      src: [leftButton.a.touched, leftButton.b.touched, leftButton.thumbStick.touched],
+      dest: { value: paths.actions.leftHand.thumb },
+      xform: xforms.any
+    },
+    {
+      src: { value: leftButton.trigger.pressed },
+      dest: { value: leftTriggerPressed1 },
       xform: xforms.copy
-    }
-  ];
-}
-
-function characterAccelerationBindings() {
-  const lJoyXDeadzoned = paths.device.webXR.v("left/joy/x/deadzoned");
-  const lJoyYDeadzoned = paths.device.webXR.v("left/joy/y/deadzoned");
-  const lJoyXScaled = paths.device.webXR.v("left/joy/x/scaled");
-  const lJoyYScaled = paths.device.webXR.v("left/joy/y/scaled");
-  return [
-    {
-      src: { value: paths.device.webXR.left.joystick.axisX },
-      dest: { value: lJoyXDeadzoned },
-      xform: xforms.deadzone(0.1)
     },
     {
-      src: { value: lJoyXDeadzoned },
-      dest: { value: lJoyXScaled },
-      xform: xforms.scale(1.5) // horizontal character speed modifier
+      src: { value: leftButton.trigger.pressed },
+      dest: { value: leftTriggerPressed2 },
+      xform: xforms.copy
     },
     {
-      src: { value: paths.device.webXR.left.joystick.axisY },
-      dest: { value: lJoyYDeadzoned },
-      xform: xforms.deadzone(0.1)
+      src: { value: leftTriggerPressed1 },
+      dest: { value: paths.actions.leftHand.index },
+      xform: xforms.copy
     },
     {
-      src: { value: lJoyYDeadzoned },
-      dest: { value: lJoyYScaled },
-      xform: xforms.scale(-1.5) // vertical character speed modifier
+      src: { value: rightButton.grip.pressed },
+      dest: { value: rightGripPressed1 },
+      xform: xforms.copy
     },
     {
-      src: { x: lJoyXScaled, y: lJoyYScaled },
-      dest: { value: paths.actions.characterAcceleration },
-      xform: xforms.compose_vec2
-    }
-  ];
-}
-
-function teleportationAndRotationBindings() {
-  const rightJoy = paths.device.webXR.v("right/joy");
-  const rightJoyWest = paths.device.webXR.v("right/joy/west");
-  const rightJoyEast = paths.device.webXR.v("right/joy/east");
-  return [
+      src: { value: rightButton.grip.pressed },
+      dest: { value: rightGripPressed2 },
+      xform: xforms.copy
+    },
+    {
+      src: { value: rightGripPressed1 },
+      dest: { value: paths.actions.rightHand.middleRingPinky },
+      xform: xforms.copy
+    },
+    {
+      src: [rightButton.a.touched, rightButton.b.touched, rightButton.thumbStick.touched],
+      dest: { value: paths.actions.rightHand.thumb },
+      xform: xforms.any
+    },
+    {
+      src: { value: rightButton.trigger.pressed },
+      dest: { value: rightTriggerPressed1 },
+      xform: xforms.copy
+    },
+    {
+      src: { value: rightButton.trigger.pressed },
+      dest: { value: rightTriggerPressed2 },
+      xform: xforms.copy
+    },
+    {
+      src: { value: rightTriggerPressed1 },
+      dest: { value: paths.actions.rightHand.index },
+      xform: xforms.copy
+    },
     {
       src: {
-        x: paths.device.webXR.right.joystick.axisX,
-        y: paths.device.webXR.right.joystick.axisY
+        x: leftAxis.joyX,
+        y: leftAxis.joyY
+      },
+      dest: { value: leftJoy },
+      xform: xforms.compose_vec2
+    },
+    {
+      src: { value: leftJoy },
+      dest: {
+        north: leftDpadNorth,
+        south: leftDpadSouth,
+        east: leftDpadEast,
+        west: leftDpadWest,
+        center: leftDpadCenter
+      },
+      xform: xforms.vec2dpad(0.2, false, true)
+    },
+    {
+      src: { value: rightAxis.joyY },
+      dest: { value: rightJoyY1 },
+      xform: xforms.copy
+    },
+    {
+      src: { value: rightAxis.joyY },
+      dest: { value: rightJoyY2 },
+      xform: xforms.copy
+    },
+    {
+      src: {
+        x: rightAxis.joyX,
+        y: rightJoyY1
       },
       dest: { value: rightJoy },
       xform: xforms.compose_vec2
     },
     {
       src: { value: rightJoy },
-      dest: { west: rightJoyWest, east: rightJoyEast },
-      xform: xforms.vec2dpad(0.2)
+      dest: {
+        north: rightDpadNorth,
+        south: rightDpadSouth,
+        east: rightDpadEast,
+        west: rightDpadWest,
+        center: rightDpadCenter
+      },
+      xform: xforms.vec2dpad(0.2, false, true)
     },
     {
-      src: { value: rightJoyWest },
-      dest: { value: paths.actions.snapRotateLeft },
-      xform: xforms.rising
-    },
-    {
-      src: { value: rightJoyEast },
+      src: { value: rightDpadEast },
       dest: { value: paths.actions.snapRotateRight },
-      xform: xforms.rising
+      xform: xforms.rising,
+      priority: 1
     },
     {
-      src: { value: paths.device.webXR.right.trigger.pressed },
-      dest: { value: paths.actions.rightHand.startTeleport },
-      xform: xforms.rising
-    }
-  ];
-}
-
-function handPoseBindings(hand) {
-  const triggerPressed = paths.device.webXR[hand].trigger.pressed;
-  const gripPressed = paths.device.webXR[hand].grip.pressed;
-  const actions = paths.actions[hand + "Hand"];
-  return [
+      src: [leftButton.a.pressed, rightButton.a.pressed],
+      dest: { value: lowerButtons },
+      xform: xforms.any
+    },
     {
-      src: { value: triggerPressed },
-      dest: { value: actions.index },
+      src: [leftButton.b.pressed, rightButton.b.pressed],
+      dest: { value: upperButtons },
+      xform: xforms.any
+    },
+    {
+      src: { value: lowerButtons },
+      dest: { value: paths.actions.ensureFrozen },
       xform: xforms.copy
     },
     {
-      src: { value: gripPressed },
-      dest: { value: actions.middleRingPinky },
-      xform: xforms.copy
-    }
-  ];
-}
-
-function cursorGrabBindings(hand) {
-  return [
-    {
-      src: { value: paths.device.webXR[hand].trigger.pressed },
-      dest: { value: paths.actions.cursor[hand].grab },
-      xform: xforms.rising
-    }
-  ];
-}
-
-function cursorDropBindings(hand) {
-  return [
-    {
-      src: { value: paths.device.webXR[hand].trigger.pressed },
-      dest: { value: paths.actions.cursor[hand].drop },
+      src: { value: lowerButtons },
+      dest: { value: paths.actions.thaw },
       xform: xforms.falling
-    }
-  ];
-}
-
-export const webXRUserBindings = addSetsToBindings({
-  [sets.global]: [
-    ...controllerTransformBindings(),
-    ...characterAccelerationBindings(),
-    ...teleportationAndRotationBindings(),
-    ...handPoseBindings("left"),
-    ...handPoseBindings("right")
-  ],
-
-  [sets.rightHandTeleporting]: [
+    },
     {
-      src: { value: paths.device.webXR.right.trigger.pressed },
+      src: { value: rightDpadWest },
+      dest: { value: paths.actions.snapRotateLeft },
+      xform: xforms.rising,
+      priority: 1
+    },
+    {
+      src: { value: leftAxis.joyY },
+      dest: { value: leftJoyYDeadzoned },
+      xform: xforms.deadzone(0.1)
+    },
+    {
+      src: { value: leftJoyYDeadzoned },
+      dest: { value: scaledLeftJoyY },
+      xform: xforms.scale(-1.5) // horizontal character speed modifier
+    },
+    {
+      src: { value: leftAxis.joyX },
+      dest: { value: leftJoyXDeadzoned },
+      xform: xforms.deadzone(0.1)
+    },
+    {
+      src: { value: leftJoyXDeadzoned },
+      dest: { value: scaledLeftJoyX },
+      xform: xforms.scale(1.5) // horizontal character speed modifier
+    },
+    {
+      src: {
+        x: scaledLeftJoyX,
+        y: scaledLeftJoyY
+      },
+      dest: { value: characterAcceleration },
+      xform: xforms.compose_vec2
+    },
+    {
+      src: { value: characterAcceleration },
+      dest: { value: paths.actions.characterAcceleration },
+      xform: xforms.copy
+    },
+    {
+      src: { value: leftButton.b.pressed },
+      dest: { value: leftBoost },
+      xform: xforms.copy
+    },
+    {
+      src: { value: rightButton.b.pressed },
+      dest: { value: rightBoost },
+      xform: xforms.copy
+    },
+    {
+      src: { value: leftButton.thumbStick.pressed },
+      dest: { value: paths.actions.nextCameraMode },
+      xform: xforms.rising
+    },
+    {
+      src: { value: rightButton.thumbStick.pressed },
+      dest: { value: paths.actions.toggleFly },
+      xform: xforms.rising
+    },
+    {
+      src: [leftBoost, rightBoost],
+      dest: { value: paths.actions.boost },
+      xform: xforms.any
+    },
+    {
+      src: { value: leftPose },
+      dest: { value: paths.actions.cursor.left.pose },
+      xform: xforms.copy
+    },
+    {
+      src: { value: rightPose },
+      dest: { value: paths.actions.cursor.right.pose },
+      xform: xforms.copy
+    },
+    {
+      src: { value: rightPose },
+      dest: { value: paths.actions.rightHand.pose },
+      xform: xforms.copy
+    },
+    {
+      src: { value: leftPose },
+      dest: { value: paths.actions.leftHand.pose },
+      xform: xforms.copy
+    },
+    {
+      src: { value: rightTriggerPressed2 },
       dest: { value: paths.actions.rightHand.stopTeleport },
+      xform: xforms.falling,
+      priority: 1
+    },
+    {
+      src: { value: leftTriggerPressed2 },
+      dest: { value: paths.actions.leftHand.stopTeleport },
+      xform: xforms.falling,
+      priority: 1
+    },
+    {
+      src: [leftButton.b.pressed, leftButton.a.pressed, leftButton.trigger.pressed, leftButton.grip.pressed],
+      dest: { value: wakeLeft },
+      xform: xforms.any
+    },
+    {
+      src: { value: wakeLeft },
+      dest: { value: paths.actions.cursor.left.wake },
+      xform: xforms.rising
+    },
+    {
+      src: [rightButton.b.pressed, rightButton.a.pressed, rightButton.trigger.pressed, rightButton.grip.pressed],
+      dest: { value: wakeRight },
+      xform: xforms.any
+    },
+    {
+      src: { value: wakeRight },
+      dest: { value: paths.actions.cursor.right.wake },
+      xform: xforms.rising
+    }
+  ],
+
+  [sets.leftHandHoveringOnNothing]: [
+    {
+      src: { value: leftTriggerPressed2 },
+      dest: { value: paths.actions.leftHand.startTeleport },
+      xform: xforms.rising,
+      priority: 1
+    }
+  ],
+
+  [sets.rightCursorHoveringOnUI]: [
+    {
+      src: { value: rightTriggerPressed2 },
+      dest: { value: paths.actions.cursor.right.grab },
+      xform: xforms.rising,
+      priority: 2
+    }
+  ],
+
+  [sets.leftCursorHoveringOnUI]: [
+    {
+      src: { value: leftTriggerPressed2 },
+      dest: { value: paths.actions.cursor.left.grab },
+      xform: xforms.rising,
+      priority: 2
+    }
+  ],
+
+  [sets.rightCursorHoveringOnVideo]: [
+    {
+      src: { value: rightAxis.joyY },
+      dest: { value: paths.actions.cursor.right.mediaVolumeMod },
+      xform: xforms.scale(-0.01)
+    }
+  ],
+
+  [sets.leftCursorHoveringOnVideo]: [
+    {
+      src: { value: leftAxis.joyY },
+      dest: { value: paths.actions.cursor.left.mediaVolumeMod },
+      xform: xforms.scale(-0.01)
+    }
+  ],
+
+  [sets.rightCursorHoveringOnNothing]: [
+    {
+      src: { value: rightTriggerPressed2 },
+      dest: { value: paths.actions.rightHand.startTeleport },
+      xform: xforms.rising,
+      priority: 1
+    }
+  ],
+
+  [sets.leftCursorHoveringOnNothing]: [
+    {
+      src: { value: leftTriggerPressed2 },
+      dest: { value: paths.actions.leftHand.startTeleport },
+      xform: xforms.rising,
+      priority: 1
+    }
+  ],
+
+  [sets.leftHandHoveringOnInteractable]: [
+    {
+      src: { value: leftGripPressed2 },
+      dest: { value: leftGripRisingGrab },
+      xform: xforms.rising,
+      priority: 2
+    },
+    {
+      src: [leftGripRisingGrab],
+      dest: { value: paths.actions.leftHand.grab },
+      xform: xforms.any,
+      priority: 2
+    },
+    {
+      src: { value: leftTriggerPressed2 },
+      dest: { value: paths.actions.leftHand.stopTeleport },
+      xform: xforms.falling,
+      priority: 2
+    }
+  ],
+
+  [sets.inspecting]: [
+    {
+      src: { value: upperButtons },
+      dest: { value: paths.actions.stopInspecting },
       xform: xforms.falling
     }
   ],
 
-  [sets.leftCursorHoveringOnUI]: [...cursorGrabBindings("left")],
-  [sets.rightCursorHoveringOnUI]: [...cursorGrabBindings("right")],
-  [sets.leftCursorHoldingUI]: [...cursorDropBindings("left")],
-  [sets.rightCursorHoldingUI]: [...cursorDropBindings("right")],
+  [sets.leftHandHoldingInteractable]: [
+    {
+      src: { value: leftGripPressed2 },
+      dest: { value: paths.actions.leftHand.drop },
+      xform: xforms.falling
+    }
+  ],
 
-  [sets.leftCursorHoveringOnInteractable]: [...cursorGrabBindings("left")],
-  [sets.rightCursorHoveringOnInteractable]: [...cursorGrabBindings("right")],
-  [sets.leftCursorHoldingInteractable]: [...cursorDropBindings("left")],
-  [sets.rightCursorHoldingInteractable]: [...cursorDropBindings("right")],
+  [sets.leftHandHoveringOnPen]: [],
+  [sets.leftHandHoldingPen]: [
+    {
+      src: { value: leftTriggerPressed2 },
+      dest: { value: paths.actions.leftHand.startDrawing },
+      xform: xforms.rising,
+      priority: 3
+    },
+    {
+      src: { value: leftTriggerPressed2 },
+      dest: { value: paths.actions.leftHand.stopDrawing },
+      xform: xforms.falling,
+      priority: 3
+    },
+    {
+      src: { value: leftDpadEast },
+      dest: { value: paths.actions.leftHand.penNextColor },
+      xform: xforms.rising,
+      priority: 2
+    },
+    {
+      src: { value: leftDpadWest },
+      dest: { value: paths.actions.leftHand.penPrevColor },
+      xform: xforms.rising,
+      priority: 2
+    },
+    {
+      src: { value: leftJoyYDeadzoned },
+      dest: { value: paths.actions.leftHand.scalePenTip },
+      xform: xforms.scaleExp(-0.005, 5),
+      priority: 1
+    },
+    {
+      src: { value: leftButton.b.pressed },
+      dest: { value: paths.actions.leftHand.switchDrawMode },
+      xform: xforms.rising,
+      priority: 1
+    },
+    {
+      src: { value: leftButton.a.pressed },
+      dest: { value: paths.actions.leftHand.undoDrawing },
+      xform: xforms.rising,
+      priority: 1
+    }
+  ],
 
-  //[sets.leftHandHoveringOnInteractable]: [...handGrabBindings("left")],
-  //[sets.rightHandHoveringOnInteractable]: [...handGrabBindings("right")],
-  //[sets.leftHandHoldingInteractable]: [...handDropBindings("left")],
-  //[sets.rightHandHoldingInteractable]: [...handDropBindings("right")]
+  [sets.rightCursorHoveringOnInteractable]: [
+    {
+      src: { value: rightGripPressed2 },
+      dest: { value: rightGripRisingGrab },
+      xform: xforms.rising,
+      priority: 2
+    },
+    {
+      src: { value: rightTriggerPressed2 },
+      dest: { value: rightTriggerRisingGrab },
+      xform: xforms.rising,
+      priority: 2
+    },
+    {
+      src: [rightGripRisingGrab],
+      dest: { value: paths.actions.cursor.right.grab },
+      xform: xforms.any,
+      priority: 2
+    },
+    {
+      src: { value: upperButtons },
+      dest: { value: paths.actions.startInspecting },
+      xform: xforms.rising
+    }
+  ],
+
+  [sets.leftCursorHoveringOnInteractable]: [
+    {
+      src: { value: leftGripPressed2 },
+      dest: { value: leftGripRisingGrab },
+      xform: xforms.rising,
+      priority: 2
+    },
+    {
+      src: { value: leftTriggerPressed2 },
+      dest: { value: leftTriggerRisingGrab },
+      xform: xforms.rising,
+      priority: 2
+    },
+    {
+      src: [leftGripRisingGrab],
+      dest: { value: paths.actions.cursor.left.grab },
+      xform: xforms.any,
+      priority: 2
+    },
+    {
+      src: { value: upperButtons },
+      dest: { value: paths.actions.startInspecting },
+      xform: xforms.rising
+    }
+  ],
+
+  [sets.rightCursorHoldingUI]: [
+    {
+      src: { value: rightTriggerPressed2 },
+      dest: { value: cursorDrop2 },
+      xform: xforms.falling,
+      priority: 5
+    }
+  ],
+  [sets.leftCursorHoldingUI]: [
+    {
+      src: { value: leftTriggerPressed2 },
+      dest: { value: leftCursorDrop2 },
+      xform: xforms.falling,
+      priority: 5
+    }
+  ],
+
+  [sets.rightCursorHoldingInteractable]: [
+    {
+      src: { value: rightAxis.joyY },
+      dest: { value: paths.actions.cursor.right.modDelta },
+      xform: xforms.scale(0.1)
+    },
+    {
+      src: { value: rightGripPressed2 },
+      dest: { value: cursorDrop1 },
+      xform: xforms.falling,
+      priority: 3
+    },
+    {
+      src: [cursorDrop1, cursorDrop2],
+      dest: { value: paths.actions.cursor.right.drop },
+      xform: xforms.any,
+      priority: 2
+    }
+  ],
+
+  [sets.leftCursorHoldingInteractable]: [
+    {
+      src: { value: leftAxis.joyY },
+      dest: { value: paths.actions.cursor.left.modDelta },
+      xform: xforms.scale(0.1)
+    },
+    {
+      src: { value: leftGripPressed2 },
+      dest: { value: leftCursorDrop1 },
+      xform: xforms.falling,
+      priority: 3
+    },
+    {
+      src: [leftCursorDrop1, leftCursorDrop2],
+      dest: { value: paths.actions.cursor.left.drop },
+      xform: xforms.any,
+      priority: 2
+    }
+  ],
+
+  [sets.rightCursorHoveringOnPen]: [],
+
+  [sets.rightCursorHoldingPen]: [
+    {
+      src: { value: rightTriggerPressed2 },
+      dest: { value: paths.actions.cursor.right.startDrawing },
+      xform: xforms.rising,
+      priority: 3
+    },
+    {
+      src: { value: rightTriggerPressed2 },
+      dest: { value: paths.actions.cursor.right.stopDrawing },
+      xform: xforms.falling,
+      priority: 3
+    },
+    {
+      src: { value: rightButton.b.pressed },
+      dest: { value: paths.actions.cursor.right.undoDrawing },
+      xform: xforms.rising,
+      priority: 1
+    }
+  ],
+  [sets.leftCursorHoldingPen]: [
+    {
+      src: { value: leftTriggerPressed2 },
+      dest: { value: paths.actions.cursor.left.startDrawing },
+      xform: xforms.rising,
+      priority: 3
+    },
+    {
+      src: { value: leftTriggerPressed2 },
+      dest: { value: paths.actions.cursor.left.stopDrawing },
+      xform: xforms.falling,
+      priority: 3
+    },
+    {
+      src: { value: leftButton.b.pressed },
+      dest: { value: paths.actions.cursor.left.undoDrawing },
+      xform: xforms.rising,
+      priority: 1
+    }
+  ],
+
+  [sets.rightHandHoveringOnInteractable]: [
+    {
+      src: { value: rightGripPressed2 },
+      dest: { value: rightGripRisingGrab },
+      xform: xforms.rising,
+      priority: 2
+    },
+    {
+      src: [rightGripRisingGrab],
+      dest: { value: paths.actions.rightHand.grab },
+      xform: xforms.any,
+      priority: 2
+    },
+    {
+      src: { value: rightTriggerPressed2 },
+      dest: { value: paths.actions.rightHand.stopTeleport },
+      xform: xforms.falling,
+      priority: 2
+    }
+  ],
+
+  [sets.rightHandHoldingInteractable]: [
+    {
+      src: { value: rightGripPressed2 },
+      dest: { value: rightHandDrop2 },
+      xform: xforms.falling,
+      priority: 3
+    },
+    {
+      src: [rightHandDrop2],
+      dest: { value: paths.actions.rightHand.drop },
+      xform: xforms.any,
+      priority: 2
+    }
+  ],
+  [sets.rightHandHoveringOnPen]: [],
+  [sets.rightHandHoldingPen]: [
+    {
+      src: { value: rightTriggerPressed2 },
+      dest: { value: paths.actions.rightHand.startDrawing },
+      xform: xforms.rising,
+      priority: 3
+    },
+    {
+      src: { value: rightTriggerPressed2 },
+      dest: { value: paths.actions.rightHand.stopDrawing },
+      xform: xforms.falling,
+      priority: 3
+    },
+    {
+      src: { value: rightDpadEast },
+      dest: { value: paths.actions.rightHand.penNextColor },
+      xform: xforms.rising,
+      priority: 2
+    },
+    {
+      src: { value: rightDpadWest },
+      dest: { value: paths.actions.rightHand.penPrevColor },
+      xform: xforms.rising,
+      priority: 2
+    },
+    {
+      src: { value: rightAxis.joyY },
+      dest: { value: rightJoyYDeadzoned },
+      xform: xforms.deadzone(0.1)
+    },
+    {
+      src: { value: rightJoyYDeadzoned },
+      dest: { value: paths.actions.rightHand.scalePenTip },
+      xform: xforms.scaleExp(-0.005, 5),
+      priority: 2
+    },
+    {
+      src: { value: rightGripPressed2 },
+      dest: { value: paths.actions.rightHand.drop },
+      xform: xforms.falling,
+      priority: 3
+    },
+    {
+      src: { value: rightButton.b.pressed },
+      dest: { value: paths.actions.rightHand.switchDrawMode },
+      xform: xforms.rising,
+      priority: 1
+    },
+    {
+      src: { value: rightButton.a.pressed },
+      dest: { value: paths.actions.rightHand.undoDrawing },
+      xform: xforms.rising,
+      priority: 1
+    }
+  ],
+
+  [sets.rightCursorHoveringOnCamera]: [],
+  [sets.rightHandHoveringOnCamera]: [],
+  [sets.leftHandHoveringOnCamera]: [],
+
+  [sets.rightHandHoldingCamera]: [
+    {
+      src: { value: rightTriggerPressed2 },
+      dest: { value: paths.actions.rightHand.takeSnapshot },
+      xform: xforms.copy,
+      priority: 4
+    }
+  ],
+  [sets.leftHandHoldingCamera]: [
+    {
+      src: { value: leftTriggerPressed2 },
+      dest: { value: paths.actions.leftHand.takeSnapshot },
+      xform: xforms.copy,
+      priority: 4
+    }
+  ],
+  [sets.rightCursorHoldingCamera]: [
+    {
+      src: { value: rightTriggerPressed2 },
+      dest: { value: paths.actions.cursor.right.takeSnapshot },
+      xform: xforms.copy,
+      priority: 4
+    }
+  ],
+  [sets.leftCursorHoldingCamera]: [
+    {
+      src: { value: leftTriggerPressed2 },
+      dest: { value: paths.actions.cursor.left.takeSnapshot },
+      xform: xforms.copy,
+      priority: 4
+    }
+  ],
+
+  [sets.rightHandHoveringOnNothing]: [],
+  [sets.inputFocused]: []
 });

--- a/src/systems/userinput/devices/webxr-controller.js
+++ b/src/systems/userinput/devices/webxr-controller.js
@@ -2,6 +2,8 @@ import { paths } from "../paths";
 import { Pose } from "../pose";
 
 const ONES = new THREE.Vector3(1, 1, 1);
+// Note these offests are specifically for the oculus touch controllers on a Quest.
+// We'll have to account for other headsets and controllers as we expand WebXR support.
 const LEFT_HAND_OFFSET = new THREE.Matrix4().makeTranslation(-0.025, -0.03, 0.12);
 const RIGHT_HAND_OFFSET = new THREE.Matrix4().makeTranslation(0.025, -0.03, 0.12);
 const m = new THREE.Matrix4();

--- a/src/systems/userinput/devices/webxr-controller.js
+++ b/src/systems/userinput/devices/webxr-controller.js
@@ -23,30 +23,30 @@ export class WebXRControllerDevice {
     if (!referenceSpace || !this.gamepad || !this.gamepad.connected) return;
 
     const hand = this.gamepad.hand || "right";
-    const path = paths.device.webXR[hand];
+    const path = paths.device.webxr[hand];
 
-    frame.setValueType(path.trigger.pressed, this.gamepad.buttons[0].pressed);
-    frame.setValueType(path.trigger.touched, this.gamepad.buttons[0].touched);
-    frame.setValueType(path.trigger.value, this.gamepad.buttons[0].value);
+    frame.setValueType(path.button.trigger.pressed, this.gamepad.buttons[0].pressed);
+    frame.setValueType(path.button.trigger.touched, this.gamepad.buttons[0].touched);
+    frame.setValueType(path.button.trigger.value, this.gamepad.buttons[0].value);
 
-    frame.setValueType(path.grip.pressed, this.gamepad.buttons[1].pressed);
-    frame.setValueType(path.grip.touched, this.gamepad.buttons[1].touched);
-    frame.setValueType(path.grip.value, this.gamepad.buttons[1].value);
+    frame.setValueType(path.button.grip.pressed, this.gamepad.buttons[1].pressed);
+    frame.setValueType(path.button.grip.touched, this.gamepad.buttons[1].touched);
+    frame.setValueType(path.button.grip.value, this.gamepad.buttons[1].value);
 
-    frame.setValueType(path.joystick.pressed, this.gamepad.buttons[3].pressed);
-    frame.setValueType(path.joystick.touched, this.gamepad.buttons[3].touched);
-    frame.setValueType(path.joystick.value, this.gamepad.buttons[3].value);
+    frame.setValueType(path.button.thumbStick.pressed, this.gamepad.buttons[3].pressed);
+    frame.setValueType(path.button.thumbStick.touched, this.gamepad.buttons[3].touched);
+    frame.setValueType(path.button.thumbStick.value, this.gamepad.buttons[3].value);
 
-    frame.setValueType(path.a.pressed, this.gamepad.buttons[4].pressed);
-    frame.setValueType(path.a.touched, this.gamepad.buttons[4].touched);
-    frame.setValueType(path.a.value, this.gamepad.buttons[4].value);
+    frame.setValueType(path.button.a.pressed, this.gamepad.buttons[4].pressed);
+    frame.setValueType(path.button.a.touched, this.gamepad.buttons[4].touched);
+    frame.setValueType(path.button.a.value, this.gamepad.buttons[4].value);
 
-    frame.setValueType(path.b.pressed, this.gamepad.buttons[5].pressed);
-    frame.setValueType(path.b.touched, this.gamepad.buttons[5].touched);
-    frame.setValueType(path.b.value, this.gamepad.buttons[5].value);
+    frame.setValueType(path.button.b.pressed, this.gamepad.buttons[5].pressed);
+    frame.setValueType(path.button.b.touched, this.gamepad.buttons[5].touched);
+    frame.setValueType(path.button.b.value, this.gamepad.buttons[5].value);
 
-    frame.setValueType(path.joystick.axisX, this.gamepad.axes[2]);
-    frame.setValueType(path.joystick.axisY, this.gamepad.axes[3]);
+    frame.setValueType(path.axis.joyX, this.gamepad.axes[2]);
+    frame.setValueType(path.axis.joyY, this.gamepad.axes[3]);
 
     this.rayObject = this.rayObject || document.querySelector(this.selector).object3D;
     this.rayObject.updateMatrixWorld();

--- a/src/systems/userinput/devices/webxr-controller.js
+++ b/src/systems/userinput/devices/webxr-controller.js
@@ -1,0 +1,75 @@
+import { paths } from "../paths";
+import { Pose } from "../pose";
+
+const ONES = new THREE.Vector3(1, 1, 1);
+const LEFT_HAND_OFFSET = new THREE.Matrix4().makeTranslation(-0.025, -0.03, 0.12);
+const RIGHT_HAND_OFFSET = new THREE.Matrix4().makeTranslation(0.025, -0.03, 0.12);
+const m = new THREE.Matrix4();
+
+export class WebXRControllerDevice {
+  constructor(gamepad) {
+    this.gamepad = gamepad;
+
+    this.selector = `#player-${gamepad.hand}-controller`;
+    this.rayObject = null;
+    this.rayObjectRotation = new THREE.Quaternion();
+    this.pose = new Pose();
+
+    this.matrix = new THREE.Matrix4();
+    this.position = new THREE.Vector3();
+    this.orientation = new THREE.Quaternion();
+  }
+  write(frame, scene, referenceSpace) {
+    if (!referenceSpace || !this.gamepad || !this.gamepad.connected) return;
+
+    const hand = this.gamepad.hand || "right";
+    const path = paths.device.webXR[hand];
+
+    frame.setValueType(path.trigger.pressed, this.gamepad.buttons[0].pressed);
+    frame.setValueType(path.trigger.touched, this.gamepad.buttons[0].touched);
+    frame.setValueType(path.trigger.value, this.gamepad.buttons[0].value);
+
+    frame.setValueType(path.grip.pressed, this.gamepad.buttons[1].pressed);
+    frame.setValueType(path.grip.touched, this.gamepad.buttons[1].touched);
+    frame.setValueType(path.grip.value, this.gamepad.buttons[1].value);
+
+    frame.setValueType(path.joystick.pressed, this.gamepad.buttons[3].pressed);
+    frame.setValueType(path.joystick.touched, this.gamepad.buttons[3].touched);
+    frame.setValueType(path.joystick.value, this.gamepad.buttons[3].value);
+
+    frame.setValueType(path.a.pressed, this.gamepad.buttons[4].pressed);
+    frame.setValueType(path.a.touched, this.gamepad.buttons[4].touched);
+    frame.setValueType(path.a.value, this.gamepad.buttons[4].value);
+
+    frame.setValueType(path.b.pressed, this.gamepad.buttons[5].pressed);
+    frame.setValueType(path.b.touched, this.gamepad.buttons[5].touched);
+    frame.setValueType(path.b.value, this.gamepad.buttons[5].value);
+
+    frame.setValueType(path.joystick.axisX, this.gamepad.axes[2]);
+    frame.setValueType(path.joystick.axisY, this.gamepad.axes[3]);
+
+    this.rayObject = this.rayObject || document.querySelector(this.selector).object3D;
+    this.rayObject.updateMatrixWorld();
+    this.rayObjectRotation.setFromRotationMatrix(m.extractRotation(this.rayObject.matrixWorld));
+
+    this.pose.position.setFromMatrixPosition(this.rayObject.matrixWorld);
+    this.pose.direction.set(0, 0, -1).applyQuaternion(this.rayObjectRotation);
+    this.pose.orientation.copy(this.rayObjectRotation);
+
+    frame.setPose(path.pose, this.pose);
+
+    const pose = scene.frame.getPose(this.gamepad.targetRaySpace, referenceSpace);
+
+    if (pose && pose.transform.position && pose.transform.orientation) {
+      this.position.copy(pose.transform.position);
+      this.orientation.copy(pose.transform.orientation);
+      this.matrix.compose(
+        this.position,
+        this.orientation,
+        ONES
+      );
+      this.matrix.multiply(hand === "left" ? LEFT_HAND_OFFSET : RIGHT_HAND_OFFSET);
+      frame.setMatrix4(path.matrix, this.matrix);
+    }
+  }
+}

--- a/src/systems/userinput/paths.js
+++ b/src/systems/userinput/paths.js
@@ -358,3 +358,20 @@ paths.device.wmr.v = name => `/vars/wmr/${name}`;
 paths.device.wmr.k = name => `/vars/wmr/keyboard/${name}`;
 paths.device.wmr.left = wmrController("left");
 paths.device.wmr.right = wmrController("right");
+
+function webXRController(side) {
+  const webXR = "/device/webxr/";
+  return {
+    pose: `${webXR}${side}/pose`,
+    matrix: `${webXR}${side}/matrix`,
+    joystick: axes(webXR, side, "joystick"),
+    trigger: button(webXR, side, "trigger"),
+    grip: button(webXR, side, "grip"),
+    a: button(webXR, side, "a"),
+    b: button(webXR, side, "b")
+  };
+}
+paths.device.webXR = {};
+paths.device.webXR.v = name => `/vars/webxr/${name}`;
+paths.device.webXR.left = webXRController("left");
+paths.device.webXR.right = webXRController("right");

--- a/src/systems/userinput/paths.js
+++ b/src/systems/userinput/paths.js
@@ -359,19 +359,35 @@ paths.device.wmr.k = name => `/vars/wmr/keyboard/${name}`;
 paths.device.wmr.left = wmrController("left");
 paths.device.wmr.right = wmrController("right");
 
-function webXRController(side) {
-  const webXR = "/device/webxr/";
-  return {
-    pose: `${webXR}${side}/pose`,
-    matrix: `${webXR}${side}/matrix`,
-    joystick: axes(webXR, side, "joystick"),
-    trigger: button(webXR, side, "trigger"),
-    grip: button(webXR, side, "grip"),
-    a: button(webXR, side, "a"),
-    b: button(webXR, side, "b")
-  };
-}
-paths.device.webXR = {};
-paths.device.webXR.v = name => `/vars/webxr/${name}`;
-paths.device.webXR.left = webXRController("left");
-paths.device.webXR.right = webXRController("right");
+const webxr = "/device/webxr/";
+paths.device.webxr = {};
+paths.device.webxr.right = {
+  button: {
+    trigger: button(webxr, "right", "trigger"),
+    grip: button(webxr, "right", "grip"),
+    a: button(webxr, "right", "a"),
+    b: button(webxr, "right", "b"),
+    thumbStick: button(webxr, "right", "thumbStick")
+  },
+  axis: {
+    joyX: `${webxr}right/axis/joyX`,
+    joyY: `${webxr}right/axis/joyY`
+  },
+  pose: `${webxr}right/pose`,
+  matrix: `${webxr}right/matrix`
+};
+paths.device.webxr.left = {
+  button: {
+    trigger: button(webxr, "left", "trigger"),
+    grip: button(webxr, "left", "grip"),
+    a: button(webxr, "left", "a"),
+    b: button(webxr, "left", "b"),
+    thumbStick: button(webxr, "left", "thumbStick")
+  },
+  axis: {
+    joyX: `${webxr}left/axis/joyX`,
+    joyY: `${webxr}left/axis/joyY`
+  },
+  pose: `${webxr}left/pose`,
+  matrix: `${webxr}left/matrix`
+};

--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -353,14 +353,13 @@ AFRAME.registerSystem("userinput", {
       let gamepadDevice;
       for (let i = 0; i < this.activeDevices.items.length; i++) {
         const activeDevice = this.activeDevices.items[i];
-        if (activeDevice.gamepad && activeDevice.gamepad.index === e.gamepad.index) {
-          // TODO BP - Figure out how to handle input source removal correctly with WebXR when re-entering immersive mode
-          //console.warn("connected already fired for gamepad", e.gamepad);
-          //return; // multiple connect events without a disconnect event
+        if (!e.gamepad.isWebXRGamepad && activeDevice.gamepad && activeDevice.gamepad.index === e.gamepad.index) {
+          console.warn("connected already fired for gamepad", e.gamepad);
+          return; // multiple connect events without a disconnect event
         }
       }
       // HACK Firefox Nightly bug causes corrupt gamepad names for OpenVR, so do startsWith
-      if (e.gamepad.primaryProfile) {
+      if (e.gamepad.isWebXRGamepad) {
         gamepadDevice = new WebXRControllerDevice(e.gamepad);
       } else if (
         e.gamepad.id.startsWith("OpenVR Gamepad") ||
@@ -414,8 +413,8 @@ AFRAME.registerSystem("userinput", {
     }
 
     const retrieveXRGamepads = ({ session }) => {
-      if (!session.inputSources) return;
       for (const inputSource of session.inputSources) {
+        inputSource.gamepad.isWebXRGamepad = true;
         inputSource.gamepad.targetRaySpace = inputSource.targetRaySpace;
         inputSource.gamepad.primaryProfile = inputSource.profiles[0];
         inputSource.gamepad.hand = inputSource.handedness;

--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -358,10 +358,10 @@ AFRAME.registerSystem("userinput", {
           return; // multiple connect events without a disconnect event
         }
       }
-      // HACK Firefox Nightly bug causes corrupt gamepad names for OpenVR, so do startsWith
       if (e.gamepad.isWebXRGamepad) {
         gamepadDevice = new WebXRControllerDevice(e.gamepad);
       } else if (
+        // HACK Firefox Nightly bug causes corrupt gamepad names for OpenVR, so do startsWith
         e.gamepad.id.startsWith("OpenVR Gamepad") ||
         e.gamepad.id.startsWith("OpenVR Knuckles") ||
         e.gamepad.id === "HTC Vive Focus Plus Controller" ||

--- a/src/systems/waypoint-system.js
+++ b/src/systems/waypoint-system.js
@@ -365,10 +365,14 @@ export class WaypointSystem {
       ) {
         elementFromTemplate.object3D.visible = this.scene.is("frozen");
         if (elementFromTemplate.object3D.visible) {
-          this.viewingCamera = this.viewingCamera || document.getElementById("viewing-camera").object3D;
+          this.viewingCamera = this.viewingCamera || document.getElementById("viewing-camera").object3DMap.camera;
           setMatrixWorld(
             elementFromTemplate.object3D,
-            calculateIconTransform(waypointComponent.el.object3D, this.viewingCamera, this.helperMat4)
+            calculateIconTransform(
+              waypointComponent.el.object3D,
+              this.viewingCamera.object3DMap.camera,
+              this.helperMat4
+            )
           );
         }
       }

--- a/src/systems/waypoint-system.js
+++ b/src/systems/waypoint-system.js
@@ -368,11 +368,7 @@ export class WaypointSystem {
           this.viewingCamera = this.viewingCamera || document.getElementById("viewing-camera").object3DMap.camera;
           setMatrixWorld(
             elementFromTemplate.object3D,
-            calculateIconTransform(
-              waypointComponent.el.object3D,
-              this.viewingCamera.object3DMap.camera,
-              this.helperMat4
-            )
+            calculateIconTransform(waypointComponent.el.object3D, this.viewingCamera, this.helperMat4)
           );
         }
       }

--- a/src/webxr-bypass-hacks.js
+++ b/src/webxr-bypass-hacks.js
@@ -1,7 +1,7 @@
 /*
 HACK: Our fork of aframe will read this global in src/utils/device.js to force the WebVR codepaths.
 */
-window.forceWebVR = true;
+window.forceWebVR = !/oculusbrowser/i.test(navigator.userAgent) || "getVRDisplays" in navigator;
 
 /*
 HACK Fix a-frame's device detection in Chrome when WebXR or WebVR flags are enabled in
@@ -19,6 +19,6 @@ if (
 /*
 HACK Call getVRDisplays to force Oculus Browser to use WebVR, which in turn disables the WebXR API.
 */
-if (/Oculus/.test(navigator.userAgent)) {
+if (/oculusbrowser/i.test(navigator.userAgent) && "getVRDisplays" in navigator) {
   navigator.getVRDisplays();
 }

--- a/src/webxr-bypass-hacks.js
+++ b/src/webxr-bypass-hacks.js
@@ -1,7 +1,11 @@
+import qsTruthy from "./utils/qs_truthy";
+
+const isOculusBrowser = /oculusbrowser/i.test(navigator.userAgent);
+
 /*
 HACK: Our fork of aframe will read this global in src/utils/device.js to force the WebVR codepaths.
 */
-window.forceWebVR = !/oculusbrowser/i.test(navigator.userAgent) || "getVRDisplays" in navigator;
+window.forceWebVR = !qsTruthy("no_force_webvr") && (!isOculusBrowser || "getVRDisplays" in navigator);
 
 /*
 HACK Fix a-frame's device detection in Chrome when WebXR or WebVR flags are enabled in
@@ -9,7 +13,7 @@ chrome://flags. See https://github.com/mozilla/hubs/issues/892
 */
 if (
   !/mobile vr/i.test(navigator.userAgent) &&
-  !/oculusbrowser/i.test(navigator.userAgent) &&
+  !isOculusBrowser &&
   /Chrome/.test(navigator.userAgent) &&
   navigator.xr &&
   !navigator.xr.requestDevice
@@ -18,7 +22,8 @@ if (
 }
 /*
 HACK Call getVRDisplays to force Oculus Browser to use WebVR, which in turn disables the WebXR API.
+This should only take effect in older version of Oculus Browser that still have the getVRDisplays API.
 */
-if (/oculusbrowser/i.test(navigator.userAgent) && "getVRDisplays" in navigator) {
+if (isOculusBrowser && "getVRDisplays" in navigator) {
   navigator.getVRDisplays();
 }


### PR DESCRIPTION
Oculus Browser has removed support for WebVR. This PR fixes our WebXR support and enables it for Oculus Browser specifically.
- Three.js' WebXRManager updates the scene's camera directly, instead of using the previous concept of a "poseTarget", so we need to grab headset transforms directly from the camera instead of the parent object3D
- Added a generic WebXRControllerDevice for WebXR gampads. The new webxr gamepad spec has different button and axis mappings, so we can't use existing controller devices, but the spec should now be much more standardized so the bindings should work for most devices when we expand webxr support. The bindings are a copy of our existing Oculus Touch bindings, with keyboard bindings removed and some cleanup. See https://immersive-web.github.io/webxr-gamepads-module/#xr-standard-gamepad-mapping
- Forced a max distance of 1000m on the skybox. Not sure why the camera's far field is different when entering webxr immersive mode. Perhaps something to investigate later.
- Updated anime.js to use `setTimeout` for animations instead of `window.requestAnimationFrame` since the global rAF is paused when in webxr immersive mode.
- Adds a `no_force_webvr` flag so that we can test webxr in other browsers.

Goes with:
- https://github.com/MozillaReality/aframe/pull/27
- https://github.com/MozillaReality/anime/pull/1