### PR TITLE
Room UI Redesign: Code Cleanup

### DIFF
--- a/src/react-components/avatar/AvatarPreviewCanvas.js
+++ b/src/react-components/avatar/AvatarPreviewCanvas.js
@@ -1,0 +1,14 @@
+import React, { memo, forwardRef } from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import styles from "./AvatarPreviewCanvas.scss";
+
+export const AvatarPreviewCanvas = memo(
+  forwardRef(({ className, ...rest }, ref) => {
+    return <canvas className={classNames(styles.avatarPreviewCanvas, className)} ref={ref} {...rest} />;
+  })
+);
+
+AvatarPreviewCanvas.propTypes = {
+  className: PropTypes.string
+};

--- a/src/react-components/avatar/AvatarPreviewCanvas.scss
+++ b/src/react-components/avatar/AvatarPreviewCanvas.scss
@@ -1,0 +1,9 @@
+@use "../styles/theme.scss";
+
+:local(.avatar-preview-canvas) {
+  width: 168px;
+  height: 300px;
+  min-height: 300px;
+  border-radius: 8px;
+  background-color: theme.$lightgrey;
+}

--- a/src/react-components/input/Button.js
+++ b/src/react-components/input/Button.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import classNames from "classnames";
 import styles from "./Button.scss";
 
