### PR TITLE
Map xbox gamepad right joystick horizontal axis to camera yaw. Fixes #2449

### DIFF
--- a/src/systems/userinput/bindings/xbox-controller-user.js
+++ b/src/systems/userinput/bindings/xbox-controller-user.js
@@ -7,6 +7,7 @@ const button = paths.device.xbox.button;
 const axis = paths.device.xbox.axis;
 const scaledRightJoystickVertical = paths.device.xbox.v("scaledRightJoystickVertical");
 const scaledLeftJoystickCursorDelta = paths.device.xbox.v("scaledLeftJoystickCursorDelta");
+const scaledRightJoystickHorizontal = paths.device.xbox.v("scaledRightJoystickHorizontal");
 const deadzonedRightJoystickHorizontal = paths.device.xbox.v("deadzonedRightJoystickHorizontal");
 const deadzonedRightJoystickVertical = paths.device.xbox.v("deadzonedRightJoystickVertical");
 const deadzonedLeftJoystickHorizontal = paths.device.xbox.v("deadzonedLeftJoystickHorizontal");
@@ -97,8 +98,8 @@ export const xboxControllerUserBindings = addSetsToBindings({
     },
     {
       src: { value: deadzonedRightJoystickHorizontal },
-      dest: { value: paths.actions.angularVelocity },
-      xform: xforms.scale(0.6) // horizontal look speed modifier
+      dest: { value: scaledRightJoystickHorizontal },
+      xform: xforms.scale(-0.125) // horizontal look speed modifier
     },
     {
       src: { value: axis("rightJoystickVertical") },
@@ -117,7 +118,7 @@ export const xboxControllerUserBindings = addSetsToBindings({
     },
     {
       src: {
-        x: zero,
+        x: scaledRightJoystickHorizontal,
         y: scaledRightJoystickVertical
       },
       dest: { value: paths.actions.cameraDelta },


### PR DESCRIPTION
Previously this axis was being mapped to `angularVelocity` which doesn't seem to be correct. With this change I can move the camera as expected with an Xbox controller.