### PR TITLE
Bunch of HLS fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6771,12 +6771,6 @@
         }
       }
     },
-    "awaitqueue": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/awaitqueue/-/awaitqueue-2.1.1.tgz",
-      "integrity": "sha512-pzmngNP5W9S0dg24oim4wEQRCBadowAxVv5aLIJmgI5a8m8Cxxm1jXtScgHzHFY1aDR5ep1rktPtRbUEuIPl0A==",
-      "dev": true
-    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -9733,7 +9727,8 @@
     "eventemitter3": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
+      "dev": true
     },
     "events": {
       "version": "3.0.0",
@@ -10872,12 +10867,19 @@
       }
     },
     "hls.js": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-0.13.2.tgz",
-      "integrity": "sha512-sIg2t4uGpWQLzuK1Iid9614WOKqxj4OYg+EbFbhhTDCsxpENBN+Du3yBFnoi+a83DuOOHdiQd1ydnti9loSGXw==",
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-0.14.6.tgz",
+      "integrity": "sha512-6s8L+Pzed3Gyf7wDxQNx9TP9y9clCDIPW8cQdDV7PF7npI75BbCbUZSQQclnt20442Ay1NL3vg2WXeSEYNiuAw==",
       "requires": {
-        "eventemitter3": "3.1.0",
+        "eventemitter3": "^4.0.3",
         "url-toolkit": "^2.1.6"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+        }
       }
     },
     "hmac-drbg": {
@@ -12844,6 +12846,12 @@
         "supports-color": "^7.1.0"
       },
       "dependencies": {
+        "awaitqueue": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/awaitqueue/-/awaitqueue-2.2.3.tgz",
+          "integrity": "sha512-vKY8hHHt1FT05UBxaTKWoA8+A3APnyzcOO1UBY5wQ7ENzXCFi3Yy4wSKsqrO0ncDD/5CI6IZDN1nVZQKziWIqg==",
+          "dev": true
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -19174,9 +19182,9 @@
       "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk="
     },
     "url-toolkit": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.1.6.tgz",
-      "integrity": "sha512-UaZ2+50am4HwrV2crR/JAf63Q4VvPYphe63WGeoJxeu8gmOm0qxPt+KsukfakPNrX9aymGNEkkaoICwn+OuvBw=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.0.tgz",
+      "integrity": "sha512-Rde0c9S4fJK3FaHim3DSgdQ8IFrSXcZCpAJo9T7/FA+BoQGhK0ow3mpwGQLJCPYsNn6TstpW7/7DzMpSpz9F9w=="
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "form-data": "^3.0.0",
     "form-urlencoded": "^2.0.4",
     "history": "^4.7.2",
