### PR TITLE
Update environment for any scene transition

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -1565,7 +1565,11 @@ document.addEventListener("DOMContentLoaded", async () => {
     window.APP.hub = hub;
     updateUIForHub(hub, hubChannel);
 
-    if (stale_fields.includes("scene")) {
+    if (
+      stale_fields.includes("scene") ||
+      stale_fields.includes("scene_listing") ||
+      stale_fields.includes("default_environment_gltf_bundle_url")
+    ) {
       const fader = document.getElementById("viewing-camera").components["fader"];
 
       fader.fadeOut().then(() => {


### PR DESCRIPTION
This fix ensures that the scene does in fact change when the hub is updated via the graphql API.