### PR TITLE
Update threejs-world-update documentation

### DIFF
--- a/src/utils/threejs-world-update.js
+++ b/src/utils/threejs-world-update.js
@@ -8,7 +8,12 @@ identity.identity();
 With this patch you must make sure to follow these rules or very strange things will happen.
 - If you modify an object's position, rotation, quaternion, or scale you MUST set matrixNeedsUpdate.
 - If you modify an object's matrix you MUST decompose() back onto its position, quaternion and scale and you MUST set matrixWorldNeedsUpdate (or matrixNeedsUpdate, but the former is more correct). (applyMatrix() and updateMatrix() handle this for you)
-- If you modify an object's matrixWorld you MUST make sure it has previously been modified so that it is not using its parent matrix as its own, you MUST update its local matrix and you MUST update its position/quaternion/scale. (setMatrixWorld() handles this for you)
+- If you modify an object's matrixWorld
+-- you MUST make sure it has previously been modified so that it is not using its parent matrix as its own,
+-- you MUST update its local matrix
+-- you MUST update its position/quaternion/scale.
+-- you MUST set childrenNeedMatrixWorldUpdate
+-- (setMatrixWorld() handles all of this for you)
 - Before you read an object's matrix you MUST call updateMatrix() or updateMatrices().
 - Before you read an object's matrixWorld you MUST call updateMatrices(). (getWorldPosition, getWorldOrientation and getWorldScale handle this for you)
 - Do not set matrixIsModified yourself. You could accidentally overwrite parent matrices.

--- a/src/utils/threejs-world-update.js
+++ b/src/utils/threejs-world-update.js
@@ -10,7 +10,7 @@ With this patch you must make sure to follow these rules or very strange things 
 - If you modify an object's matrix you MUST decompose() back onto its position, quaternion and scale and you MUST set matrixWorldNeedsUpdate (or matrixNeedsUpdate, but the former is more correct). (applyMatrix() and updateMatrix() handle this for you)
 - If you modify an object's matrixWorld you MUST make sure it has previously been modified so that it is not using its parent matrix as its own, you MUST update its local matrix and you MUST update its position/quaternion/scale. (setMatrixWorld() handles this for you)
 - Before you read an object's matrix you MUST call updateMatrix() or updateMatrices().
-- Before you read object's matrixWorld you MUST call updateMatrices(). (getWorldPosition, getWorldOrientation and getWorldScale handle this for you)
+- Before you read an object's matrixWorld you MUST call updateMatrices(). (getWorldPosition, getWorldOrientation and getWorldScale handle this for you)
 - Do not set matrixIsModified yourself. You could accidentally overwrite parent matrices.
 - Note updateMatrix, updateMatrixWorld, updateWorldMatrix, updateMatrices, setMatrixWorld, matrixNeedsUpdate, matrixWorldNeedsUpdate, and matrixIsModified are all different things. Most already exist in ThreeJS but some have been added here. Double check you are using the one you intend to.
 - Be on the lookout for compatibility issues with third party libraries.

