### PR TITLE
Wait for the camera to get added to the object3DMap

### DIFF
--- a/src/components/audio-feedback.js
+++ b/src/components/audio-feedback.js
@@ -170,7 +170,6 @@ AFRAME.registerComponent("scale-audio-feedback", {
   async init() {
     await waitForDOMContentLoaded();
     this.cameraEl = document.getElementById("viewing-camera");
-
   },
 
   tick() {

--- a/src/components/audio-feedback.js
+++ b/src/components/audio-feedback.js
@@ -169,14 +169,15 @@ AFRAME.registerComponent("scale-audio-feedback", {
 
   async init() {
     await waitForDOMContentLoaded();
-    this.camera = document.getElementById("viewing-camera").object3DMap.camera;
+    this.cameraEl = document.getElementById("viewing-camera");
+
   },
 
   tick() {
     // TODO: come up with a cleaner way to handle this.
     // bone's are "hidden" by scaling them with bone-visibility, without this we would overwrite that.
     if (!this.el.object3D.visible) return;
-    if (!this.camera) return;
+    if (!this.cameraEl) return;
     if (!this.analyser) this.analyser = getAnalyser(this.el);
 
     const { minScale, maxScale } = this.data;
@@ -185,7 +186,7 @@ AFRAME.registerComponent("scale-audio-feedback", {
 
     const scale = getAudioFeedbackScale(
       this.el.object3D,
-      this.camera,
+      this.cameraEl.object3DMap.camera,
       minScale,
       maxScale,
       this.analyser ? this.analyser.volume : 0

--- a/src/components/visibility-while-frozen.js
+++ b/src/components/visibility-while-frozen.js
@@ -24,7 +24,7 @@ AFRAME.registerComponent("visibility-while-frozen", {
     this.objWorldPos = new THREE.Vector3();
 
     waitForDOMContentLoaded().then(() => {
-      this.cam = document.getElementById("viewing-camera").object3DMap.camera;
+      this.cameraEl = document.getElementById("viewing-camera");
       this.updateVisibility();
     });
 
@@ -68,7 +68,7 @@ AFRAME.registerComponent("visibility-while-frozen", {
   },
 
   updateVisibility() {
-    if (!this.cam) return;
+    if (!this.cameraEl) return;
     const isFrozen = this.el.sceneEl.is("frozen");
 
     let isWithinDistance = true;
@@ -81,7 +81,7 @@ AFRAME.registerComponent("visibility-while-frozen", {
         this.el.object3D.updateMatrices(true, true);
       }
 
-      getLastWorldPosition(this.cam, this.camWorldPos);
+      getLastWorldPosition(this.cameraEl.object3DMap.camera, this.camWorldPos);
       this.objWorldPos.copy(this.el.object3D.position);
       this.el.object3D.localToWorld(this.objWorldPos);
 

--- a/src/systems/menu-animation-system.js
+++ b/src/systems/menu-animation-system.js
@@ -7,7 +7,7 @@ export class MenuAnimationSystem {
     this.data = new Map();
     this.tick = this.tick.bind(this);
     waitForDOMContentLoaded().then(() => {
-      this.viewingCamera = document.getElementById("viewing-camera").object3DMap.camera;
+      this.viewingCameraEl = document.getElementById("viewing-camera");
     });
   }
   register(component, menuEl, chooseScale) {
@@ -32,11 +32,12 @@ export class MenuAnimationSystem {
     const menuPosition = new THREE.Vector3();
     const cameraPosition = new THREE.Vector3();
     return function tick(t) {
-      if (!this.viewingCamera) {
+      if (!this.viewingCameraEl) {
         return;
       }
-      this.viewingCamera.updateMatrices();
-      cameraPosition.setFromMatrixPosition(this.viewingCamera.matrixWorld);
+      const camera = this.viewingCameraEl.object3DMap.camera;
+      camera.updateMatrices();
+      cameraPosition.setFromMatrixPosition(camera.matrixWorld);
 
       for (let i = 0; i < this.components.length; i++) {
         const datum = this.data.get(this.components[i]);


### PR DESCRIPTION
The `THREE.PerspectiveCamera` is added to the `object3DMap` when the `AFRAME` `camera` component `init`'s (https://github.com/MozillaReality/aframe/blob/hubs/master/src/components/camera.js#L28), which may happen _after_ other components and systems try to access it. This PR avoids reaching into the `object3DMap` until after the `init` has had a chance to run.

Fixes https://github.com/mozilla/hubs/issues/2472