### PR TITLE
Fix networked-audio-analyser scheduling & cleanup

### DIFF
--- a/src/components/audio-feedback.js
+++ b/src/components/audio-feedback.js
@@ -54,17 +54,22 @@ AFRAME.registerComponent("networked-audio-analyser", {
   async init() {
     this.volume = 0;
     this.prevVolume = 0;
+    this.avatarIsQuiet = true;
 
     this._updateAnalysis = this._updateAnalysis.bind(this);
     this._runScheduledWork = this._runScheduledWork.bind(this);
-    this.el.sceneEl.systems["frame-scheduler"].schedule(this._updateAnalysis, "audio-analyser");
-    this.el.addEventListener("sound-source-set", event => {
-      const ctx = THREE.AudioContext.getContext();
-      this.analyser = ctx.createAnalyser();
-      this.analyser.fftSize = 32;
-      this.levels = new Uint8Array(this.analyser.fftSize);
-      event.detail.soundSource.connect(this.analyser);
-    });
+    this.el.sceneEl.systems["frame-scheduler"].schedule(this._runScheduledWork, "audio-analyser");
+    this.el.addEventListener(
+      "sound-source-set",
+      event => {
+        const ctx = THREE.AudioContext.getContext();
+        this.analyser = ctx.createAnalyser();
+        this.analyser.fftSize = 32;
+        this.levels = new Uint8Array(this.analyser.fftSize);
+        event.detail.soundSource.connect(this.analyser);
+      },
+      { once: true }
+    );
 
     this.playerSessionId = findAncestorWithComponent(this.el, "player-info").components["player-info"].playerSessionId;
     registerComponentInstance(this, "networked-audio-analyser");


### PR DESCRIPTION
Fixes a few issues in the initialization of `networked-audio-analyser` that were resulting in it doing extra work per frame and not cleaning up after itself correctly.

fixes #2601