### PR TITLE
OpenID Connect Login

### DIFF
--- a/admin/src/react-components/service-editor.js
+++ b/admin/src/react-components/service-editor.js
@@ -230,6 +230,23 @@ class ConfigurationEditor extends Component {
     );
   }
 
+  renderListInput(path, descriptor, currentValue) {
+    const displayPath = path.join(" > ");
+    return (
+      <TextField
+        key={displayPath}
+        id={displayPath}
+        label={descriptor.name || displayPath}
+        value={((currentValue && Object.values(currentValue)) || []).join(",")}
+        onChange={ev => this.onChange(path, ev.target.value.split(",").map(v => v.trim()))}
+        helperText={descriptor.description}
+        type="text"
+        fullWidth
+        margin="normal"
+      />
+    );
+  }
+
   renderLongTextInput(path, descriptor, currentValue) {
     const displayPath = path.join(" > ");
     return (
@@ -312,7 +329,7 @@ class ConfigurationEditor extends Component {
   renderConfigurable(path, descriptor, currentValue) {
     switch (descriptor.type) {
       case "list":
-        return null;
+        return descriptor.of === "string" ? this.renderListInput(path, descriptor, currentValue) : null;
       case "file":
         return this.renderFileInput(path, descriptor, currentValue);
       case "boolean":

--- a/admin/src/react-components/service-editor.js
+++ b/admin/src/react-components/service-editor.js
@@ -124,6 +124,14 @@ function isEmptyObject(obj) {
   return true;
 }
 
+function getConfigurables(categorySchema) {
+  return getDescriptors(categorySchema).filter(
+    ([path, descriptor]) =>
+      (qs.get("show_internal_configs") !== null || descriptor.internal !== "true") &&
+      (qs.get("show_oidc_configs") !== null || path[1] !== "oidc")
+  );
+}
+
 class ConfigurationEditor extends Component {
   constructor(props) {
     super(props);
@@ -321,9 +329,9 @@ class ConfigurationEditor extends Component {
   }
 
   renderTree(schema, category, config) {
-    const configurables = getDescriptors(schema[category])
-      .filter(([, descriptor]) => qs.get("show_internal_configs") !== null || descriptor.internal !== "true")
-      .map(([path, descriptor]) => this.renderConfigurable(path, descriptor, getConfigValue(config, path)));
+    const configurables = getConfigurables(schema[category]).map(([path, descriptor]) =>
+      this.renderConfigurable(path, descriptor, getConfigValue(config, path))
+    );
 
     return (
       <form onSubmit={this.onSubmit.bind(this)}>
@@ -363,7 +371,7 @@ class ConfigurationEditor extends Component {
             onChange={this.handleTabChange.bind(this)}
           >
             {schemaCategories
-              .filter(c => this.props.schema[c] && !isEmptyObject(this.props.schema[c]))
+              .filter(c => this.props.schema[c] && !isEmptyObject(getConfigurables(this.props.schema[c])))
               .map(c => (
                 <Tab label={getCategoryDisplayName(c)} key={c} value={c} />
               ))}

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -15,6 +15,7 @@
   "sign-in.admin-no-permission": "You don't have access to admin tools. Sign into another account or ask an administrator to grant you permission.",
   "sign-in.hub": "An account is required to join rooms.\n\nEnter your email to create your account or sign in.",
   "sign-in.auth-started": "Email sent to {email}!\n\nTo continue, click on the link in the email using your phone, tablet, or PC.\n\nNo email? You may not be able to create an account.",
+  "sign-in.oidc-auth-started": "Waiting for signin...",
   "sign-in.pin": "You'll need to sign in to pin objects.",
   "sign-in.pin-complete": "You are now signed in.",
   "sign-in.unpin": "You'll need to sign in to un-pin objects.",

--- a/src/react-components/auth/AuthContext.js
+++ b/src/react-components/auth/AuthContext.js
@@ -65,7 +65,7 @@ export function AuthContextProvider({ children, store }) {
       const authChannel = new AuthChannel(store);
       const socket = await connectToReticulum();
       authChannel.setSocket(socket);
-      await authChannel.verifyAuthentication(authParams.topic, authParams.token, authParams.payload);
+      await authChannel.verifyAuthentication(authParams.topic, authParams.token, authParams.payload, authParams.origin);
     },
     [store]
   );

--- a/src/react-components/auth/AuthContext.js
+++ b/src/react-components/auth/AuthContext.js
@@ -1,6 +1,7 @@
 import React, { createContext, useState, useEffect, useCallback } from "react";
 import PropTypes from "prop-types";
 import configs from "../../utils/configs";
+import maskEmail from "../../utils/mask-email";
 
 // TODO: We really shouldn't include these dependencies on every page. A dynamic import would work better.
 import jwtDecode from "jwt-decode";
@@ -82,7 +83,8 @@ export function AuthContextProvider({ children, store }) {
     initialized: false,
     isSignedIn: !!store.state.credentials && store.state.credentials.token,
     isAdmin: configs.isAdmin(),
-    email: store.state.credentials && store.state.credentials.email,
+    displayName:
+      store.state.credentials && (store.state.credentials.displayName || maskEmail(store.state.credentials.email)),
     userId: store.credentialsAccountId,
     signIn,
     verify,
@@ -97,7 +99,9 @@ export function AuthContextProvider({ children, store }) {
           ...state,
           isSignedIn: !!store.state.credentials && store.state.credentials.token,
           isAdmin: configs.isAdmin(),
-          email: store.state.credentials && store.state.credentials.email,
+          displayName:
+            store.state.credentials &&
+            (store.state.credentials.displayName || maskEmail(store.state.credentials.email)),
           userId: store.credentialsAccountId
         }));
       };

--- a/src/react-components/auth/AuthContext.js
+++ b/src/react-components/auth/AuthContext.js
@@ -49,11 +49,13 @@ async function checkIsAdmin(socket, store) {
 
 export function AuthContextProvider({ children, store }) {
   const signIn = useCallback(
-    async email => {
+    async authPayload => {
       const authChannel = new AuthChannel(store);
       const socket = await connectToReticulum();
       authChannel.setSocket(socket);
-      const { authComplete } = await authChannel.startAuthentication(email);
+      const { authComplete } = await (authPayload == "oidc"
+        ? authChannel.startOIDCAuthentication()
+        : authChannel.startAuthentication(authPayload));
       await authComplete;
       await checkIsAdmin(socket, store);
     },

--- a/src/react-components/layout/Header.js
+++ b/src/react-components/layout/Header.js
@@ -4,7 +4,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCog } from "@fortawesome/free-solid-svg-icons/faCog";
 import IfFeature from "../if-feature";
 import configs from "../../utils/configs";
-import maskEmail from "../../utils/mask-email";
 import styles from "./Header.scss";
 import { AuthContext } from "../auth/AuthContext";
 import { WrappedIntlProvider } from "../wrapped-intl-provider";
@@ -72,7 +71,7 @@ export function Header() {
           {auth.isSignedIn ? (
             <div>
               <span>
-                <FormattedMessage id="sign-in.as" /> {maskEmail(auth.email)}
+                <FormattedMessage id="sign-in.as" /> {auth.displayName}
               </span>{" "}
               <a href="#" onClick={auth.signOut}>
                 <FormattedMessage id="sign-in.out" />

--- a/src/react-components/presence-list.js
+++ b/src/react-components/presence-list.js
@@ -7,7 +7,6 @@ import classNames from "classnames";
 
 import rootStyles from "../assets/stylesheets/ui-root.scss";
 import styles from "../assets/stylesheets/presence-list.scss";
-import maskEmail from "../utils/mask-email";
 import StateLink from "./state-link.js";
 import { WithHoverSound } from "./wrap-with-audio";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -67,7 +66,7 @@ export default class PresenceList extends Component {
     history: PropTypes.object,
     sessionId: PropTypes.string,
     signedIn: PropTypes.bool,
-    email: PropTypes.string,
+    displayName: PropTypes.string,
     onSignIn: PropTypes.func,
     onSignOut: PropTypes.func,
     expanded: PropTypes.bool,
@@ -218,7 +217,7 @@ export default class PresenceList extends Component {
             {this.props.signedIn ? (
               <div>
                 <span>
-                  <FormattedMessage id="sign-in.as" /> {maskEmail(this.props.email)}
+                  <FormattedMessage id="sign-in.as" /> {this.props.displayName}
                 </span>{" "}
                 <a onClick={this.props.onSignOut}>
                   <FormattedMessage id="sign-in.out" />

--- a/src/react-components/sign-in-dialog.js
+++ b/src/react-components/sign-in-dialog.js
@@ -33,6 +33,12 @@ export default class SignInDialog extends Component {
     this.props.onSignIn(this.state.email);
   };
 
+  startOIDCFlow = e => {
+    e.preventDefault();
+    e.stopPropagation();
+    this.props.onSignIn("oidc");
+  };
+
   render() {
     let contents;
     if (this.props.authStarted) {
@@ -103,6 +109,13 @@ export default class SignInDialog extends Component {
             next
           </button>
         </form>
+      );
+
+      // TODO check app config to decide login type and customize button
+      contents = (
+        <div>
+          <button onClick={this.startOIDCFlow}>Sign in with OIDC</button>
+        </div>
       );
     }
 

--- a/src/react-components/sign-in-dialog.js
+++ b/src/react-components/sign-in-dialog.js
@@ -39,10 +39,9 @@ export default class SignInDialog extends Component {
     this.props.onSignIn("oidc");
   };
 
-  render() {
-    let contents;
+  renderEmailAuth() {
     if (this.props.authStarted) {
-      contents = (
+      return (
         <div>
           <p>
             <FormattedMessage className="preformatted" id="sign-in.auth-started" values={{ email: this.state.email }} />
@@ -58,7 +57,7 @@ export default class SignInDialog extends Component {
         </div>
       );
     } else if (this.props.authComplete) {
-      contents = (
+      return (
         <div className={styles.signInComplete}>
           <p>{this.props.message}</p>
           <button onClick={this.props.onContinue} className={styles.continueButton}>
@@ -67,7 +66,7 @@ export default class SignInDialog extends Component {
         </div>
       );
     } else {
-      contents = (
+      return (
         <form onSubmit={this.onSubmit} className={styles.signInForm}>
           <span>{this.props.message}</span>
           <input
@@ -110,18 +109,40 @@ export default class SignInDialog extends Component {
           </button>
         </form>
       );
+    }
+  }
 
-      // TODO check app config to decide login type and customize button
-      contents = (
+  renderOIDCAuth() {
+    if (this.props.authStarted) {
+      return (
         <div>
-          <button onClick={this.startOIDCFlow}>Sign in with OIDC</button>
+          <p>
+            <FormattedMessage className="preformatted" id="sign-in.oidc-auth-started" />
+          </p>
+        </div>
+      );
+    } else if (this.props.authComplete) {
+      return (
+        <div className={styles.signInComplete}>
+          <p>{this.props.message}</p>
+          <button onClick={this.props.onContinue} className={styles.continueButton}>
+            {this.props.continueText}
+          </button>
+        </div>
+      );
+    } else {
+      return (
+        <div>
+          <button onClick={this.startOIDCFlow}>{configs.APP_CONFIG.auth.oidc_button_label || "Sign In"}</button>
         </div>
       );
     }
+  }
 
+  render() {
     return (
       <DialogContainer title="Sign In" {...this.props}>
-        {contents}
+        {configs.APP_CONFIG.auth.use_oidc ? this.renderOIDCAuth() : this.renderEmailAuth()}
       </DialogContainer>
     );
   }

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -11,6 +11,7 @@ import IfFeature from "./if-feature";
 import UnlessFeature from "./unless-feature";
 import { VR_DEVICE_AVAILABILITY } from "../utils/vr-caps-detect";
 import { canShare } from "../utils/share";
+import maskEmail from "../utils/mask-email";
 import styles from "../assets/stylesheets/ui-root.scss";
 import entryStyles from "../assets/stylesheets/entry.scss";
 import inviteStyles from "../assets/stylesheets/invite-dialog.scss";
@@ -868,8 +869,10 @@ class UIRoot extends Component {
   showSignInDialog = () => {
     this.showNonHistoriedDialog(SignInDialog, {
       message: getMessages()["sign-in.prompt"],
-      onSignIn: async email => {
-        const { authComplete } = await this.props.authChannel.startAuthentication(email, this.props.hubChannel);
+      onSignIn: async authPayload => {
+        const { authComplete } = await (authPayload == "oidc"
+          ? this.props.authChannel.startOIDCAuthentication(this.props.hubChannel)
+          : this.props.authChannel.startAuthentication(authPayload, this.props.hubChannel));
 
         this.showNonHistoriedDialog(SignInDialog, { authStarted: true });
 
@@ -2067,7 +2070,9 @@ class UIRoot extends Component {
                 presences={this.props.presences}
                 sessionId={this.props.sessionId}
                 signedIn={this.state.signedIn}
-                email={this.props.store.state.credentials.email}
+                displayName={
+                  this.props.store.state.credentials.displayName || maskEmail(this.props.store.state.credentials.email)
+                }
                 onSignIn={this.showSignInDialog}
                 onSignOut={this.signOut}
                 expanded={!this.state.isObjectListExpanded && this.state.isPresenceListExpanded}

--- a/src/schema.toml
+++ b/src/schema.toml
@@ -83,3 +83,6 @@ links.model_collection = { category = "links", type = "string", name = "Model Co
 
 auth.login_subject = { category = "auth", type="string", name="Magic Link Email Subject", description="Customize the email subject line for users logging in" }
 auth.login_body = { category = "auth", type="longstring", name="Magic Link Email Body", description="Customize message. Add '{{ link }}' to insert the magic link, otherwise it will be appended at the end." }
+
+auth.use_oidc = { category = "auth", type = "boolean", name = "Use OpenID Connect for login", description = "Log in using an OpenID connect provider instead of email verification", internal = "true" }
+auth.oidc_button_label = { category = "auth", type="string", name="OpenID Connect Sign In button label", description="Text to display on the sign in button. Ex: Sign in with Google", internal = "true" }

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -56,7 +56,8 @@ export const SCHEMA = {
       additionalProperties: false,
       properties: {
         token: { type: ["null", "string"] },
-        email: { type: ["null", "string"] }
+        email: { type: ["null", "string"] },
+        displayName: { type: ["null", "string"] }
       }
     },
 
@@ -249,7 +250,7 @@ export default class Store extends EventTarget {
 
     const expiry = jwtDecode(this.state.credentials.token).exp * 1000;
     if (expiry <= Date.now()) {
-      this.update({ credentials: { token: null, email: null } });
+      this.update({ credentials: { token: null, email: null, displayName: null } });
     }
   };
 

--- a/src/utils/auth-channel.js
+++ b/src/utils/auth-channel.js
@@ -39,12 +39,10 @@ export default class AuthChannel {
       channel
         .join()
         .receive("ok", () => {
-          channel.on("auth_credentials", async ({ credentials: token, payload: payload }) => {
-            await this.handleAuthCredentials(payload.email, token);
-            resolve();
-          });
-
-          channel.push("auth_verified", { token: authToken, payload: authPayload });
+            channel.on("auth_credentials", async ({ credentials: token, payload: payload }) => {
+              await this.handleAuthCredentials({ email: payload.email }, token);
+              resolve();
+            });
         })
         .receive("error", reject);
     });
@@ -61,7 +59,7 @@ export default class AuthChannel {
 
     const authComplete = new Promise(resolve =>
       channel.on("auth_credentials", async ({ credentials: token }) => {
-        await this.handleAuthCredentials(email, token, hubChannel);
+        await this.handleAuthCredentials({ email }, token, hubChannel);
         resolve();
       })
     );
@@ -73,8 +71,9 @@ export default class AuthChannel {
     return { authComplete };
   }
 
-  async handleAuthCredentials(email, token, hubChannel) {
-    this.store.update({ credentials: { email, token } });
+  async handleAuthCredentials(userInfo, token, hubChannel) {
+    console.log("handleAuthCredentials", userInfo, token, hubChannel);
+    this.store.update({ credentials: { ...userInfo, token } });
 
     if (hubChannel) {
       await hubChannel.signIn(token);

--- a/src/utils/auth-channel.js
+++ b/src/utils/auth-channel.js
@@ -28,7 +28,7 @@ export default class AuthChannel {
     this._signedIn = false;
   };
 
-  verifyAuthentication(authTopic, authToken, authPayload) {
+  verifyAuthentication(authTopic, authToken, authPayload, origin) {
     const channel = this.socket.channel(authTopic);
     return new Promise((resolve, reject) => {
       channel.onError(() => {
@@ -39,13 +39,54 @@ export default class AuthChannel {
       channel
         .join()
         .receive("ok", () => {
+          if (origin === "oidc") {
+            channel
+              .push("auth_verified", { token: authToken, payload: authPayload })
+              .receive("ok", resolve)
+              .receive("error", reject);
+          } else {
+            channel.push("auth_verified", { token: authToken, payload: authPayload });
             channel.on("auth_credentials", async ({ credentials: token, payload: payload }) => {
               await this.handleAuthCredentials({ email: payload.email }, token);
               resolve();
             });
+          }
         })
         .receive("error", reject);
     });
+  }
+
+  async startOIDCAuthentication(hubChannel) {
+    const channel = this.socket.channel(`oidc:${uuid()}`);
+    await new Promise((resolve, reject) =>
+      channel
+        .join()
+        .receive("ok", resolve)
+        .receive("error", reject)
+    );
+
+    const authorizeUrl = await new Promise((resolve, reject) =>
+      channel
+        .push("auth_request")
+        .receive("ok", function({ authorize_url }) {
+          resolve(authorize_url);
+        })
+        .receive("error", reject)
+    );
+
+    window.open(authorizeUrl, "hubs_oidc");
+
+    const authComplete = new Promise(resolve =>
+      channel.on("auth_credentials", async ({ user_info, credentials: token }) => {
+        console.log("got credentials", user_info, token);
+        await this.handleAuthCredentials(user_info, token, hubChannel);
+        resolve();
+      })
+    );
+
+    // Returning an object with the authComplete promise since we want the caller to wait for the above await but not
+    // for authComplete.
+    return { authComplete };
   }
 
   async startAuthentication(email, hubChannel) {

--- a/src/utils/configs.js
+++ b/src/utils/configs.js
@@ -51,9 +51,14 @@ if (window.APP_CONFIG) {
   if (!configs.APP_CONFIG.features) {
     configs.APP_CONFIG.features = {};
   }
+
+  if (!configs.APP_CONFIG.auth) {
+    configs.APP_CONFIG.auth = {};
+  }
 } else {
   configs.APP_CONFIG = {
-    features: {}
+    features: {},
+    auth: {}
   };
 }
 

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -189,7 +189,7 @@ export async function createAndRedirectToNewHub(name, sceneId, replace) {
 
   if (res.error === "invalid_token") {
     // Clear the invalid token from store.
-    store.update({ credentials: { token: null, email: null } });
+    store.update({ credentials: { token: null, email: null, displayName: null } });
 
     // Create hub anonymously
     delete headers.authorization;


### PR DESCRIPTION
This adds support for signing in with OpenID Connect when the Hubs instance is configured to do so. most of the changes are on the backend in https://github.com/mozilla/reticulum/pull/426

At first shipping this will not yet be a "supported" feature as we still need to figure out edge cases, mostly around changing auth providers (you will end up with orphaned accounts, and can also easily lock yourself out of the admin interface).

The admin panel options are all marked as "internal" and so will be hidden unless the `show_internal_configs` query param is added to the admin panel. Additionally the server side configs are hidden behind another query param `show_oidc_configs`, so both should be set when configuring this.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/HUBS-826)
