### PR TITLE
Account for logos with different aspect ratios.

### DIFF
--- a/src/assets/stylesheets/avatar.scss
+++ b/src/assets/stylesheets/avatar.scss
@@ -21,7 +21,8 @@ body {
   @extend %unselectable;
 
   :local(.logo) {
-    width: 150px;
+    max-width: 150px;
+    max-height: 64px;
     margin-bottom: 22px;
     filter: drop-shadow(0 0 4px #888);
 

--- a/src/assets/stylesheets/link.scss
+++ b/src/assets/stylesheets/link.scss
@@ -15,7 +15,6 @@ body {
   -webkit-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  overflow-y: hidden;
 }
 
 button {
@@ -46,6 +45,7 @@ a {
   width: 100%;
   display: flex;
   justify-content: center;
+  align-items: center;
   margin-top: 24px;
 
   img {
@@ -65,7 +65,6 @@ a {
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100%;
 }
 
 :local(.link-contents) {
@@ -105,7 +104,7 @@ a {
 }
 
 :local(.create-link) {
-  margin-top: 36px;
+  margin-top: 1em;
   font-size: 0.8em;
 
   @media(max-width: 690px) {

--- a/src/assets/stylesheets/profile.scss
+++ b/src/assets/stylesheets/profile.scss
@@ -19,7 +19,8 @@
   }
 
   :local(.logo) {
-    width: 150px;
+    max-width: 150px;
+    max-height: 64px;
     position: absolute;
     right: 32px;
     bottom: 32px;

--- a/src/naf-dialog-adapter.js
+++ b/src/naf-dialog-adapter.js
@@ -46,6 +46,7 @@ export default class DialogAdapter {
     this._initialAudioConsumerPromise = null;
     this._initialAudioConsumerResolvers = new Map();
     this._serverTimeRequests = 0;
+    this._avgTimeOffset = 0;
     this._blockedClients = new Map();
     this.type = "dialog";
     this.occupants = []; // This is a public field
@@ -669,10 +670,10 @@ export default class DialogAdapter {
       this._timeOffsets[this._serverTimeRequests % 10] = timeOffset;
     }
 
-    this.avgTimeOffset = this._timeOffsets.reduce((acc, offset) => (acc += offset), 0) / this._timeOffsets.length;
+    this._avgTimeOffset = this._timeOffsets.reduce((acc, offset) => (acc += offset), 0) / this._timeOffsets.length;
 
     if (this._serverTimeRequests > 10) {
-      debug(`new server time offset: ${this.avgTimeOffset}ms`);
+      debug(`new server time offset: ${this._avgTimeOffset}ms`);
       setTimeout(() => this.updateTimeOffset(), 5 * 60 * 1000); // Sync clock every 5 minutes.
     } else {
       this.updateTimeOffset();


### PR DESCRIPTION
Includes #2499 and #2390. Fixes #2474 

- Fixes logo overlap on link page (thanks to @antpb)
- Fixes stretched logo on link page in Safari
- Adjust margins and allows scrolling of link page on small screens.
- Limit logo size on avatar and profile UI.