### PR TITLE
Fix WrappedIntlProvider import

### DIFF
--- a/src/react-components/scene-ui.js
+++ b/src/react-components/scene-ui.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import { FormattedMessage } from "react-intl";
-import WrappedIntlProvider from "./wrapped-intl-provider";
+import { WrappedIntlProvider } from "./wrapped-intl-provider";
 import configs from "../utils/configs";
 import IfFeature from "./if-feature";
 import styles from "../assets/stylesheets/scene-ui.scss";


### PR DESCRIPTION
I'm surprised this didn't result in a failed build. Maybe we need to change our Webpack config to fail on these sorts of warnings?