### PR TITLE
Fix crash when adding uv-scroll to unlit material

### DIFF
--- a/src/components/uv-scroll.js
+++ b/src/components/uv-scroll.js
@@ -37,12 +37,14 @@ AFRAME.registerComponent("uv-scroll", {
       this.instance = instance;
       this.map = material.map || material.emissiveMap;
 
-      if (!textureToData.has(this.map)) {
+      if (this.map && !textureToData.has(this.map)) {
         textureToData.set(this.map, {
           offset: new THREE.Vector2(),
           instances: [instance]
         });
         registeredTextures.push(this.map);
+      } else if (!this.map) {
+        console.warn("Ignoring uv-scroll added to mesh with no scrollable texture.");
       } else {
         console.warn(
           "Multiple uv-scroll instances added to objects sharing a texture, only the speed/increment from the first one will have any effect"

--- a/src/components/uv-scroll.js
+++ b/src/components/uv-scroll.js
@@ -35,19 +35,19 @@ AFRAME.registerComponent("uv-scroll", {
       const instance = { component: this, mesh };
 
       this.instance = instance;
-      this.map = material.map;
+      this.map = material.map || material.emissiveMap;
 
-      if (!textureToData.has(material.map)) {
-        textureToData.set(material.map, {
+      if (!textureToData.has(this.map)) {
+        textureToData.set(this.map, {
           offset: new THREE.Vector2(),
           instances: [instance]
         });
-        registeredTextures.push(material.map);
+        registeredTextures.push(this.map);
       } else {
         console.warn(
           "Multiple uv-scroll instances added to objects sharing a texture, only the speed/increment from the first one will have any effect"
         );
-        textureToData.get(material.map).instances.push(instance);
+        textureToData.get(this.map).instances.push(instance);
       }
     }
   },


### PR DESCRIPTION
Dropping an object into hubs which has an emissive map (e.g., for unlit material) and uv-scroll component set crashes the client due to `registeredTextures[i];` being null in UVScrollSystem.tick.

An alternative fix would be to check for a null `material.map` in line 32.