### PR TITLE
Fix bug blocking mouse wheel events

### DIFF
--- a/src/systems/userinput/devices/mouse.js
+++ b/src/systems/userinput/devices/mouse.js
@@ -7,17 +7,14 @@ const modeMod = {
   [WheelEvent.DOM_DELTA_PAGE]: 2
 };
 
-const isInModal = (() => {
-  let uiRoot = null;
-
-  return function() {
-    if (!uiRoot) {
-      uiRoot = document.querySelector(".ui-root");
-    }
-
-    return uiRoot && uiRoot.classList.contains("in-modal-or-overlay");
-  };
-})();
+function isInModal() {
+  // Performing a querySelector on each wheel event is not desired,
+  // but we can't simply cache the .ui-root element because it can be destroyed
+  // and recreated on full-screen takeovers (e.g. showing the preference screen)
+  // TODO: Tech debt. Find better way to handle this state that is available in react.
+  const uiRoot = document.querySelector(".ui-root");
+  return (uiRoot && uiRoot.classList.contains("in-modal-or-overlay")) || window.APP.preferenceScreenIsVisible;
+}
 
 export class MouseDevice {
   constructor() {
@@ -45,7 +42,7 @@ export class MouseDevice {
       "wheel",
       e => {
         // Do not capture wheel events if they are being sent to an modal/overlay
-        if (!isInModal() && !window.APP.preferenceScreenIsVisible) {
+        if (!isInModal()) {
           e.preventDefault();
         }
       },

--- a/src/systems/userinput/devices/mouse.js
+++ b/src/systems/userinput/devices/mouse.js
@@ -7,14 +7,17 @@ const modeMod = {
   [WheelEvent.DOM_DELTA_PAGE]: 2
 };
 
-function isInModal() {
-  // Performing a querySelector on each wheel event is not desired,
-  // but we can't simply cache the .ui-root element because it can be destroyed
-  // and recreated on full-screen takeovers (e.g. showing the preference screen)
-  // TODO: Tech debt. Find better way to handle this state that is available in react.
-  const uiRoot = document.querySelector(".ui-root");
-  return (uiRoot && uiRoot.classList.contains("in-modal-or-overlay")) || window.APP.preferenceScreenIsVisible;
-}
+const isInModal = (function() {
+  let uiRoot;
+  return function isInModal() {
+    // TODO: Tech debt. Find better way to handle this state that is available in react.
+    uiRoot = uiRoot || document.getElementById("ui-root");
+    return (
+      (uiRoot && uiRoot.children[0] && uiRoot.children[0].classList.contains("in-modal-or-overlay")) ||
+      window.APP.preferenceScreenIsVisible
+    );
+  };
+})();
 
 export class MouseDevice {
   constructor() {


### PR DESCRIPTION
We can't simply cache the element with class `ui-root` like we were doing because it is destroyed and recreated on full-screen takeovers (e.g. showing the preference screen). The fix is to cache its parent element whose `id` (rather than its `class`) is `ui-root`, then inspect the child for the `class` we're interested in. 

Fix https://github.com/mozilla/hubs/issues/2670
Fix https://github.com/mozilla/hubs/issues/2658