### PR TITLE
add missing occupant data

### DIFF
--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -142,9 +142,10 @@ export default class HubChannel extends EventTarget {
 
     // This is fairly hacky, but gets the # of initial occupants
     let initialOccupantCount = 0;
-
-    if (NAF.connection.adapter && NAF.connection.adapter.publisher) {
-      initialOccupantCount = NAF.connection.adapter.publisher.initialOccupants.length;
+    if (NAF.connection.adapter) {
+      // When I enter room as avatar, count number of people inside the room as avatars and lobby
+      // I enter room alone, no one in lobby, this is 0
+      initialOccupantCount = Object.keys(NAF.connection.adapter.occupants).length;
     }
 
     const entryTimingFlags = this.getEntryTimingFlags();


### PR DESCRIPTION
set_last_active and max occupants were missing in hub room table with the new dialog update. Integrate them back.