### PR TITLE
Fix 2474 - sets dial pad logo position relative

### DIFF
--- a/src/assets/stylesheets/link.scss
+++ b/src/assets/stylesheets/link.scss
@@ -40,7 +40,7 @@ a {
 }
 
 :local(.logo) {
-  position: absolute;
+  position: relative;
   top: 0;
   left: 0;
   width: 100%;


### PR DESCRIPTION
I've noticed the issue outlined in #2474 where the logo has the ability to overlap with the dial pad for room login. This is due to the absolute positioning of the logo used on that page. This PR may have unintended consequences so testing probably should be done before merge.

here's what the logo looks like with relative positioning set.

![ezgif-4-a00f2833aa2e](https://user-images.githubusercontent.com/8985705/81765774-55962880-949a-11ea-8d16-d240bb872494.gif)