-export const presets = ["basic", "accept", "cancel", "red", "orange", "green", "blue", "purple"];
+export const presets = ["transparent", "basic", "accept", "cancel", "red", "orange", "green", "blue", "purple"];
 
 export const Button = memo(
   forwardRef(({ preset, className, children, ...rest }, ref) => {

--- a/src/react-components/input/Button.scss
+++ b/src/react-components/input/Button.scss
@@ -2,6 +2,7 @@
 
 :local(.button) {
   height: 48px;
+  min-height: 48px;
   width: min-content;
   min-width: 156px;
   font-weight: 700;
@@ -12,12 +13,38 @@
   transition: background-color 0.1s ease-in-out;
   white-space: nowrap;
   padding: 0 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  svg {
+    flex-shrink: 0;
+    margin-right: 8px;
+
+    *[stroke=\#000] {
+      stroke: theme.$white;
+    }
+
+    *[fill=\#000] {
+      fill: theme.$white;
+    }
+  }
 }
 
-:local(.basic) {
+:local(.basic), :local(.transparent) {
   color: theme.$darkgrey;
   border: 1px solid theme.$darkgrey;
-  background-color: theme.$transparent;
+  background-color: theme.$white;
+
+  svg {
+    *[stroke=\#000] {
+      stroke: theme.$darkgrey;
+    }
+
+    *[fill=\#000] {
+      fill: theme.$darkgrey;
+    }
+  }
 
   &:hover {
     background-color: theme.$white-hover;
@@ -26,6 +53,11 @@
   &:active {
     background-color: theme.$white-pressed;
   }
+}
+
+:local(.transparent) {
+  border-color: theme.$transparent;
+  background-color: theme.$transparent;
 }
 
 :local(.accept), :local(.green) {

--- a/src/react-components/input/Button.scss
+++ b/src/react-components/input/Button.scss
@@ -132,4 +132,8 @@
   &:first-child {
     margin-right: 2px;
   }
+
+  &:last-child {
+    margin-left: 3px;
+  }
 }

--- a/src/react-components/input/Button.scss
+++ b/src/react-components/input/Button.scss
@@ -8,6 +8,7 @@
   font-size: 12px;
   border-radius: 8px;
   border-width: 0;
+  border-color: transparent;
   transition: background-color 0.1s ease-in-out;
   white-space: nowrap;
   padding: 0 24px;
@@ -100,40 +101,6 @@
   background-color: theme.$lightgrey;
 }
 
-:global(body.keyboard-user) :local(.button):focus {
-  outline: none;
-  border: 3px solid theme.$black;
-}
-
-:local(.input-group) :local(.button) {
-  height: 100%;
-  border-radius: 0;
-  min-width: auto;
-  padding: 0 16px;
-
-  &:local(.basic) {
-    border-width: 0 0 0 1px;
-  }
-}
-
-:local(.input-group):focus-within :local(.button) {
-  &:first-child {
-    padding-left: 14px;
-  }
-
-  &:last-child {
-    padding-right: 14px;
-  }
-}
-
-:global(.keyboard-user) :local(.input-group) :local(.button):focus {
-  padding: 0 11px;
-
-  &:first-child {
-    margin-right: 2px;
-  }
-
-  &:last-child {
-    margin-left: 3px;
-  }
+:global(.keyboard-user) :local(.button):focus {
+  border-color: transparent;
 }

--- a/src/react-components/input/CopyableTextInputField.js
+++ b/src/react-components/input/CopyableTextInputField.js
@@ -3,19 +3,28 @@ import PropTypes from "prop-types";
 import { useClipboard } from "use-clipboard-copy";
 import { TextInputField } from "./TextInputField";
 import { Button } from "./Button";
+import styles from "./CopyableTextInputField.scss";
 
-export function CopyableTextInputField({ buttonPreset, ...rest }) {
+export function CopyableTextInputField({ buttonPreset, copiedLabel, copyLabel, ...rest }) {
   const clipboard = useClipboard({
     copiedTimeout: 600
   });
+
+  // Use a dynamic width based on the content to account for i18n
+  const maxLabelLength = Math.max(copyLabel.length, copiedLabel.length);
 
   return (
     <TextInputField
       ref={clipboard.target}
       afterInput={
         clipboard.isSupported() ? (
-          <Button preset={buttonPreset} onClick={clipboard.copy}>
-            {clipboard.copied ? "Copied" : "Copy"}
+          <Button
+            preset={buttonPreset}
+            onClick={clipboard.copy}
+            className={styles.copyButton}
+            style={{ width: `${maxLabelLength}ch` }} // ch is a unit representing the width of the 0 character
+          >
+            {clipboard.copied ? copiedLabel : copyLabel}
           </Button>
         ) : (
           undefined
@@ -27,5 +36,12 @@ export function CopyableTextInputField({ buttonPreset, ...rest }) {
 }
 
 CopyableTextInputField.propTypes = {
+  copyLabel: PropTypes.string,
+  copiedLabel: PropTypes.string,
   buttonPreset: PropTypes.string
+};
+
+CopyableTextInputField.defaultProps = {
+  copyLabel: "Copy",
+  copiedLabel: "Copied"
 };

--- a/src/react-components/input/CopyableTextInputField.scss
+++ b/src/react-components/input/CopyableTextInputField.scss
@@ -1,0 +1,11 @@
+@use "../styles/theme.scss";
+
+:local(.copy-button) {
+  // Use content box so we can dynamically adjust the content size separately from the padding/margin
+  box-sizing: content-box;
+}
+
+:global(.keyboard-user) :local(.copy-button):focus {
+  // Because the height of the box no longer includes the border we need to subtract the border width from the height when focused.
+  height: calc(100% - #{theme.$outline-width * 2});
+}

--- a/src/react-components/input/CopyableTextInputField.scss
+++ b/src/react-components/input/CopyableTextInputField.scss
@@ -4,8 +4,3 @@
   // Use content box so we can dynamically adjust the content size separately from the padding/margin
   box-sizing: content-box;
 }
-
-:global(.keyboard-user) :local(.copy-button):focus {
-  // Because the height of the box no longer includes the border we need to subtract the border width from the height when focused.
-  height: calc(100% - #{theme.$outline-width * 2});
-}

--- a/src/react-components/input/IconButton.scss
+++ b/src/react-components/input/IconButton.scss
@@ -1,11 +1,25 @@
 @use '../styles/theme';
 
 :local(.icon-button) {
+  display: flex;
+  align-items: center;
   background: transparent;
   border-width: 0;
   border-color: transparent;
+  font-size: theme.$font-size-xs;
+  font-weight: theme.$font-weight-bold;
+
+  & > * {
+    margin-right: 4px;
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
 
   &:hover {
+    color: theme.$blue-hover;
+
     svg {
       *[stroke=\#000] {
         stroke: theme.$blue-hover;
@@ -18,6 +32,8 @@
   }
 
   &:active {
+    color: theme.$blue-pressed;
+
     svg {
       *[stroke=\#000] {
         stroke: theme.$blue-pressed;

--- a/src/react-components/input/IconButton.scss
+++ b/src/react-components/input/IconButton.scss
@@ -2,7 +2,8 @@
 
 :local(.icon-button) {
   background: transparent;
-  border: none;
+  border-width: 0;
+  border-color: transparent;
 
   &:hover {
     svg {
@@ -27,27 +28,4 @@
       }
     }
   }
-
-  :global(.keyboard-user) &:focus {
-    outline: 0;
-
-    svg {
-      outline: 3px solid theme.$black;
-    }
-  }
 }
-
-:local(.input-group) :local(.icon-button) {
-  padding: 0 16px;
-}
-
-:local(.input-group):focus-within :local(.icon-button) {
-  &:first-child {
-    padding-left: 14px;
-  }
-
-  &:last-child {
-    padding-right: 14px;
-  }
-}
-

--- a/src/react-components/input/IconButton.scss
+++ b/src/react-components/input/IconButton.scss
@@ -28,7 +28,7 @@
     }
   }
 
-  &:focus {
+  :global(.keyboard-user) &:focus {
     outline: 0;
 
     svg {

--- a/src/react-components/input/InputField.scss
+++ b/src/react-components/input/InputField.scss
@@ -3,12 +3,14 @@
 :local(.label) {
   margin-bottom: 8px;
   color: theme.$grey;
+  align-self: flex-start;
 }
 
 :local(.input-field) {
   display: flex;
   flex-direction: column;
   width: 100%;
+  max-width: 300px;
 }
 
 :local(.error) {

--- a/src/react-components/input/TextInput.scss
+++ b/src/react-components/input/TextInput.scss
@@ -13,12 +13,41 @@ $input-height: 40px;
   overflow: hidden;
 
   &:focus-within  {
-    border-width: 3px;
     border-color: theme.$blue;
+    box-shadow: 0 0 0 2px theme.$blue;
+  }
 
-    :local(.input-wrapper):first-child {
-      :local(.text-input) {
-        padding-left: 6px;
+  button {
+    height: 100%;
+    border-radius: 0;
+    min-width: auto;
+    padding: 0 16px;
+    border-width: 0;
+
+    &:first-child {
+      border-right-width: 1px;
+    }
+
+    &:last-child {
+      border-left-width: 1px;
+    }
+    
+
+    :global(.keyboard-user) &:focus {
+      border-width: 0;
+
+      &:first-child {
+        margin-right: 1px;
+        box-shadow: inset 0 0 0 3px theme.$black, -1px 0 0 2px theme.$black;
+        border-top-left-radius: theme.$border-radius-regular;
+        border-bottom-left-radius: theme.$border-radius-regular;
+      }
+  
+      &:last-child {
+        margin-left: 1px;
+        box-shadow: inset 0 0 0 3px theme.$black, 1px 0 0 2px theme.$black;
+        border-top-right-radius: theme.$border-radius-regular;
+        border-bottom-right-radius: theme.$border-radius-regular;
       }
     }
   }
@@ -37,6 +66,10 @@ $input-height: 40px;
 
 :local(.invalid) {
   border-color: theme.$red !important;
+
+  &:focus-within  {
+    box-shadow: 0 0 0 2px theme.$red;
+  }
 }
 
 :local(.text-input) {
@@ -46,18 +79,14 @@ $input-height: 40px;
   background-color: transparent;
   padding-left: 8px;
   line-height: calc(#{$input-height} - 2px);
-  
+
   &:focus {
-    outline: none;
+    box-shadow: none;
   }
 }
 
 :local(.invalid-icon) {
   margin: 0 8px;
-
-  :local(.outer-wrapper):focus-within &:last-child {
-    margin-right: 6px;
-  }
 
   *[fill=\#000] {
     stroke: theme.$red;

--- a/src/react-components/input/TextInput.scss
+++ b/src/react-components/input/TextInput.scss
@@ -53,6 +53,10 @@
 :local(.invalid-icon) {
   margin: 0 8px;
 
+  :local(.outer-wrapper):focus-within &:last-child {
+    margin-right: 6px;
+  }
+
   *[fill=\#000] {
     stroke: theme.$red;
   }

--- a/src/react-components/input/TextInput.scss
+++ b/src/react-components/input/TextInput.scss
@@ -1,10 +1,12 @@
 @use "../styles/theme";
 
+$input-height: 40px;
+
 :local(.outer-wrapper) {
   display: flex;
   align-items: center;
   position: relative;
-  height: 40px;
+  height: $input-height;
   border: 1px solid theme.$darkgrey;
   border-radius: theme.$border-radius-regular;
   color: theme.$black;
@@ -43,7 +45,7 @@
   border: none;
   background-color: transparent;
   padding-left: 8px;
-  vertical-align: middle;
+  line-height: calc(#{$input-height} - 2px);
   
   &:focus {
     outline: none;

--- a/src/react-components/input/TextInput.scss
+++ b/src/react-components/input/TextInput.scss
@@ -23,6 +23,7 @@ $input-height: 40px;
     min-width: auto;
     padding: 0 16px;
     border-width: 0;
+    min-height: auto;
 
     &:first-child {
       border-right-width: 1px;

--- a/src/react-components/layout/RoomLayout.js
+++ b/src/react-components/layout/RoomLayout.js
@@ -14,6 +14,7 @@ export function RoomLayout({
   toolbarCenter,
   toolbarRight,
   toolbarClassName,
+  modal,
   ...rest
 }) {
   return (
@@ -26,6 +27,7 @@ export function RoomLayout({
         right={toolbarRight}
       />
       {sidebar && <div className={classNames(styles.sidebar, sidebarClassName)}>{sidebar}</div>}
+      <div className={classNames(styles.modalContainer, styles.viewport)}>{modal}</div>
     </div>
   );
 }
@@ -39,5 +41,6 @@ RoomLayout.propTypes = {
   toolbarLeft: PropTypes.node,
   toolbarCenter: PropTypes.node,
   toolbarRight: PropTypes.node,
-  toolbarClassName: PropTypes.string
+  toolbarClassName: PropTypes.string,
+  modal: PropTypes.node
 };

--- a/src/react-components/layout/RoomLayout.scss
+++ b/src/react-components/layout/RoomLayout.scss
@@ -14,6 +14,7 @@
   
   background-color: theme.$grey;
   overflow: hidden;
+  position: relative;
 }
 
 :local(.main) {
@@ -22,6 +23,20 @@
 
 :local(.sidebar) {
   grid-column-start: sidebar;
+  background-color: theme.$white;
+  height: 100%;
+  width: 450px;
+
+  @media(max-width: theme.$breakpoint-md - 1) {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    margin: 0;
+    width: 100%;
+    z-index: 100;
+  }
 }
 
 :local(.viewport) {
@@ -30,4 +45,14 @@
 
 :local(.toolbar) {
   grid-row-start: toolbar;
+  grid-column-end: -1;
+}
+
+:local(.modal-container) {
+  grid-column: main;
+  grid-row: viewport;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }

--- a/src/react-components/modal/Modal.js
+++ b/src/react-components/modal/Modal.js
@@ -1,0 +1,29 @@
+import React from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import styles from "./Modal.scss";
+
+export function Modal({ title, beforeTitle, afterTitle, children, contentClassName, className, disableFullscreen }) {
+  return (
+    <div className={classNames(styles.modal, { [styles.smFullscreen]: !disableFullscreen }, className)}>
+      {(title || beforeTitle || afterTitle) && (
+        <div className={styles.header}>
+          <div className={styles.beforeTitle}>{beforeTitle}</div>
+          <h1>{title}</h1>
+          <div className={styles.afterTitle}>{afterTitle}</div>
+        </div>
+      )}
+      <div className={classNames(styles.content, contentClassName)}>{children}</div>
+    </div>
+  );
+}
+
+Modal.propTypes = {
+  title: PropTypes.string,
+  beforeTitle: PropTypes.node,
+  afterTitle: PropTypes.node,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  contentClassName: PropTypes.string,
+  disableFullscreen: PropTypes.bool
+};

--- a/src/react-components/modal/Modal.scss
+++ b/src/react-components/modal/Modal.scss
@@ -1,0 +1,65 @@
+@use "../styles/theme.scss";
+
+:local(.modal) {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: max-content;
+  background-color: theme.$white;
+  border: 1px solid theme.$lightgrey;
+  border-radius: theme.$border-radius-regular;
+  margin: 24px;
+  width: 204px;
+
+  @media (min-width: theme.$breakpoint-md) {
+    width: 360px;
+  }
+}
+
+:local(.header) {
+  display: flex;
+  height: 48px;
+  border-bottom: 1px solid theme.$lightgrey;
+  align-items: center;
+  justify-content: center;
+
+  h1 {
+    font-size: theme.$font-size-sm;
+    font-weight: theme.$font-weight-bold;
+  }
+}
+
+:local(.before-title) {
+  position: absolute;
+  left: 0;
+}
+
+:local(.after-title) {
+  position: absolute;
+  right: 0;
+}
+
+:local(.content) {
+  min-height: 200px;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
+:local(.sm-fullscreen) {
+  @media(max-width: theme.$breakpoint-md - 1) {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    border-width: 0;
+    border-radius: 0;
+    margin: 0;
+    width: 100%;
+
+    :local(.content) {
+      overflow-y: auto;
+    }
+  }
+}

--- a/src/react-components/modal/Modal.stories.js
+++ b/src/react-components/modal/Modal.stories.js
@@ -1,0 +1,13 @@
+import React from "react";
+import { RoomLayout } from "../layout/RoomLayout";
+import { Modal } from "./Modal";
+
+export default {
+  title: "Modal"
+};
+
+export const Base = () => <RoomLayout modal={<Modal title="Modal">Test</Modal>} />;
+
+Base.parameters = {
+  layout: "fullscreen"
+};

--- a/src/react-components/room/AvatarSettingsContent.js
+++ b/src/react-components/room/AvatarSettingsContent.js
@@ -1,0 +1,38 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Button } from "../input/Button";
+import styles from "./AvatarSettingsContent.scss";
+import { TextInputField } from "../input/TextInputField";
+import { AvatarPreviewCanvas } from "../avatar/AvatarPreviewCanvas";
+
+export function AvatarSettingsContent({
+  displayName,
+  onChangeDisplayName,
+  avatarPreviewCanvasRef,
+  onChangeAvatar,
+  onAccept,
+  ...rest
+}) {
+  return (
+    <div className={styles.content} {...rest}>
+      <TextInputField label="Display Name" value={displayName} onChange={onChangeDisplayName} />
+      <div className={styles.avatarPreviewContainer}>
+        <AvatarPreviewCanvas ref={avatarPreviewCanvasRef} />
+        <Button onClick={onChangeAvatar}>Change Avatar</Button>
+      </div>
+      <Button preset="accept" onClick={onAccept}>
+        Accept
+      </Button>
+    </div>
+  );
+}
+
+AvatarSettingsContent.propTypes = {
+  className: PropTypes.string,
+  displayName: PropTypes.string,
+  onChangeDisplayName: PropTypes.func,
+  avatarPreviewCanvasRef: PropTypes.object,
+  onChangeAvatar: PropTypes.func,
+  onAccept: PropTypes.func,
+  onBack: PropTypes.func
+};

--- a/src/react-components/room/AvatarSettingsContent.scss
+++ b/src/react-components/room/AvatarSettingsContent.scss
@@ -1,0 +1,31 @@
+@use "../styles/theme.scss";
+
+:local(.content) {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px;
+  text-align: center;
+
+  & > * {
+    margin-bottom: 16px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
+
+:local(.avatar-preview-container) {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  align-items: center;
+
+  button {
+    position: absolute;
+    bottom: 0;
+    margin-bottom: 8px;
+  }
+}

--- a/src/react-components/room/AvatarSettingsSidebar.js
+++ b/src/react-components/room/AvatarSettingsSidebar.js
@@ -1,0 +1,49 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Sidebar } from "../sidebar/Sidebar";
+import { ReactComponent as ChevronBackIcon } from "../icons/ChevronBack.svg";
+import { IconButton } from "../input/IconButton";
+import { AvatarSettingsContent } from "./AvatarSettingsContent";
+
+export function AvatarSettingsSidebar({
+  className,
+  displayName,
+  onChangeDisplayName,
+  avatarPreviewCanvasRef,
+  onChangeAvatar,
+  onAccept,
+  onBack,
+  ...rest
+}) {
+  return (
+    <Sidebar
+      title="Avatar Settings"
+      beforeTitle={
+        <IconButton onClick={onBack}>
+          <ChevronBackIcon />
+          <span>Back</span>
+        </IconButton>
+      }
+      className={className}
+      {...rest}
+    >
+      <AvatarSettingsContent
+        displayName={displayName}
+        onChangeDisplayName={onChangeDisplayName}
+        avatarPreviewCanvasRef={avatarPreviewCanvasRef}
+        onChangeAvatar={onChangeAvatar}
+        onAccept={onAccept}
+      />
+    </Sidebar>
+  );
+}
+
+AvatarSettingsSidebar.propTypes = {
+  className: PropTypes.string,
+  displayName: PropTypes.string,
+  onChangeDisplayName: PropTypes.func,
+  avatarPreviewCanvasRef: PropTypes.object,
+  onChangeAvatar: PropTypes.func,
+  onAccept: PropTypes.func,
+  onBack: PropTypes.func
+};

--- a/src/react-components/room/AvatarSettingsSidebar.stories.js
+++ b/src/react-components/room/AvatarSettingsSidebar.stories.js
@@ -1,0 +1,13 @@
+import React from "react";
+import { RoomLayout } from "../layout/RoomLayout";
+import { AvatarSettingsSidebar } from "./AvatarSettingsSidebar";
+
+export default {
+  title: "AvatarSettingsSidebar"
+};
+
+export const Base = () => <RoomLayout sidebar={<AvatarSettingsSidebar />} />;
+
+Base.parameters = {
+  layout: "fullscreen"
+};

--- a/src/react-components/room/AvatarSetupModal.js
+++ b/src/react-components/room/AvatarSetupModal.js
@@ -1,0 +1,49 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Modal } from "../modal/Modal";
+import { ReactComponent as ChevronBackIcon } from "../icons/ChevronBack.svg";
+import { IconButton } from "../input/IconButton";
+import { AvatarSettingsContent } from "./AvatarSettingsContent";
+
+export function AvatarSetupModal({
+  className,
+  displayName,
+  onChangeDisplayName,
+  avatarPreviewCanvasRef,
+  onChangeAvatar,
+  onAccept,
+  onBack,
+  ...rest
+}) {
+  return (
+    <Modal
+      title="Avatar Setup"
+      beforeTitle={
+        <IconButton onClick={onBack}>
+          <ChevronBackIcon />
+          <span>Back</span>
+        </IconButton>
+      }
+      className={className}
+      {...rest}
+    >
+      <AvatarSettingsContent
+        displayName={displayName}
+        onChangeDisplayName={onChangeDisplayName}
+        avatarPreviewCanvasRef={avatarPreviewCanvasRef}
+        onChangeAvatar={onChangeAvatar}
+        onAccept={onAccept}
+      />
+    </Modal>
+  );
+}
+
+AvatarSetupModal.propTypes = {
+  className: PropTypes.string,
+  displayName: PropTypes.string,
+  onChangeDisplayName: PropTypes.func,
+  avatarPreviewCanvasRef: PropTypes.object,
+  onChangeAvatar: PropTypes.func,
+  onAccept: PropTypes.func,
+  onBack: PropTypes.func
+};

--- a/src/react-components/room/AvatarSetupModal.stories.js
+++ b/src/react-components/room/AvatarSetupModal.stories.js
@@ -1,0 +1,13 @@
+import React from "react";
+import { RoomLayout } from "../layout/RoomLayout";
+import { AvatarSetupModal } from "./AvatarSetupModal";
+
+export default {
+  title: "AvatarSetupModal"
+};
+
+export const Base = () => <RoomLayout modal={<AvatarSetupModal />} />;
+
+Base.parameters = {
+  layout: "fullscreen"
+};

--- a/src/react-components/room/EnterOnDeviceModal.js
+++ b/src/react-components/room/EnterOnDeviceModal.js
@@ -1,0 +1,69 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Modal } from "../modal/Modal";
+import { Button } from "../input/Button";
+import { ReactComponent as VRIcon } from "../icons/VR.svg";
+import { ReactComponent as ChevronBackIcon } from "../icons/ChevronBack.svg";
+import styles from "./EnterOnDeviceModal.scss";
+import { IconButton } from "../input/IconButton";
+
+export function EnterOnDeviceModal({
+  className,
+  shortUrl,
+  code,
+  headsetConnected,
+  onEnterOnConnectedHeadset,
+  onBack,
+  ...rest
+}) {
+  const codeCharacters = code.split("");
+
+  return (
+    <Modal
+      title="Enter on Device"
+      beforeTitle={
+        <IconButton onClick={onBack}>
+          <ChevronBackIcon />
+          <span>Back</span>
+        </IconButton>
+      }
+      className={className}
+      contentClassName={styles.content}
+      {...rest}
+    >
+      <h1>Enter on Wireless Headset / Phone</h1>
+      <p>{"In your device's web browser, go to:"}</p>
+      <div className={styles.shortUrlContainer}>{shortUrl}</div>
+      <p>Then, enter this one-time code:</p>
+      <div className={styles.codeContainer}>
+        {codeCharacters.map((char, i) => (
+          <div key={i} className={styles.codeLetter}>
+            {char}
+          </div>
+        ))}
+      </div>
+      <small>Your account and avatar will be transferred to the device.</small>
+      <small>Keep this page open to use this code.</small>
+      {headsetConnected && (
+        <>
+          <hr data-or-text="or" />
+          <h1>Enter on Connected Headset</h1>
+          <p>You have a VR headset connected to this device.</p>
+          <Button preset="purple" onClick={onEnterOnConnectedHeadset}>
+            <VRIcon />
+            <span>Enter in VR</span>
+          </Button>
+        </>
+      )}
+    </Modal>
+  );
+}
+
+EnterOnDeviceModal.propTypes = {
+  className: PropTypes.string,
+  shortUrl: PropTypes.string.isRequired,
+  code: PropTypes.string.isRequired,
+  headsetConnected: PropTypes.bool,
+  onEnterOnConnectedHeadset: PropTypes.func,
+  onBack: PropTypes.func
+};

--- a/src/react-components/room/EnterOnDeviceModal.scss
+++ b/src/react-components/room/EnterOnDeviceModal.scss
@@ -1,0 +1,81 @@
+@use "../styles/theme.scss";
+
+:local(.content) {
+  align-items: center;
+  padding: 24px 8px;
+  text-align: center;
+
+  & > * {
+    margin-bottom: 16px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  h1 {
+    font-weight: theme.$font-weight-bold; 
+  }
+
+  p {
+    font-size: theme.$font-size-sm;
+    font-weight: theme.$font-weight-medium;
+  }
+
+  small {
+    font-size: theme.$font-size-xs;
+    font-weight: theme.$font-weight-regular;
+    margin-bottom: 8px;
+  }
+
+  hr {
+    position: relative;
+    width: 90%;
+    border: none;
+    border-bottom: 1px solid theme.$grey;
+    margin: 16px 0;
+
+    &:after {
+      background: theme.$white;
+      content: attr(data-or-text);
+      padding: 0 4px;
+      position: relative;
+      color: theme.$black;
+      font-size: theme.$font-size-sm;
+      font-weight: theme.$font-weight-bold;
+      position: absolute;
+      transform: translateY(-50%);
+    }
+  }
+
+  :local(.code-container) {
+    display: flex;
+
+    & > * {
+      margin-right: 4px;
+  
+      &:last-child {
+        margin-right: 0;
+      }
+    }
+  }
+
+  :local(.short-url-container), :local(.code-letter) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 64px;
+    border-radius: 12px;
+    border: 1px solid theme.$darkgrey;
+    font-size: 32px;
+    font-weight: theme.$font-weight-regular;
+  }
+
+  :local(.short-url-container) {
+    width: 204px;
+  }
+
+  :local(.code-letter) {
+    width: 40px;
+  }
+}

--- a/src/react-components/room/EnterOnDeviceModal.stories.js
+++ b/src/react-components/room/EnterOnDeviceModal.stories.js
@@ -1,0 +1,21 @@
+import React from "react";
+import { RoomLayout } from "../layout/RoomLayout";
+import { EnterOnDeviceModal } from "./EnterOnDeviceModal";
+
+export default {
+  title: "EnterOnDeviceModal"
+};
+
+export const Base = () => <RoomLayout modal={<EnterOnDeviceModal shortUrl="hub.link" code="IDEB" />} />;
+
+Base.parameters = {
+  layout: "fullscreen"
+};
+
+export const HeadsetConnected = () => (
+  <RoomLayout modal={<EnterOnDeviceModal shortUrl="hub.link" code="IDEB" headsetConnected />} />
+);
+
+HeadsetConnected.parameters = {
+  layout: "fullscreen"
+};

--- a/src/react-components/room/MoreMenuPopover.scss
+++ b/src/react-components/room/MoreMenuPopover.scss
@@ -43,7 +43,7 @@
   @media(min-width: theme.$breakpoint-md) {
     width: calc(100% + 2px);
 
-    &:hover, &:active, &:focus {
+    &:hover, &:active, :global(body.keyboard-user) &:focus {
       margin-left: -1px;
       margin-right: -1px;
       padding-left: 17px;
@@ -75,9 +75,7 @@
   }
 
   :global(body.keyboard-user) &:focus {
-    outline: 0;
-    border: 3px solid theme.$black;
-    padding: 0 14px;
+    box-shadow: inset 0 0 0 3px theme.$black;
   }
 }
 

--- a/src/react-components/room/RoomEntryModal.js
+++ b/src/react-components/room/RoomEntryModal.js
@@ -1,0 +1,74 @@
+import React from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import { Modal } from "../modal/Modal";
+import { Button } from "../input/Button";
+import { ReactComponent as EnterIcon } from "../icons/Enter.svg";
+import { ReactComponent as VRIcon } from "../icons/VR.svg";
+import { ReactComponent as ShowIcon } from "../icons/Show.svg";
+import { ReactComponent as SettingsIcon } from "../icons/Settings.svg";
+import styles from "./RoomEntryModal.scss";
+import styleUtils from "../styles/style-utils.scss";
+import { useCssBreakpoints } from "react-use-css-breakpoints";
+
+export function RoomEntryModal({
+  appName,
+  logoSrc,
+  className,
+  roomName,
+  onJoinRoom,
+  onEnterOnDevice,
+  onSpectate,
+  onOptions,
+  ...rest
+}) {
+  const breakpoint = useCssBreakpoints();
+  return (
+    <Modal
+      className={classNames(styles.roomEntryModal, className)}
+      contentClassName={styles.content}
+      disableFullscreen
+      {...rest}
+    >
+      {breakpoint !== "sm" && (
+        <div className={styles.logoContainer}>
+          <img src={logoSrc} alt={appName} />
+        </div>
+      )}
+      <div className={styles.roomName}>
+        <h5>Room Name</h5>
+        <p>{roomName}</p>
+      </div>
+      <div className={styles.buttons}>
+        <Button preset="blue" onClick={onJoinRoom}>
+          <EnterIcon /> Join Room
+        </Button>
+        <Button preset="purple" onClick={onEnterOnDevice}>
+          <VRIcon /> Enter On Device
+        </Button>
+        <Button preset="orange" onClick={onSpectate}>
+          <ShowIcon /> Spectate
+        </Button>
+        {breakpoint !== "sm" && (
+          <>
+            <hr className={styleUtils.showMd} />
+            <Button preset="transparent" className={styleUtils.showMd} onClick={onOptions}>
+              <SettingsIcon /> Options
+            </Button>
+          </>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+RoomEntryModal.propTypes = {
+  appName: PropTypes.string,
+  logoSrc: PropTypes.string,
+  className: PropTypes.className,
+  roomName: PropTypes.string.isRequired,
+  onJoinRoom: PropTypes.func,
+  onEnterOnDevice: PropTypes.func,
+  onSpectate: PropTypes.func,
+  onOptions: PropTypes.func
+};

--- a/src/react-components/room/RoomEntryModal.scss
+++ b/src/react-components/room/RoomEntryModal.scss
@@ -1,0 +1,74 @@
+@use "../styles/theme.scss";
+
+:local(.content) {
+  align-items: center;
+  padding: 24px 8px;
+
+  & > * {
+    margin-bottom: 16px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  hr {
+    width: 100%;
+    border: none;
+    border-bottom: 1px solid theme.$grey;
+  }
+
+  button {
+    width: 156px;
+  }
+
+  @media(min-width: theme.$breakpoint-md) {
+    padding: 24px;
+  }
+}
+
+:local(.logo-container) {
+  padding: 0 16px;
+  margin-top: 16px;
+  margin-bottom: 32px;
+}
+
+:local(.room-name) {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  h5 {
+    font-size: theme.$font-size-xs;
+    color: theme.$grey;
+    margin-bottom: 4px;
+  }
+
+  p {
+    font-size: theme.$font-size-sm;
+
+    @media(min-width: theme.$breakpoint-md) {
+      font-size: 20px;
+    }
+  }
+}
+
+:local(.buttons) {
+  button {
+    margin-left: 16px;
+    margin-right: 16px;
+
+    @media(min-width: theme.$breakpoint-md) {
+      margin-left: 8px;
+      margin-right: 8px;
+    }
+  }
+
+  & > * {
+    margin-bottom: 16px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/src/react-components/room/RoomEntryModal.stories.js
+++ b/src/react-components/room/RoomEntryModal.stories.js
@@ -1,0 +1,14 @@
+import React from "react";
+import { RoomLayout } from "../layout/RoomLayout";
+import { RoomEntryModal } from "./RoomEntryModal";
+import logoSrc from "../../assets/images/app-logo.png";
+
+export default {
+  title: "RoomEntryModal"
+};
+
+export const Base = () => <RoomLayout modal={<RoomEntryModal logoSrc={logoSrc} roomName="Example Room" />} />;
+
+Base.parameters = {
+  layout: "fullscreen"
+};

--- a/src/react-components/room/UserProfileSidebar.js
+++ b/src/react-components/room/UserProfileSidebar.js
@@ -1,0 +1,72 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Sidebar } from "../sidebar/Sidebar";
+import { ReactComponent as ChevronBackIcon } from "../icons/ChevronBack.svg";
+import { IconButton } from "../input/IconButton";
+import { Button } from "../input/Button";
+import styles from "./UserProfileSidebar.scss";
+import { AvatarPreviewCanvas } from "../avatar/AvatarPreviewCanvas";
+
+export function UserProfileSidebar({
+  className,
+  displayName,
+  avatarPreviewCanvasRef,
+  canPromote,
+  onPromote,
+  canHide,
+  onHide,
+  canMute,
+  onMute,
+  canKick,
+  onKick,
+  onBack,
+  ...rest
+}) {
+  return (
+    <Sidebar
+      title={displayName}
+      beforeTitle={
+        <IconButton onClick={onBack}>
+          <ChevronBackIcon />
+          <span>Back</span>
+        </IconButton>
+      }
+      className={className}
+      contentClassName={styles.content}
+      {...rest}
+    >
+      <AvatarPreviewCanvas ref={avatarPreviewCanvasRef} />
+      {canPromote && (
+        <Button preset="green" onClick={onPromote}>
+          Promote
+        </Button>
+      )}
+      {canHide && <Button onClick={onHide}>Hide</Button>}
+      {canMute && (
+        <Button preset="red" onClick={onMute}>
+          Mute
+        </Button>
+      )}
+      {canKick && (
+        <Button preset="red" onClick={onKick}>
+          Kick
+        </Button>
+      )}
+    </Sidebar>
+  );
+}
+
+UserProfileSidebar.propTypes = {
+  className: PropTypes.string,
+  displayName: PropTypes.string,
+  avatarPreviewCanvasRef: PropTypes.object,
+  canPromote: PropTypes.bool,
+  onPromote: PropTypes.func,
+  canHide: PropTypes.bool,
+  onHide: PropTypes.func,
+  canMute: PropTypes.bool,
+  onMute: PropTypes.func,
+  canKick: PropTypes.bool,
+  onKick: PropTypes.func,
+  onBack: PropTypes.func
+};

--- a/src/react-components/room/UserProfileSidebar.scss
+++ b/src/react-components/room/UserProfileSidebar.scss
@@ -1,10 +1,11 @@
 @use "../styles/theme.scss";
 
-:local(.invite-popover) {
+:local(.content) {
   display: flex;
   flex-direction: column;
-  padding: 16px;
   align-items: center;
+  padding: 24px;
+  text-align: center;
 
   & > * {
     margin-bottom: 16px;
@@ -12,10 +13,5 @@
     &:last-child {
       margin-bottom: 0;
     }
-  }
-
-  @media(min-width: theme.$breakpoint-md) {
-    padding-top: 8px;
-    width: 272px;
   }
 }

--- a/src/react-components/room/UserProfileSidebar.stories.js
+++ b/src/react-components/room/UserProfileSidebar.stories.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { RoomLayout } from "../layout/RoomLayout";
+import { UserProfileSidebar } from "./UserProfileSidebar";
+
+export default {
+  title: "UserProfileSidebar"
+};
+
+export const Base = () => (
+  <RoomLayout sidebar={<UserProfileSidebar displayName="Robert" canHide canKick canMute canPromote />} />
+);
+
+Base.parameters = {
+  layout: "fullscreen"
+};

--- a/src/react-components/sidebar/Sidebar.js
+++ b/src/react-components/sidebar/Sidebar.js
@@ -1,0 +1,29 @@
+import React from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import styles from "./Sidebar.scss";
+
+export function Sidebar({ title, beforeTitle, afterTitle, children, contentClassName, className }) {
+  return (
+    <div className={classNames(styles.sidebar, className)}>
+      {(title || beforeTitle || afterTitle) && (
+        <div className={styles.header}>
+          <div className={styles.beforeTitle}>{beforeTitle}</div>
+          <h1>{title}</h1>
+          <div className={styles.afterTitle}>{afterTitle}</div>
+        </div>
+      )}
+      <div className={classNames(styles.content, contentClassName)}>{children}</div>
+    </div>
+  );
+}
+
+Sidebar.propTypes = {
+  title: PropTypes.string,
+  beforeTitle: PropTypes.node,
+  afterTitle: PropTypes.node,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  contentClassName: PropTypes.string,
+  disableFullscreen: PropTypes.bool
+};

--- a/src/react-components/sidebar/Sidebar.scss
+++ b/src/react-components/sidebar/Sidebar.scss
@@ -1,0 +1,41 @@
+@use "../styles/theme.scss";
+
+:local(.sidebar) {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+:local(.header) {
+  display: flex;
+  height: 48px;
+  border-bottom: 1px solid theme.$lightgrey;
+  align-items: center;
+  justify-content: center;
+
+  h1 {
+    font-size: theme.$font-size-sm;
+    font-weight: theme.$font-weight-bold;
+  }
+}
+
+:local(.before-title) {
+  position: absolute;
+  left: 0;
+}
+
+:local(.after-title) {
+  position: absolute;
+  right: 0;
+}
+
+:local(.content) {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+
+  @media(max-width: theme.$breakpoint-md - 1) {
+    overflow-y: auto;
+  }
+}

--- a/src/react-components/sidebar/Sidebar.stories.js
+++ b/src/react-components/sidebar/Sidebar.stories.js
@@ -1,0 +1,13 @@
+import React from "react";
+import { RoomLayout } from "../layout/RoomLayout";
+import { Sidebar } from "./Sidebar";
+
+export default {
+  title: "Sidebar"
+};
+
+export const Base = () => <RoomLayout sidebar={<Sidebar title="Sidebar">Test</Sidebar>} />;
+
+Base.parameters = {
+  layout: "fullscreen"
+};

--- a/src/react-components/styles/global.scss
+++ b/src/react-components/styles/global.scss
@@ -167,16 +167,12 @@ label {
   font-weight: theme.$font-weight-bold;
 }
 
-body:not(:global(.keyboard-user)) {
-  :focus {
-    outline: none;
-  }
+body :focus {
+  outline: none;
 }
 
-:global(.keyboard-user) {
-  :focus {
-    outline: 3px solid theme.$black;
-  }
+:global(.keyboard-user) :focus {
+  box-shadow: 0 0 0 3px theme.$black;
 }
 
 /* We want svg icons to have title elements for screen readers, but we don't need to show their tooltips when they are inside buttons */

--- a/src/react-components/styles/style-utils.scss
+++ b/src/react-components/styles/style-utils.scss
@@ -1,18 +1,14 @@
 @use './theme';
 
 :local(.hide-md) {
-  display: inherit !important;
-
   @media (min-width: theme.$breakpoint-md) {
     display: none !important;
   }
 }
 
 :local(.show-md) {
-  display: none !important;
-
-  @media (min-width: theme.$breakpoint-md) {
-    display: inherit !important;
+  @media (max-width: theme.$breakpoint-md - 1px) {
+    display: none !important;
   }
 }
 

--- a/src/react-components/styles/theme.scss
+++ b/src/react-components/styles/theme.scss
@@ -49,6 +49,8 @@ $purple: #7854F6;
 $purple-hover: #8C6EF7;
 $purple-pressed: #663DF5;
 
+$overlay-color: rgba(0, 0, 0, 0.5);
+
 $font-size-xs: 10px;
 $font-size-sm: 12px;
 

--- a/src/react-components/styles/theme.scss
+++ b/src/react-components/styles/theme.scss
@@ -57,3 +57,5 @@ $font-weight-medium: 500;
 $font-weight-bold: 700;
 
 $border-radius-regular: 8px;
+
+$outline-width: 3px;


### PR DESCRIPTION
This PR fixes a bunch of small bugs in the redesign:

Fixed:
- The `CopyableTextInputField`'s copy button shouldn't change size between the "copy" and "copied" state. This should also work with i18n
- The `IconButton`'s focus style is now only visible for keyboard users.
- The placeholder text is fixed in Safari
- I've switched to using box-shadow for outline styles which has significantly reduced the amount of code needed to get proper outline styles.
