### PR TITLE
Fix bug - reactivate the same waypoint

### DIFF
--- a/src/systems/waypoint-system.js
+++ b/src/systems/waypoint-system.js
@@ -330,6 +330,7 @@ export class WaypointSystem {
       const waypoint = this.ready.find(c => c.el.object3D.name === waypointName);
       if (waypoint) {
         this.moveToWaypoint(waypoint, this.previousWaypointHash === null);
+        window.location.hash = ""; // Reset so you can re-activate the same waypoint
       }
       this.previousWaypointHash = window.location.hash;
     }


### PR DESCRIPTION
Activating a `waypoint` via the `hash` method has a bug where you can't re-activate the same one multiple times. This is a simple fix where we reset the hash back to an empty string. 

This addresses one of the problems mentioned in this issue https://github.com/mozilla/hubs/issues/2897#issuecomment-677988368 and this discussion https://github.com/mozilla/hubs/discussions/2949

There is still a UX issue where this method of waypoint travel adds a bunch of entries into your browser history -- we can address that issue separately.