### PR TITLE
Add preferenced for "Preferred camera"

### DIFF
--- a/src/assets/translations.data.json
+++ b/src/assets/translations.data.json
@@ -282,7 +282,7 @@
     "preferences.category_misc": "Misc",
     "preferences.category_movement": "Movement",
     "preferences.category_touchscreen": "Touchscreen",
-    "preferences.preferedCamera": "Prefered camera",
+    "preferences.preferredCamera": "Preferred camera",
     "preferences.muteMicOnEntry": "Mute microphone on entry",
     "preferences.globalVoiceVolume": "Incoming Voice Volume",
     "preferences.globalMediaVolume": "Media Volume",

--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -490,8 +490,8 @@ CloseButton.propTypes = {
   onClick: PropTypes.func
 };
 
-const preferedCamera = {
-  key: "preferedCamera",
+const preferredCamera = {
+  key: "preferredCamera",
   prefType: PREFERENCE_LIST_ITEM_TYPE.SELECT,
   options: [
     { value: "user", text: "User-Facing" },
@@ -585,7 +585,7 @@ const DEFINITIONS = new Map([
     [
       { key: "onlyShowNametagsInFreeze", prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX, defaultBool: false },
       { key: "maxResolution", prefType: PREFERENCE_LIST_ITEM_TYPE.MAX_RESOLUTION },
-      preferedCamera,
+      preferredCamera,
       {
         key: "materialQualitySetting",
         prefType: PREFERENCE_LIST_ITEM_TYPE.SELECT,
@@ -601,14 +601,14 @@ const DEFINITIONS = new Map([
   ]
 ]);
 
-// add camera choices to preferedCamera's options
+// add camera choices to preferredCamera's options
 navigator.mediaDevices
   .enumerateDevices()
   .then(function(devices) {
     devices.forEach(function(device) {
       if (device.kind == "videoinput") {
         const shortId = device.deviceId.substr(0, 9);
-        preferedCamera.options.push({
+        preferredCamera.options.push({
           value: device.deviceId,
           text: device.label || `Camera (${shortId})`
         });

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -447,7 +447,7 @@ export default class SceneEntryManager {
 
       // check preferences
       const store = window.APP.store;
-      const preferredCamera = store.state.preferences.preferredCamera;
+      const preferredCamera = store.state.preferences.preferredCamera || "default";
       switch (preferredCamera) {
         case "default":
           constraints.video.mediaSource = "camera";

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -447,17 +447,17 @@ export default class SceneEntryManager {
 
       // check preferences
       const store = window.APP.store;
-      const preferedCamera = store.state.preferences.preferedCamera;
-      switch (preferedCamera) {
+      const preferredCamera = store.state.preferences.preferredCamera;
+      switch (preferredCamera) {
         case "default":
           constraints.video.mediaSource = "camera";
           break;
         case "user":
         case "environment":
-          constraints.video.facingMode = preferedCamera;
+          constraints.video.facingMode = preferredCamera;
           break;
         default:
-          constraints.video.deviceId = preferedCamera;
+          constraints.video.deviceId = preferredCamera;
           break;
       }
       shareVideoMediaStream(constraints);

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -437,7 +437,7 @@ export default class SceneEntryManager {
     };
 
     this.scene.addEventListener("action_share_camera", () => {
-      let constraints = {
+      const constraints = {
         video: {
           width: isIOS ? { max: 1280 } : { max: 1280, ideal: 720 },
           frameRate: 30

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -67,7 +67,7 @@ export const SCHEMA = {
       additionalProperties: false,
       properties: {
         shouldPromptForRefresh: { type: "bool" },
-        preferedCamera: { type: "string" },
+        preferredCamera: { type: "string" },
         muteMicOnEntry: { type: "bool" },
         audioOutputMode: { type: "string" },
         invertTouchscreenCameraMove: { type: "bool" },

--- a/src/systems/camera-tools.js
+++ b/src/systems/camera-tools.js
@@ -57,7 +57,7 @@ AFRAME.registerSystem("camera-tools", {
       this.myCamera = this.cameraEls.find(NAF.utils.isMine);
     }
 
-    if (!!this.myCamera) {
+    if (this.myCamera) {
       this.sceneEl.addState("camera");
     } else {
       this.sceneEl.removeState("camera");


### PR DESCRIPTION
Allows user to set the default camera used for camera sharing. Note that until the user has accepted permissions the non-generic camera options will just be `Camera(XXXXX)` with some identifier, once the user has accepted video permissions elsewhere they will start showing the full name. This is a browser security limitation.

Thanks to @machenmusik for the PR!