### PR TITLE
Remove matrix auto update from interactable media template

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -281,7 +281,6 @@
                     scalable-when-grabbed
                     floaty-object="modifyGravityOnRelease: true; autoLockOnLoad: true;"
                     set-yxz-order
-                    matrix-auto-update
                     hoverable-visuals
                     position-at-border__freeze="target:.freeze-menu"
                     position-at-border__freeze-unprivileged="target:.freeze-unprivileged-menu"

--- a/src/systems/physics-system.js
+++ b/src/systems/physics-system.js
@@ -165,9 +165,11 @@ export class PhysicsSystem {
                 this.objectMatricesFloatArray,
                 index * BUFFER_CONFIG.BODY_DATA_SIZE + BUFFER_CONFIG.MATRIX_OFFSET
               );
+              object3D.parent.updateMatrices();
               inverse.getInverse(object3D.parent.matrixWorld);
               transform.multiplyMatrices(inverse, matrix);
               transform.decompose(object3D.position, object3D.quaternion, scale);
+              object3D.matrixNeedsUpdate = true;
             }
 
             object3D.updateMatrices();

--- a/src/systems/physics-system.js
+++ b/src/systems/physics-system.js
@@ -256,6 +256,7 @@ export class PhysicsSystem {
   addShapes(bodyUuid, mesh, options) {
     if (mesh) {
       const scale = new THREE.Vector3();
+      mesh.updateMatrices();
       scale.setFromMatrixScale(mesh.matrixWorld);
     }
     this.workerHelpers.addShapes(bodyUuid, this.nextShapeUuid, mesh, options);


### PR DESCRIPTION
- Calls updateMatrices before accessing matrixWorld
- Sets matrixNeedsUpdate to true after writing to position and quaternion
- Removes matrix auto update
