### PR TITLE
Clean up additional home page styling

### DIFF
--- a/src/assets/stylesheets/globals.scss
+++ b/src/assets/stylesheets/globals.scss
@@ -1,0 +1,38 @@
+@import 'root-vars';
+@import 'shared';
+
+* {
+  box-sizing: border-box;
+}
+
+html, body, #ui-root, .home-root {
+  margin: 0;
+  height:100%;
+}
+
+body {
+  @extend %default-font;
+  background: var(--home-background-color);
+  color: var(--home-text-color);
+}
+
+#ui-root, .home-root {
+  display: flex; 
+  flex-direction: column;
+}
+
+h1 {
+  font-size: 2rem;
+}
+
+h2 {
+  font-size: 1.5rem;
+}
+
+h3 {
+  font-size: 1.2rem;
+}
+
+small {
+  font-size: 0.8rem;
+}

--- a/src/assets/stylesheets/media-browser.scss
+++ b/src/assets/stylesheets/media-browser.scss
@@ -558,6 +558,10 @@
 }
 
 :local(.media-browser-inline) {
+  :local(.body) {
+    width: 100%;
+  }
+
   position: relative;
   background-color: var(--home-media-panel-background-color);
   width: 100%;

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import Store from "./storage/store";
 import "./utils/theme";
 import { HomePage } from "./react-components/home/HomePage";
 import { lang, messages } from "./utils/i18n";
+import "./assets/stylesheets/globals.scss";
 import { AuthContextProvider } from "./react-components/auth/AuthContext";
 
 registerTelemetry("/home", "Hubs Home Page");

--- a/src/react-components/home/HomePage.js
+++ b/src/react-components/home/HomePage.js
@@ -10,10 +10,10 @@ import { CreateRoomButton } from "../input/CreateRoomButton";
 import { PWAButton } from "../input/PWAButton";
 import { useFeaturedRooms } from "./useFeaturedRooms";
 import styles from "./HomePage.scss";
-import mediaBrowserStyles from "../../assets/stylesheets/media-browser.scss";
-import discordLogoSmall from "../../assets/images/discord-logo-small.png";
+import discordLogoUrl from "../../assets/images/discord-logo-small.png";
 import { AuthContext } from "../auth/AuthContext";
 import { createAndRedirectToNewHub } from "../../utils/phoenix-utils";
+import mediaBrowserStyles from "../../assets/stylesheets/media-browser.scss";
 
 addLocaleData([...en]);
 
@@ -42,59 +42,60 @@ export function HomePage() {
 
   const canCreateRooms = !configs.feature("disable_room_creation") || auth.isAdmin;
 
-  return (
-    <Page className={styles.homePage}>
-      <div className={styles.heroContent} style={{ backgroundImage: configs.image("home_background", true) }}>
-        <div className={styles.heroPanel}>
-          <div className={styles.container}>
-            <div className={classNames([styles.logo, styles.logoMargin])}>
-              <img src={configs.image("logo")} />
-            </div>
-            {featuredRooms.length === 0 && (
-              <div className={styles.blurb}>
-                <FormattedMessage id="app-description" />
-              </div>
-            )}
-          </div>
-          <div className={styles.ctaButtons}>
-            {canCreateRooms && <CreateRoomButton />}
-            <PWAButton />
-          </div>
-        </div>
-        {featuredRooms.length > 0 && (
-          <div className={styles.heroPanel}>
-            <div className={classNames([mediaBrowserStyles.mediaBrowser, mediaBrowserStyles.mediaBrowserInline])}>
-              <div className={classNames([mediaBrowserStyles.box, mediaBrowserStyles.darkened])}>
-                <MediaTiles entries={featuredRooms} urlSource="favorites" />
-              </div>
-            </div>
-          </div>
-        )}
-        <div className={classNames(styles.heroPanel, styles.rightPanel)}>
-          <div>
-            <div className={styles.secondaryLink}>
-              <a href="/link">
-                <FormattedMessage id="home.have_code" />
-              </a>
-            </div>
+  const pageStyle = { backgroundImage: configs.image("home_background", true) };
 
+  const logoUrl = configs.image("logo");
+
+  const showDescription = featuredRooms.length === 0;
+
+  const logoStyles = classNames(styles.logoContainer, {
+    [styles.centerLogo]: !showDescription
+  });
+
+  return (
+    <Page className={styles.homePage} style={pageStyle}>
+      <section>
+        <div className={styles.appInfo}>
+          <div className={logoStyles}>
+            <img src={logoUrl} />
+          </div>
+          {showDescription && (
+            <div className={styles.appDescription}>
+              <FormattedMessage id="app-description" />
+            </div>
+          )}
+        </div>
+        <div className={styles.ctaButtons}>
+          {canCreateRooms && <CreateRoomButton />}
+          <PWAButton />
+        </div>
+      </section>
+      {featuredRooms.length > 0 && (
+        <section className={styles.featuredRooms}>
+          <section className={classNames([mediaBrowserStyles.mediaBrowser, mediaBrowserStyles.mediaBrowserInline])}>
+            <div className={classNames([mediaBrowserStyles.box, mediaBrowserStyles.darkened])}>
+              <MediaTiles entries={featuredRooms} urlSource="favorites" />
+            </div>
+          </section>
+        </section>
+      )}
+      <section>
+        <div className={styles.secondaryLinks}>
+          <a href="/link">
+            <FormattedMessage id="home.have_code" />
+          </a>
+          <div>
             <IfFeature name="show_discord_bot_link">
-              <div className={styles.secondaryLink}>
-                <div>
-                  <FormattedMessage id="home.add_to_discord_1" />
-                </div>
-                <img src={discordLogoSmall} />
-                <a href="/discord">
-                  <FormattedMessage id="home.add_to_discord_2" />
-                </a>
-                <div>
-                  <FormattedMessage id="home.add_to_discord_3" />
-                </div>
-              </div>
+              <FormattedMessage id="home.add_to_discord_1" />
+              <img src={discordLogoUrl} />
+              <a href="/discord">
+                <FormattedMessage id="home.add_to_discord_2" />
+              </a>
+              <FormattedMessage id="home.add_to_discord_3" />
             </IfFeature>
           </div>
         </div>
-      </div>
+      </section>
     </Page>
   );
 }

--- a/src/react-components/home/HomePage.scss
+++ b/src/react-components/home/HomePage.scss
@@ -1,172 +1,87 @@
-@import '../../assets/stylesheets/root-vars';
 @import '../../assets/stylesheets/shared';
 
 :local(.home-page) {
   flex: 1;
-}
-
-:local(.video-container) {
-  position: absolute;
-  z-index: -1;
-  top: 0px;
-  left: 0px;
-  bottom: 0px;
-  right: 0px;
-  overflow: hidden;
   background-size: cover;
-  background-repeat: no-repeat;
-  background-position: 50% 50%;
-  background-image: none;
+  padding: 1.5em;
 }
 
-:local(.background-video) {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  min-width: 100%;
-  min-height: 100%;
-  z-index: -1;
-  overflow: hidden;
-  opacity: 0.3;
-}
-
-:local(.hero-content) {
+:local(.app-info) {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  position: relative;
-  flex: 1;
-  background-size: cover;
-  padding: 1.5em;
+  align-items: center;
+  padding: 0;
+  margin-top: 36px;
+}
 
-  @media (max-width: 768px), (max-height: 480px) {
-    padding: 0;
-    padding-bottom: 64px;
-    order: -1;
+:local(.app-description) {
+  white-space: pre-wrap;
+  align-self: auto;
+  font-size: 14pt;
+  text-align: center;
+  margin: 0.5em 0;
+  margin-bottom: 1em;
+
+  @media (min-width: $breakpoint-lg) {
+    font-size: 18pt;
+    align-self: flex-start;
+    text-align: start;
+  }
+}
+
+:local(.logo-container) {
+  max-width: 250px;
+  align-self: auto;
+  margin: 24px 0;
+
+  @media (min-width: $breakpoint-lg) {
+    align-self: flex-start;
   }
 
-  :local(.container) {
+  img {
+    width: 100%;
+    height: auto;
+  }
+}
+
+:local(.center-logo) {
+  align-self: auto;
+}
+
+:local(.cta-buttons) {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 150px;
+}
+
+:local(.featured-rooms) {
+  width: 100%;
+}
+
+:local(.secondary-links) {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  font-weight: bold;
+  color: var(--home-header-link-color);
+
+  & > * {
     display: flex;
-    flex-direction: column;
-    justify-content: center;
     align-items: center;
-    padding: 0;
-    margin-top: 36px;
-
-    @media (max-width: 768px) {
-      width: 80%;
-    }
-
-    @media (max-height: 480px) {
-      padding: 1em;
-      padding-bottom: 0;
-    }
-
-    :local(.logo) {
-      max-width: 250px;
-
-      align-self: flex-start;
-      margin-left: -25px;
-      margin-bottom: -12px;
-
-      @media (max-width: 768px) {
-        align-self: auto;
-      }
-
-      img {
-        width: 100%;
-        height: auto;
-      }
-    }
-    :local(.logo-margin) {
-      margin: 24px 0;
-    }
-    :local(.blurb) {
-      white-space: pre-wrap;
-      font-size: 18pt;
-      margin: 0.5em 0;
-      margin-bottom: 1em;
-      align-self: flex-start;
-
-      @media (max-width: 768px) {
-        align-self: auto;
-        font-size: 14pt;
-        text-align: center;
-      }
-    }
-  }
-  :local(.hero-panel) {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    margin: 2em 0;
-  }
-  :local(.cta-buttons) {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    min-height: 150px;
-    :local(.primary-button) {
-      @extend %big-action-button;
-    }
-    :local(.cta-button) {
-      font-size: 14pt;
-      width: 19em;
-      margin-right: 1em;
-
-      @media (max-width: 380px) {
-        width: 18em;
-      }
-    }
-    :local(.secondary-button) {
-      @extend %action-button-secondary;
-      display: flex;
-      flex-direction: row;
-      width: 250px;
-      margin-top: 18px;
-      margin-bottom: 18px;
-      padding-right: 20px;
-
-      i {
-        margin-right: 16px;
-      }
-    }
-  }
-  :local(.rightPanel) {
-    flex: 0;
-  }
-  :local(.hero-video) {
-    flex: 1;
-    display: flex;
-    :local(video) {
-      width: 100%;
-    }
-  }
-  :local(.have-code) {
-    justify-content: flex-end;
-    font-size: 14pt;
-    margin-top: -2em;
-  }
-  :local(.secondary-link) {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    font-weight: bold;
-    color: var(--home-header-link-color);
     margin-top: 8px;
+  }
 
-    img {
-      width: 24px;
-      height: 24px;
-    }
+  img {
+    width: 24px;
+    height: 24px;
+  }
 
-    a { 
-      color: var(--home-header-link-color);
-      margin-right: 4px;
-      margin-left: 2px;
-    }
+  a { 
+    color: var(--home-header-link-color);
+    margin-right: 4px;
+    margin-left: 2px;
   }
 }

--- a/src/react-components/home/HomePage.scss
+++ b/src/react-components/home/HomePage.scss
@@ -33,7 +33,6 @@
 :local(.logo-container) {
   max-width: 250px;
   align-self: auto;
-  margin: 24px 0;
 
   @media (min-width: $breakpoint-lg) {
     align-self: flex-start;
@@ -45,8 +44,10 @@
   }
 }
 
+
 :local(.center-logo) {
   align-self: auto;
+  margin: 24px 0;
 }
 
 :local(.cta-buttons) {

--- a/src/signin.js
+++ b/src/signin.js
@@ -7,6 +7,7 @@ import "./utils/theme";
 import { lang, messages } from "./utils/i18n";
 import { AuthContextProvider } from "./react-components/auth/AuthContext";
 import { SignInPage } from "./react-components/auth/SignInPage";
+import "./assets/stylesheets/globals.scss";
 
 registerTelemetry("/signin", "Hubs Sign In Page");
 

--- a/src/verify.js
+++ b/src/verify.js
@@ -7,6 +7,7 @@ import "./utils/theme";
 import { lang, messages } from "./utils/i18n";
 import { AuthContextProvider } from "./react-components/auth/AuthContext";
 import { VerifyPage } from "./react-components/auth/VerifyPage";
+import "./assets/stylesheets/globals.scss";
 
 registerTelemetry("/verify", "Hubs Verify Email Page");
 


### PR DESCRIPTION
This PR brings the homepage styling more inline with what is in #2562 

![Screenshot_2020-07-09 App(2)](https://user-images.githubusercontent.com/1753624/87099631-22081e00-c1ff-11ea-9284-dd0de620d101.png)

![Screenshot_2020-07-09 App](https://user-images.githubusercontent.com/1753624/87099642-29c7c280-c1ff-11ea-88e0-d8060ca4f815.png)

![Screenshot_2020-07-09 App(1)](https://user-images.githubusercontent.com/1753624/87099647-2f250d00-c1ff-11ea-9795-564d344e884c.png)

![Screenshot_2020-07-09 Sign In](https://user-images.githubusercontent.com/1753624/87099649-30eed080-c1ff-11ea-9ed1-ab0e1331687c.png)

Disregard the error, I navigated to the URL directly so that's normal
![Screenshot_2020-07-09 Verify Email](https://user-images.githubusercontent.com/1753624/87099653-33512a80-c1ff-11ea-9896-29acfba1b804.png)

