### PR TITLE
Allow mixing of multiple outbound mediaStreams' audio

### DIFF
--- a/src/components/audio-feedback.js
+++ b/src/components/audio-feedback.js
@@ -106,16 +106,6 @@ AFRAME.registerComponent("networked-audio-analyser", {
   }
 });
 
-function connectAnalyser(mediaStream) {
-  const ctx = THREE.AudioContext.getContext();
-  const source = ctx.createMediaStreamSource(mediaStream);
-  const analyser = ctx.createAnalyser();
-  analyser.fftSize = 32;
-  const levels = new Uint8Array(analyser.fftSize);
-  source.connect(analyser);
-  return { analyser, levels };
-}
-
 function getAnalyser(el) {
   // Is this the local player
   const ikRootEl = findAncestorWithComponent(el, "ik-root");
@@ -137,16 +127,10 @@ AFRAME.registerSystem("local-audio-analyser", {
     this.loudest = 0;
     this.prevVolume = 0;
 
-    this.el.addEventListener("local-media-stream-created", e => {
-      const mediaStream = e.detail.mediaStream;
-      if (this.stream) {
-        console.warn("media stream changed", this.stream, mediaStream);
-        // TODO: cleanup?
-      }
-      this.stream = mediaStream;
-      const { analyser, levels } = connectAnalyser(mediaStream);
-      this.analyser = analyser;
-      this.levels = levels;
+    this.el.addEventListener("local-media-stream-created", () => {
+      const audioSystem = this.el.sceneEl.systems["hubs-systems"].audioSystem;
+      this.analyser = audioSystem.outboundAnalyser;
+      this.levels = audioSystem.analyserLevels;
     });
   },
 

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -652,7 +652,6 @@ class UIRoot extends Component {
       const audioSystem = this.props.scene.systems["hubs-systems"].audioSystem;
       audioSystem.addStreamToOutboundAudio("microphone", newStream);
       const mediaStream = audioSystem.outboundStream;
-      // const audioTrack = mediaStream.getAudioTracks()[0];
       const audioTrack = newStream.getAudioTracks()[0];
 
       this.setState({ audioTrack, mediaStream });

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -620,9 +620,6 @@ class UIRoot extends Component {
     if (this.state.audioTrack) {
       this.state.audioTrack.stop();
     }
-    if (this.state.audioTrackClone) {
-      this.state.audioTrackClone.stop();
-    }
 
     constraints.audio.echoCancellation =
       window.APP.store.state.preferences.disableEchoCancellation === true ? false : true;
@@ -650,9 +647,15 @@ class UIRoot extends Component {
     }
 
     try {
-      const mediaStream = await navigator.mediaDevices.getUserMedia(constraints);
-      const audioTrack = mediaStream.getAudioTracks()[0];
-      this.setState({ audioTrack });
+      const newStream = await navigator.mediaDevices.getUserMedia(constraints);
+
+      const audioSystem = this.props.scene.systems["hubs-systems"].audioSystem;
+      audioSystem.addStreamToOutboundAudio("microphone", newStream);
+      const mediaStream = audioSystem.outboundStream;
+      // const audioTrack = mediaStream.getAudioTracks()[0];
+      const audioTrack = newStream.getAudioTracks()[0];
+
+      this.setState({ audioTrack, mediaStream });
 
       if (/Oculus/.test(navigator.userAgent)) {
         // HACK Oculus Browser 6 seems to randomly end the microphone audio stream. This re-creates it.
@@ -662,23 +665,15 @@ class UIRoot extends Component {
             "Oculus Browser 6 bug hit: Audio stream track ended without calling stop. Recreating audio stream."
           );
 
-          const mediaStream = await navigator.mediaDevices.getUserMedia(constraints);
-          const audioTrack = mediaStream.getAudioTracks()[0];
-          const audioTrackClone = audioTrack.clone();
+          const newStream = await navigator.mediaDevices.getUserMedia(constraints);
+          const audioTrack = newStream.getAudioTracks()[0];
 
-          await NAF.connection.adapter.setLocalMediaStream(mediaStream);
+          audioSystem.addStreamToOutboundAudio("microphone", newStream);
 
-          if (this.props.scene.is("muted")) {
-            console.warn("re-muting microphone");
-            NAF.connection.adapter.enableMicrophone(false);
-            audioTrack.enabled = false;
-          }
+          this.setState({ audioTrack });
 
-          this.setState({ mediaStream, audioTrack, audioTrackClone });
+          this.props.scene.emit("local-media-stream-created");
 
-          const mediaStreamForMicAnalysis = new MediaStream();
-          mediaStreamForMicAnalysis.addTrack(audioTrackClone);
-          this.props.scene.emit("local-media-stream-created", { mediaStream: mediaStreamForMicAnalysis });
           audioTrack.addEventListener("ended", recreateAudioStream, { once: true });
         };
 
@@ -688,31 +683,23 @@ class UIRoot extends Component {
       return true;
     } catch (e) {
       // Error fetching audio track, most likely a permission denial.
+      console.error("Error during getUserMedia: ", e);
       this.setState({ audioTrack: null });
       return false;
     }
   };
 
   setupNewMediaStream = async () => {
-    const mediaStream = new MediaStream();
-
     await this.fetchMicDevices();
 
     // we should definitely have an audioTrack at this point unless they denied mic access
-    if (this.state.audioTrack) {
-      mediaStream.addTrack(this.state.audioTrack);
-      const micDeviceId = this.micDeviceIdForMicLabel(this.micLabelForMediaStream(mediaStream));
+    if (this.state.mediaStream) {
+      const micDeviceId = this.micDeviceIdForMicLabel(this.micLabelForMediaStream(this.state.mediaStream));
       if (micDeviceId) {
         this.props.store.update({ settings: { lastUsedMicDeviceId: micDeviceId } });
       }
-      const mediaStreamForMicAnalysis = new MediaStream();
-      const audioTrackClone = this.state.audioTrack.clone();
-      this.setState({ audioTrackClone });
-      mediaStreamForMicAnalysis.addTrack(audioTrackClone);
-      this.props.scene.emit("local-media-stream-created", { mediaStream: mediaStreamForMicAnalysis });
+      this.props.scene.emit("local-media-stream-created");
     }
-
-    this.setState({ mediaStream });
   };
 
   onMicGrantButton = async () => {

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -418,6 +418,13 @@ export default class SceneEntryManager {
 
       if (videoTracks.length > 0) {
         newStream.getVideoTracks().forEach(track => mediaStream.addTrack(track));
+
+        const audioTracks = newStream ? newStream.getAudioTracks() : [];
+        if (audioTracks.length > 0) {
+          const audioSystem = this.scene.systems["hubs-systems"].audioSystem;
+          audioSystem.addStreamToOutboundAudio("screenshare", newStream);
+        }
+
         await NAF.connection.adapter.setLocalMediaStream(mediaStream);
         currentVideoShareEntity = spawnMediaInfrontOfPlayer(mediaStream, undefined);
 
@@ -468,6 +475,9 @@ export default class SceneEntryManager {
       for (const track of mediaStream.getVideoTracks()) {
         mediaStream.removeTrack(track);
       }
+
+      const audioSystem = this.scene.systems["hubs-systems"].audioSystem;
+      audioSystem.removeStreamFromOutboundAudio("screenshare");
 
       await NAF.connection.adapter.setLocalMediaStream(mediaStream);
       currentVideoShareEntity = null;

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -443,6 +443,7 @@ export default class SceneEntryManager {
           width: isIOS ? { max: 1280 } : { max: 1280, ideal: 720 },
           frameRate: 30
         }
+        //TODO: Capture audio from camera?
       });
     });
 
@@ -456,7 +457,11 @@ export default class SceneEntryManager {
             height: 720,
             frameRate: 30
           },
-          audio: true
+          audio: {
+            echoCancellation: window.APP.store.state.preferences.disableEchoCancellation === true ? false : true,
+            noiseSuppression: window.APP.store.state.preferences.disableNoiseSuppression === true ? false : true,
+            autoGainControl: window.APP.store.state.preferences.disableAutoGainControl === true ? false : true
+          }
         },
         true
       );

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -419,8 +419,7 @@ export default class SceneEntryManager {
       if (videoTracks.length > 0) {
         newStream.getVideoTracks().forEach(track => mediaStream.addTrack(track));
 
-        const audioTracks = newStream ? newStream.getAudioTracks() : [];
-        if (audioTracks.length > 0) {
+        if (newStream && newStream.getAudioTracks().length > 0) {
           const audioSystem = this.scene.systems["hubs-systems"].audioSystem;
           audioSystem.addStreamToOutboundAudio("screenshare", newStream);
         }

--- a/src/systems/audio-system.js
+++ b/src/systems/audio-system.js
@@ -35,20 +35,25 @@ async function enableChromeAEC(gainNode) {
     audioEl.srcObject = e.streams[0];
   });
 
-  gainNode.disconnect();
-  gainNode.connect(loopbackDestination);
+  try {
+    //The following should never fail, but just in case, we won't disconnect/reconnect the gainNode unless all of this succeeds
+    loopbackDestination.stream.getTracks().forEach(track => {
+      outboundPeerConnection.addTrack(track, loopbackDestination.stream);
+    });
 
-  loopbackDestination.stream.getTracks().forEach(track => {
-    outboundPeerConnection.addTrack(track, loopbackDestination.stream);
-  });
+    const offer = await outboundPeerConnection.createOffer();
+    outboundPeerConnection.setLocalDescription(offer);
+    await inboundPeerConnection.setRemoteDescription(offer);
 
-  const offer = await outboundPeerConnection.createOffer().catch(onError);
-  outboundPeerConnection.setLocalDescription(offer).catch(onError);
-  await inboundPeerConnection.setRemoteDescription(offer).catch(onError);
+    const answer = await inboundPeerConnection.createAnswer();
+    inboundPeerConnection.setLocalDescription(answer);
+    outboundPeerConnection.setRemoteDescription(answer);
 
-  const answer = await inboundPeerConnection.createAnswer();
-  inboundPeerConnection.setLocalDescription(answer).catch(onError);
-  outboundPeerConnection.setRemoteDescription(answer).catch(onError);
+    gainNode.disconnect();
+    gainNode.connect(loopbackDestination);
+  } catch (e) {
+    onError(e);
+  }
 }
 
 export class AudioSystem {
@@ -57,36 +62,33 @@ export class AudioSystem {
     if (sceneEl.camera) {
       sceneEl.camera.add(sceneEl.audioListener);
     }
-    sceneEl.addEventListener("camera-set-active", evt => {
+    sceneEl.addEventListener("camera-set- active", evt => {
       evt.detail.cameraEl.getObject3D("camera").add(sceneEl.audioListener);
     });
 
-    const ctx = THREE.AudioContext.getContext();
-    this.outboundContext = new (window.AudioContext || window.webkitAudioContext)();
+    this.audioContext = THREE.AudioContext.getContext();
     this.audioNodes = new Map();
+    this.mediaStreamDestinationNode = this.audioContext.createMediaStreamDestination();
+    this.outboundStream = this.mediaStreamDestinationNode.stream;
+    this.outboundGainNode = this.audioContext.createGain();
+    this.outboundAnalyser = this.audioContext.createAnalyser();
+    this.outboundAnalyser.fftSize = 32;
+    this.analyserLevels = new Uint8Array(this.outboundAnalyser.fftSize);
+    this.outboundGainNode.connect(this.outboundAnalyser);
+    this.outboundAnalyser.connect(this.mediaStreamDestinationNode);
 
     /**
      * Chrome and Safari will start Audio contexts in a "suspended" state.
      * A user interaction (touch/mouse event) is needed in order to resume the AudioContext.
      */
     const resume = () => {
-      ctx.resume();
-      this.outboundContext.resume();
+      this.audioContext.resume();
 
       setTimeout(() => {
-        if (ctx.state === "running" && this.outboundContext.state === "running") {
+        if (this.audioContext.state === "running") {
           if (!AFRAME.utils.device.isMobile() && /chrome/i.test(navigator.userAgent)) {
             enableChromeAEC(sceneEl.audioListener.gain);
           }
-
-          this.mediaStreamDestinationNode = this.outboundContext.createMediaStreamDestination();
-          this.outboundStream = this.mediaStreamDestinationNode.stream;
-          this.outboundGainNode = this.outboundContext.createGain();
-          this.outboundAnalyser = this.outboundContext.createAnalyser();
-          this.outboundAnalyser.fftSize = 32;
-          this.analyserLevels = new Uint8Array(this.outboundAnalyser.fftSize);
-          this.outboundGainNode.connect(this.outboundAnalyser);
-          this.outboundAnalyser.connect(this.mediaStreamDestinationNode);
 
           document.body.removeEventListener("touchend", resume, false);
           document.body.removeEventListener("mouseup", resume, false);
@@ -103,8 +105,8 @@ export class AudioSystem {
       this.removeStreamFromOutboundAudio(id);
     }
 
-    const sourceNode = this.outboundContext.createMediaStreamSource(mediaStream);
-    const gainNode = this.outboundContext.createGain();
+    const sourceNode = this.audioContext.createMediaStreamSource(mediaStream);
+    const gainNode = this.audioContext.createGain();
     sourceNode.connect(gainNode);
     gainNode.connect(this.outboundGainNode);
     this.audioNodes.set(id, { sourceNode, gainNode });


### PR DESCRIPTION
This update refactors how outbound audio is handled. Instead of using the `mediaStream` returned from `getUserMedia` directly in NAF/naf-janus-adapter, the stream is passed into the web audio API via a new `AudioContext` to allow for audio from multiple `mediaStreams` to be "mixed" together. The output of this new `AudioContext` is a new `mediaStream` that is then sent over the network. This allows for mixing of audio from additional sources such as screensharing on Chrome, as well as generally simplifying some logic around how the `audio-feedback` component works as well as how we handle when your microphone stream has to be recreated/reconnected (e.g. sometimes Quest will kill the microphone stream so it has to restarted).

This also has the side effect that every outbound audio stream can be individually processed via the Web Audio API (so you can control gain for your microphone, for example). Exposing this ability in preferences will come in a later update. This should also allow for re-selection of your microphone device (without restarting hubs) to be much easier to do in a future update as well. 