### PR TITLE
Resolve the audio noise problem happened at the moment when zooming in an object

### DIFF
--- a/src/systems/camera-system.js
+++ b/src/systems/camera-system.js
@@ -283,6 +283,8 @@ export class CameraSystem {
       setMatrixWorld(this.snapshot.audio, this.audioSourceTargetTransform);
     }
 
+    this.ensureListenerIsParentedCorrectly(scene);
+
     moveRigSoCameraLooksAtPivot(
       this.viewingRig.object3D,
       this.viewingCamera.object3DMap.camera,
@@ -314,6 +316,21 @@ export class CameraSystem {
     }
     this.snapshot.mode = null;
     this.tick(AFRAME.scenes[0]);
+  }
+
+  ensureListenerIsParentedCorrectly(scene) {
+    if (scene.audioListener && this.avatarPOV) {
+      if (this.mode === CAMERA_MODE_INSPECT && scene.audioListener.parent !== this.avatarPOV.object3D) {
+        this.avatarPOV.object3D.add(scene.audioListener);
+      } else if (
+        (this.mode === CAMERA_MODE_FIRST_PERSON ||
+          this.mode === CAMERA_MODE_THIRD_PERSON_NEAR ||
+          this.mode === CAMERA_MODE_THIRD_PERSON_FAR) &&
+        scene.audioListener.parent !== this.viewingCamera.object3DMap.camera
+      ) {
+        this.viewingCamera.object3DMap.camera.add(scene.audioListener);
+      }
+    }
   }
 
   hideEverythingButThisObject(o) {
@@ -420,6 +437,8 @@ export class CameraSystem {
         return;
       }
 
+      this.ensureListenerIsParentedCorrectly(scene);
+
       if (this.mode === CAMERA_MODE_FIRST_PERSON) {
         this.viewingCameraRotator.on = false;
         this.avatarRig.object3D.updateMatrices();
@@ -496,19 +515,6 @@ export class CameraSystem {
             dt,
             panY
           );
-        }
-      }
-
-      if (scene.audioListener && this.avatarPOV) {
-        if (this.mode === CAMERA_MODE_INSPECT && scene.audioListener.parent !== this.avatarPOV.object3D) {
-          this.avatarPOV.object3D.add(scene.audioListener);
-        } else if (
-          (this.mode === CAMERA_MODE_FIRST_PERSON ||
-            this.mode === CAMERA_MODE_THIRD_PERSON_NEAR ||
-            this.mode === CAMERA_MODE_THIRD_PERSON_FAR) &&
-          scene.audioListener.parent !== this.viewingCamera.object3DMap.camera
-        ) {
-          this.viewingCamera.object3DMap.camera.add(scene.audioListener);
         }
       }
     };


### PR DESCRIPTION
Resolves #3098

**How the audio noise problem happens**

@johnshaughnessy's https://github.com/mozilla/hubs/issues/3098#issuecomment-703917282 seems correct.

1. Audio listener's parent is viewing camera in non-inspect mode
2. [Viewing camera moves close to the object in `inspect()`](https://github.com/mozilla/hubs/blob/master/src/systems/camera-system.js#L286-L292)
3. In the next [renderer's `render()`](https://github.com/MozillaReality/three.js/blob/hubs/master/src/renderers/WebGLRenderer.js#L1033) and [in the beginning of the next tick()](https://github.com/mozilla/hubs/blob/master/src/systems/camera-system.js#L354) and , [the audio listener's world matrix is updated as the listener is under the viewing camera and the panner position is updated so](https://github.com/MozillaReality/three.js/blob/hubs/master/src/audio/AudioListener.js#L116-L137)
4. [In the tick() audio listener is reparented with avatar pov](https://github.com/mozilla/hubs/blob/master/src/systems/camera-system.js#L502-L513)
5. In the next renderer's `render()`, audio listener's world matrix is updated as the listener is under the avatar pov and the panner position is updated so

The panner position is close to the object just for one frame (3 in the above list) and this causes an audio noise.

**How to resolve**

Insert the code reparenting the audio listener in `inspect()`. With this change, the audio world matrix and panner position are calculated as it's under the avatar pov in the 3 in the above list.

**Should we insert the code in `uninspect()`, too?**

We shouldn't. If we do, 

1. The audio listener is reparented with the viewing camera in `uninspect()`
2. The viewing camera is still close to the object and the audio listener world matrix and the panner position is updated
3. The viewing camera move back close to the avatar

and it causes an audio noise.

**Future ideal change**

The state management in camera system seems complex. We may need to refactor at some point. But the change can be big so I'd like to suggest merging this PR so far as quick patch and then thinking of refactoring later.
