### PR TITLE
Audio bug fixes and refactor

### DIFF
--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -58,6 +58,7 @@ AFRAME.registerComponent("avatar-audio-source", {
   createAudio: async function() {
     this.isCreatingAudio = true;
     const stream = await getMediaStream(this.el);
+    this.isCreatingAudio = false;
     const isRemoved = !this.el.parentNode;
     if (!stream || isRemoved) return;
 
@@ -75,7 +76,6 @@ AFRAME.registerComponent("avatar-audio-source", {
     audio.setNodeSource(mediaStreamSource);
     this.el.setObject3D(this.attrName, audio);
     this.el.emit("sound-source-set", { soundSource: mediaStreamSource });
-    this.isCreatingAudio = false;
   },
 
   destroyAudio() {

--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -1,4 +1,4 @@
-const INFO_INIT_FAILED = "Failed to initialize networked-audio-source.";
+const INFO_INIT_FAILED = "Failed to initialize avatar-audio-source.";
 const INFO_NO_NETWORKED_EL = "Could not find networked el.";
 const INFO_NO_OWNER = "Networked component has no owner.";
 
@@ -50,7 +50,7 @@ async function getMediaStream(el) {
   return stream;
 }
 
-AFRAME.registerComponent("networked-audio-source", {
+AFRAME.registerComponent("avatar-audio-source", {
   schema: {
     positional: { default: true },
     distanceModel: {

--- a/src/components/avatar-volume-controls.js
+++ b/src/components/avatar-volume-controls.js
@@ -42,11 +42,10 @@ AFRAME.registerComponent("avatar-volume-controls", {
   },
 
   update() {
-    const audioOutputMode = window.APP.store.state.preferences.audioOutputMode;
     if (
       this.networkedAudioSource &&
       this.networkedAudioSource.sound &&
-      (audioOutputMode === undefined || audioOutputMode === "panner")
+      window.APP.store.state.preferences.audioOutputMode !== "audio"
     ) {
       const globalVoiceVolume =
         window.APP.store.state.preferences.globalVoiceVolume !== undefined

--- a/src/components/avatar-volume-controls.js
+++ b/src/components/avatar-volume-controls.js
@@ -45,8 +45,7 @@ AFRAME.registerComponent("avatar-volume-controls", {
     const positionA = new THREE.Vector3();
     const positionB = new THREE.Vector3();
     return function update() {
-      const audio =
-        this.networkedAudioSource && this.networkedAudioSource.el.getObject3D(this.networkedAudioSource.attrName);
+      const audio = this.avatarAudioSource && this.avatarAudioSource.el.getObject3D(this.avatarAudioSource.attrName);
       if (!audio) {
         return;
       }
@@ -55,7 +54,7 @@ AFRAME.registerComponent("avatar-volume-controls", {
       const volumeModifier = (globalVoiceVolume !== undefined ? globalVoiceVolume : 100) / 100;
       let gain = volumeModifier * this.data.volume;
       if (audioOutputMode === "audio") {
-        this.networkedAudioSource.el.object3D.getWorldPosition(positionA);
+        this.avatarAudioSource.el.object3D.getWorldPosition(positionA);
         this.el.sceneEl.camera.getWorldPosition(positionB);
         const squaredDistance = positionA.distanceToSquared(positionB);
         gain = gain * Math.min(1, 10 / Math.max(1, squaredDistance));
@@ -76,14 +75,14 @@ AFRAME.registerComponent("avatar-volume-controls", {
   },
 
   tick() {
-    if (!this.networkedAudioSource && !this.searchFailed) {
+    if (!this.avatarAudioSource && !this.searchFailed) {
       // Walk up to Spine and then search down.
-      const sourceEl = this.el.parentNode.parentNode.querySelector("[networked-audio-source]");
-      if (!sourceEl || !sourceEl.components["networked-audio-source"]) {
+      const sourceEl = this.el.parentNode.parentNode.querySelector("[avatar-audio-source]");
+      if (!sourceEl || !sourceEl.components["avatar-audio-source"]) {
         this.searchFailed = true;
         return;
       }
-      this.networkedAudioSource = sourceEl.components["networked-audio-source"];
+      this.avatarAudioSource = sourceEl.components["avatar-audio-source"];
     }
 
     this.update();

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -339,7 +339,7 @@ AFRAME.registerComponent("media-video", {
     });
 
     this.audioOutputModePref = window.APP.store.state.preferences.audioOutputMode;
-    window.APP.store.addEventListener("statechanged", () => {
+    this.onPreferenceChanged = () => {
       const newPref = window.APP.store.state.preferences.audioOutputMode;
       if (this.audioOutputModePref !== newPref) {
         this.audioOutputModePref = newPref;
@@ -347,7 +347,8 @@ AFRAME.registerComponent("media-video", {
           this.setupAudio();
         }
       }
-    });
+    };
+    window.APP.store.addEventListener("statechanged", this.onPreferenceChanged);
   },
 
   isMineOrLocal() {
@@ -945,6 +946,8 @@ AFRAME.registerComponent("media-video", {
       this.seekForwardButton.object3D.removeEventListener("interact", this.seekForward);
       this.seekBackButton.object3D.removeEventListener("interact", this.seekBack);
     }
+
+    window.APP.store.removeEventListener("statechanged", this.onPreferenceChanged);
   }
 });
 

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -492,7 +492,7 @@ AFRAME.registerComponent("media-video", {
     }
   },
 
-  async update(oldData) {
+  update(oldData) {
     this.updatePlaybackState();
 
     const shouldUpdateSrc = this.data.src && this.data.src !== oldData.src;

--- a/src/components/networked-audio-source.js
+++ b/src/components/networked-audio-source.js
@@ -63,6 +63,7 @@ AFRAME.registerComponent("networked-audio-source", {
   },
 
   init: async function() {
+    this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem.registerAvatarAudioSource(this);
     const stream = await getMediaStream(this.el);
     const isRemoved = !this.el.parentNode;
     if (!stream || isRemoved) return;
@@ -84,7 +85,6 @@ AFRAME.registerComponent("networked-audio-source", {
     audio.setNodeSource(mediaStreamSource);
     this.el.emit("sound-source-set", { soundSource: mediaStreamSource });
     this.el.setObject3D(this.attrName, audio);
-    this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem.registerAvatarAudioSource(this);
   },
 
   update(oldData) {

--- a/src/components/networked-audio-source.js
+++ b/src/components/networked-audio-source.js
@@ -1,0 +1,115 @@
+const INFO_INIT_FAILED = "Failed to initialize networked-audio-source.";
+const INFO_NO_NETWORKED_EL = "Could not find networked el.";
+const INFO_NO_OWNER = "Networked component has no owner.";
+
+// Chrome seems to require a MediaStream be attached to an AudioElement before AudioNodes work correctly
+// We don't want to do this in other browsers, particularly in Safari, which actually plays the audio despite
+// setting the volume to 0.
+const SHOULD_CREATE_SILENT_AUDIO_ELS = /chrome/i.test(navigator.userAgent);
+function createSilentAudioEl(stream) {
+  const audioEl = new Audio();
+  audioEl.setAttribute("autoplay", "autoplay");
+  audioEl.setAttribute("playsinline", "playsinline");
+  audioEl.srcObject = stream;
+  audioEl.volume = 0; // we don't actually want to hear audio from this element
+  return audioEl;
+}
+
+function getOrCreateAudioListenerForScene(scene) {
+  if (!scene.audioListener) {
+    // Would prefer not to have to do this, and am not sure if it's required,
+    // so adding a warning for now and hoping to remove this later.
+    console.warn("Scene did not have an audio listener. Creating one now.");
+    scene.audioListener = new THREE.AudioListener();
+    scene.camera && scene.camera.add(scene.audioListener);
+    scene.addEventListener("camera-set-active", function(evt) {
+      evt.detail.cameraEl.getObject3D("camera").add(scene.audioListener);
+    });
+  }
+  return scene.audioListener;
+}
+
+async function getMediaStream(el) {
+  const networkedEl = await NAF.utils.getNetworkedEntity(el).catch(e => {
+    console.error(INFO_INIT_FAILED, INFO_NO_NETWORKED_EL, e);
+  });
+  if (!networkedEl) {
+    return null;
+  }
+  const ownerId = networkedEl.components.networked.data.owner;
+  if (!ownerId) {
+    console.error(INFO_INIT_FAILED, INFO_NO_OWNER);
+    return null;
+  }
+  const stream = await NAF.connection.adapter.getMediaStream(ownerId).catch(e => {
+    console.error(INFO_INIT_FAILED, `Error getting media stream for ${ownerId}`, e);
+  });
+  if (!stream) {
+    return null;
+  }
+  return stream;
+}
+
+AFRAME.registerComponent("networked-audio-source", {
+  schema: {
+    positional: { default: true },
+    distanceModel: {
+      default: "inverse",
+      oneOf: ["linear", "inverse", "exponential"]
+    },
+    maxDistance: { default: 10000 },
+    refDistance: { default: 1 },
+    rolloffFactor: { default: 1 }
+  },
+
+  init: async function() {
+    const stream = await getMediaStream(this.el);
+    const isRemoved = !this.el.parentNode;
+    if (!stream || isRemoved) return;
+
+    const audioListener = getOrCreateAudioListenerForScene(this.el.sceneEl);
+    const audio = this.data.positional ? new THREE.PositionalAudio(audioListener) : new THREE.Audio(audioListener);
+    if (this.data.positional) {
+      audio.setDistanceModel(this.data.distanceModel);
+      audio.setMaxDistance(this.data.maxDistance);
+      audio.setRefDistance(this.data.refDistance);
+      audio.setRolloffFactor(this.data.rolloffFactor);
+    }
+
+    if (SHOULD_CREATE_SILENT_AUDIO_ELS) {
+      createSilentAudioEl(stream); // TODO: Do the audio els need to get cleaned up?
+    }
+
+    const mediaStreamSource = audio.context.createMediaStreamSource(stream);
+    audio.setNodeSource(mediaStreamSource);
+    this.el.emit("sound-source-set", { soundSource: mediaStreamSource });
+    this.el.setObject3D(this.attrName, audio);
+    this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem.registerAvatarAudioSource(this);
+  },
+
+  update(oldData) {
+    const audio = this.el.getObject3D(this.attrName);
+    if (!audio) return;
+
+    const shouldRecreateAudio = oldData.positional !== this.data.positional;
+    if (shouldRecreateAudio) {
+      audio.disconnect();
+      this.el.removeObject3D(this.attrName);
+      this.init();
+    } else if (this.data.positional) {
+      audio.setDistanceModel(this.data.distanceModel);
+      audio.setMaxDistance(this.data.maxDistance);
+      audio.setRefDistance(this.data.refDistance);
+      audio.setRolloffFactor(this.data.rolloffFactor);
+    }
+  },
+
+  remove: function() {
+    const audio = this.el.getObject3D(this.attrName);
+    if (!audio) return;
+
+    audio.disconnect();
+    this.el.removeObject3D(this.attrName);
+    this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem.unregisterAvatarAudioSource(this);
+  }
+});

--- a/src/hub.html
+++ b/src/hub.html
@@ -188,7 +188,7 @@
 
                         <template data-name="Head">
                             <a-entity
-                                networked-audio-source="rolloffFactor: 2.0;"
+                                avatar-audio-source="rolloffFactor: 2.0;"
                                 personal-space-invader="radius: 0.15; useMaterial: true;"
                                 bone-visibility
                                 body-helper="type: kinematic; collisionFilterGroup: 4; collisionFilterMask: 1;"

--- a/src/hub.html
+++ b/src/hub.html
@@ -189,7 +189,6 @@
                         <template data-name="Head">
                             <a-entity
                                 networked-audio-source="rolloffFactor: 2.0;"
-                                audio-source="type: avatar"
                                 personal-space-invader="radius: 0.15; useMaterial: true;"
                                 bone-visibility
                                 body-helper="type: kinematic; collisionFilterGroup: 4; collisionFilterMask: 1;"
@@ -287,7 +286,7 @@
                     position-at-border__freeze="target:.freeze-menu"
                     position-at-border__freeze-unprivileged="target:.freeze-unprivileged-menu"
                     listed-media
-                    audio-source="type: media"
+                    use-audio-system-settings
                 >
                     <a-entity class="ui interactable-ui">
                         <a-entity class="freeze-menu" visibility-while-frozen="withinDistance: 100; withPermission: spawn_and_move_media">

--- a/src/hub.js
+++ b/src/hub.js
@@ -112,7 +112,7 @@ import "./components/billboard";
 import "./components/periodic-full-syncs";
 import "./components/inspect-button";
 import "./components/set-max-resolution";
-import "./components/networked-audio-source";
+import "./components/avatar-audio-source";
 import { sets as userinputSets } from "./systems/userinput/sets";
 
 import ReactDOM from "react-dom";

--- a/src/hub.js
+++ b/src/hub.js
@@ -112,6 +112,7 @@ import "./components/billboard";
 import "./components/periodic-full-syncs";
 import "./components/inspect-button";
 import "./components/set-max-resolution";
+import "./components/networked-audio-source";
 import { sets as userinputSets } from "./systems/userinput/sets";
 
 import ReactDOM from "react-dom";

--- a/src/message-dispatch.js
+++ b/src/message-dispatch.js
@@ -141,13 +141,14 @@ export default class MessageDispatch {
         }
         break;
       case "audiomode":
-        if (window.APP.store.state.preferences.audioOutputMode !== "audio") {
-          window.APP.store.state.preferences.audioOutputMode = "audio";
-          this.log("Positional Audio disabled.");
-        } else {
-          window.APP.store.state.preferences.audioOutputMode = "panner";
-          this.log("Positional Audio enabled.");
+        {
+          const shouldEnablePositionalAudio = window.APP.store.state.preferences.audioOutputMode === "audio";
+          window.APP.store.update({
+            preferences: { audioOutputMode: shouldEnablePositionalAudio ? "panner" : "audio" }
+          });
+          this.log(`Positional Audio ${shouldEnablePositionalAudio ? "enabled" : "disabled"}.`);
         }
+        break;
     }
   };
 }

--- a/src/systems/audio-settings-system.js
+++ b/src/systems/audio-settings-system.js
@@ -1,24 +1,23 @@
-function updateMediaAudioSettings(audio, settings) {
-  if (audio.setDistanceModel) {
-    audio.setDistanceModel(settings.mediaDistanceModel);
-    audio.setRolloffFactor(settings.mediaRolloffFactor);
-    audio.setRefDistance(settings.mediaRefDistance);
-    audio.setMaxDistance(settings.mediaMaxDistance);
-  }
-  if (audio.panner) {
-    audio.panner.coneInnerAngle = settings.mediaConeInnerAngle;
-    audio.panner.coneOuterAngle = settings.mediaConeOuterAngle;
-    audio.panner.coneOuterGain = settings.mediaConeOuterGain;
-  }
+function updateMediaAudioSettings(mediaVideo, settings) {
+  mediaVideo.el.setAttribute("media-video", {
+    distanceModel: settings.mediaDistanceModel,
+    rolloffFactor: settings.mediaRolloffFactor,
+    refDistance: settings.mediaRefDistance,
+    maxDistance: settings.mediaMaxDistance,
+    coneInnerAngle: settings.mediaConeInnerAngle,
+    coneOuterAngle: settings.mediaConeOuterAngle,
+    coneOuterGain: settings.mediaConeOuterGain
+  });
 }
 
-function updateAvatarAudioSettings(audio, settings) {
-  if (audio.setDistanceModel) {
-    audio.setDistanceModel(settings.avatarDistanceModel);
-    audio.setRolloffFactor(settings.avatarRolloffFactor);
-    audio.setRefDistance(settings.avatarRefDistance);
-    audio.setMaxDistance(settings.avatarMaxDistance);
-  }
+function updateAvatarAudioSettings(networkedAudioSource, settings, positional) {
+  networkedAudioSource.el.setAttribute("networked-audio-source", {
+    positional,
+    distanceModel: settings.avatarDistanceModel,
+    maxDistance: settings.avatarMaxDistance,
+    refDistance: settings.avatarRefDistance,
+    rolloffFactor: settings.avatarRolloffFactor
+  });
 }
 
 export class AudioSettingsSystem {
@@ -39,45 +38,67 @@ export class AudioSettingsSystem {
       mediaConeOuterGain: 0
     };
     this.audioSettings = this.defaultSettings;
-    this.mediaAudioSources = [];
-    this.avatarAudioSources = [];
+    this.mediaVideos = [];
+    this.networkedAudioSources = [];
 
     this.sceneEl.addEventListener("reset_scene", this.onSceneReset);
 
     if (window.APP.store.state.preferences.audioOutputMode === "audio") {
+      //hack to always reset to "panner"
       window.APP.store.update({
         preferences: { audioOutputMode: "panner" }
-      }); //hack to always reset to "panner"
+      });
     }
+    this.audioOutputMode = window.APP.store.state.preferences.audioOutputMode;
+    this.onPreferenceChanged = () => {
+      const newPref = window.APP.store.state.preferences.audioOutputMode;
+      const shouldUpdateAudioSettings = this.audioOutputMode !== newPref;
+      this.audioOutputMode = newPref;
+      if (shouldUpdateAudioSettings) {
+        this.updateAudioSettings(this.audioSettings);
+      }
+    };
+    window.APP.store.addEventListener("statechanged", this.onPreferenceChanged);
   }
 
-  registerMediaAudioSource(audioSource) {
-    this.mediaAudioSources.push(audioSource);
-    updateMediaAudioSettings(audioSource, this.audioSettings);
+  registerMediaAudioSource(mediaVideo) {
+    const index = this.mediaVideos.indexOf(mediaVideo);
+    if (index === -1) {
+      this.mediaVideos.push(mediaVideo);
+    }
+    updateMediaAudioSettings(mediaVideo, this.audioSettings);
   }
 
-  unregisterMediaAudioSource(audioSource) {
-    this.mediaAudioSources.splice(this.mediaAudioSources.indexOf(audioSource, 1));
+  unregisterMediaAudioSource(mediaVideo) {
+    this.mediaVideos.splice(this.mediaVideos.indexOf(mediaVideo), 1);
   }
 
-  registerAvatarAudioSource(audioSource) {
-    this.avatarAudioSources.push(audioSource);
-    updateAvatarAudioSettings(audioSource, this.audioSettings);
+  registerAvatarAudioSource(networkedAudioSource) {
+    const index = this.networkedAudioSources.indexOf(networkedAudioSource);
+    if (index === -1) {
+      this.networkedAudioSources.push(networkedAudioSource);
+    }
+    const positional = window.APP.store.state.preferences.audioOutputMode !== "audio";
+    updateAvatarAudioSettings(networkedAudioSource, this.audioSettings, positional);
   }
 
-  unregisterAvatarAudioSource(audioSource) {
-    this.avatarAudioSources.splice(this.avatarAudioSources.indexOf(audioSource, 1));
+  unregisterAvatarAudioSource(networkedAudioSource) {
+    const index = this.networkedAudioSources.indexOf(networkedAudioSource);
+    if (index !== -1) {
+      this.networkedAudioSources.splice(index, 1);
+    }
   }
 
   updateAudioSettings(settings) {
     this.audioSettings = Object.assign({}, this.defaultSettings, settings);
 
-    for (const mediaAudioSource of this.mediaAudioSources) {
-      updateMediaAudioSettings(mediaAudioSource, settings);
+    for (const mediaVideo of this.mediaVideos) {
+      updateMediaAudioSettings(mediaVideo, settings);
     }
 
-    for (const avatarAudioSource of this.avatarAudioSources) {
-      updateAvatarAudioSettings(avatarAudioSource, settings);
+    const positional = window.APP.store.state.preferences.audioOutputMode !== "audio";
+    for (const networkedAudioSource of this.networkedAudioSources) {
+      updateAvatarAudioSettings(networkedAudioSource, settings, positional);
     }
   }
 
@@ -86,103 +107,26 @@ export class AudioSettingsSystem {
   };
 }
 
-AFRAME.registerComponent("audio-source", {
-  schema: {
-    type: { type: "string" } // avatar, media
-  },
-
+AFRAME.registerComponent("use-audio-system-settings", {
   init() {
-    this.audioSource = null;
-    this.networkedAudioSource = null;
-
-    if (this.data.type === "avatar") {
-      this.onSoundSourceSet = this.onSoundSourceSet.bind(this);
-      this.el.addEventListener("sound-source-set", this.onSoundSourceSet);
-    } else if (this.data.type === "media") {
-      this.onVideoLoaded = this.onVideoLoaded.bind(this);
-      this.el.addEventListener("video-loaded", this.onVideoLoaded);
-    }
-
-    this.audioOutputModePref = window.APP.store.state.preferences.audioOutputMode;
-    this.onPreferenceChanged = () => {
-      const newPref = window.APP.store.state.preferences.audioOutputMode;
-      if (this.audioOutputModePref !== newPref) {
-        this.audioOutputModePref = newPref;
-        if (this.networkedAudioSource) {
-          this.updateNetworkedAudioSource(this.networkedAudioSource);
-        }
-      }
-    };
-    window.APP.store.addEventListener("statechanged", this.onPreferenceChanged);
-  },
-
-  updateNetworkedAudioSource(networkedAudioSource) {
-    if (networkedAudioSource.sound) {
-      networkedAudioSource.sound.disconnect();
-      networkedAudioSource.el.removeObject3D(networkedAudioSource.attrName);
-      delete networkedAudioSource.sound;
-    }
-    const disablePositionalAudio = this.audioOutputModePref === "audio";
-    if (networkedAudioSource.data.positional === disablePositionalAudio) {
-      networkedAudioSource.el.setAttribute("networked-audio-source", { positional: !disablePositionalAudio });
-    }
-    networkedAudioSource.setupSound();
-    const soundSource = networkedAudioSource.sound.context.createMediaStreamSource(networkedAudioSource.stream);
-    networkedAudioSource.sound.setNodeSource(soundSource);
-    networkedAudioSource.el.emit("sound-source-set", { soundSource });
-  },
-
-  tick: function() {
-    const networkedAudioSource = this.el.components["networked-audio-source"];
-    if (networkedAudioSource && this.networkedAudioSource !== networkedAudioSource) {
-      this.networkedAudioSource = networkedAudioSource;
-      this.updateNetworkedAudioSource(networkedAudioSource);
-    }
-  },
-
-  onSoundSourceSet() {
-    const audioSettingsSystem = this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem;
-    const networkedAudioSource = this.el.components["networked-audio-source"];
-
-    if (this.audioSource) {
-      audioSettingsSystem.unregisterAvatarAudioSource(this.audioSource);
-    }
-
-    if (networkedAudioSource) {
-      this.audioSource = networkedAudioSource.sound;
-      audioSettingsSystem.registerAvatarAudioSource(this.audioSource);
-    }
+    this.onVideoLoaded = this.onVideoLoaded.bind(this);
+    this.el.addEventListener("video-loaded", this.onVideoLoaded);
   },
 
   onVideoLoaded() {
     const audioSettingsSystem = this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem;
-    const mediaVideo = this.el.components["media-video"];
-
-    if (this.audioSource) {
-      audioSettingsSystem.unregisterMediaAudioSource(this.audioSource);
+    if (this.mediaVideo) {
+      audioSettingsSystem.unregisterMediaAudioSource(this.mediaVideo);
     }
-
-    if (mediaVideo && mediaVideo.audio) {
-      this.audioSource = mediaVideo.audio;
-      audioSettingsSystem.registerMediaAudioSource(this.audioSource);
-    }
+    this.mediaVideo = this.el.components["media-video"];
+    audioSettingsSystem.registerMediaAudioSource(this.mediaVideo);
   },
 
   remove() {
-    window.APP.store.removeEventListener("statechanged", this.onPreferenceChanged);
-
-    if (!this.audioSource) {
-      return;
-    }
-
     const audioSettingsSystem = this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem;
-
-    if (this.data.type === "avatar") {
-      audioSettingsSystem.unregisterAvatarAudioSource(this.audioSource);
-      this.el.removeEventListener("sound-source-set", this.onSoundSourceSet);
-    } else if (this.data.type === "media") {
-      audioSettingsSystem.unregisterMediaAudioSource(this.audioSource);
-      this.el.removeEventListener("video-loaded", this.onVideoLoaded);
+    if (this.mediaVideo) {
+      audioSettingsSystem.unregisterMediaAudioSource(this.mediaVideo);
     }
+    this.el.removeEventListener("video-loaded", this.onVideoLoaded);
   }
 });

--- a/src/systems/audio-settings-system.js
+++ b/src/systems/audio-settings-system.js
@@ -10,8 +10,8 @@ function updateMediaAudioSettings(mediaVideo, settings) {
   });
 }
 
-function updateAvatarAudioSettings(networkedAudioSource, settings, positional) {
-  networkedAudioSource.el.setAttribute("networked-audio-source", {
+function updateAvatarAudioSettings(avatarAudioSource, settings, positional) {
+  avatarAudioSource.el.setAttribute("avatar-audio-source", {
     positional,
     distanceModel: settings.avatarDistanceModel,
     maxDistance: settings.avatarMaxDistance,
@@ -39,7 +39,7 @@ export class AudioSettingsSystem {
     };
     this.audioSettings = this.defaultSettings;
     this.mediaVideos = [];
-    this.networkedAudioSources = [];
+    this.avatarAudioSources = [];
 
     this.sceneEl.addEventListener("reset_scene", this.onSceneReset);
 
@@ -73,19 +73,19 @@ export class AudioSettingsSystem {
     this.mediaVideos.splice(this.mediaVideos.indexOf(mediaVideo), 1);
   }
 
-  registerAvatarAudioSource(networkedAudioSource) {
-    const index = this.networkedAudioSources.indexOf(networkedAudioSource);
+  registerAvatarAudioSource(avatarAudioSource) {
+    const index = this.avatarAudioSources.indexOf(avatarAudioSource);
     if (index === -1) {
-      this.networkedAudioSources.push(networkedAudioSource);
+      this.avatarAudioSources.push(avatarAudioSource);
     }
     const positional = window.APP.store.state.preferences.audioOutputMode !== "audio";
-    updateAvatarAudioSettings(networkedAudioSource, this.audioSettings, positional);
+    updateAvatarAudioSettings(avatarAudioSource, this.audioSettings, positional);
   }
 
-  unregisterAvatarAudioSource(networkedAudioSource) {
-    const index = this.networkedAudioSources.indexOf(networkedAudioSource);
+  unregisterAvatarAudioSource(avatarAudioSource) {
+    const index = this.avatarAudioSources.indexOf(avatarAudioSource);
     if (index !== -1) {
-      this.networkedAudioSources.splice(index, 1);
+      this.avatarAudioSources.splice(index, 1);
     }
   }
 
@@ -97,8 +97,8 @@ export class AudioSettingsSystem {
     }
 
     const positional = window.APP.store.state.preferences.audioOutputMode !== "audio";
-    for (const networkedAudioSource of this.networkedAudioSources) {
-      updateAvatarAudioSettings(networkedAudioSource, settings, positional);
+    for (const avatarAudioSource of this.avatarAudioSources) {
+      updateAvatarAudioSettings(avatarAudioSource, settings, positional);
     }
   }
 

--- a/src/systems/audio-settings-system.js
+++ b/src/systems/audio-settings-system.js
@@ -104,7 +104,7 @@ AFRAME.registerComponent("audio-source", {
     }
 
     this.audioOutputModePref = window.APP.store.state.preferences.audioOutputMode;
-    window.APP.store.addEventListener("statechanged", () => {
+    this.onPreferenceChanged = () => {
       const newPref = window.APP.store.state.preferences.audioOutputMode;
       if (this.audioOutputModePref !== newPref) {
         this.audioOutputModePref = newPref;
@@ -112,7 +112,8 @@ AFRAME.registerComponent("audio-source", {
           this.updateNetworkedAudioSource(this.networkedAudioSource);
         }
       }
-    });
+    };
+    window.APP.store.addEventListener("statechanged", this.onPreferenceChanged);
   },
 
   updateNetworkedAudioSource(networkedAudioSource) {
@@ -165,6 +166,8 @@ AFRAME.registerComponent("audio-source", {
   },
 
   remove() {
+    window.APP.store.removeEventListener("statechanged", this.onPreferenceChanged);
+
     if (!this.audioSource) {
       return;
     }

--- a/src/systems/audio-settings-system.js
+++ b/src/systems/audio-settings-system.js
@@ -117,10 +117,14 @@ AFRAME.registerComponent("audio-source", {
   },
 
   updateNetworkedAudioSource(networkedAudioSource) {
-    const disablePositionalAudio = this.audioOutputModePref === "audio";
-    networkedAudioSource.data.positional = disablePositionalAudio ? false : this.originalValueOfPositional;
     if (networkedAudioSource.sound) {
       networkedAudioSource.sound.disconnect();
+      networkedAudioSource.el.removeObject3D(networkedAudioSource.attrName);
+      delete networkedAudioSource.sound;
+    }
+    const disablePositionalAudio = this.audioOutputModePref === "audio";
+    if (networkedAudioSource.data.positional === disablePositionalAudio) {
+      networkedAudioSource.el.setAttribute("networked-audio-source", { positional: !disablePositionalAudio });
     }
     networkedAudioSource.setupSound();
     const soundSource = networkedAudioSource.sound.context.createMediaStreamSource(networkedAudioSource.stream);
@@ -132,7 +136,6 @@ AFRAME.registerComponent("audio-source", {
     const networkedAudioSource = this.el.components["networked-audio-source"];
     if (networkedAudioSource && this.networkedAudioSource !== networkedAudioSource) {
       this.networkedAudioSource = networkedAudioSource;
-      this.originalValueOfPositional = networkedAudioSource.data.positional;
       this.updateNetworkedAudioSource(networkedAudioSource);
     }
   },

--- a/src/systems/sound-effects-system.js
+++ b/src/systems/sound-effects-system.js
@@ -139,11 +139,10 @@ export class SoundEffectsSystem {
     const audioBuffer = this.sounds.get(sound);
     if (!audioBuffer) return null;
 
-    const audioOutputMode = window.APP.store.state.preferences.audioOutputMode === "audio" ? "audio" : "panner";
-    const positionalAudio =
-      audioOutputMode === "panner"
-        ? new THREE.PositionalAudio(this.scene.audioListener)
-        : new THREE.Audio(this.scene.audioListener);
+    const disablePositionalAudio = window.APP.store.state.preferences.audioOutputMode === "audio";
+    const positionalAudio = disablePositionalAudio
+      ? new THREE.Audio(this.scene.audioListener)
+      : new THREE.PositionalAudio(this.scene.audioListener);
     positionalAudio.setBuffer(audioBuffer);
     positionalAudio.loop = loop;
     this.pendingPositionalAudios.push(positionalAudio);


### PR DESCRIPTION
This PR:
- Fixes bug causing `PositionalAudio`s to get created instead of `Audio`s, even if the `media-video`'s `audioType` was not set to `"pannernode"`. Closes https://github.com/mozilla/hubs/issues/2398 
- Fixes a bug where `audio-source` component attempts to access the `networked-audio-source`'s `sound` before it exists. Closes https://github.com/mozilla/hubs/issues/2466
- Uses the `update` method and `statechanged` events when interfacing with the preference `store`. 
- Updates `media-video` such that it will recreate their `Audio` or `PositionalAudio`s when necessary. 
- Adds `avatar-audio-source`, which is a re-write of `networked-audio-source` that will recreate its `Audio` or `PositionalAudio` when its `positional` component data changes. (It also uses `async` and `await` as a quality of life improvement, which we can do because it's not in the NAF repo which doesn't use those language features.)
- Updates `avatar-volume-controls` so that they continue to work if an `Audio` or `PositionalAudio`s get recreated.

