### PR TITLE
switch over to using SAB for physics

### DIFF
--- a/src/systems/physics-system.js
+++ b/src/systems/physics-system.js
@@ -5,7 +5,8 @@ import * as ammoWasmUrl from "ammo.js/builds/ammo.wasm.wasm";
 
 const MESSAGE_TYPES = CONSTANTS.MESSAGE_TYPES,
   TYPE = CONSTANTS.TYPE,
-  BUFFER_CONFIG = CONSTANTS.BUFFER_CONFIG;
+  BUFFER_CONFIG = CONSTANTS.BUFFER_CONFIG,
+  BUFFER_STATE = CONSTANTS.BUFFER_STATE;
 
 const WORLD_CONFIG = {
   debugDrawMode: AmmoDebugConstants.DrawWireframe,
@@ -34,20 +35,33 @@ export class PhysicsSystem {
     this.nextBodyUuid = 0;
     this.nextShapeUuid = 0;
 
-    const arrayBuffer = new ArrayBuffer(4 * BUFFER_CONFIG.BODY_DATA_SIZE * MAX_BODIES);
-    this.objectMatricesFloatArray = new Float32Array(arrayBuffer);
-    this.objectMatricesIntArray = new Int32Array(arrayBuffer);
-
-    this.ammoWorker.postMessage(
-      {
-        type: MESSAGE_TYPES.INIT,
-        worldConfig: WORLD_CONFIG,
-        arrayBuffer,
-        maxBodies: MAX_BODIES,
-        wasmUrl: new URL(ammoWasmUrl, configs.BASE_ASSETS_PATH || window.location).href
-      },
-      [arrayBuffer]
+    const sharedArrayBuffer = new window.SharedArrayBuffer(
+      4 * BUFFER_CONFIG.HEADER_LENGTH + //header
+      4 * BUFFER_CONFIG.BODY_DATA_SIZE * MAX_BODIES + //matrices
+        4 * BUFFER_CONFIG.MAX_BODIES //velocities
     );
+    this.headerIntArray = new Int32Array(sharedArrayBuffer, 0, BUFFER_CONFIG.HEADER_LENGTH);
+    this.headerFloatArray = new Int32Array(sharedArrayBuffer, 0, BUFFER_CONFIG.HEADER_LENGTH);
+    this.objectMatricesIntArray = new Int32Array(
+      sharedArrayBuffer,
+      BUFFER_CONFIG.HEADER_LENGTH * 4,
+      BUFFER_CONFIG.BODY_DATA_SIZE * MAX_BODIES
+    );
+    this.objectMatricesFloatArray = new Float32Array(
+      sharedArrayBuffer,
+      BUFFER_CONFIG.HEADER_LENGTH * 4,
+      BUFFER_CONFIG.BODY_DATA_SIZE * MAX_BODIES
+    );
+
+    this.headerIntArray[0] = BUFFER_STATE.UNINITIALIZED;
+
+    this.ammoWorker.postMessage({
+      type: MESSAGE_TYPES.INIT,
+      worldConfig: WORLD_CONFIG,
+      sharedArrayBuffer,
+      maxBodies: MAX_BODIES,
+      wasmUrl: new URL(ammoWasmUrl, configs.BASE_ASSETS_PATH || window.location).href
+    });
 
     this.ammoWorker.onmessage = async event => {
       if (event.data.type === MESSAGE_TYPES.READY) {
@@ -78,10 +92,6 @@ export class PhysicsSystem {
         } else {
           console.warn(`Shape initialized but body with uuid: ${bodyUuid} missing.`);
         }
-      } else if (event.data.type === MESSAGE_TYPES.TRANSFER_DATA) {
-        this.objectMatricesFloatArray = event.data.objectMatricesFloatArray;
-        this.objectMatricesIntArray = new Int32Array(this.objectMatricesFloatArray.buffer);
-        this.stepDuration = event.data.stepDuration;
       }
     };
   }
@@ -153,7 +163,8 @@ export class PhysicsSystem {
          * 18-25  first 8 Collisions (ints)
          */
 
-        if (this.objectMatricesFloatArray.buffer.byteLength !== 0) {
+        if (window.Atomics.load(this.headerIntArray, 0) === BUFFER_STATE.READY) {
+          this.stepDuration = window.Atomics.load(this.headerFloatArray, 1);
           for (let i = 0; i < this.bodyUuids.length; i++) {
             const uuid = this.bodyUuids[i];
             const body = this.bodyUuidToData.get(uuid);
@@ -196,10 +207,7 @@ export class PhysicsSystem {
             }
           }
 
-          this.ammoWorker.postMessage(
-            { type: MESSAGE_TYPES.TRANSFER_DATA, objectMatricesFloatArray: this.objectMatricesFloatArray },
-            [this.objectMatricesFloatArray.buffer]
-          );
+          window.Atomics.store(this.headerIntArray, 0, BUFFER_STATE.CONSUMED);
         }
 
         /* DEBUG RENDERING */


### PR DESCRIPTION
This is a PR to be merged in the future when SharedArrayBuffer and Atomics become available across all browsers that Hubs is supporting. This switches over the PhysicsSystem to use SAB instead of transferrables for communication with the physics worker.