### PR TITLE
Fix uv-scroll on shared materials, add increment

### DIFF
--- a/src/components/uv-scroll.js
+++ b/src/components/uv-scroll.js
@@ -2,7 +2,7 @@ const textureToData = new Map();
 const registeredTextures = [];
 
 export class UVScrollSystem {
-  tick(_t, dt) {
+  tick(dt) {
     for (let i = 0; i < registeredTextures.length; i++) {
       const map = registeredTextures[i];
       const { offset, instances } = textureToData.get(map);
@@ -43,7 +43,6 @@ AFRAME.registerComponent("uv-scroll", {
     const mesh = this.el.getObject3D("mesh") || this.el.getObject3D("skinnedmesh");
     const material = mesh && mesh.material;
     if (material) {
-      const offset = new THREE.Vector2();
       // We store mesh here instead of the material directly because we end up swapping out the material in injectCustomShaderChunks.
       // We need material in the first place because of MobileStandardMaterial
       const instance = { component: this, mesh };
@@ -53,7 +52,7 @@ AFRAME.registerComponent("uv-scroll", {
 
       if (!textureToData.has(material.map)) {
         textureToData.set(material.map, {
-          offset,
+          offset: new THREE.Vector2(),
           instances: [instance]
         });
         registeredTextures.push(material.map);
@@ -64,16 +63,17 @@ AFRAME.registerComponent("uv-scroll", {
         textureToData.get(material.map).instances.push(instance);
       }
     }
-    // }, 0);
   },
 
   pause() {
-    const instances = textureToData.get(this.map).instances;
-    instances.splice(instances.indexOf(this.instance), 1);
-    // If this was the last uv-scroll component for a given texture
-    if (!instances.length) {
-      textureToData.delete(this.map);
-      registeredTextures.splice(registeredTextures.indexOf(this.map), 1);
+    if (this.map) {
+      const instances = textureToData.get(this.map).instances;
+      instances.splice(instances.indexOf(this.instance), 1);
+      // If this was the last uv-scroll component for a given texture
+      if (!instances.length) {
+        textureToData.delete(this.map);
+        registeredTextures.splice(registeredTextures.indexOf(this.map), 1);
+      }
     }
   }
 });

--- a/src/components/uv-scroll.js
+++ b/src/components/uv-scroll.js
@@ -1,20 +1,79 @@
+const textureToData = new Map();
+const registeredTextures = [];
+
+export class UVScrollSystem {
+  tick(_t, dt) {
+    for (let i = 0; i < registeredTextures.length; i++) {
+      const map = registeredTextures[i];
+      const { offset, instances } = textureToData.get(map);
+      const { component } = instances[0];
+
+      offset.addScaledVector(component.data.speed, dt / 1000);
+
+      const increment = component.data.increment;
+      map.offset.x = increment.x ? offset.x - (offset.x % increment.x) : offset.x;
+      map.offset.y = increment.y ? offset.y - (offset.y % increment.y) : offset.y;
+
+      // TODO this should be handled by MobileStandardMaterial itself
+      let matrixUpdated = false;
+      for (let j = 0; j < instances.length; j++) {
+        const mesh = instances[j].mesh;
+        if (mesh.material.isMobileStandardMaterial) {
+          if (!matrixUpdated) {
+            map.updateMatrix();
+            matrixUpdated = true;
+          }
+          mesh.material.uniforms.uvTransform.value.copy(map.matrix);
+        }
+      }
+    }
+  }
+}
+
 /**
  * Animate the UV offset of a mesh's material
  * @component uv-scroll
  */
 AFRAME.registerComponent("uv-scroll", {
   schema: {
-    speed: { type: "vec2", default: { x: 0, y: 0 } }
+    speed: { type: "vec2", default: { x: 0, y: 0 } },
+    increment: { type: "vec2", default: { x: 0, y: 0 } }
   },
-  tick(_t, dt) {
+  play() {
     const mesh = this.el.getObject3D("mesh") || this.el.getObject3D("skinnedmesh");
     const material = mesh && mesh.material;
-    if (!material || !material.map) return;
-    material.map.offset.addScaledVector(this.data.speed, dt / 1000);
+    if (material) {
+      const offset = new THREE.Vector2();
+      // We store mesh here instead of the material directly because we end up swapping out the material in injectCustomShaderChunks.
+      // We need material in the first place because of MobileStandardMaterial
+      const instance = { component: this, mesh };
 
-    // TODO this should be handled by MobileStandardMaterial itself
-    if (material.isMobileStandardMaterial) {
-      material.refreshUniforms();
+      this.instance = instance;
+      this.map = material.map;
+
+      if (!textureToData.has(material.map)) {
+        textureToData.set(material.map, {
+          offset,
+          instances: [instance]
+        });
+        registeredTextures.push(material.map);
+      } else {
+        console.warn(
+          "Multiple uv-scroll instances added to objects sharing a texture, only the speed/increment from the first one will have any effect"
+        );
+        textureToData.get(material.map).instances.push(instance);
+      }
+    }
+    // }, 0);
+  },
+
+  pause() {
+    const instances = textureToData.get(this.map).instances;
+    instances.splice(instances.indexOf(this.instance), 1);
+    // If this was the last uv-scroll component for a given texture
+    if (!instances.length) {
+      textureToData.delete(this.map);
+      registeredTextures.splice(registeredTextures.indexOf(this.map), 1);
     }
   }
 });

--- a/src/systems/hubs-systems.js
+++ b/src/systems/hubs-systems.js
@@ -103,7 +103,7 @@ AFRAME.registerSystem("hubs-systems", {
     this.menuAnimationSystem.tick(t);
     this.spriteSystem.tick(t, dt);
     this.enterVRButtonSystem.tick();
-    this.uvScrollSystem.tick(t, dt);
+    this.uvScrollSystem.tick(dt);
 
     // We run this late in the frame so that its the last thing to have an opinion about the scale of an object
     this.boneVisibilitySystem.tick();

--- a/src/systems/hubs-systems.js
+++ b/src/systems/hubs-systems.js
@@ -2,6 +2,7 @@ import { CursorTargettingSystem } from "./cursor-targetting-system";
 import { PositionAtBorderSystem } from "../components/position-at-border";
 import { BoneVisibilitySystem } from "../components/bone-visibility";
 import { AnimationMixerSystem } from "../components/animation-mixer";
+import { UVScrollSystem } from "../components/uv-scroll";
 import { CursorTogglingSystem } from "./cursor-toggling-system";
 import { PhysicsSystem } from "./physics-system";
 import { ConstraintsSystem } from "./constraints-system";
@@ -61,6 +62,7 @@ AFRAME.registerSystem("hubs-systems", {
     this.enterVRButtonSystem = new EnterVRButtonSystem(this.el);
     this.animationMixerSystem = new AnimationMixerSystem();
     this.boneVisibilitySystem = new BoneVisibilitySystem();
+    this.uvScrollSystem = new UVScrollSystem();
   },
 
   tick(t, dt) {
@@ -101,6 +103,7 @@ AFRAME.registerSystem("hubs-systems", {
     this.menuAnimationSystem.tick(t);
     this.spriteSystem.tick(t, dt);
     this.enterVRButtonSystem.tick();
+    this.uvScrollSystem.tick(t, dt);
 
     // We run this late in the frame so that its the last thing to have an opinion about the scale of an object
     this.boneVisibilitySystem.tick();


### PR DESCRIPTION
Fixes `uv-scroll` to not combine offsets when multiple objects share a material. When multiple instances exist, only the values from the first one will have any effect. 

Also adds support for `increment` which when non 0 will make the uv scrolling increment in steps. This is useful for doing "sprite animation" style effects.

The hack for `MobileStandardMaterial` got a bit more ugly here... All the code that cares about Materials could go away if fixed. I did look into doing it the "right way" but it requires a ThreeJS update to add the hook we would need, and that feels a bit heavy handed for this "quick" feature.