### PR TITLE
Fix Avatar Editor upload

### DIFF
--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -147,7 +147,7 @@ export default class AvatarEditor extends Component {
       });
     }
 
-    this.inputFiles.thumbnail = new File([await this.preview.getWrappedInstance().snapshot()], "thumbnail.png", {
+    this.inputFiles.thumbnail = new File([await this.preview.snapshot()], "thumbnail.png", {
       type: "image/png"
     });
 

--- a/src/react-components/avatar-preview.js
+++ b/src/react-components/avatar-preview.js
@@ -373,4 +373,4 @@ class AvatarPreview extends Component {
   }
 }
 
-export default injectIntl(AvatarPreview, { withRef: true });
+export default injectIntl(AvatarPreview, { forwardRef: true });


### PR DESCRIPTION
react-intl updated the way that they forward references to components when using the `injectIntl` API. https://formatjs.io/docs/react-intl/upgrade-guide-3x#migrate-withref-to-forwardref

This PR updates our usage of that API in the Avatar Editor, restoring the ability to upload avatars.