### PR TITLE
Remove page number from media search

### DIFF
--- a/src/assets/stylesheets/media-browser.scss
+++ b/src/assets/stylesheets/media-browser.scss
@@ -486,14 +486,6 @@
         font-weight: bold;
       }
 
-      :local(.page-number) {
-        font-size: 1.2em;
-        font-weight: bold;
-        text-align: center;
-        color: var(--panel-subtext-link-color);
-        margin: 12px;
-      }
-
       :local(.pager-button-disabled) {
         pointer-events: none;
         background-color: var(--panel-subtext-disabled-color);

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -286,7 +286,6 @@ class MediaBrowser extends Component {
     const meta = this.state.result && this.state.result.meta;
     const hasNext = !!(meta && meta.next_cursor);
     const hasPrevious = searchParams.get("cursor");
-    const page = (meta && meta.page) || 0;
     const apiSource = (meta && meta.source) || null;
     const isVariableWidth = ["bing_images", "tenor"].includes(apiSource);
 
@@ -451,7 +450,6 @@ class MediaBrowser extends Component {
               entries={entries}
               hasNext={hasNext}
               hasPrevious={hasPrevious}
-              page={page}
               isVariableWidth={isVariableWidth}
               history={this.props.history}
               urlSource={urlSource}

--- a/src/react-components/media-tiles.js
+++ b/src/react-components/media-tiles.js
@@ -40,7 +40,6 @@ class MediaTiles extends Component {
     hasNext: PropTypes.bool,
     hasPrevious: PropTypes.bool,
     isVariableWidth: PropTypes.bool,
-    page: PropTypes.number,
     history: PropTypes.object,
     urlSource: PropTypes.string,
     handleEntryClicked: PropTypes.func,
@@ -66,7 +65,7 @@ class MediaTiles extends Component {
   };
 
   render() {
-    const { urlSource, hasNext, hasPrevious, page, isVariableWidth } = this.props;
+    const { urlSource, hasNext, hasPrevious, isVariableWidth } = this.props;
     const entries = this.props.entries || [];
     const [createTileWidth, createTileHeight] = this.getTileDimensions(false, urlSource === "avatars");
 
@@ -120,7 +119,6 @@ class MediaTiles extends Component {
               >
                 <FontAwesomeIcon icon={faAngleLeft} />
               </a>
-              <div className={styles.pageNumber}>{page}</div>
               <a
                 className={classNames({ [styles.nextPage]: true, [styles.pagerButtonDisabled]: !hasNext })}
                 onClick={() => this.props.handlePager(1)}


### PR DESCRIPTION
A recent refactor accidentally re-surfaced an old pagination page number that was actually removed from the backend
a long while ago. Fixes #2396