### PR TITLE
Removes the highlight around the camera iconButton

### DIFF
--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -247,6 +247,7 @@ AFRAME.registerComponent("camera-tool", {
   remove() {
     this.cameraSystem.deregister(this.el);
     this.el.sceneEl.emit("camera_removed");
+    this.el.sceneEl.removeState("camera");
     this.stopRecording();
   },
 


### PR DESCRIPTION
Here's a video of the bug:
[https://drive.google.com/file/d/18fajfIKtyfNGFikc5ogex6E5kncWx1rQ/view?usp=sharing](url)

Here's a video of the fix:
https://drive.google.com/file/d/1jU0yw0hAsNvAUBcybTY8CxTJsX2zlEmG/view?usp=sharing

I also would have to agree with this comment in ui-root.js
`  // TODO: we need to come up with a cleaner way to handle the shared state between aframe and react than emmitting events and setting state on the scene
  onAframeStateChanged = e => {
    if (!(e.detail === "muted" || e.detail === "frozen")) return;
    this.setState({
      [e.detail]: this.props.scene.is(e.detail)
    });
  };
`
I spent way more time trying to figure out why code changes I was making seemed to be overwritten/ignored on HMD browsers while working perfectly in the desktop browser. This duplicity of state between aframe and react will likely cause more headache down the line.

On the bright side, spent a day deep diving into the hubs code and am pretty familiar now. LOL

fixes #1205