### PR TITLE
Remove whitelist/blacklist terms from code and docs

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -347,7 +347,7 @@ Instantiates GLTF models as specified in a bundle JSON.
 <a name="components/gltf/gltf-model-plus"></a>
 #### gltf-model-plus
 
-Loads a GLTF model, optionally recursively "inflates" the child nodes of a model into a-entities and sets whitelisted components on them if defined in the node's extras.
+Loads a GLTF model, optionally recursively "inflates" the child nodes of a model into a-entities and sets allowed components on them if defined in the node's extras.
 
 `src/components/gltf-model-plus.js`
           

--- a/src/components/avatar-replay.js
+++ b/src/components/avatar-replay.js
@@ -1,5 +1,5 @@
 // These controls are removed from the controller entities so that motion-capture-replayer is in full control of them.
-const controlsBlacklist = [
+const disallowedControls = [
   "tracked-controls",
   "hand-controls2",
   "vive-controls",
@@ -58,7 +58,7 @@ AFRAME.registerComponent("avatar-replay", {
   },
 
   _setupController: function(controller) {
-    controlsBlacklist.forEach(controlsComponent => controller.removeAttribute(controlsComponent));
+    disallowedControls.forEach(controlsComponent => controller.removeAttribute(controlsComponent));
     controller.setAttribute("visible", true);
     controller.setAttribute("motion-capture-replayer", { loop: true });
   }

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -472,7 +472,7 @@ function resolveAsset(src) {
 
 /**
  * Loads a GLTF model, optionally recursively "inflates" the child nodes of a model into a-entities and sets
- * whitelisted components on them if defined in the node's extras.
+ * allowed components on them if defined in the node's extras.
  * @namespace gltf
  * @component gltf-model-plus
  */

--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -24,8 +24,8 @@ const defaultEditors = [
     url: "https://tryquilt.io/?gltf=$AVATAR_GLTF"
   }
 ];
-const useEditorWhitelist = true;
-const editorWhitelist = [
+const useAllowedEditors = true;
+const allowedEditors = [
   ...defaultEditors,
   {
     name: "Skindex Editor",
@@ -430,8 +430,8 @@ export default class AvatarEditor extends Component {
   handleGltfLoaded = gltf => {
     const ext = gltf.parser.json.extensions && gltf.parser.json.extensions["MOZ_hubs_avatar"];
     let editorLinks = (ext && ext.editors) || defaultEditors;
-    if (useEditorWhitelist) {
-      editorLinks = editorLinks.filter(e => editorWhitelist.some(w => w.name === e.name && w.url === e.url));
+    if (useAllowedEditors) {
+      editorLinks = editorLinks.filter(e => allowedEditors.some(w => w.name === e.name && w.url === e.url));
     }
     this.setState({ editorLinks });
   };

--- a/src/utils/vr-caps-detect.js
+++ b/src/utils/vr-caps-detect.js
@@ -18,9 +18,9 @@ function isMaybeDaydreamCompatibleDevice(ua) {
   return /\WAndroid\W/.test(ua);
 }
 
-// Blacklist of VR device name regex matchers that we do not want to consider as valid VR devices
+// Disallowed list of VR device name regex matchers that we do not want to consider as valid VR devices
 // that can be entered into as a "generic" entry flow.
-const GENERIC_ENTRY_TYPE_DEVICE_BLACKLIST = [/cardboard/i];
+const GENERIC_ENTRY_TYPE_DISALLOWED_DEVICES = [/cardboard/i];
 
 // Tries to determine VR entry compatibility regardless of the current browser.
 //
@@ -112,9 +112,9 @@ export async function getAvailableVREntryTypes() {
       : VR_DEVICE_AVAILABILITY.no;
 
   if (isWebVRCapableBrowser) {
-    // Generic is supported for non-blacklisted devices and presentable HMDs.
+    // Generic is supported for allowed devices and presentable HMDs.
     generic = displays.find(
-      d => d.capabilities.canPresent && !GENERIC_ENTRY_TYPE_DEVICE_BLACKLIST.find(r => r.test(d.displayName))
+      d => d.capabilities.canPresent && !GENERIC_ENTRY_TYPE_DISALLOWED_DEVICES.find(r => r.test(d.displayName))
     )
       ? VR_DEVICE_AVAILABILITY.yes
       : VR_DEVICE_AVAILABILITY.no;


### PR DESCRIPTION
Whitelist and blacklist are racially charged terms that can easily be avoided with terms such as allowed/disallowed or safelist/blocklist. We should make efforts to avoid these terms and other racially charged language in the future across all Hubs projects.