### PR TITLE
stop video track to properly stop screen sharing

### DIFF
--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -477,6 +477,7 @@ export default class SceneEntryManager {
       }
 
       for (const track of mediaStream.getVideoTracks()) {
+        track.stop(); // Stop video track to remove the "Stop screen sharing" bar right away.
         mediaStream.removeTrack(track);
       }
 


### PR DESCRIPTION
I found out that explicitly stopping the video track will remove the "stop screen sharing" bar in chrome or the screen sharing icon in firefox right away. Without this, the bar is removed after some seconds, I guess when the video track is garbage collected.