### PR TITLE
Fix signin dialog bug

### DIFF
--- a/src/react-components/sign-in-dialog.js
+++ b/src/react-components/sign-in-dialog.js
@@ -39,7 +39,7 @@ export default class SignInDialog extends Component {
       contents = (
         <div>
           <p>
-            <FormattedMessage className="preformatted" id="sign-in.auth-started" value={{ email: this.state.email }} />
+            <FormattedMessage className="preformatted" id="sign-in.auth-started" values={{ email: this.state.email }} />
           </p>
           <IfFeature name="show_newsletter_signup">
             <p>


### PR DESCRIPTION
This PR fixes signin dialog bug that the input email is not displayed but `{email}` is displayed. The root issue is `<FormattedMessage>` takes `values` but wrongly `value` (dropping s) is set.

![image](https://user-images.githubusercontent.com/7637832/89240614-79f13500-d5b1-11ea-8ab5-b557d30667fe.png)