-    "hls.js": "^0.13.2",
+    "hls.js": "^0.14.6",
     "js-cookie": "^2.2.0",
     "jsonschema": "^1.2.2",
     "jwt-decode": "^2.2.0",

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -402,7 +402,7 @@ AFRAME.registerComponent("media-loader", {
       }
 
       // Some servers treat m3u8 playlists as "audio/x-mpegurl", we always want to treat them as HLS videos
-      if (contentType === "audio/x-mpegurl") {
+      if (contentType === "audio/x-mpegurl" || contentType === "audio/mpegurl") {
         contentType = "application/vnd.apple.mpegurl";
       }
 

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -35,9 +35,6 @@ const TYPE_IMG_PNG = { type: "image/png" };
 const parseGIF = promisifyWorker(new GIFWorker());
 
 const isIOS = AFRAME.utils.device.isIOS();
-const isMobileVR = AFRAME.utils.device.isMobileVR();
-const isFirefoxReality = isMobileVR && navigator.userAgent.match(/Firefox/);
-const HLS_TIMEOUT = 10000; // HLS can sometimes fail, we re-try after this duration
 const audioIconTexture = new THREE.TextureLoader().load(audioIcon);
 
 export const VOLUME_LABELS = [];
@@ -789,20 +786,6 @@ AFRAME.registerComponent("media-video", {
           };
 
           setupHls();
-
-          // Sometimes for weird streams HLS fails to initialize.
-          const setupInterval = setInterval(() => {
-            // Stop retrying if the src changed.
-            const isNoLongerSrc = this.data.src !== url;
-
-            if (isReady() || isNoLongerSrc) {
-              clearInterval(setupInterval);
-            } else {
-              console.warn("HLS failed to read video, trying again");
-              setupHls();
-            }
-          }, HLS_TIMEOUT);
-          // If not, see if native support will work
         } else if (videoEl.canPlayType(contentType)) {
           videoEl.src = url;
           videoEl.onerror = failLoad;

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -605,31 +605,19 @@ AFRAME.registerComponent("media-video", {
       this.video.addEventListener("play", this.onPauseStateChange);
 
       if (texture.hls) {
-        const updateLiveState = () => {
+        const updateHLSLiveState = () => {
           if (texture.hls.currentLevel >= 0) {
-            const videoWasLive = !!this.videoIsLive;
             this.videoIsLive = texture.hls.levels[texture.hls.currentLevel].details.live;
             this.updateHoverMenu();
-
-            if (!videoWasLive && this.videoIsLive) {
-              this.el.emit("video_is_live_update", { videoIsLive: this.videoIsLive });
-              // We just determined the video is live (there can be a delay due to autoplay issues, etc)
-              // so catch it up to HEAD.
-              if (!isFirefoxReality) {
-                // HACK this causes live streams to freeze in FxR due to https://github.com/MozillaReality/FirefoxReality/issues/1602, TODO remove once 1.4 ships
-                this.video.currentTime = this.video.duration - 0.01;
-              }
-            }
           }
         };
-        texture.hls.on(HLS.Events.LEVEL_LOADED, updateLiveState);
-        texture.hls.on(HLS.Events.LEVEL_SWITCHED, updateLiveState);
+        texture.hls.on(HLS.Events.LEVEL_LOADED, updateHLSLiveState);
+        texture.hls.on(HLS.Events.LEVEL_SWITCHED, updateHLSLiveState);
         if (texture.hls.currentLevel >= 0) {
-          updateLiveState();
+          updateHLSLiveState();
         }
       } else {
         this.videoIsLive = this.video.duration === Infinity;
-        this.el.emit("video_is_live_update", { videoIsLive: this.videoIsLive });
         this.updateHoverMenu();
       }
 

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -777,7 +777,7 @@ AFRAME.registerComponent("media-video", {
                   u = buildAbsoluteURL(baseUrl, u.startsWith("/") ? u : `/${u}`);
                 }
 
-                xhr.open("GET", proxiedUrlFor(u));
+                xhr.open("GET", proxiedUrlFor(u), true);
               }
             });
 

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -17,6 +17,8 @@ import { refreshMediaMirror, getCurrentMirroredMedia } from "../utils/mirror-uti
 import { detect } from "detect-browser";
 import semver from "semver";
 
+import qsTruthy from "../utils/qs_truthy";
+
 /**
  * Warning! This require statement is fragile!
  *
@@ -748,6 +750,7 @@ AFRAME.registerComponent("media-video", {
             }
 
             const hls = new HLS({
+              debug: qsTruthy("hlsDebug"),
               xhrSetup: (xhr, u) => {
                 if (u.startsWith(corsProxyPrefix)) {
                   u = u.substring(corsProxyPrefix.length);

--- a/src/components/refresh-media-button.js
+++ b/src/components/refresh-media-button.js
@@ -9,7 +9,7 @@ AFRAME.registerComponent("local-refresh-media-button", {
         if (c["media-video"] && c["media-video"].videoTexture && c["media-video"].videoTexture.hls) {
           c["media-video"].videoTexture.hls.recoverMediaError();
         } else if (c["media-loader"]) {
-          // Otherwise fall back to hard resolve-level refresh which should work for any meida
+          // Otherwise fall back to hard resolve-level refresh which should work for any media
           c["media-loader"].update(c["media-loader"].data, true);
         }
       }

--- a/src/components/refresh-media-button.js
+++ b/src/components/refresh-media-button.js
@@ -4,36 +4,23 @@ AFRAME.registerComponent("local-refresh-media-button", {
   init() {
     this.onClick = async () => {
       if (this.targetEl) {
-        this.targetEl.components["media-loader"] &&
-          this.targetEl.components["media-loader"].update(this.targetEl.components["media-loader"].data, true);
+        const c = this.targetEl.components;
+        // If an HLS stream is loaded, refresh directly with HLS.js
+        if (c["media-video"] && c["media-video"].videoTexture && c["media-video"].videoTexture.hls) {
+          c["media-video"].videoTexture.hls.recoverMediaError();
+        } else if (c["media-loader"]) {
+          // Otherwise fall back to hard resolve-level refresh which should work for any meida
+          c["media-loader"].update(c["media-loader"].data, true);
+        }
       }
     };
 
     NAF.utils
       .getNetworkedEntity(this.el)
-      .then(networkedEl => {
-        this.targetEl = networkedEl;
-        const isNonLiveVideo =
-          this.targetEl.components["media-video"] && this.targetEl.components["media-video"].videoIsLive === false;
-        const src =
-          (this.targetEl.components["media-loader"] && this.targetEl.components["media-loader"].data.src) || "";
-        const shouldHaveLocalRefreshButton = !isNonLiveVideo && src.indexOf("twitch.tv") !== -1;
-        if (!shouldHaveLocalRefreshButton) {
-          this.el.parentNode.removeChild(this.el);
-        } else {
-          const onVideoIsLiveUpdate = e => {
-            if (!e.detail.videoIsLive) {
-              this.targetEl.removeEventListener("video_is_live_update", onVideoIsLiveUpdate);
-              this.el.parentNode.removeChild(this.el);
-            }
-          };
-          this.targetEl.addEventListener("video_is_live_update", onVideoIsLiveUpdate);
-        }
-      })
-      .catch(() => {
-        this.el.parentNode.removeChild(this.el);
-      });
+      .then(networkedEl => (this.targetEl = networkedEl))
+      .catch(() => this.el.parentNode.removeChild(this.el));
   },
+
   play() {
     this.el.object3D.addEventListener("interact", this.onClick);
   },

--- a/src/systems/hover-menu-system.js
+++ b/src/systems/hover-menu-system.js
@@ -1,6 +1,7 @@
 function getSpecificHoverMenu(el) {
   return (
     el &&
+    el.components &&
     (el.components["hover-menu"] ||
       el.components["hover-menu__video"] ||
       el.components["hover-menu__pager"] ||
@@ -20,7 +21,7 @@ function findHoverMenu(hovered) {
     return null;
   }
   let el = hovered.parentNode;
-  while (!getSpecificHoverMenu(el)) {
+  while (el && !getSpecificHoverMenu(el)) {
     el = el.parentNode;
   }
   return getSpecificHoverMenu(el);


### PR DESCRIPTION
A round of fixes for HLS videos. A lot of this is just removing hacks we have in place and letting HLS.js do its thing. I have still run into cases where I can get the player to stall indefinitely, but adding a manual refresh button should hopefully alleviate most of these. Probably not the last round of these but seems worth cutting a PR for.

- Update HLS.js to 0.14.6 (from 0.13.2), contains a whole bunch of bugfixes which people may or may not be hitting. Given the complexity of HLS and wide userbase of HLS.js it seems worth keeping this as up to date as we can.
- Fix handling of audio-only streams (fixes #2521)
- The XHR override we were using was running in sync mode, this was likely slowing requests down and stalling the main thread. Fixed to be async as is the default in HLS.js
- Enable refresh buttons in the pause menu for all objects. We were previously limiting this just to live twitch streams, but it feels generally useful and is a better option than page refresh. When the media is an HLS stream, uses `recoverMediaError()` in hls.js instead of a hard resolve-level refresh.
- Not in this PR but linking here since its related to this round of fixes, and should enable the client to actually do adaptive bitrate streaming when available in the source playlist https://github.com/mozilla/reticulum/pull/397
- Remove HLS timeout hacks. HLS.js has a bunch of internal logic for this already and we are just messing with it. In cases HLS.js stalls out (still can make it happen) the manual refresh above seems preferable and less likely to break what would have otherwise been a working stream. This is especially important with the fixes to adaptive bitrate streaming, since it should automatically fallback to lower bitrate streams if things are taking too long to load.
- Remove hacks we had in place for seeking ahead on live videos. This is handled internally already in HLS.js and us doing it messes with the buffering (fixes #2572)
- added `hlsDebug` query param to turn on HLS.js debugging to help diagnose future issues
