### PR TITLE
Fix fader

### DIFF
--- a/src/components/fader.js
+++ b/src/components/fader.js
@@ -17,7 +17,8 @@ AFRAME.registerComponent("fader", {
     mesh.scale.x = mesh.scale.y = 1;
     mesh.scale.z = 0.15;
     mesh.matrixNeedsUpdate = true;
-    this.el.object3D.add(mesh);
+
+    this.el.object3DMap.camera.add(mesh);
     this.mesh = mesh;
   },
 

--- a/src/components/fader.js
+++ b/src/components/fader.js
@@ -17,8 +17,8 @@ AFRAME.registerComponent("fader", {
     mesh.scale.x = mesh.scale.y = 1;
     mesh.scale.z = 0.15;
     mesh.matrixNeedsUpdate = true;
-
     this.el.object3DMap.camera.add(mesh);
+
     this.mesh = mesh;
   },
 

--- a/src/components/fader.js
+++ b/src/components/fader.js
@@ -18,7 +18,6 @@ AFRAME.registerComponent("fader", {
     mesh.scale.z = 0.15;
     mesh.matrixNeedsUpdate = true;
     this.el.object3DMap.camera.add(mesh);
-
     this.mesh = mesh;
   },
 


### PR DESCRIPTION
This PR makes the `fader`'s `mesh` a child of the `THREE.PerspectiveCamera`

Fixes https://github.com/mozilla/hubs/issues/2478

(Note that I'm not waiting like I do in this PR (https://github.com/mozilla/hubs/pull/2496) because the `fader` is defined on the same entity as the `camera` component and the `camera` component runs first.)