### PR TITLE
Split out MediaGrid component for HomePage

### DIFF
--- a/src/react-components/home/HomePage.js
+++ b/src/react-components/home/HomePage.js
@@ -5,7 +5,6 @@ import classNames from "classnames";
 import configs from "../../utils/configs";
 import IfFeature from "../if-feature";
 import { Page } from "../layout/Page";
-import MediaTiles from "../media-tiles";
 import { CreateRoomButton } from "../input/CreateRoomButton";
 import { PWAButton } from "../input/PWAButton";
 import { useFeaturedRooms } from "./useFeaturedRooms";
@@ -13,7 +12,8 @@ import styles from "./HomePage.scss";
 import discordLogoUrl from "../../assets/images/discord-logo-small.png";
 import { AuthContext } from "../auth/AuthContext";
 import { createAndRedirectToNewHub } from "../../utils/phoenix-utils";
-import mediaBrowserStyles from "../../assets/stylesheets/media-browser.scss";
+import { MediaGrid } from "./MediaGrid";
+import { RoomTile } from "./RoomTile";
 
 addLocaleData([...en]);
 
@@ -72,11 +72,7 @@ export function HomePage() {
       </section>
       {featuredRooms.length > 0 && (
         <section className={styles.featuredRooms}>
-          <section className={classNames([mediaBrowserStyles.mediaBrowser, mediaBrowserStyles.mediaBrowserInline])}>
-            <div className={classNames([mediaBrowserStyles.box, mediaBrowserStyles.darkened])}>
-              <MediaTiles entries={featuredRooms} urlSource="favorites" />
-            </div>
-          </section>
+          <MediaGrid>{featuredRooms.map(room => <RoomTile key={room.id} room={room} />)}</MediaGrid>
         </section>
       )}
       <section>

--- a/src/react-components/home/HomePage.scss
+++ b/src/react-components/home/HomePage.scss
@@ -59,6 +59,7 @@
 
 :local(.featured-rooms) {
   width: 100%;
+  background-color: var(--home-media-panel-background-color);
 }
 
 :local(.secondary-links) {

--- a/src/react-components/home/MediaGrid.js
+++ b/src/react-components/home/MediaGrid.js
@@ -1,0 +1,17 @@
+import React from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import styles from "./MediaGrid.scss";
+
+export function MediaGrid({ children, className, ...rest }) {
+  return (
+    <div className={classNames(styles.mediaGrid, className)} {...rest}>
+      {children}
+    </div>
+  );
+}
+
+MediaGrid.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node
+};

--- a/src/react-components/home/MediaGrid.scss
+++ b/src/react-components/home/MediaGrid.scss
@@ -1,0 +1,14 @@
+@import '../../assets/stylesheets/shared';
+
+:local(.media-grid) {
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+  padding: 20px;
+  justify-items: center;
+  justify-content: space-evenly;
+
+  & > * {
+    margin: 8px;
+  }
+}

--- a/src/react-components/home/RoomTile.js
+++ b/src/react-components/home/RoomTile.js
@@ -1,0 +1,50 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styles from "./RoomTile.scss";
+import { scaledThumbnailUrlFor } from "../../utils/media-url-utils";
+import { FormattedMessage } from "react-intl";
+import dayjs from "dayjs-ext";
+import relativeTime from "dayjs-ext/plugin/relativeTime";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faStar } from "@fortawesome/free-solid-svg-icons/faStar";
+import { faUsers } from "@fortawesome/free-solid-svg-icons/faUsers";
+
+dayjs.extend(relativeTime);
+
+// TODO: Don't hardcode this or make MediaGrid pull from a single set of constants.
+const thumbnailWidth = 355;
+const thumbnailHeight = 200;
+
+export function RoomTile({ room, ...rest }) {
+  const thumbnailUrl = scaledThumbnailUrlFor(room.images.preview.url, thumbnailWidth, thumbnailHeight);
+
+  return (
+    <a
+      className={styles.roomTile}
+      href={room.url}
+      rel="noreferrer noopener"
+      style={{ width: thumbnailWidth }}
+      {...rest}
+    >
+      <div className={styles.thumbnailContainer}>
+        <img src={thumbnailUrl} alt={room.name} width={thumbnailWidth} height={thumbnailHeight} />
+        {room.favorited && <FontAwesomeIcon className={styles.favoriteIcon} icon={faStar} />}
+        <div className={styles.memberCount}>
+          <FontAwesomeIcon icon={faUsers} /> <span>{room.member_count}</span>
+        </div>
+      </div>
+      <div className={styles.roomInfo}>
+        <h3>{room.name}</h3>
+        {room.last_activated_at && (
+          <small>
+            <FormattedMessage id="media-browser.hub.joined-prefix" /> {dayjs(room.last_activated_at).fromNow()}
+          </small>
+        )}
+      </div>
+    </a>
+  );
+}
+
+RoomTile.propTypes = {
+  room: PropTypes.object
+};

