### PR TITLE
Fix morph-audio-feedback for meshes with mutliple primitives

### DIFF
--- a/src/components/audio-feedback.js
+++ b/src/components/audio-feedback.js
@@ -196,23 +196,36 @@ AFRAME.registerComponent("morph-audio-feedback", {
   },
 
   init() {
-    this.mesh = this.el.object3DMap.skinnedmesh;
-    this.morphNumber = this.mesh.morphTargetDictionary[this.data.name];
+    const meshes = [];
+    if (this.el.object3DMap.skinnedmesh) {
+      meshes.push(this.el.object3DMap.skinnedmesh);
+    } else if (this.el.object3DMap.group) {
+      // skinned mesh with multiple materials
+      this.el.object3DMap.group.traverse(o => o.isSkinnedMesh && meshes.push(o));
+    }
+    if (meshes.length) {
+      this.morphs = meshes
+        .map(mesh => ({ mesh, morphNumber: mesh.morphTargetDictionary[this.data.name] }))
+        .filter(m => m.morphNumber !== undefined);
+    }
   },
 
   tick() {
-    if (!this.mesh) return;
+    if (!this.morphs.length) return;
 
     if (!this.analyser) this.analyser = getAnalyser(this.el);
 
     const { minValue, maxValue } = this.data;
-    this.mesh.morphTargetInfluences[this.morphNumber] = THREE.Math.mapLinear(
+    const morphValue = THREE.Math.mapLinear(
       easeOutQuadratic(this.analyser ? this.analyser.volume : 0),
       0,
       1,
       minValue,
       maxValue
     );
+    for (let i = 0; i < this.morphs.length; i++) {
+      this.morphs[i].mesh.morphTargetInfluences[this.morphs[i].morphNumber] = morphValue;
+    }
   }
 });
 


### PR DESCRIPTION
Meshes in a gltf with multiple primitives end up becoming multiple `THREE.SkinnedMesh`es inside of a `THREE.Group`, this fixes handling of that case for `morph-audio-feedback`