### PR TITLE
Room UI Redesign: Add User Modals and Sidebars

### DIFF
--- a/src/react-components/avatar/AvatarPreviewCanvas.js
+++ b/src/react-components/avatar/AvatarPreviewCanvas.js
@@ -1,0 +1,14 @@
+import React, { memo, forwardRef } from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import styles from "./AvatarPreviewCanvas.scss";
+
+export const AvatarPreviewCanvas = memo(
+  forwardRef(({ className, ...rest }, ref) => {
+    return <canvas className={classNames(styles.avatarPreviewCanvas, className)} ref={ref} {...rest} />;
+  })
+);
+
+AvatarPreviewCanvas.propTypes = {
+  className: PropTypes.string
+};

--- a/src/react-components/avatar/AvatarPreviewCanvas.scss
+++ b/src/react-components/avatar/AvatarPreviewCanvas.scss
@@ -3,6 +3,7 @@
 :local(.avatar-preview-canvas) {
   width: 168px;
   height: 300px;
+  min-height: 300px;
   border-radius: 8px;
   background-color: theme.$lightgrey;
 }

--- a/src/react-components/avatar/AvatarPreviewCanvas.scss
+++ b/src/react-components/avatar/AvatarPreviewCanvas.scss
@@ -1,0 +1,8 @@
+@use "../styles/theme.scss";
+
+:local(.avatar-preview-canvas) {
+  width: 168px;
+  height: 300px;
+  border-radius: 8px;
+  background-color: theme.$lightgrey;
+}

