### PR TITLE
Fix race conditions in lightmap loading and add support for intensity.

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -310,6 +310,16 @@ function runMigration(version, json) {
   }
 }
 
+const loadLightmap = async (parser, materialIndex) => {
+  const lightmapDef = parser.json.materials[materialIndex].extensions.MOZ_lightmap;
+  const [material, lightMap] = await Promise.all([
+    parser.getDependency("material", materialIndex),
+    parser.getDependency("texture", lightmapDef.index)
+  ]);
+  material.lightMap = lightMap;
+  return lightMap;
+};
+
 export async function loadGLTF(src, contentType, preferredTechnique, onProgress, jsonPreprocessor) {
   let gltfUrl = src;
   let fileMap;
@@ -342,42 +352,7 @@ export async function loadGLTF(src, contentType, preferredTechnique, onProgress,
   }
   runMigration(version, parser.json);
 
-  const materials = parser.json.materials;
-  const dependencies = [];
-
-  if (materials) {
-    for (let i = 0; i < materials.length; i++) {
-      const material = materials[i];
-
-      if (!material.extensions) {
-        continue;
-      }
-
-      if (
-        material.extensions.MOZ_alt_materials &&
-        material.extensions.MOZ_alt_materials[preferredTechnique] !== undefined
-      ) {
-        const altMaterialIndex = material.extensions.MOZ_alt_materials[preferredTechnique];
-        materials[i] = materials[altMaterialIndex];
-      } else if (material.extensions.MOZ_lightmap) {
-        const lightmapDef = material.extensions.MOZ_lightmap;
-
-        const loadLightmap = async () => {
-          const [material, lightMap] = await Promise.all([
-            parser.getDependency("material", i),
-            parser.getDependency("texture", lightmapDef.index)
-          ]);
-
-          material.lightMap = lightMap;
-        };
-
-        dependencies.push(loadLightmap);
-      }
-    }
-  }
-
   const nodes = parser.json.nodes;
-
   if (nodes) {
     for (let i = 0; i < nodes.length; i++) {
       const node = nodes[i];
@@ -390,8 +365,48 @@ export async function loadGLTF(src, contentType, preferredTechnique, onProgress,
     }
   }
 
-  // Note: dependency functions need to be called after parser.parse() so that the cache isn't cleared.
-  const [gltf] = await Promise.all([new Promise(parser.parse.bind(parser)), dependencies.map(fn => fn())]);
+  // Mark the special nodes/meshes in json for efficient parse, all json manipulation should happen before this point
+  parser.markDefs();
+
+  const materials = parser.json.materials;
+  const extensionDeps = [];
+  if (materials) {
+    for (let i = 0; i < materials.length; i++) {
+      const materialNode = materials[i];
+
+      if (!materialNode.extensions) continue;
+
+      if (
+        materialNode.extensions.MOZ_alt_materials &&
+        materialNode.extensions.MOZ_alt_materials[preferredTechnique] !== undefined
+      ) {
+        const altMaterialIndex = materialNode.extensions.MOZ_alt_materials[preferredTechnique];
+        materials[i] = materials[altMaterialIndex];
+      } else if (materialNode.extensions.MOZ_lightmap) {
+        extensionDeps.push(loadLightmap(parser, i));
+      }
+    }
+  }
+
+  // Note this is being done in place of parser.parse() which we now no longer call. This gives us more control over the order of execution.
+  const [scenes, animations, cameras] = await Promise.all([
+    parser.getDependencies("scene"),
+    parser.getDependencies("animation"),
+    parser.getDependencies("camera"),
+    Promise.all(extensionDeps)
+  ]);
+  var gltf = {
+    scene: scenes[parser.json.scene || 0],
+    scenes,
+    animations,
+    cameras,
+    asset: parser.json.asset,
+    parser,
+    userData: {}
+  };
+
+  // this is likely a noop since the whole parser will get GCed
+  parser.cache.removeAll();
 
   gltf.scene.traverse(object => {
     // GLTFLoader sets matrixAutoUpdate on animated objects, we want to keep the defaults

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -317,6 +317,7 @@ const loadLightmap = async (parser, materialIndex) => {
     parser.getDependency("texture", lightmapDef.index)
   ]);
   material.lightMap = lightMap;
+  material.lightMapIntensity = lightmapDef.intensity !== undefined ? lightmapDef.intensity : 1;
   return lightMap;
 };
 

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -396,7 +396,7 @@ export async function loadGLTF(src, contentType, preferredTechnique, onProgress,
     parser.getDependencies("camera"),
     Promise.all(extensionDeps)
   ]);
-  var gltf = {
+  const gltf = {
     scene: scenes[parser.json.scene || 0],
     scenes,
     animations,


### PR DESCRIPTION
Previously loading lightmaps would sometimes fail due to a race condition. The original code had 2 issues:
1. Promise.all was being passed a nested array, the values that were arrays were not actually awaited on but just passed through. This caused the Promise to resolve sometimes before lightmap loading was actually done.
2. Even with the above change, the promise on `parser.parse()` could still resolve before lightmaps have finished loading (though unlikely since there is probably more work to be done in all of the gltf than there is just for lightmaps), when that happens the gltf parser cache is cleared, which could cause multiple materials/textures to get created for the same resource, causing lightmaps not to be applied correctly. (I did not see this later race actually ever come out broken, but seems best to fix it anyway)

The fix involves inlining most of what `parser.parse()` was doing. This turns out in my opinion to actually be cleaner code since its more clear what is going on when.