### PR TITLE
Remove space from event name

### DIFF
--- a/src/systems/audio-system.js
+++ b/src/systems/audio-system.js
@@ -62,7 +62,7 @@ export class AudioSystem {
     if (sceneEl.camera) {
       sceneEl.camera.add(sceneEl.audioListener);
     }
-    sceneEl.addEventListener("camera-set- active", evt => {
+    sceneEl.addEventListener("camera-set-active", evt => {
       evt.detail.cameraEl.getObject3D("camera").add(sceneEl.audioListener);
     });
 


### PR DESCRIPTION
Just noticed this typo in an event name. 

Not sure whether the typo is causing any issues, or why the same event listener is added [elsewhere](https://github.com/mozilla/hubs/blob/c01312e976919c2043c4c85ce26c77f6f8a932f9/src/components/media-views.js#L350) but figured I should remove the accidental space. Maybe I should remove the line entirely, but I don't fully understand what it's for.

The event is emitted from aframe code : https://github.com/MozillaReality/aframe/blob/05b980199e5e79e7dde1f6acb63ca74660ceee33/src/systems/camera.js#L185