--- a/src/react-components/input/Button.scss
+++ b/src/react-components/input/Button.scss
@@ -34,7 +34,7 @@
 :local(.basic), :local(.transparent) {
   color: theme.$darkgrey;
   border: 1px solid theme.$darkgrey;
-  background-color: theme.$transparent;
+  background-color: theme.$white;
 
   svg {
     *[stroke=\#000] {
@@ -57,6 +57,7 @@
 
 :local(.transparent) {
   border-color: theme.$transparent;
+  background-color: theme.$transparent;
 }
 
 :local(.accept), :local(.green) {

--- a/src/react-components/input/InputField.scss
+++ b/src/react-components/input/InputField.scss
@@ -9,6 +9,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  align-items: flex-start;
 }
 
 :local(.error) {

--- a/src/react-components/input/InputField.scss
+++ b/src/react-components/input/InputField.scss
@@ -3,13 +3,14 @@
 :local(.label) {
   margin-bottom: 8px;
   color: theme.$grey;
+  align-self: flex-start;
 }
 
 :local(.input-field) {
   display: flex;
   flex-direction: column;
   width: 100%;
-  align-items: flex-start;
+  max-width: 300px;
 }
 
 :local(.error) {

--- a/src/react-components/layout/RoomLayout.scss
+++ b/src/react-components/layout/RoomLayout.scss
@@ -23,6 +23,20 @@
 
 :local(.sidebar) {
   grid-column-start: sidebar;
+  background-color: theme.$white;
+  height: 100%;
+  width: 450px;
+
+  @media(max-width: theme.$breakpoint-md - 1) {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    margin: 0;
+    width: 100%;
+    z-index: 100;
+  }
 }
 
 :local(.viewport) {
@@ -31,6 +45,7 @@
 
 :local(.toolbar) {
   grid-row-start: toolbar;
+  grid-column-end: -1;
 }
 
 :local(.modal-container) {

--- a/src/react-components/room/AvatarSettingsContent.js
+++ b/src/react-components/room/AvatarSettingsContent.js
@@ -1,0 +1,38 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Button } from "../input/Button";
+import styles from "./AvatarSettingsContent.scss";
+import { TextInputField } from "../input/TextInputField";
+import { AvatarPreviewCanvas } from "../avatar/AvatarPreviewCanvas";
+
+export function AvatarSettingsContent({
+  displayName,
+  onChangeDisplayName,
+  avatarPreviewCanvasRef,
+  onChangeAvatar,
+  onAccept,
+  ...rest
+}) {
+  return (
+    <div className={styles.content} {...rest}>
+      <TextInputField label="Display Name" value={displayName} onChange={onChangeDisplayName} />
+      <div className={styles.avatarPreviewContainer}>
+        <AvatarPreviewCanvas ref={avatarPreviewCanvasRef} />
+        <Button onClick={onChangeAvatar}>Change Avatar</Button>
+      </div>
+      <Button preset="accept" onClick={onAccept}>
+        Accept
+      </Button>
+    </div>
+  );
+}
+
+AvatarSettingsContent.propTypes = {
+  className: PropTypes.string,
+  displayName: PropTypes.string,
+  onChangeDisplayName: PropTypes.func,
+  avatarPreviewCanvasRef: PropTypes.object,
+  onChangeAvatar: PropTypes.func,
+  onAccept: PropTypes.func,
+  onBack: PropTypes.func
+};

--- a/src/react-components/room/AvatarSettingsContent.scss
+++ b/src/react-components/room/AvatarSettingsContent.scss
@@ -1,6 +1,8 @@
 @use "../styles/theme.scss";
 
 :local(.content) {
+  display: flex;
+  flex-direction: column;
   align-items: center;
   padding: 24px;
   text-align: center;

--- a/src/react-components/room/AvatarSettingsSidebar.js
+++ b/src/react-components/room/AvatarSettingsSidebar.js
@@ -1,11 +1,11 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Modal } from "../modal/Modal";
+import { Sidebar } from "../sidebar/Sidebar";
 import { ReactComponent as ChevronBackIcon } from "../icons/ChevronBack.svg";
 import { IconButton } from "../input/IconButton";
 import { AvatarSettingsContent } from "./AvatarSettingsContent";
 
-export function AvatarSetupModal({
+export function AvatarSettingsSidebar({
   className,
   displayName,
   onChangeDisplayName,
@@ -16,8 +16,8 @@ export function AvatarSetupModal({
   ...rest
 }) {
   return (
-    <Modal
-      title="Avatar Setup"
+    <Sidebar
+      title="Avatar Settings"
       beforeTitle={
         <IconButton onClick={onBack}>
           <ChevronBackIcon />
@@ -34,11 +34,11 @@ export function AvatarSetupModal({
         onChangeAvatar={onChangeAvatar}
         onAccept={onAccept}
       />
-    </Modal>
+    </Sidebar>
   );
 }
 
-AvatarSetupModal.propTypes = {
+AvatarSettingsSidebar.propTypes = {
   className: PropTypes.string,
   displayName: PropTypes.string,
   onChangeDisplayName: PropTypes.func,

--- a/src/react-components/room/AvatarSettingsSidebar.stories.js
+++ b/src/react-components/room/AvatarSettingsSidebar.stories.js
@@ -1,0 +1,13 @@
+import React from "react";
+import { RoomLayout } from "../layout/RoomLayout";
+import { AvatarSettingsSidebar } from "./AvatarSettingsSidebar";
+
+export default {
+  title: "AvatarSettingsSidebar"
+};
+
+export const Base = () => <RoomLayout sidebar={<AvatarSettingsSidebar />} />;
+
+Base.parameters = {
+  layout: "fullscreen"
+};

--- a/src/react-components/room/AvatarSetupModal.js
+++ b/src/react-components/room/AvatarSetupModal.js
@@ -1,0 +1,54 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Modal } from "../modal/Modal";
+import { Button } from "../input/Button";
+import { ReactComponent as ChevronBackIcon } from "../icons/ChevronBack.svg";
+import styles from "./AvatarSetupModal.scss";
+import { IconButton } from "../input/IconButton";
+import { TextInputField } from "../input/TextInputField";
+import { AvatarPreviewCanvas } from "../avatar/AvatarPreviewCanvas";
+
+export function AvatarSetupModal({
+  className,
+  displayName,
+  onChangeDisplayName,
+  avatarPreviewCanvasRef,
+  onChangeAvatar,
+  onAccept,
+  onBack,
+  ...rest
+}) {
+  return (
+    <Modal
+      title="Avatar Setup"
+      beforeTitle={
+        <IconButton onClick={onBack}>
+          <ChevronBackIcon />
+          <span>Back</span>
+        </IconButton>
+      }
+      className={className}
+      contentClassName={styles.content}
+      {...rest}
+    >
+      <TextInputField label="Display Name" value={displayName} onChange={onChangeDisplayName} />
+      <div className={styles.avatarPreviewContainer}>
+        <AvatarPreviewCanvas ref={avatarPreviewCanvasRef} />
+        <Button onClick={onChangeAvatar}>Change Avatar</Button>
+      </div>
+      <Button preset="accept" onClick={onAccept}>
+        Accept
+      </Button>
+    </Modal>
+  );
+}
+
+AvatarSetupModal.propTypes = {
+  className: PropTypes.string,
+  displayName: PropTypes.string,
+  onChangeDisplayName: PropTypes.func,
+  avatarPreviewCanvasRef: PropTypes.object,
+  onChangeAvatar: PropTypes.func,
+  onAccept: PropTypes.func,
+  onBack: PropTypes.func
+};

--- a/src/react-components/room/AvatarSetupModal.scss
+++ b/src/react-components/room/AvatarSetupModal.scss
@@ -1,0 +1,29 @@
+@use "../styles/theme.scss";
+
+:local(.content) {
+  align-items: center;
+  padding: 24px;
+  text-align: center;
+
+  & > * {
+    margin-bottom: 16px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
+
+:local(.avatar-preview-container) {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  align-items: center;
+
+  button {
+    position: absolute;
+    bottom: 0;
+    margin-bottom: 8px;
+  }
+}

--- a/src/react-components/room/AvatarSetupModal.stories.js
+++ b/src/react-components/room/AvatarSetupModal.stories.js
@@ -1,0 +1,13 @@
+import React from "react";
+import { RoomLayout } from "../layout/RoomLayout";
+import { AvatarSetupModal } from "./AvatarSetupModal";
+
+export default {
+  title: "AvatarSetupModal"
+};
+
+export const Base = () => <RoomLayout modal={<AvatarSetupModal />} />;
+
+Base.parameters = {
+  layout: "fullscreen"
+};

--- a/src/react-components/room/InvitePopover.scss
+++ b/src/react-components/room/InvitePopover.scss
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   padding: 16px;
+  align-items: center;
 
   & > * {
     margin-bottom: 16px;

--- a/src/react-components/room/UserProfileSidebar.js
+++ b/src/react-components/room/UserProfileSidebar.js
@@ -1,0 +1,72 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Sidebar } from "../sidebar/Sidebar";
+import { ReactComponent as ChevronBackIcon } from "../icons/ChevronBack.svg";
+import { IconButton } from "../input/IconButton";
+import { Button } from "../input/Button";
+import styles from "./UserProfileSidebar.scss";
+import { AvatarPreviewCanvas } from "../avatar/AvatarPreviewCanvas";
+
+export function UserProfileSidebar({
+  className,
+  displayName,
+  avatarPreviewCanvasRef,
+  canPromote,
+  onPromote,
+  canHide,
+  onHide,
+  canMute,
+  onMute,
+  canKick,
+  onKick,
+  onBack,
+  ...rest
+}) {
+  return (
+    <Sidebar
+      title={displayName}
+      beforeTitle={
+        <IconButton onClick={onBack}>
+          <ChevronBackIcon />
+          <span>Back</span>
+        </IconButton>
+      }
+      className={className}
+      contentClassName={styles.content}
+      {...rest}
+    >
+      <AvatarPreviewCanvas ref={avatarPreviewCanvasRef} />
+      {canPromote && (
+        <Button preset="green" onClick={onPromote}>
+          Promote
+        </Button>
+      )}
+      {canHide && <Button onClick={onHide}>Hide</Button>}
+      {canMute && (
+        <Button preset="red" onClick={onMute}>
+          Mute
+        </Button>
+      )}
+      {canKick && (
+        <Button preset="red" onClick={onKick}>
+          Kick
+        </Button>
+      )}
+    </Sidebar>
+  );
+}
+
+UserProfileSidebar.propTypes = {
+  className: PropTypes.string,
+  displayName: PropTypes.string,
+  avatarPreviewCanvasRef: PropTypes.object,
+  canPromote: PropTypes.bool,
+  onPromote: PropTypes.func,
+  canHide: PropTypes.bool,
+  onHide: PropTypes.func,
+  canMute: PropTypes.bool,
+  onMute: PropTypes.func,
+  canKick: PropTypes.bool,
+  onKick: PropTypes.func,
+  onBack: PropTypes.func
+};

--- a/src/react-components/room/UserProfileSidebar.scss
+++ b/src/react-components/room/UserProfileSidebar.scss
@@ -1,0 +1,17 @@
+@use "../styles/theme.scss";
+
+:local(.content) {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px;
+  text-align: center;
+
+  & > * {
+    margin-bottom: 16px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/src/react-components/room/UserProfileSidebar.stories.js
+++ b/src/react-components/room/UserProfileSidebar.stories.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { RoomLayout } from "../layout/RoomLayout";
+import { UserProfileSidebar } from "./UserProfileSidebar";
+
+export default {
+  title: "UserProfileSidebar"
+};
+
+export const Base = () => (
+  <RoomLayout sidebar={<UserProfileSidebar displayName="Robert" canHide canKick canMute canPromote />} />
+);
+
+Base.parameters = {
+  layout: "fullscreen"
+};

--- a/src/react-components/sidebar/Sidebar.js
+++ b/src/react-components/sidebar/Sidebar.js
@@ -1,0 +1,29 @@
+import React from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import styles from "./Sidebar.scss";
+
+export function Sidebar({ title, beforeTitle, afterTitle, children, contentClassName, className }) {
+  return (
+    <div className={classNames(styles.sidebar, className)}>
+      {(title || beforeTitle || afterTitle) && (
+        <div className={styles.header}>
+          <div className={styles.beforeTitle}>{beforeTitle}</div>
+          <h1>{title}</h1>
+          <div className={styles.afterTitle}>{afterTitle}</div>
+        </div>
+      )}
+      <div className={classNames(styles.content, contentClassName)}>{children}</div>
+    </div>
+  );
+}
+
+Sidebar.propTypes = {
+  title: PropTypes.string,
+  beforeTitle: PropTypes.node,
+  afterTitle: PropTypes.node,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  contentClassName: PropTypes.string,
+  disableFullscreen: PropTypes.bool
+};

--- a/src/react-components/sidebar/Sidebar.scss
+++ b/src/react-components/sidebar/Sidebar.scss
@@ -4,6 +4,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
+  height: 100%;
 }
 
 :local(.header) {

--- a/src/react-components/sidebar/Sidebar.scss
+++ b/src/react-components/sidebar/Sidebar.scss
@@ -1,0 +1,40 @@
+@use "../styles/theme.scss";
+
+:local(.sidebar) {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+:local(.header) {
+  display: flex;
+  height: 48px;
+  border-bottom: 1px solid theme.$lightgrey;
+  align-items: center;
+  justify-content: center;
+
+  h1 {
+    font-size: theme.$font-size-sm;
+    font-weight: theme.$font-weight-bold;
+  }
+}
+
+:local(.before-title) {
+  position: absolute;
+  left: 0;
+}
+
+:local(.after-title) {
+  position: absolute;
+  right: 0;
+}
+
+:local(.content) {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+
+  @media(max-width: theme.$breakpoint-md - 1) {
+    overflow-y: auto;
+  }
+}

--- a/src/react-components/sidebar/Sidebar.stories.js
+++ b/src/react-components/sidebar/Sidebar.stories.js
@@ -1,0 +1,13 @@
+import React from "react";
+import { RoomLayout } from "../layout/RoomLayout";
+import { Sidebar } from "./Sidebar";
+
+export default {
+  title: "Sidebar"
+};
+
+export const Base = () => <RoomLayout sidebar={<Sidebar title="Sidebar">Test</Sidebar>} />;
+
+Base.parameters = {
+  layout: "fullscreen"
+};


### PR DESCRIPTION
This PR adds the AvatarSetupModal, AvatarSettingsSidebar, and UserProfileSidebar components. They all serve a similar purpose, to display data and actions centered around a user and their avatar. The avatar preview is intentionally a blank canvas. It takes a ref prop which will be used by a hook to drive the avatar preview logic. It is purely a presentational component.

Here's the AvatarSetupModal on desktop:
![Screenshot_2020-09-01 AvatarSetupModal - Base ⋅ Storybook](https://user-images.githubusercontent.com/1753624/91893513-178b6300-ec49-11ea-9e85-b44912a0e05c.png)

The AvatarSetupModal on mobile:
![Screenshot_2020-09-01 AvatarSetupModal - Base ⋅ Storybook(1)](https://user-images.githubusercontent.com/1753624/91894126-098a1200-ec4a-11ea-91d5-812db3dc9ba3.png)

The AvatarSettingsSidebar on Desktop:
![Screenshot_2020-09-01 AvatarSettingsSidebar - Base ⋅ Storybook](https://user-images.githubusercontent.com/1753624/91894165-1d357880-ec4a-11ea-8ec2-006ef9824aa1.png)

The AvatarSettingsSidebar on Mobile
![Screenshot_2020-09-01 AvatarSettingsSidebar - Base ⋅ Storybook(1)](https://user-images.githubusercontent.com/1753624/91894188-258db380-ec4a-11ea-916f-ea520b320f6f.png)

The UserProfileSidebar on Desktop:
![Screenshot_2020-09-01 UserProfileSidebar - Base ⋅ Storybook(1)](https://user-images.githubusercontent.com/1753624/91894283-4ce48080-ec4a-11ea-84d0-f02fd1e03dd2.png)

The UserProfileSidebar on Mobile:
![Screenshot_2020-09-01 UserProfileSidebar - Base ⋅ Storybook](https://user-images.githubusercontent.com/1753624/91894246-3dfdce00-ec4a-11ea-8a4a-7abe8e3d69a7.png)