--- a/src/utils/threejs-world-update.js
+++ b/src/utils/threejs-world-update.js
@@ -7,18 +7,25 @@ identity.identity();
 /**
 With this patch you must make sure to follow these rules or very strange things will happen.
 - If you modify an object's position, rotation, quaternion, or scale you MUST set matrixNeedsUpdate.
-- If you modify an object's matrix you MUST decompose() back onto its position, quaternion and scale and you MUST set matrixWorldNeedsUpdate (or matrixNeedsUpdate, but the former is more correct). (applyMatrix() and updateMatrix() handle this for you)
+- If you modify an object's matrix
+      you MUST decompose() back onto its position, quaternion and scale and
+      you MUST set matrixWorldNeedsUpdate (or matrixNeedsUpdate, but the former is more correct).
+      (applyMatrix() and updateMatrix() handle this for you)
 - If you modify an object's matrixWorld
--- you MUST make sure it has previously been modified so that it is not using its parent matrix as its own,
--- you MUST update its local matrix
--- you MUST update its position/quaternion/scale.
--- you MUST set childrenNeedMatrixWorldUpdate
--- (setMatrixWorld() handles all of this for you)
+      you MUST make sure it has previously been modified so that it is not using its parent matrix as its own,
+      you MUST update its local matrix,
+      you MUST update its position/quaternion/scale, and
+      you MUST set childrenNeedMatrixWorldUpdate.
+      (setMatrixWorld() handles all of this for you)
 - Before you read an object's matrix you MUST call updateMatrix() or updateMatrices().
-- Before you read an object's matrixWorld you MUST call updateMatrices(). (getWorldPosition, getWorldOrientation and getWorldScale handle this for you)
-- Do not set matrixIsModified yourself. You could accidentally overwrite parent matrices.
-- Note updateMatrix, updateMatrixWorld, updateWorldMatrix, updateMatrices, setMatrixWorld, matrixNeedsUpdate, matrixWorldNeedsUpdate, and matrixIsModified are all different things. Most already exist in ThreeJS but some have been added here. Double check you are using the one you intend to.
-- Be on the lookout for compatibility issues with third party libraries.
+- Before you read an object's matrixWorld you MUST call updateMatrices().
+      (getWorldPosition, getWorldOrientation and getWorldScale handle this for you)
+- Do not set matrixIsModified yourself; You could accidentally overwrite a shared parent matrixWorld.
+- Note updateMatrix, updateMatrixWorld, updateWorldMatrix, updateMatrices, setMatrixWorld,
+      matrixNeedsUpdate, matrixWorldNeedsUpdate, and matrixIsModified are all different things.
+      Most already exist in ThreeJS but some have been added here.
+      Double check you are using the one you intend to.
+      Be on the lookout for compatibility issues with third party libraries.
 */
 
 // Patch animation system

--- a/src/utils/threejs-world-update.js
+++ b/src/utils/threejs-world-update.js
@@ -6,13 +6,14 @@ identity.identity();
 
 /**
 With this patch you must make sure to follow these rules or very strange things will happen.
-- If you modify a transform value (position, rotation, scale) you MUST set matrixNeedsUpdate
-- If you manually modify an objects matrix you MUST set matrixIsModified and decompose() to the objects components (applyMatrix and updateMatrix handle this for you)
-- If you want to directly read an objects matrixWorld you MUST call updateMatricies(). (getWorldPosition, getWorldOrientation and getWorldScale handle this for you)
-- If you want to directly read an objects matrix you MUST call updateMatrix()
-- Note updateMatrix, updateMatrixWorld, updateWorldMatrix, matrixNeedsUpdate, matrixWorldNeedsUpdate, 
-  matrixIsModified are all different things, most of which already exist in ThreeJS but some which have been added, 
-  double check you are using the one you intend to. 
+- If you modify an object's position, rotation, quaternion, or scale you MUST set matrixNeedsUpdate.
+- If you modify an object's matrix you MUST decompose() back onto its position, quaternion and scale and you MUST set matrixWorldNeedsUpdate (or matrixNeedsUpdate, but the former is more correct). (applyMatrix() and updateMatrix() handle this for you)
+- If you modify an object's matrixWorld you MUST make sure it has previously been modified so that it is not using its parent matrix as its own, you MUST update its local matrix and you MUST update its position/quaternion/scale. (setMatrixWorld() handles this for you)
+- Before you read an object's matrix you MUST call updateMatrix() or updateMatrices().
+- Before you read object's matrixWorld you MUST call updateMatrices(). (getWorldPosition, getWorldOrientation and getWorldScale handle this for you)
+- Do not set matrixIsModified yourself. You could accidentally overwrite parent matrices.
+- Note updateMatrix, updateMatrixWorld, updateWorldMatrix, updateMatrices, setMatrixWorld, matrixNeedsUpdate, matrixWorldNeedsUpdate, and matrixIsModified are all different things. Most already exist in ThreeJS but some have been added here. Double check you are using the one you intend to.
+- Be on the lookout for compatibility issues with third party libraries.
 */
 
 // Patch animation system


### PR DESCRIPTION
Fix an issue advising users to set `matrixIsModified` when they shouldn't.
Add instructions for modifying `matrixWorld` (they are complicated, so just use `setMatrixWorld`)
Clarify some minor points
