### PR TITLE
Fix missing occupant data

### DIFF
--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -143,8 +143,8 @@ export default class HubChannel extends EventTarget {
     // This is fairly hacky, but gets the # of initial occupants
     let initialOccupantCount = 0;
 
-    if (NAF.connection.adapter && NAF.connection.adapter.occupants) {
-      // When I enter room as avater, count number of people inside the room as avatars and lobby
+    if (NAF.connection.adapter) {
+      // When I enter room as avatar, count number of people inside the room as avatars and lobby
       // I enter room alone, no one in lobby, this is 0
       initialOccupantCount = Object.keys(NAF.connection.adapter.occupants).length;
     }

--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -143,9 +143,15 @@ export default class HubChannel extends EventTarget {
     // This is fairly hacky, but gets the # of initial occupants
     let initialOccupantCount = 0;
 
-    if (NAF.connection.adapter && NAF.connection.adapter.publisher) {
-      initialOccupantCount = NAF.connection.adapter.publisher.initialOccupants.length;
+    if (NAF.connection.adapter && NAF.connection.adapter.occupants) {
+      console.log(NAF);
+      // Count number of people inside the room as avatars
+      // Does not count lobby users
+      // I enter room, will be 0
+      initialOccupantCount = Object.keys(NAF.connection.adapter.occupants).length;
     }
+    console.log("initialOccupantCount: " + initialOccupantCount);
+    console.log(initialOccupantCount);
 
     const entryTimingFlags = this.getEntryTimingFlags();
 

--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -144,14 +144,10 @@ export default class HubChannel extends EventTarget {
     let initialOccupantCount = 0;
 
     if (NAF.connection.adapter && NAF.connection.adapter.occupants) {
-      console.log(NAF);
-      // Count number of people inside the room as avatars
-      // Does not count lobby users
-      // I enter room, will be 0
+      // When I enter room as avater, count number of people inside the room as avatars and lobby
+      // I enter room alone, no one in lobby, this is 0
       initialOccupantCount = Object.keys(NAF.connection.adapter.occupants).length;
     }
-    console.log("initialOccupantCount: " + initialOccupantCount);
-    console.log(initialOccupantCount);
 
     const entryTimingFlags = this.getEntryTimingFlags();
 


### PR DESCRIPTION
With the update from janus to media-soup the initial occupant count was referenced incorrectly. Rather than .publisher we look at the occupants object.

Occupants is defined in naf-dialog-adapter.js.