### PR TITLE
Allow "Custom GLB" when no base avatars are set

### DIFF
--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -462,7 +462,7 @@ export default class AvatarEditor extends Component {
                 {debug && this.textField("parent_avatar_id", "Parent Avatar ID")}
                 {debug && this.textField("parent_avatar_listing_id", "Parent Avatar Listing ID")}
                 {debug && this.textarea("description", "Description")}
-                {!!this.state.baseAvatarResults.length && this.selectListingGrid("parent_avatar_listing_id", "Model")}
+                {!this.props.avatarId && this.selectListingGrid("parent_avatar_listing_id", "Model")}
 
                 <label>Skin</label>
                 {this.mapField("base_map", "Base Map", "image/*")}


### PR DESCRIPTION
If you have no base avatars set on your Hubs instance we would also inadvertently hide the "Custom GLB" option. 

We were also using `baseAvatarResults` to detect if you were editing an existing avatar or creating a new one (since we don't bother fetching them in the edit case). Instead uses the existence of an `avatarId` to hide the "Model" section (this is what we use elsewhere to decide to fetch baseAvatarResults or not), and lets `map` handle the fact that an empty set of results doesn't display anything.