### PR TITLE
Expose transparency to media options

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -1009,7 +1009,8 @@ AFRAME.registerComponent("media-image", {
     version: { type: "number" },
     projection: { type: "string", default: "flat" },
     contentType: { type: "string" },
-    batch: { default: false }
+    batch: { default: false },
+    transparent: { default: undefined }
   },
 
   remove() {
@@ -1127,12 +1128,12 @@ AFRAME.registerComponent("media-image", {
       this.el.setObject3D("mesh", this.mesh);
     }
 
-    // We only support transparency on gifs. Other images will support cutout as part of batching, but not alpha transparency for now
+    // if transparency setting isnt explicitly defined, default to on for all non batched things, gifs, and basis textures with alpha
     this.mesh.material.transparent =
-      !this.data.batch ||
       texture == errorTexture ||
-      this.data.contentType.includes("image/gif") ||
-      !!(texture.image && texture.image.hasAlpha);
+      (this.data.transparent === undefined
+        ? !this.data.batch || this.data.contentType.includes("image/gif") || !!(texture.image && texture.image.hasAlpha)
+        : this.data.transparent);
 
     this.mesh.material.map = texture;
     this.mesh.material.needsUpdate = true;

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -1010,7 +1010,7 @@ AFRAME.registerComponent("media-image", {
     projection: { type: "string", default: "flat" },
     contentType: { type: "string" },
     batch: { default: false },
-    transparencyMode: { type: "string", default: undefined },
+    alphaMode: { type: "string", default: undefined },
     alphaCutoff: { type: "number" }
   },
 
@@ -1133,15 +1133,15 @@ AFRAME.registerComponent("media-image", {
       this.mesh.material.transparent = true;
     } else {
       // if transparency setting isnt explicitly defined, default to on for all non batched things, gifs, and basis textures with alpha
-      switch (this.data.transparencyMode) {
-        case "none":
+      switch (this.data.alphaMode) {
+        case "opaque":
           this.mesh.material.transparent = false;
           break;
-        case "alpha":
+        case "blend":
           this.mesh.material.transparent = true;
           this.mesh.material.alphaTest = 0;
           break;
-        case "cutout":
+        case "mask":
           this.mesh.material.transparent = false;
           this.mesh.material.alphaTest = this.data.alphaCutoff;
           break;

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -204,12 +204,12 @@ async function mediaInflator(el, componentName, componentData, components) {
     });
   }
 
-  const mediaOptions = {
-    transparent: componentData.transparent
-  };
+  const mediaOptions = {};
 
   if (componentName === "video" || componentName === "image") {
     mediaOptions.projection = componentData.projection;
+    mediaOptions.transparencyMode = componentData.transparencyMode;
+    mediaOptions.alphaCutoff = componentData.alphaCutoff;
   }
 
   if (componentName === "video" || componentName === "audio") {

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -208,7 +208,7 @@ async function mediaInflator(el, componentName, componentData, components) {
 
   if (componentName === "video" || componentName === "image") {
     mediaOptions.projection = componentData.projection;
-    mediaOptions.transparencyMode = componentData.transparencyMode;
+    mediaOptions.alphaMode = componentData.alphaMode;
     mediaOptions.alphaCutoff = componentData.alphaCutoff;
   }
 

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -204,7 +204,9 @@ async function mediaInflator(el, componentName, componentData, components) {
     });
   }
 
-  const mediaOptions = {};
+  const mediaOptions = {
+    transparent: componentData.transparent
+  };
 
   if (componentName === "video" || componentName === "image") {
     mediaOptions.projection = componentData.projection;


### PR DESCRIPTION
Allow setting image transparency mode via mediaOptions in gltfs. This is to allow spoke to configure image transparency. Defaults remain the same for runtime spawned objects and old scenes without transparency settings on images, but the new default in spoke for newly created image elements will be to have transparency off. This should help both with performance as well as user confusion with accidentally overlapping transparent images (particularly when people use 360 images as skyboxes)

Spoke PR https://github.com/mozilla/Spoke/pull/987