### PR TITLE
Fix the last used input device id

### DIFF
--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -596,6 +596,8 @@ class UIRoot extends Component {
     let hasAudio = false;
     const { lastUsedMicDeviceId } = this.props.store.state.settings;
 
+    console.log(`Last used input device: ${lastUsedMicDeviceId}`);
+
     // Try to fetch last used mic, if there was one.
     if (lastUsedMicDeviceId) {
       hasAudio = await this.fetchAudioTrack({ audio: { deviceId: { ideal: lastUsedMicDeviceId } } });
@@ -684,12 +686,15 @@ class UIRoot extends Component {
     await this.fetchMicDevices();
 
     // we should definitely have an audioTrack at this point unless they denied mic access
-    if (this.state.mediaStream) {
-      const micDeviceId = this.micDeviceIdForMicLabel(this.micLabelForMediaStream(this.state.mediaStream));
+    if (this.state.audioTrack) {
+      const micDeviceId = this.micDeviceIdForMicLabel(this.micLabelForAudioTrack(this.state.audioTrack));
       if (micDeviceId) {
         this.props.store.update({ settings: { lastUsedMicDeviceId: micDeviceId } });
+        console.log(`Selected input device: ${this.micLabelForDeviceId(micDeviceId)}`);
       }
       this.props.scene.emit("local-media-stream-created");
+    } else {
+      console.log("No available audio tracks");
     }
   };
 
@@ -718,13 +723,16 @@ class UIRoot extends Component {
   };
 
   fetchMicDevices = () => {
+    console.log("Available input devices: ");
     return new Promise(resolve => {
       navigator.mediaDevices.enumerateDevices().then(mediaDevices => {
+        const inputDevices = mediaDevices
+          .filter(d => d.kind === "audioinput")
+          .map(d => ({ deviceId: d.deviceId, label: d.label }));
+        inputDevices.forEach(d => console.log(`\t${d.label} (${d.deviceId})`));
         this.setState(
           {
-            micDevices: mediaDevices
-              .filter(d => d.kind === "audioinput")
-              .map(d => ({ deviceId: d.deviceId, label: d.label }))
+            micDevices: inputDevices
           },
           resolve
         );
@@ -744,16 +752,20 @@ class UIRoot extends Component {
     return !!this.state.micDevices.find(d => HMD_MIC_REGEXES.find(r => d.label.match(r)));
   };
 
-  micLabelForMediaStream = mediaStream => {
-    return (mediaStream && mediaStream.getAudioTracks().length > 0 && mediaStream.getAudioTracks()[0].label) || "";
+  micLabelForAudioTrack = audioTrack => {
+    return (audioTrack && audioTrack.label) || "";
   };
 
   selectedMicLabel = () => {
-    return this.micLabelForMediaStream(this.state.mediaStream);
+    return this.micLabelForAudioTrack(this.state.audioTrack);
   };
 
   micDeviceIdForMicLabel = label => {
     return this.state.micDevices.filter(d => d.label === label).map(d => d.deviceId)[0];
+  };
+
+  micLabelForDeviceId = deviceId => {
+    return this.state.micDevices.filter(d => d.deviceId === deviceId).map(d => d.label)[0];
   };
 
   selectedMicDeviceId = () => {
@@ -786,8 +798,8 @@ class UIRoot extends Component {
     const mediaStream = this.state.mediaStream;
 
     if (mediaStream) {
-      if (mediaStream.getAudioTracks().length > 0) {
-        console.log(`Using microphone: ${mediaStream.getAudioTracks()[0].label}`);
+      if (this.state.audioTrack) {
+        console.log(`Using microphone: ${this.state.audioTrack.label}`);
       }
 
       if (mediaStream.getVideoTracks().length > 0) {

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -596,8 +596,6 @@ class UIRoot extends Component {
     let hasAudio = false;
     const { lastUsedMicDeviceId } = this.props.store.state.settings;
 
-    console.log(`Last used input device: ${lastUsedMicDeviceId}`);
-
     // Try to fetch last used mic, if there was one.
     if (lastUsedMicDeviceId) {
       hasAudio = await this.fetchAudioTrack({ audio: { deviceId: { ideal: lastUsedMicDeviceId } } });
@@ -723,16 +721,13 @@ class UIRoot extends Component {
   };
 
   fetchMicDevices = () => {
-    console.log("Available input devices: ");
     return new Promise(resolve => {
       navigator.mediaDevices.enumerateDevices().then(mediaDevices => {
-        const inputDevices = mediaDevices
-          .filter(d => d.kind === "audioinput")
-          .map(d => ({ deviceId: d.deviceId, label: d.label }));
-        inputDevices.forEach(d => console.log(`\t${d.label} (${d.deviceId})`));
         this.setState(
           {
-            micDevices: inputDevices
+            micDevices: mediaDevices
+              .filter(d => d.kind === "audioinput")
+              .map(d => ({ deviceId: d.deviceId, label: d.label }))
           },
           resolve
         );


### PR DESCRIPTION
As part of my research on audio issues, I have stumbled upon this one. When storing the `lastUsedMicDeviceId` we are trying to get the deviceId using the mediaStream destination node, but the label in that mediaStream is not an input device label. We already store the current audioTrack in the state so we can use that one to get the correct input device label otherwise `lastUsedMicDeviceId` is always undefined.