### PR TITLE
Allow hub_refresh without session id

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -1553,60 +1553,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     addToPresenceLog(incomingMessage);
   });
 
-  hubPhxChannel.on("hub_refresh_by_api", ({ hubs, stale_fields }) => {
-    const hub = hubs[0];
-    window.APP.hub = hub;
-    updateUIForHub(hub, hubChannel);
-
-    if (stale_fields.includes("scene")) {
-      const fader = document.getElementById("viewing-camera").components["fader"];
-
-      fader.fadeOut().then(() => {
-        scene.emit("reset_scene");
-        updateEnvironmentForHub(hub, entryManager);
-      });
-
-      addToPresenceLog({
-        type: "scene_changed",
-        name: "Admin API",
-        sceneName: hub.scene ? hub.scene.name : "a custom URL"
-      });
-    }
-
-    if (stale_fields.includes("member_permissions")) {
-      hubChannel.fetchPermissions();
-    }
-
-    if (stale_fields.includes("name")) {
-      const titleParts = document.title.split(" | "); // Assumes title has | trailing site name
-      titleParts[0] = hub.name;
-      document.title = titleParts.join(" | ");
-
-      // Re-write the slug in the browser history
-      const pathParts = history.location.pathname.split("/");
-      const oldSlug = pathParts[1];
-      const { search, state } = history.location;
-      const pathname = history.location.pathname.replace(`/${oldSlug}`, `/${hub.slug}`);
-
-      history.replace({ pathname, search, state });
-
-      addToPresenceLog({
-        type: "hub_name_changed",
-        name: "Admin API",
-        hubName: hub.name
-      });
-    }
-
-    if (hub.entry_mode === "deny") {
-      scene.emit("hub_closed");
-    }
-
-    scene.emit("hub_updated", { hub });
-  });
-
   hubPhxChannel.on("hub_refresh", ({ session_id, hubs, stale_fields }) => {
     const hub = hubs[0];
     const userInfo = hubChannel.presence.state[session_id];
+    const displayName = (userInfo && userInfo.metas[0].profile.displayName) || "API";
 
     window.APP.hub = hub;
     updateUIForHub(hub, hubChannel);
@@ -1621,7 +1571,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
       addToPresenceLog({
         type: "scene_changed",
-        name: userInfo.metas[0].profile.displayName,
+        name: displayName,
         sceneName: hub.scene ? hub.scene.name : "a custom URL"
       });
     }
@@ -1645,7 +1595,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
       addToPresenceLog({
         type: "hub_name_changed",
-        name: userInfo.metas[0].profile.displayName,
+        name: displayName,
         hubName: hub.name
       });
     }

--- a/src/utils/identity.js
+++ b/src/utils/identity.js
@@ -100,7 +100,7 @@ export function generateRandomName() {
 
 export async function fetchRandomDefaultAvatarId() {
   const defaultAvatarEndpoint = "/api/v1/media/search?filter=default&source=avatar_listings";
-  const defaultAvatars = (await fetchReticulumAuthenticated(defaultAvatarEndpoint)).entries;
+  const defaultAvatars = (await fetchReticulumAuthenticated(defaultAvatarEndpoint)).entries || [];
   if (defaultAvatars.length === 0) {
     // If reticulum doesn't return any default avatars, just default to the duck model. This should only happen
     // when running against a fresh reticulum server, e.g. a local ret instance.


### PR DESCRIPTION
The upcoming graphql API will broadcast `hub_refresh` on the hub channel, but will not have a `session_id`. In this case, we want the same behavior, except that the message to users will not have another user's display name and instead will say, "API".