### PR TITLE
Add uv-scroll component to animate UV offsets

### DIFF
--- a/src/components/scene-components.js
+++ b/src/components/scene-components.js
@@ -11,6 +11,7 @@ import "./hemisphere-light";
 import "./hide-when-quality";
 import "./layers";
 import "./loop-animation";
+import "./uv-scroll";
 import "./media-loader";
 import "./point-light";
 import "./quack";

--- a/src/components/uv-scroll.js
+++ b/src/components/uv-scroll.js
@@ -4,29 +4,11 @@
  */
 AFRAME.registerComponent("uv-scroll", {
   schema: {
-    speed: { type: "vec2", default: { x: 0, y: 0 } },
-    animateBase: { type: "boolean", default: true },
-    animateEmissive: { type: "boolean", default: true },
-    animateNormal: { type: "boolean", default: false },
-    animateAO: { type: "boolean", default: false },
-    animateRoughness: { type: "boolean", default: false },
-    animateMetalness: { type: "boolean", default: false },
-    animateLightmap: { type: "boolean", default: false }
-  },
-  init() {
-    this.offset = new THREE.Vector2();
+    speed: { type: "vec2", default: { x: 0, y: 0 } }
   },
   tick(_t, dt) {
     const material = this.el.getObject3D("mesh") && this.el.getObject3D("mesh").material;
-    if (!material) return;
-
-    this.offset.addScaledVector(this.data.speed, dt / 1000);
-    this.data.animateBase && material.map && material.map.offset.copy(this.offset);
-    this.data.animateEmissive && material.emissiveMap && material.emissiveMap.offset.copy(this.offset);
-    this.data.animateNormal && material.normalMap && material.normalMap.offset.copy(this.offset);
-    this.data.animateAO && material.aoMap && material.aoMap.offset.coyp(this.offset);
-    this.data.animateRoughness && material.roughnessMap && material.roughnessMap.offset.copy(this.offset);
-    this.data.animateMetalness && material.metalnessMap && material.metalnessMap.offset.copy(this.offset);
-    this.data.animateLightmap && material.lightMap && material.lightMap.offset.copy(this.offset);
+    if (!material || !material.map) return;
+    material.map.offset.addScaledVector(this.data.speed, dt / 1000);
   }
 });

--- a/src/components/uv-scroll.js
+++ b/src/components/uv-scroll.js
@@ -1,0 +1,32 @@
+/**
+ * Animate the UV offset of a mesh's material
+ * @component uv-scroll
+ */
+AFRAME.registerComponent("uv-scroll", {
+  schema: {
+    speed: { type: "vec2", default: { x: 0, y: 0 } },
+    animateBase: { type: "boolean", default: true },
+    animateEmissive: { type: "boolean", default: true },
+    animateNormal: { type: "boolean", default: false },
+    animateAO: { type: "boolean", default: false },
+    animateRoughness: { type: "boolean", default: false },
+    animateMetalness: { type: "boolean", default: false },
+    animateLightmap: { type: "boolean", default: false }
+  },
+  init() {
+    this.offset = new THREE.Vector2();
+  },
+  tick(_t, dt) {
+    const material = this.el.getObject3D("mesh") && this.el.getObject3D("mesh").material;
+    if (!material) return;
+
+    this.offset.addScaledVector(this.data.speed, dt / 1000);
+    this.data.animateBase && material.map && material.map.offset.copy(this.offset);
+    this.data.animateEmissive && material.emissiveMap && material.emissiveMap.offset.copy(this.offset);
+    this.data.animateNormal && material.normalMap && material.normalMap.offset.copy(this.offset);
+    this.data.animateAO && material.aoMap && material.aoMap.offset.coyp(this.offset);
+    this.data.animateRoughness && material.roughnessMap && material.roughnessMap.offset.copy(this.offset);
+    this.data.animateMetalness && material.metalnessMap && material.metalnessMap.offset.copy(this.offset);
+    this.data.animateLightmap && material.lightMap && material.lightMap.offset.copy(this.offset);
+  }
+});

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -80,6 +80,7 @@ AFRAME.GLTFModelPlus.registerComponent("scale-audio-feedback", "scale-audio-feed
 AFRAME.GLTFModelPlus.registerComponent("morph-audio-feedback", "morph-audio-feedback");
 AFRAME.GLTFModelPlus.registerComponent("animation-mixer", "animation-mixer");
 AFRAME.GLTFModelPlus.registerComponent("loop-animation", "loop-animation");
+AFRAME.GLTFModelPlus.registerComponent("uv-scroll", "uv-scroll");
 AFRAME.GLTFModelPlus.registerComponent(
   "box-collider",
   "shape-helper",


### PR DESCRIPTION
The `uv-scroll` component will animate the offsets for maps associated with the material of the `mesh` of an entity. This can be expanded to become more feature and target other meshes, multiple materials, etc, but this has high utility and low impact so it felt silly not to write. It assumes the material has at least a `base` map.

![image](https://user-images.githubusercontent.com/130735/84092907-a0c62d00-a9ad-11ea-97dc-5e5c79ad50f5.png)
