### PR TITLE
Improved room links w/ anchor hash

### DIFF
--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -359,7 +359,7 @@ AFRAME.registerComponent("media-loader", {
 
       //check if url is an anchor hash e.g. #Spawn_Point_1
       if (src.charAt(0) === "#") {
-        src = this.data.src = `${window.location.origin}${window.location.pathname}${src}`;
+        src = this.data.src = `${window.location.origin}${window.location.pathname}${window.location.search}${src}`;
       }
 
       let canonicalUrl = src;

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -359,7 +359,7 @@ AFRAME.registerComponent("media-loader", {
 
       //check if url is an anchor hash e.g. #Spawn_Point_1
       if (src.charAt(0) === "#") {
-        src = `${window.location.origin}${window.location.pathname}${src}`;
+        src = this.data.src = `${window.location.origin}${window.location.pathname}${src}`;
       }
 
       let canonicalUrl = src;

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -327,7 +327,8 @@ AFRAME.registerComponent("media-loader", {
   },
 
   async update(oldData, forceLocalRefresh) {
-    const { src, version, contentSubtype } = this.data;
+    const { version, contentSubtype } = this.data;
+    let src = this.data.src;
     if (!src) return;
 
     const srcChanged = oldData.src !== src;
@@ -354,6 +355,11 @@ AFRAME.registerComponent("media-loader", {
     try {
       if ((forceLocalRefresh || srcChanged) && !this.showLoaderTimeout) {
         this.showLoaderTimeout = setTimeout(this.showLoader, 100);
+      }
+
+      //check if url is an anchor hash e.g. #Spawn_Point_1
+      if (src.charAt(0) === "#") {
+        src = `${window.location.origin}${window.location.pathname}${src}`;
       }
 
       let canonicalUrl = src;

--- a/src/components/open-media-button.js
+++ b/src/components/open-media-button.js
@@ -26,7 +26,7 @@ AFRAME.registerComponent("open-media-button", {
             label = "use scene";
           } else if (await isHubsRoomUrl(src)) {
             const url = new URL(this.src);
-            if (url.hash && window.location.pathname == url.pathname) {
+            if (url.hash && window.location.pathname === url.pathname) {
               label = "go to";
             } else {
               label = "visit room";

--- a/src/components/open-media-button.js
+++ b/src/components/open-media-button.js
@@ -27,7 +27,7 @@ AFRAME.registerComponent("open-media-button", {
           } else if (await isHubsRoomUrl(src)) {
             const url = new URL(this.src);
             if (url.hash && window.location.pathname == url.pathname) {
-              label = url.hash.replace("#", "");
+              label = "go to";
             } else {
               label = "visit room";
             }
@@ -52,13 +52,8 @@ AFRAME.registerComponent("open-media-button", {
       } else if ((await isLocalHubsSceneUrl(this.src)) && mayChangeScene) {
         this.el.sceneEl.emit("scene_media_selected", this.src);
       } else if (await isHubsRoomUrl(this.src)) {
-        const url = new URL(this.src);
-        if (url.hash && window.location.pathname == url.pathname) {
-          window.location.hash = url.hash;
-        } else {
-          await exitImmersive();
-          location.href = this.src;
-        }
+        await exitImmersive();
+        location.href = this.src;
       } else {
         await exitImmersive();
         window.open(this.src);

--- a/src/components/open-media-button.js
+++ b/src/components/open-media-button.js
@@ -27,7 +27,7 @@ AFRAME.registerComponent("open-media-button", {
           } else if (await isHubsRoomUrl(src)) {
             const url = new URL(this.src);
             if (url.hash && window.location.pathname == url.pathname) {
-              label = `goto: ${url.hash}`;
+              label = url.hash.replace("#", "");
             } else {
               label = "visit room";
             }

--- a/src/components/open-media-button.js
+++ b/src/components/open-media-button.js
@@ -25,7 +25,12 @@ AFRAME.registerComponent("open-media-button", {
           } else if ((await isLocalHubsSceneUrl(src)) && mayChangeScene) {
             label = "use scene";
           } else if (await isHubsRoomUrl(src)) {
-            label = "visit room";
+            const url = new URL(this.src);
+            if (url.hash && window.location.pathname == url.pathname) {
+              label = `goto: ${url.hash}`;
+            } else {
+              label = "visit room";
+            }
           }
         }
         this.label.setAttribute("text", "value", label);
@@ -47,8 +52,13 @@ AFRAME.registerComponent("open-media-button", {
       } else if ((await isLocalHubsSceneUrl(this.src)) && mayChangeScene) {
         this.el.sceneEl.emit("scene_media_selected", this.src);
       } else if (await isHubsRoomUrl(this.src)) {
-        await exitImmersive();
-        location.href = this.src;
+        const url = new URL(this.src);
+        if (url.hash && window.location.pathname == url.pathname) {
+          window.location.hash = url.hash;
+        } else {
+          await exitImmersive();
+          location.href = this.src;
+        }
       } else {
         await exitImmersive();
         window.open(this.src);


### PR DESCRIPTION
As requested in https://github.com/mozilla/hubs/issues/2898, this replaces the button text in anchor hashed room links with "Go To". This also adds a check such that if an anchor hash is pasted by itself (e.g. "#Spawn_Point_1"), the rest of the current room url will be prepended so that it resolves correctly as a room link.

![waypoints3](https://user-images.githubusercontent.com/1821537/91109275-5315a400-e62f-11ea-8f48-21a91159163d.gif)

Closes https://github.com/mozilla/hubs/issues/2898

