### PR TITLE
Fix crossOrigin not getting set on texture loads

### DIFF
--- a/src/loaders/HubsTextureLoader.js
+++ b/src/loaders/HubsTextureLoader.js
@@ -3,10 +3,9 @@ function loadAsync(loader, url, onProgress) {
 }
 
 export default class HubsTextureLoader {
-  static crossOrigin = "anonymous";
-
   constructor(manager = THREE.DefaultLoadingManager) {
     this.manager = manager;
+    this.crossOrigin = "anonymous";
   }
 
   load(url, onLoad, onProgress, onError) {


### PR DESCRIPTION
The `crossOrigin` setting set not correctly being set on texture loads. This can cause issues in some environments.

fixes #2616