### PR TITLE
Fix non-detached heads for avatars

### DIFF
--- a/src/components/animation-mixer.js
+++ b/src/components/animation-mixer.js
@@ -2,16 +2,29 @@
  * Instantiates and updates a THREE.AnimationMixer on an entity.
  * @component animation-mixer
  */
+
+const components = [];
+export class AnimationMixerSystem {
+  tick(dt) {
+    for (let i = 0; i < components.length; i++) {
+      const cmp = components[i];
+      if (cmp.mixer) {
+        cmp.mixer.update(dt / 1000);
+      }
+    }
+  }
+}
+
 AFRAME.registerComponent("animation-mixer", {
   initMixer(animations) {
     this.mixer = new THREE.AnimationMixer(this.el.object3D);
     this.el.object3D.animations = animations;
     this.animations = animations;
   },
-
-  tick: function(t, dt) {
-    if (this.mixer) {
-      this.mixer.update(dt / 1000);
-    }
+  play() {
+    components.push(this);
+  },
+  pause() {
+    components.splice(components.indexOf(this), 1);
   }
 });

--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -624,11 +624,15 @@ AFRAME.registerComponent("camera-tool", {
         }
 
         const bubbleSystem = this.el.sceneEl.systems["personal-space-bubble"];
+        const boneVisibilitySystem = this.el.sceneEl.systems["hubs-systems"].boneVisibilitySystem;
 
         if (bubbleSystem) {
           for (let i = 0, l = bubbleSystem.invaders.length; i < l; i++) {
             bubbleSystem.invaders[i].disable();
           }
+          // HACK, bone visibility typically takes a tick to update, but since we want to be able
+          // to have enable() and disable() be reflected this frame, we need to do it immediately.
+          boneVisibilitySystem.tick();
         }
 
         const tmpVRFlag = renderer.vr.enabled;
@@ -678,6 +682,9 @@ AFRAME.registerComponent("camera-tool", {
           for (let i = 0, l = bubbleSystem.invaders.length; i < l; i++) {
             bubbleSystem.invaders[i].enable();
           }
+          // HACK, bone visibility typically takes a tick to update, but since we want to be able
+          // to have enable() and disable() be reflected this frame, we need to do it immediately.
+          boneVisibilitySystem.tick();
         }
 
         this.lastUpdate = now;

--- a/src/hub.html
+++ b/src/hub.html
@@ -1219,7 +1219,7 @@
                     </a-entity>
                 </template>
                 <template data-name="Head">
-                    <a-entity id="avatar-head" visible="false" bone-visibility></a-entity>
+                    <a-entity id="avatar-head" visible="false" bone-visibility="updateWhileInvisible: true;"></a-entity>
                 </template>
 
                 <template data-name="LeftHand">

--- a/src/systems/hubs-systems.js
+++ b/src/systems/hubs-systems.js
@@ -1,5 +1,7 @@
 import { CursorTargettingSystem } from "./cursor-targetting-system";
 import { PositionAtBorderSystem } from "../components/position-at-border";
+import { BoneVisibilitySystem } from "../components/bone-visibility";
+import { AnimationMixerSystem } from "../components/animation-mixer";
 import { CursorTogglingSystem } from "./cursor-toggling-system";
 import { PhysicsSystem } from "./physics-system";
 import { ConstraintsSystem } from "./constraints-system";
@@ -57,6 +59,8 @@ AFRAME.registerSystem("hubs-systems", {
     this.menuAnimationSystem = new MenuAnimationSystem();
     this.audioSettingsSystem = new AudioSettingsSystem(this.el);
     this.enterVRButtonSystem = new EnterVRButtonSystem(this.el);
+    this.animationMixerSystem = new AnimationMixerSystem();
+    this.boneVisibilitySystem = new BoneVisibilitySystem();
   },
 
   tick(t, dt) {
@@ -64,6 +68,10 @@ AFRAME.registerSystem("hubs-systems", {
     const systems = AFRAME.scenes[0].systems;
     systems.userinput.tick2();
     systems.interaction.tick2();
+
+    // We run this earlier in the frame so things have a chance to override properties run by animations
+    this.animationMixerSystem.tick(dt);
+
     this.characterController.tick(t, dt);
     this.cursorTogglingSystem.tick(systems.interaction, systems.userinput, this.el);
     this.interactionSfxSystem.tick(systems.interaction, systems.userinput, this.soundEffectsSystem);
@@ -93,6 +101,9 @@ AFRAME.registerSystem("hubs-systems", {
     this.menuAnimationSystem.tick(t);
     this.spriteSystem.tick(t, dt);
     this.enterVRButtonSystem.tick();
+
+    // We run this late in the frame so that its the last thing to have an opinion about the scale of an object
+    this.boneVisibilitySystem.tick();
   },
 
   remove() {

--- a/src/systems/personal-space-bubble.js
+++ b/src/systems/personal-space-bubble.js
@@ -238,19 +238,11 @@ AFRAME.registerComponent("personal-space-invader", {
     }
 
     this.disabled = true;
-    this.updateBoneVisibility();
   },
 
   enable() {
     this.disabled = false;
     this.applyInvasionToMesh(this.invading);
-    this.updateBoneVisibility();
-  },
-
-  updateBoneVisibility() {
-    // HACK, bone visibility typically takes a tick to update, but since we want to be able
-    // to have enable() and disable() be reflected this frame, we need to do it immediately.
-    this.el.components["bone-visibility"] && this.el.components["bone-visibility"].tick();
   },
 
   applyInvasionToMesh(invading) {


### PR DESCRIPTION
This PR fixes avatars with non detached heads stretching out the neck verts to the last position the avatar was updated (spawn or when camera tool is open). It does this by continuing to update the head bone's matrix even when it is hidden. 

Fixing this uncovered another issue where animations were still playing on the invisible head bone. This has been fixed by moving animation-mixer and bone-visibility into systems and ensuring they tick in the correct order such that bone-visibility has the final say.