### PR TITLE
Fix PWAButton Visibility

### DIFF
--- a/src/react-components/input/PWAButton.js
+++ b/src/react-components/input/PWAButton.js
@@ -10,19 +10,18 @@ import { useInstallPWA } from "./useInstallPWA";
 const isMobile = checkIsMobile();
 
 export function PWAButton() {
-  const { supported, installed, installPWA } = useInstallPWA();
+  const [pwaAvailable, installPWA] = useInstallPWA();
 
   return (
     <>
-      {supported &&
-        !installed && (
-          <button className={classNames(styles.secondaryButton)} onClick={installPWA}>
-            <i>
-              <FontAwesomeIcon icon={faPlus} />
-            </i>
-            <FormattedMessage id={`home.${isMobile ? "mobile" : "desktop"}.add_pwa`} />
-          </button>
-        )}
+      {pwaAvailable && (
+        <button className={classNames(styles.secondaryButton)} onClick={installPWA}>
+          <i>
+            <FontAwesomeIcon icon={faPlus} />
+          </i>
+          <FormattedMessage id={`home.${isMobile ? "mobile" : "desktop"}.add_pwa`} />
+        </button>
+      )}
     </>
   );
 }

--- a/src/react-components/input/PWAButton.js
+++ b/src/react-components/input/PWAButton.js
@@ -1,49 +1,13 @@
-import React, { useEffect, useCallback, useState, useRef } from "react";
+import React from "react";
 import classNames from "classnames";
 import { FormattedMessage } from "react-intl";
 import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import styles from "./Button.scss";
 import checkIsMobile from "../../utils/is-mobile";
+import { useInstallPWA } from "./useInstallPWA";
 
 const isMobile = checkIsMobile();
-
-const supported =
-  "relList" in HTMLLinkElement.prototype &&
-  document.createElement("link").relList.supports("manifest") &&
-  "onbeforeinstallprompt" in window;
-
-function useInstallPWA() {
-  const installEventRef = useRef();
-
-  const [installed, setInstalled] = useState(false);
-
-  useEffect(() => {
-    const onBeforeInstallPrompt = event => {
-      console.log("beforeinstallprompt", event);
-      event.preventDefault();
-      installEventRef.current = event;
-    };
-
-    window.addEventListener("beforeinstallprompt", onBeforeInstallPrompt);
-
-    return () => {
-      window.removeEventListener("beforeinstallprompt", onBeforeInstallPrompt);
-    };
-  }, []);
-
-  const installPWA = useCallback(async () => {
-    installEventRef.current.prompt();
-
-    const choiceResult = await installEventRef.current.userChoice;
-
-    if (choiceResult.outcome === "accepted") {
-      setInstalled(true);
-    }
-  }, []);
-
-  return { supported, installed, installPWA };
-}
 
 export function PWAButton() {
   const { supported, installed, installPWA } = useInstallPWA();

--- a/src/react-components/input/useInstallPWA.js
+++ b/src/react-components/input/useInstallPWA.js
@@ -1,0 +1,37 @@
+import { useEffect, useCallback, useState, useRef } from "react";
+
+const supported =
+  "relList" in HTMLLinkElement.prototype &&
+  document.createElement("link").relList.supports("manifest") &&
+  "onbeforeinstallprompt" in window;
+
+export function useInstallPWA() {
+  const installEventRef = useRef();
+
+  const [installed, setInstalled] = useState(false);
+
+  useEffect(() => {
+    const onBeforeInstallPrompt = event => {
+      event.preventDefault();
+      installEventRef.current = event;
+    };
+
+    window.addEventListener("beforeinstallprompt", onBeforeInstallPrompt);
+
+    return () => {
+      window.removeEventListener("beforeinstallprompt", onBeforeInstallPrompt);
+    };
+  }, []);
+
+  const installPWA = useCallback(async () => {
+    installEventRef.current.prompt();
+
+    const choiceResult = await installEventRef.current.userChoice;
+
+    if (choiceResult.outcome === "accepted") {
+      setInstalled(true);
+    }
+  }, []);
+
+  return { supported, installed, installPWA };
+}

--- a/src/react-components/input/useInstallPWA.js
+++ b/src/react-components/input/useInstallPWA.js
@@ -1,6 +1,6 @@
 import { useEffect, useCallback, useState, useRef } from "react";
 
-const supported =
+const browserSupport =
   "relList" in HTMLLinkElement.prototype &&
   document.createElement("link").relList.supports("manifest") &&
   "onbeforeinstallprompt" in window;
@@ -8,12 +8,14 @@ const supported =
 export function useInstallPWA() {
   const installEventRef = useRef();
 
+  const [available, setAvailable] = useState(false);
   const [installed, setInstalled] = useState(false);
 
   useEffect(() => {
     const onBeforeInstallPrompt = event => {
       event.preventDefault();
       installEventRef.current = event;
+      setAvailable(true);
     };
 
     window.addEventListener("beforeinstallprompt", onBeforeInstallPrompt);
@@ -33,5 +35,5 @@ export function useInstallPWA() {
     }
   }, []);
 
-  return { supported, installed, installPWA };
+  return [browserSupport && available && !installed, installPWA];
 }


### PR DESCRIPTION
The code I added in #2460 doesn't properly handle visibility of the PWAButton. This PR extracts the code I added in #2562 to fix this issue. The `useInstallPWA` hook uses feature detection, the `onbeforeinstallprompt` event, and the install prompt result to determine the visibility of the button.