--- a/src/react-components/home/RoomTile.scss
+++ b/src/react-components/home/RoomTile.scss
@@ -1,0 +1,58 @@
+@import '../../assets/stylesheets/shared';
+
+:local(.room-tile) {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+}
+
+:local(.thumbnail-container) {
+  display: flex;
+  background-color: var(--tile-background-color);
+  border-radius: 12px;
+  position: relative;
+
+  img {
+    border-radius: 12px;
+  }
+}
+
+:local(.favorite-icon) {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  color: $favorited-color;
+}
+
+:local(.member-count) {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  background: var(--tile-button-background-color);
+  color: var(--tile-button-icon-color);
+  height: 30px;
+  border-radius: 30px;
+  line-height: 30px;
+  padding: 0 10px;
+}
+
+:local(.room-info) {
+  margin-top: 4px;
+
+  & > * {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    margin: 0;
+    display:block;
+  }
+
+
+  h3 {
+    color: var(--tile-title-color);
+  }
+
+  small {
+    color: var(--tile-subtitle-color);
+  }
+}

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -75,6 +75,7 @@ const DEFAULT_FACETS = {
   scenes: [{ text: "Featured", params: { filter: "featured" } }, { text: "My Scenes", params: { filter: "my-scenes" } }]
 };
 
+// TODO: Migrate to use MediaGrid and media specific components like RoomTile
 class MediaBrowser extends Component {
   static propTypes = {
     mediaSearchStore: PropTypes.object,

--- a/src/react-components/media-tiles.js
+++ b/src/react-components/media-tiles.js
@@ -32,6 +32,7 @@ const PUBLISHER_FOR_ENTRY_TYPE = {
   twitch_stream: "Twitch"
 };
 
+// TODO: Migrate to use MediaGrid and media specific components like RoomTile
 class MediaTiles extends Component {
   static propTypes = {
     intl: PropTypes.object,


### PR DESCRIPTION
This PR splits out the MediaGrid and RoomTile components from media-browser.js and media-tiles.js. Rather than include code for all of the different types of media, this approach keeps them separate so the home page stays as lean as possible. In the future as we refactor the rest of the media browser, we can move to this style.

I also fixed a bug where the RoomTile would say "visited a few seconds ago" for all public rooms. Because there is no last visited field, I chose to hide the text.

![Screenshot_2020-07-09 App(9)](https://user-images.githubusercontent.com/1753624/87101037-d788a080-c202-11ea-8dc6-51c24d643ed6.png)

![Screenshot_2020-07-09 App(8)](https://user-images.githubusercontent.com/1753624/87101039-d9526400-c202-11ea-9432-c81a8c5a9be6.png)

![Screenshot_2020-07-09 App(7)](https://user-images.githubusercontent.com/1753624/87101048-de171800-c202-11ea-9c02-60b6aa9d325f.png)

