### PR TITLE
Add Ability to Hide Object Info UI

### DIFF
--- a/src/assets/stylesheets/client-info-dialog.scss
+++ b/src/assets/stylesheets/client-info-dialog.scss
@@ -2,7 +2,8 @@
 
 :local(.title-and-close){
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
+  align-items: center;
 }
 
 :local(.object-display-string) {

--- a/src/assets/stylesheets/entry.scss
+++ b/src/assets/stylesheets/entry.scss
@@ -11,10 +11,15 @@
 :local(.collapse-button) {
   @extend %fa-icon-button;
   color: var(--panel-widget-color);
-  display: inline;
-  position: absolute;
-  top: 0px;
-  left: 24px;
+
+  i {
+    font-size: 24px;
+  }
+}
+
+:local(.hide-button) {
+  @extend %fa-icon-button;
+  color: var(--panel-widget-color);
 
   i {
     font-size: 24px;
@@ -23,11 +28,7 @@
 
 :local(.favorite-button) {
   @extend %fa-icon-button;
-  position: absolute;
-  top: 0px;
-  right: 24px;
   color: var(--unfavorited-color);
-  display: inline;
 
   i {
     font-size: 1.2em;
@@ -134,9 +135,11 @@
   :local(.name) {
     @extend %top-title;
     @extend %glass-text;
+    display: flex;
+    justify-content: space-between;
     margin-bottom: 4px;
-    margin-right: 48px;
-    margin-left: 48px;
+    margin-right: 20px;
+    margin-left: 20px;
 
     :local(.rename-button) {
       @extend %glass-text;
@@ -275,7 +278,7 @@
 
   @media (min-width: 768px) {
     position: absolute;
-    top: 12px;
+    top: 28px;
     left: 26px;
   }
 

--- a/src/assets/stylesheets/info-dialog.scss
+++ b/src/assets/stylesheets/info-dialog.scss
@@ -51,11 +51,6 @@
       position: relative;
       background-color: var(--full-panel-background-color);
 
-
-      @media (max-width: 801px) {
-        padding: 5px;
-      }
-
       &__title {
         @extend %top-title;
         margin-bottom: 20px;

--- a/src/assets/stylesheets/object-info-dialog.scss
+++ b/src/assets/stylesheets/object-info-dialog.scss
@@ -1,5 +1,15 @@
 @import 'shared.scss';
 
+:local(.hidden) {
+  .dialog__box__contents {
+    padding: 20px;
+  }
+
+  .dialog__box__contents__body {
+    margin: 0;
+  }
+}
+
 :local(.flex){
   display: flex;
 }

--- a/src/assets/stylesheets/shared.scss
+++ b/src/assets/stylesheets/shared.scss
@@ -314,7 +314,6 @@ $breakpoint-xxl: 1600px; // Extra Large Desktops
 
 %fa-icon-button {
   @extend %default-font;
-  margin: 16px 0;
   padding: 0;
   display: block;
   background: none;

--- a/src/react-components/object-info-dialog.js
+++ b/src/react-components/object-info-dialog.js
@@ -10,6 +10,8 @@ import { FormattedMessage } from "react-intl";
 import { faTimes } from "@fortawesome/free-solid-svg-icons/faTimes";
 import { faChevronLeft } from "@fortawesome/free-solid-svg-icons/faChevronLeft";
 import { faChevronRight } from "@fortawesome/free-solid-svg-icons/faChevronRight";
+import { faChevronDown } from "@fortawesome/free-solid-svg-icons/faChevronDown";
+import { faChevronUp } from "@fortawesome/free-solid-svg-icons/faChevronUp";
 import { faTrashAlt } from "@fortawesome/free-solid-svg-icons/faTrashAlt";
 import { faStreetView } from "@fortawesome/free-solid-svg-icons/faStreetView";
 import { faLightbulb } from "@fortawesome/free-solid-svg-icons/faLightbulb";
@@ -105,7 +107,8 @@ export default class ObjectInfoDialog extends Component {
 
   state = {
     enableLights: false,
-    mediaEntities: []
+    mediaEntities: [],
+    hidden: false
   };
 
   componentDidMount() {
@@ -235,6 +238,10 @@ export default class ObjectInfoDialog extends Component {
       this._isRemoving = false;
     });
   }
+
+  onToggleHidden = () => {
+    this.setState({ hidden: !this.state.hidden });
+  };
 
   renderSmallScreen(
     targetIndex,
@@ -390,7 +397,12 @@ export default class ObjectInfoDialog extends Component {
     }
 
     return (
-      <DialogContainer noOverlay={true} wide={true} {...this.props}>
+      <DialogContainer
+        noOverlay={true}
+        wide={true}
+        className={classNames({ [oStyles.hidden]: this.state.hidden })}
+        {...this.props}
+      >
         <div className={cStyles.roomInfo}>
           <div className={cStyles.titleAndClose}>
             <button
@@ -406,52 +418,66 @@ export default class ObjectInfoDialog extends Component {
             <a className={cStyles.objectDisplayString} href={this.props.src} target="_blank" rel="noopener noreferrer">
               <FormattedMessage id={`object-info.open-link`} />
             </a>
+            <button
+              aria-label={`${this.state.hidden ? "Show" : "Hide"} object info panel`}
+              className={entryStyles.hideButton}
+              onClick={this.onToggleHidden}
+            >
+              <i>
+                <FontAwesomeIcon icon={this.state.hidden ? faChevronUp : faChevronDown} />
+              </i>
+            </button>
           </div>
-          <div className={cStyles.actionButtonSections}>
-            <div className={cStyles.leftActionButtons}>
-              {showNavigationButtons && (
-                <button aria-label="Previous Object" className={cStyles.navigationButton} onClick={this.navigatePrev}>
-                  <i>
-                    <FontAwesomeIcon icon={faChevronLeft} />
-                  </i>
+          {!this.state.hidden && (
+            <div className={cStyles.actionButtonSections}>
+              <div className={cStyles.leftActionButtons}>
+                {showNavigationButtons && (
+                  <button aria-label="Previous Object" className={cStyles.navigationButton} onClick={this.navigatePrev}>
+                    <i>
+                      <FontAwesomeIcon icon={faChevronLeft} />
+                    </i>
+                  </button>
+                )}
+              </div>
+              <div className={cStyles.primaryActionButtons}>
+                <button onClick={this.toggleLights.bind(this)}>
+                  <FormattedMessage id={`object-info.${this.state.enableLights ? "lower" : "raise"}-lights`} />
                 </button>
-              )}
+                {this.props.scene.is("entered") && (
+                  <button onClick={this.enqueueWaypointTravel}>
+                    <FormattedMessage id="object-info.waypoint" />
+                  </button>
+                )}
+                {showRemoveButton ? (
+                  <button onClick={this.remove.bind(this)}>
+                    <FormattedMessage id="object-info.remove-button" />
+                  </button>
+                ) : (
+                  <div className={cStyles.actionButtonPlaceholder} />
+                )}
+                {showPinOrUnpin && (
+                  <button
+                    className={pinned ? "" : cStyles.primaryActionButton}
+                    onClick={pinned ? this.unpin : this.pin}
+                  >
+                    <FormattedMessage id={`object-info.${pinned ? "unpin-button" : "pin-button"}`} />
+                  </button>
+                )}
+                <a className={cStyles.cancelText} href="#" onClick={onClose}>
+                  <FormattedMessage id="client-info.cancel" />
+                </a>
+              </div>
+              <div className={cStyles.rightActionButtons}>
+                {showNavigationButtons && (
+                  <button aria-label="Next Object" className={cStyles.navigationButton} onClick={this.navigateNext}>
+                    <i>
+                      <FontAwesomeIcon icon={faChevronRight} />
+                    </i>
+                  </button>
+                )}
+              </div>
             </div>
-            <div className={cStyles.primaryActionButtons}>
-              <button onClick={this.toggleLights.bind(this)}>
-                <FormattedMessage id={`object-info.${this.state.enableLights ? "lower" : "raise"}-lights`} />
-              </button>
-              {this.props.scene.is("entered") && (
-                <button onClick={this.enqueueWaypointTravel}>
-                  <FormattedMessage id="object-info.waypoint" />
-                </button>
-              )}
-              {showRemoveButton ? (
-                <button onClick={this.remove.bind(this)}>
-                  <FormattedMessage id="object-info.remove-button" />
-                </button>
-              ) : (
-                <div className={cStyles.actionButtonPlaceholder} />
-              )}
-              {showPinOrUnpin && (
-                <button className={pinned ? "" : cStyles.primaryActionButton} onClick={pinned ? this.unpin : this.pin}>
-                  <FormattedMessage id={`object-info.${pinned ? "unpin-button" : "pin-button"}`} />
-                </button>
-              )}
-              <a className={cStyles.cancelText} href="#" onClick={onClose}>
-                <FormattedMessage id="client-info.cancel" />
-              </a>
-            </div>
-            <div className={cStyles.rightActionButtons}>
-              {showNavigationButtons && (
-                <button aria-label="Next Object" className={cStyles.navigationButton} onClick={this.navigateNext}>
-                  <i>
-                    <FontAwesomeIcon icon={faChevronRight} />
-                  </i>
-                </button>
-              )}
-            </div>
-          </div>
+          )}
         </div>
       </DialogContainer>
     );

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1052,6 +1052,16 @@ class UIRoot extends Component {
     return (
       <div className={entryStyles.entryPanel}>
         <div className={entryStyles.name}>
+          <button
+            aria-label="Close room entry panel and spectate from lobby"
+            onClick={() => this.setState({ watching: true })}
+            className={entryStyles.collapseButton}
+          >
+            <i>
+              <FontAwesomeIcon icon={faTimes} />
+            </i>
+          </button>
+
           {this.props.hubChannel.canOrWillIfCreator("update_hub") ? (
             <button
               className={entryStyles.renameButton}
@@ -1068,15 +1078,6 @@ class UIRoot extends Component {
           ) : (
             <span>{this.props.hub.name}</span>
           )}
-          <button
-            aria-label="Close room entry panel and spectate from lobby"
-            onClick={() => this.setState({ watching: true })}
-            className={entryStyles.collapseButton}
-          >
-            <i>
-              <FontAwesomeIcon icon={faTimes} />
-            </i>
-          </button>
 
           <button
             aria-label="Toggle Favorited"


### PR DESCRIPTION
The object info UI gets in the way of media when you click on it in the object list:
![Screenshot_2020-08-03 Room App by Company(2)](https://user-images.githubusercontent.com/1753624/89214700-287a8300-d57c-11ea-8e44-26e2d156a5b8.png)

Now you can collapse that UI so that it doesn't get in the way:
![Screenshot_2020-08-03 Room App by Company(1)](https://user-images.githubusercontent.com/1753624/89214830-62e42000-d57c-11ea-8c8c-d117f64abad6.png)


Fixes #2299 