### PR TITLE
Fix scene transitions when src url does not change

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -445,6 +445,10 @@ async function updateEnvironmentForHub(hub, entryManager) {
         );
 
         sceneEl.emit("leaving_loading_environment");
+        if (environmentEl.components["gltf-model-plus"].data.src === sceneUrl) {
+          console.warn("Updating environment to the same url.");
+          environmentEl.setAttribute("gltf-model-plus", { src: "" });
+        }
         environmentEl.setAttribute("gltf-model-plus", { src: sceneUrl });
       },
       { once: true }
@@ -454,6 +458,10 @@ async function updateEnvironmentForHub(hub, entryManager) {
       environmentEl.addEventListener("model-error", sceneErrorHandler, { once: true });
     }
 
+    if (environmentEl.components["gltf-model-plus"].data.src === loadingEnvironment) {
+      console.warn("Transitioning to loading environment but was already in loading environment.");
+      environmentEl.setAttribute("gltf-model-plus", { src: "" });
+    }
     environmentEl.setAttribute("gltf-model-plus", { src: loadingEnvironment });
   }
 }


### PR DESCRIPTION
If the `src` of the environment's `gltf-model-plus` doesn't change (which might happen if you are going to/from the loading scene url on purpose, or if two scene transitions occur in rapid succession), then `update` is never called and you can get stuck with a black screen because the transition never finishes and the `fader` never fades back in.