### PR TITLE
Fix uv scroll on MobileStandardMaterial

### DIFF
--- a/src/components/uv-scroll.js
+++ b/src/components/uv-scroll.js
@@ -11,5 +11,10 @@ AFRAME.registerComponent("uv-scroll", {
     const material = mesh && mesh.material;
     if (!material || !material.map) return;
     material.map.offset.addScaledVector(this.data.speed, dt / 1000);
+
+    // TODO this should be handled by MobileStandardMaterial itself
+    if (material.isMobileStandardMaterial) {
+      material.refreshUniforms();
+    }
   }
 });

--- a/src/materials/MobileStandardMaterial.js
+++ b/src/materials/MobileStandardMaterial.js
@@ -113,7 +113,8 @@ export default class MobileStandardMaterial extends THREE.ShaderMaterial {
     mobileMaterial.emissiveIntensity = material.emissiveIntensity;
     mobileMaterial.emissiveMap = material.emissiveMap;
 
-    // TODO this actually needs to get called whenever any of these material properties change
+    // TODO this actually needs to get called whenever any of these material properties change,
+    // when we do look for other usages of isMobileStandardMaterial as they may be doing updates manually
     mobileMaterial.refreshUniforms();
 
     return mobileMaterial;


### PR DESCRIPTION
MobileStandardMaterial does not automatically update its uniforms. This updates it in the uv-scroll component. If we find ourselves doing this more we should centralize this update.