### PR TITLE
Fix bug where camera drifts while focusing on an object

### DIFF
--- a/src/utils/three-utils.js
+++ b/src/utils/three-utils.js
@@ -318,12 +318,17 @@ export const rotateInPlaceAroundWorldUp = (function() {
 })();
 
 export const childMatch = (function() {
+  const inverseParentWorld = new THREE.Matrix4();
+  const childRelativeToParent = new THREE.Matrix4();
   const childInverse = new THREE.Matrix4();
   const newParentMatrix = new THREE.Matrix4();
   // transform the parent such that its child matches the target
   return function childMatch(parent, child, target) {
+    parent.updateMatrices();
+    inverseParentWorld.getInverse(parent.matrixWorld);
     child.updateMatrices();
-    childInverse.getInverse(child.matrix);
+    childRelativeToParent.multiplyMatrices(inverseParentWorld, child.matrixWorld);
+    childInverse.getInverse(childRelativeToParent);
     newParentMatrix.multiplyMatrices(target, childInverse);
     setMatrixWorld(parent, newParentMatrix);
   };


### PR DESCRIPTION
In a previous commit (https://github.com/mozilla/hubs/pull/2450/files#diff-35afe0dd6ad5010112331046b02295bcR248), we started referring to `viewingCamera.object3DMap.camera` instead of `viewingCamera.object3D`, which meant that when calling `childMatch` here https://github.com/mozilla/hubs/blob/master/src/systems/camera-system.js#L68 and here https://github.com/mozilla/hubs/blob/master/src/systems/camera-system.js#L114 , we were using the `object3DMap.camera`'s `matrix` as if it were the offset relative to the `rig` object. However, the `viewingCamera`'s `object3D` is still being altered (I think only by the `pitch-yaw-rotator`, so an alternative might be to change _that_ rather than change this), so the `object3DMap.camera`'s `matrix` is only _part_ of its relative transform.

This PR changes `childMatch` so that the `child` can be an arbitrarily nested element of the given `parent` by computing `childRelativeToParent` using the `matrixWorld`'s of both.