### PR TITLE
Fix several avatar issues

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -18,7 +18,6 @@
     - [player-info](#components/avatar/player-info)
     - [spawn-controller](#components/avatar/spawn-controller)
   - [avatar/personal-space-bubble](#components/avatar/personal-space-bubble)
-    - [space-invader-mesh](#components/avatar/personal-space-bubble/space-invader-mesh)
     - [personal-space-invader](#components/avatar/personal-space-bubble/personal-space-invader)
     - [personal-space-bubble](#components/avatar/personal-space-bubble/personal-space-bubble)
   - [environment](#components/environment)
@@ -471,14 +470,6 @@ Toggle the isPlaying state of a component based on app mode
 
 <a name="components/avatar/personal-space-bubble"></a>
 ### avatar/personal-space-bubble
-      
-<a name="components/avatar/personal-space-bubble/space-invader-mesh"></a>
-#### space-invader-mesh
-
-Specifies a mesh associated with an invader.
-
-`src/systems/personal-space-bubble.js`
-          
 
 <a name="components/avatar/personal-space-bubble/personal-space-invader"></a>
 #### personal-space-invader

--- a/src/components/ik-controller.js
+++ b/src/components/ik-controller.js
@@ -53,6 +53,17 @@ const HAND_ROTATIONS = {
   right: new Matrix4().makeRotationFromEuler(new Euler(-Math.PI / 2, -Math.PI / 2, 0))
 };
 
+const angleOnXZPlaneBetweenMatrixRotations = (function() {
+  const XZ_PLANE_NORMAL = new THREE.Vector3(0, -1, 0);
+  const v1 = new THREE.Vector3();
+  const v2 = new THREE.Vector3();
+  return function angleOnXZPlaneBetweenMatrixRotations(matrixA, matrixB) {
+    v1.setFromMatrixColumn(matrixA, 2).projectOnPlane(XZ_PLANE_NORMAL);
+    v2.setFromMatrixColumn(matrixB, 2).projectOnPlane(XZ_PLANE_NORMAL);
+    return v1.angleTo(v2);
+  };
+})();
+
 /**
  * Performs IK on a hip-rooted skeleton to align the hip, head and hands with camera and controller inputs.
  * @namespace avatar
@@ -214,6 +225,7 @@ AFRAME.registerComponent("ik-controller", {
       // frustum culling errors since three.js does not take into account skinning when
       // computing frustum culling sphere bounds.
       avatar.position.setFromMatrixPosition(headTransform).add(invHipsToHeadVector);
+      avatar.matrixNeedsUpdate = true;
 
       // Animate the hip rotation to follow the Y rotation of the camera with some damping.
       cameraYRotation.setFromRotationMatrix(cameraForward, "YXZ");
@@ -222,9 +234,11 @@ AFRAME.registerComponent("ik-controller", {
       cameraYQuaternion.setFromEuler(cameraYRotation);
 
       if (this._hadFirstTick) {
-        const yDelta = Math.abs(
-          Math.atan2(Math.sin(cameraYRotation.y - avatar.rotation.y), Math.cos(cameraYRotation.y - avatar.rotation.y))
-        );
+        camera.object3D.updateMatrices();
+        avatar.updateMatrices();
+        // Note: Camera faces down -Z, avatar faces down +Z
+        const yDelta = Math.PI - angleOnXZPlaneBetweenMatrixRotations(camera.object3D.matrixWorld, avatar.matrixWorld);
+
         if (yDelta > this.data.maxLerpAngle) {
           avatar.quaternion.copy(cameraYQuaternion);
         } else {

--- a/src/hub.html
+++ b/src/hub.html
@@ -197,11 +197,11 @@
                         </template>
 
                         <template data-name="LeftHand">
-                            <a-entity personal-space-invader="radius: 0.1" bone-visibility></a-entity>
+                            <a-entity personal-space-invader="radius: 0.1" bone-visibility="updateWhileInvisible: true;"></a-entity>
                         </template>
 
                         <template data-name="RightHand">
-                            <a-entity personal-space-invader="radius: 0.1" bone-visibility></a-entity>
+                            <a-entity personal-space-invader="radius: 0.1" bone-visibility="updateWhileInvisible: true;"></a-entity>
                         </template>
                     </a-entity>
                 </a-entity>
@@ -1223,11 +1223,11 @@
                 </template>
 
                 <template data-name="LeftHand">
-                    <a-entity bone-visibility hover-visuals="hand: left;"></a-entity>
+                    <a-entity bone-visibility="updateWhileInvisible: true;" hover-visuals="hand: left;"></a-entity>
                 </template>
 
                 <template data-name="RightHand">
-                    <a-entity bone-visibility hover-visuals="hand: right;"></a-entity>
+                    <a-entity bone-visibility="updateWhileInvisible: true;" hover-visuals="hand: right;"></a-entity>
                 </template>
 
             </a-entity>

--- a/src/systems/personal-space-bubble.js
+++ b/src/systems/personal-space-bubble.js
@@ -151,26 +151,12 @@ function createSphereGizmo(radius) {
   return line;
 }
 
-// TODO: we need to come up with a more generic way of doing this as this is very specific to our avatars.
-/**
- * Specifies a mesh associated with an invader.
- * @namespace avatar/personal-space-bubble
- * @component space-invader-mesh
- */
-AFRAME.registerComponent("space-invader-mesh", {
-  schema: {
-    meshName: { type: "string" }
-  },
-  update() {
-    this.targetMesh = this.el.object3D.getObjectByName(this.data.meshName);
-  }
-});
-
 function findInvaderMesh(entity) {
-  while (entity && !(entity.components && entity.components["space-invader-mesh"])) {
+  while (entity && !(entity.components && entity.components["gltf-model-plus"])) {
     entity = entity.parentNode;
   }
-  return entity && entity.components["space-invader-mesh"].targetMesh;
+  // TODO this assumes a single skinned mesh, should be some way for avatar to override this
+  return entity && entity.object3D.getObjectByProperty("type", "SkinnedMesh");
 }
 
 const DEBUG_OBJ = "psb-debug";


### PR DESCRIPTION
Fixes:
- Hands showing at the origin
- Lerping of body following the head. There was a typo breaking this completely, also improved it slightly by adding a maximum angle at which the body will just snap instead of lerping
- Fixed personal space bubbles and ditched the `space-invader-mesh` component. This can still be improved but fixes the behavior to at least be consistent on all avatars.