### PR TITLE
Fix transparency on some images, notably avatar previews

### DIFF
--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -589,7 +589,7 @@ AFRAME.registerComponent("media-loader", {
           { once: true }
         );
         this.el.setAttribute("floaty-object", { reduceAngularFloat: true, releaseGravity: -1 });
-        let batch = !disableBatching;
+        let batch = !disableBatching && forceImageBatching;
         if (this.data.mediaOptions.hasOwnProperty("batch") && !this.data.mediaOptions.batch) {
           batch = false;
         }

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -1104,7 +1104,7 @@ AFRAME.registerComponent("media-image", {
       !this.data.batch ||
       texture == errorTexture ||
       this.data.contentType.includes("image/gif") ||
-      (texture.image && texture.image.hasAlpha);
+      !!(texture.image && texture.image.hasAlpha);
 
     this.mesh.material.map = texture;
     this.mesh.material.needsUpdate = true;


### PR DESCRIPTION
Transparency on some images, particularly web previews, most notably avatar previews, was sometimes being set incorrectly. This manifested in some weird issues, particularly on scene transitions.

Fixes this by:
1. correctly checking batching flags for web thumbnails (they were missed when batching was flipped to disabled by default) 
2. preventing `transparent` from being `undefined`, this was happening for cases where `image` or `image.hasAlpha` was undefined.

fixes #2463 