### PR TITLE
Set default quality settings via qs params

### DIFF
--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -9,9 +9,8 @@ import { FormattedMessage } from "react-intl";
 import { WrappedIntlProvider } from "./wrapped-intl-provider";
 import styles from "../assets/stylesheets/preferences-screen.scss";
 import { getMessages } from "../utils/i18n";
+import { defaultMaterialQualitySetting } from "../storage/store";
 import { AVAILABLE_LOCALES } from "../assets/locales/locale_config";
-
-const isMobile = AFRAME.utils.device.isMobile() || AFRAME.utils.device.isMobileVR();
 
 function round(step, n) {
   return Math.round(n / step) * step;
@@ -606,7 +605,7 @@ const DEFINITIONS = new Map([
         key: "materialQualitySetting",
         prefType: PREFERENCE_LIST_ITEM_TYPE.SELECT,
         options: [{ value: "low", text: "Low" }, { value: "medium", text: "Medium" }, { value: "high", text: "High" }],
-        defaultString: isMobile ? "low" : "high",
+        defaultString: defaultMaterialQualitySetting,
         promptForRefresh: true
       },
       {

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -2,6 +2,7 @@ import { Validator } from "jsonschema";
 import merge from "deepmerge";
 import Cookies from "js-cookie";
 import jwtDecode from "jwt-decode";
+import { qsGet } from "../utils/qs_truthy.js";
 
 const LOCAL_STORE_KEY = "___hubs_store";
 const STORE_STATE_CACHE_KEY = Symbol();
@@ -9,6 +10,27 @@ const OAUTH_FLOW_CREDENTIALS_KEY = "ret-oauth-flow-account-credentials";
 const validator = new Validator();
 import { EventTarget } from "event-target-shim";
 import { fetchRandomDefaultAvatarId, generateRandomName } from "../utils/identity.js";
+
+export const defaultMaterialQualitySetting = (function() {
+  const MATERIAL_QUALITY_OPTIONS = ["low", "medium", "high"];
+  const isMobile = AFRAME.utils.device.isMobile();
+  const isMobileVR = AFRAME.utils.device.isMobileVR();
+
+  if (isMobile || isMobileVR) {
+    const qsMobileDefault = qsGet("default_mobile_material_quality");
+    if (qsMobileDefault && MATERIAL_QUALITY_OPTIONS.indexOf(qsMobileDefault) !== -1) {
+      return qsMobileDefault;
+    }
+    return "low";
+  }
+
+  const qsDefault = qsGet("default_material_quality");
+  if (qsDefault && MATERIAL_QUALITY_OPTIONS.indexOf(qsDefault) !== -1) {
+    return qsDefault;
+  }
+
+  return "high";
+})();
 
 // Durable (via local-storage) schema-enforced state that is meant to be consumed via forward data flow.
 // (Think flux but with way less incidental complexity, at least for now :))
@@ -335,13 +357,6 @@ export default class Store extends EventTarget {
       return this.state.preferences.materialQualitySetting;
     }
 
-    const isMobile = AFRAME.utils.device.isMobile();
-    const isMobileVR = AFRAME.utils.device.isMobileVR();
-
-    if (isMobile || isMobileVR) {
-      return "low";
-    }
-
-    return "high";
+    return defaultMaterialQualitySetting;
   }
 }


### PR DESCRIPTION
Users requested that we bring back the ability to set material quality defaults via query string parameters. This introduces `default_material_quality` and `default_mobile_material_quality` for this purpose. If the user specifies a preference via the preference menu, it will take precedence over the default value, but if the user has not set a preference, the query string parameter default will be used. 

Close https://github.com/mozilla/hubs/issues/2937

TODO: Add documentation for query string parameters: `default_material_quality=low|medium|high` and `default_mobile_material_quality=low|medium|high`