### PR TITLE
fix broken pdf when the pdf is not on the first page and a participant join

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -1216,8 +1216,15 @@ AFRAME.registerComponent("media-pdf", {
         this.el.setAttribute("media-pager", { maxIndex: this.pdf.numPages - 1 });
       }
 
-      const page = await this.pdf.getPage(index + 1);
-      if (src !== this.data.src || index !== this.data.index) return;
+      if (!this.pdf) {
+        // The pdf may not have been loaded yet, this can happen with initial
+        // render followed with a networked update with index > 0
+        // (not the first page of the pdf)
+        return;
+      }
+      // Use here this.data.index and not index to have the networked update.
+      const page = await this.pdf.getPage(this.data.index + 1);
+      if (src !== this.data.src) return;
 
       const viewport = page.getViewport({ scale: 3 });
       const pw = viewport.width;
@@ -1234,7 +1241,7 @@ AFRAME.registerComponent("media-pdf", {
 
       this.renderTask = null;
 
-      if (src !== this.data.src || index !== this.data.index) return;
+      if (src !== this.data.src) return;
     } catch (e) {
       console.error("Error loading PDF", this.data.src, e);
       texture = errorTexture;


### PR DESCRIPTION
Fix broken pdf when a pdf which is not on the first page is in the scene and a new participant joins the room.

You can reproduce the issue like this:
With Participant A:
- create a room
- spawn a pdf
- go to page 2 of the pdf

Then participant B joins and sees a broken pdf (the media-error.gif texture).
The console error is:
```
TypeError: "this.pdf is undefined"
    update media-views.js:1219
    asyncGeneratorStep hub-424d731663df443df67f.js:10178
    _next hub-424d731663df443df67f.js:10180
    _asyncToGenerator hub-424d731663df443df67f.js:10180
    _asyncToGenerator hub-424d731663df443df67f.js:10180
    update media-views.js:1195
```
