### PR TITLE
non-admins see a "sorry not an admin" page

### DIFF
--- a/admin/src/admin.js
+++ b/admin/src/admin.js
@@ -84,7 +84,6 @@ class AdminUI extends Component {
     if (process.env.NODE_ENV !== "development" || qs.get("idle_timeout")) detectIdle();
     window.addEventListener("idle_detected", this.onIdleDetected);
     window.addEventListener("activity_detected", this.onActivityDetected);
-    console.log("inside did mount");
     const adminInfo = await getAdminInfo();
     // Unauthorized account
     if (adminInfo.status === 401) this.setState({ isAdmin: false });

--- a/admin/src/admin.js
+++ b/admin/src/admin.js
@@ -9,7 +9,8 @@ import {
   schemaByCategories,
   schemaCategories,
   getSchemas as getItaSchemas,
-  setAuthToken as setItaAuthToken
+  setAuthToken as setItaAuthToken,
+  getAdminInfo
 } from "./utils/ita";
 import { detectIdle } from "./utils/idle-detector";
 import { connectToReticulum } from "hubs/src/utils/phoenix-utils";
@@ -34,6 +35,7 @@ import { AutoEndSessionDialog } from "./react-components/auto-end-session-dialog
 import Store from "hubs/src/storage/store";
 import registerTelemetry from "hubs/src/telemetry";
 import { createMuiTheme, withStyles } from "@material-ui/core/styles";
+import { UnauthorizedPage } from "./react-components/unauthorized";
 
 const qs = new URLSearchParams(location.hash.split("?")[1]);
 
@@ -74,13 +76,18 @@ class AdminUI extends Component {
   };
 
   state = {
-    showAutoEndSessionDialog: false
+    showAutoEndSessionDialog: false,
+    isAdmin: true
   };
 
-  componentDidMount() {
+  async componentDidMount() {
     if (process.env.NODE_ENV !== "development" || qs.get("idle_timeout")) detectIdle();
     window.addEventListener("idle_detected", this.onIdleDetected);
     window.addEventListener("activity_detected", this.onActivityDetected);
+    console.log("inside did mount");
+    const adminInfo = await getAdminInfo();
+    // Unauthorized account
+    if (adminInfo.status === 401) this.setState({ isAdmin: false });
   }
 
   componentWillUnmount() {
@@ -101,60 +108,66 @@ class AdminUI extends Component {
   render() {
     return (
       <>
-        <Admin
-          dashboard={SystemEditor}
-          appLayout={this.props.layout}
-          customRoutes={this.props.customRoutes}
-          dataProvider={this.props.dataProvider}
-          authProvider={this.props.authProvider}
-          loginPage={false}
-          logoutButton={() => <span />}
-          theme={theme}
-        >
-          <Resource name="pending_scenes" list={PendingSceneList} />
-          <Resource
-            name="scene_listings"
-            list={SceneListingList}
-            edit={SceneListingEdit}
-            options={{ label: "Approved scenes" }}
-          />
-          <Resource
-            name="featured_scene_listings"
-            list={FeaturedSceneListingList}
-            edit={FeaturedSceneListingEdit}
-            options={{ label: "Featured scenes" }}
-          />
+        {this.state.isAdmin ? (
+          <>
+            <Admin
+              dashboard={SystemEditor}
+              appLayout={this.props.layout}
+              customRoutes={this.props.customRoutes}
+              dataProvider={this.props.dataProvider}
+              authProvider={this.props.authProvider}
+              loginPage={false}
+              logoutButton={() => <span />}
+              theme={theme}
+            >
+              <Resource name="pending_scenes" list={PendingSceneList} />
+              <Resource
+                name="scene_listings"
+                list={SceneListingList}
+                edit={SceneListingEdit}
+                options={{ label: "Approved scenes" }}
+              />
+              <Resource
+                name="featured_scene_listings"
+                list={FeaturedSceneListingList}
+                edit={FeaturedSceneListingEdit}
+                options={{ label: "Featured scenes" }}
+              />
 
-          <Resource name="pending_avatars" list={AvatarList} />
-          <Resource
-            name="avatar_listings"
-            list={AvatarListingList}
-            edit={AvatarListingEdit}
-            options={{ label: "Approved avatars" }}
-          />
-          <Resource
-            name="featured_avatar_listings"
-            list={AvatarListingList}
-            edit={AvatarListingEdit}
-            options={{ label: "Featured avatars" }}
-          />
+              <Resource name="pending_avatars" list={AvatarList} />
+              <Resource
+                name="avatar_listings"
+                list={AvatarListingList}
+                edit={AvatarListingEdit}
+                options={{ label: "Approved avatars" }}
+              />
+              <Resource
+                name="featured_avatar_listings"
+                list={AvatarListingList}
+                edit={AvatarListingEdit}
+                options={{ label: "Featured avatars" }}
+              />
 
-          <Resource name="accounts" list={AccountList} edit={AccountEdit} />
-          <Resource name="identities" list={IdentityList} create={IdentityCreate} edit={IdentityEdit} />
-          <Resource name="scenes" list={SceneList} edit={SceneEdit} />
-          <Resource name="avatars" list={AvatarList} create={IdentityCreate} edit={AvatarEdit} />
-          <Resource name="owned_files" />
+              <Resource name="accounts" list={AccountList} edit={AccountEdit} />
+              <Resource name="identities" list={IdentityList} create={IdentityCreate} edit={IdentityEdit} />
+              <Resource name="scenes" list={SceneList} edit={SceneEdit} />
+              <Resource name="avatars" list={AvatarList} create={IdentityCreate} edit={AvatarEdit} />
+              <Resource name="owned_files" />
 
-          <Resource name="projects" list={ProjectList} show={ProjectShow} />
-        </Admin>
-        {this.state.showAutoEndSessionDialog && (
-          <AutoEndSessionDialog
-            onCancel={() => this.setState({ showAutoEndSessionDialog: false })}
-            onEndSession={() => {
-              this.props.onEndSession();
-              this.setState({ sessionEnded: true });
-            }}
-          />
+              <Resource name="projects" list={ProjectList} show={ProjectShow} />
+            </Admin>
+            {this.state.showAutoEndSessionDialog && (
+              <AutoEndSessionDialog
+                onCancel={() => this.setState({ showAutoEndSessionDialog: false })}
+                onEndSession={() => {
+                  this.props.onEndSession();
+                  this.setState({ sessionEnded: true });
+                }}
+              />
+            )}
+          </>
+        ) : (
+          <UnauthorizedPage />
         )}
       </>
     );

--- a/admin/src/admin.js
+++ b/admin/src/admin.js
@@ -86,7 +86,7 @@ class AdminUI extends Component {
     window.addEventListener("activity_detected", this.onActivityDetected);
     const adminInfo = await getAdminInfo();
     // Unauthorized account
-    if (adminInfo.status === 401) this.setState({ isAdmin: false });
+    if (adminInfo.error && adminInfo.code === 401) this.setState({ isAdmin: false });
   }
 
   componentWillUnmount() {

--- a/admin/src/react-components/unauthorized.js
+++ b/admin/src/react-components/unauthorized.js
@@ -1,0 +1,32 @@
+import React from "react";
+import Typography from "@material-ui/core/Typography";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import Button from "@material-ui/core/Button";
+
+export const UnauthorizedPage = () => (
+  <div
+    style={{
+      marginLeft: "auto",
+      marginRight: "auto",
+      padding: "20px",
+      maxWidth: "700px"
+    }}
+  >
+    <Card>
+      <CardContent
+        style={{
+          padding: "40px 20px",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center"
+        }}
+      >
+        <Typography variant="title">Sorry! Your account is not an admin.</Typography>
+        <Button variant="contained" style={{ marginTop: "40px" }} color="secondary" href="/">
+          Return Home
+        </Button>
+      </CardContent>
+    </Card>
+  </div>
+);

--- a/admin/src/utils/ita.js
+++ b/admin/src/utils/ita.js
@@ -112,9 +112,9 @@ function getAdminInfo() {
   return fetchWithAuth(getEndpoint("admin-info"))
     .then(resp => {
       if (resp.status === 200) return resp.json();
-      else return resp;
+      else return { error: true, code: resp.status };
     })
-    .catch(e => console.log(e));
+    .catch(e => console.error(e));
 }
 
 function getEditableConfig(service) {

--- a/admin/src/utils/ita.js
+++ b/admin/src/utils/ita.js
@@ -109,7 +109,12 @@ function getSchemas() {
 }
 
 function getAdminInfo() {
-  return fetchWithAuth(getEndpoint("admin-info")).then(resp => resp.json());
+  return fetchWithAuth(getEndpoint("admin-info"))
+    .then(resp => {
+      if (resp.status === 200) return resp.json();
+      else return resp;
+    })
+    .catch(e => console.log(e));
 }
 
 function getEditableConfig(service) {


### PR DESCRIPTION
Added Unauthorized page (see screenshot)

If not an admin, admin panel renders briefly, then you are redirected to the unauthorized page. (added via this PR + reticulum PR (https://github.com/mozilla/reticulum/pull/415/files))
If an admin, you see the admin panel. (obviously, already implemented)
If not logged in at all and try to access admin panel, you're redirected to login (already implemented)

![image](https://user-images.githubusercontent.com/29560735/93148186-0a8a5d00-f6a8-11ea-88d8-ca8983cdce7e.png)
