### PR TITLE
Add volume option to run-bot.js

### DIFF
--- a/scripts/bot/run-bot.js
+++ b/scripts/bot/run-bot.js
@@ -3,12 +3,13 @@ const doc = `
 Usage:
     ./run-bot.js [options]
 Options:
-    -h --help         Show this screen
-    -u --url=<url>    URL
-    -o --host=<host>  Hubs host if URL is not specified [default: localhost:8080]
-    -r --room=<room>  Room id
-    -a --audio=<file> File to replay for the bot's outgoing audio
-    -d --data=<file>  File to replay for the bot's data channel
+    -h --help            Show this screen
+    -u --url=<url>       URL
+    -o --host=<host>     Hubs host if URL is not specified [default: localhost:8080]
+    -r --room=<room>     Room id
+    -a --audio=<file>    File to replay for the bot's outgoing audio
+    -v --volume=<number> Audio volume (default: 1.0)
+    -d --data=<file>     File to replay for the bot's data channel
 `;
 
 const docopt = require("docopt").docopt;
@@ -41,6 +42,10 @@ function log(...objs) {
   const roomOption = options["--room"];
   if (roomOption) {
     params.hub_id = roomOption;
+  }
+  const volumeOption = options["--volume"];
+  if (volumeOption !== null && options["--audio"]) {
+    params.audio_volume = volumeOption;
   }
 
   const url = `${baseUrl}?${querystring.stringify(params)}`;

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -617,13 +617,28 @@ export default class SceneEntryManager {
     }
 
     await new Promise(resolve => audioEl.addEventListener("canplay", resolve));
-    mediaStream.addTrack(
-      audioEl.captureStream
-        ? audioEl.captureStream().getAudioTracks()[0]
+
+    const audioStream = audioEl.captureStream
+        ? audioEl.captureStream()
         : audioEl.mozCaptureStream
-          ? audioEl.mozCaptureStream().getAudioTracks()[0]
-          : null
-    );
+          ? audioEl.mozCaptureStream()
+          : null;
+
+    if (audioStream) {
+      let audioVolume = Number(qs.get("audio_volume") || "1.0");
+      if (isNaN(audioVolume)) {
+        audioVolume = 1.0;
+      }
+      const audioContext = THREE.AudioContext.getContext();
+      const audioSource = audioContext.createMediaStreamSource(audioStream);
+      const audioDestination = audioContext.createMediaStreamDestination();
+      const gainNode = audioContext.createGain();
+      audioSource.connect(gainNode);
+      gainNode.connect(audioDestination);
+      gainNode.gain.value = audioVolume;
+      mediaStream.addTrack(audioDestination.stream.getAudioTracks()[0]);
+    }
+
     await NAF.connection.adapter.setLocalMediaStream(mediaStream);
     audioEl.play();
   };


### PR DESCRIPTION
This PR resolves #2793 by adding `-v --volume` option to `run-bot.js` which controls audio volume level of bot.

```
$ node run-bot.js -r roomid -a bot-recording.mp3 -v 0.2
```

Some notes:
* I insert GainNode to control the volume instead of setting `audio` element volume because "the audio level or volume of the media element does not affect the volume of captured audio"

https://www.w3.org/TR/mediacapture-fromelement/#html-media-element-media-capture-extensions

* I pass `audio_volume` parameter to `scene-entry-manager.js` by adding `audio_volume` in URL like `https://localhost:8080/hub.html?allow_multi=true&audio_volume=2.0&bot=true`. Let me know if there is a better way
* `-v --volume` option has an effect only if `-a --audio` option is set