### PR TITLE
Fix dataChannelOpen not getting called for existing peers

### DIFF
--- a/src/naf-dialog-adapter.js
+++ b/src/naf-dialog-adapter.js
@@ -445,6 +445,7 @@ export default class DialogAdapter {
       // This will gate the connection flow until all voices will be heard.
       for (let i = 0; i < peers.length; i++) {
         const peerId = peers[i].id;
+        this._onOccupantConnected(peerId);
         this.occupants.push(peerId);
         if (!peers[i].hasProducers) continue;
         audioConsumerPromises.push(new Promise(res => this._initialAudioConsumerResolvers.set(peerId, res)));


### PR DESCRIPTION
Ensures `dataChannelOpen` is called when connecting to a room with existing peers in `naf-dialog-adapter`. This fixes an issue preventing drawings from networking correctly.

