### PR TITLE
Correctly handle MPDs that don't use relative urls

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -700,6 +700,9 @@ AFRAME.registerComponent("media-video", {
         // If hls.js is supported we always use it as it gives us better events
       } else if (contentType.startsWith("application/dash")) {
         const dashPlayer = MediaPlayer().create();
+        dashPlayer.extend("RequestModifier", function() {
+          return { modifyRequestHeader: xhr => xhr, modifyRequestURL: proxiedUrlFor };
+        });
         dashPlayer.on(MediaPlayer.events.ERROR, failLoad);
         dashPlayer.initialize(videoEl, url);
         dashPlayer.setTextDefaultEnabled(false);


### PR DESCRIPTION
Some mpd's like http://livesim.dashif.org/livesim/testpic_2s/Manifest.mpd specify a baseUrl, this results in us hitting the origin directly, not using our CORS proxy. Implement a `RequestModifier` to ensure all requests are rewritten to our CORS proxy when needed. 