### PR TITLE
Update Error message on iPads for unsupported browser features

### DIFF
--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -458,6 +458,7 @@
   "support.missing-features": "Your browser is missing required features.",
   "support.in-app-browser-ios": "Copy and paste this link directly into Safari",
   "support.in-app-browser-android": "Copy and paste this link directly into Chrome or Firefox",
+  "support.non-safari-ios": "Apple prevents third-party browsers from accessing media devices.",
   "support.update-browser": "Please try switching or updating to a newer browser",
   "support.copy": "copy",
   "support.copied": "copied!",

--- a/src/assets/locales/es.json
+++ b/src/assets/locales/es.json
@@ -457,6 +457,7 @@
   "support.missing-features": "Tu navegador web no cumple con las características requeridas.",
   "support.in-app-browser-ios": "Copia y pega este vínculo directamente en Safari",
   "support.in-app-browser-android": "Copia y pega este vínculo directamente en Chrome o Firefox",
+  "support.non-safari-ios": "Apple impide navegadores web tercero de usar características requeridas.",
   "support.update-browser": "Por favor, trata de cambiar a otro navegador web o actualizar éste",
   "support.copy": "copiar",
   "support.copied": "¡copiado!",

--- a/src/assets/locales/jp.json
+++ b/src/assets/locales/jp.json
@@ -457,6 +457,7 @@
   "support.missing-features": "ブラウザに必要な機能がありません。",
   "support.in-app-browser-ios": "このリンクをコピーしてSafariに直接貼り付けます",
   "support.in-app-browser-android": "このリンクをコピーしてChromeまたはFirefoxに直接貼り付けます",
+  "support.non-safari-ios": "Apple prevents third-party browsers from accessing media devices.",
   "support.update-browser": "新しいブラウザに切り替えてみてください",
   "support.copy": "copy",
   "support.copied": "コピーされました！",

--- a/src/assets/locales/pt-br.json
+++ b/src/assets/locales/pt-br.json
@@ -457,6 +457,7 @@
   "support.missing-features": "Seu navegador não possui os recursos necessários.",
   "support.in-app-browser-ios": "Copie e cole este link diretamente no Safari",
   "support.in-app-browser-android": "Copie e cole este link diretamente no Chrome ou Firefox",
+  "support.non-safari-ios": "Apple prevents third-party browsers from accessing media devices.",
   "support.update-browser": "Tente trocar ou atualizar para um navegador mais recente",
   "support.copy": "copiar",
   "support.copied": "copiado!",

--- a/src/assets/locales/zh.json
+++ b/src/assets/locales/zh.json
@@ -459,6 +459,7 @@
   "support.in-app-browser-ios": "Copy and paste this link directly into Safari",
   "support.in-app-browser-android": "Copy and paste this link directly into Chrome or Firefox",
   "support.update-browser": "Please try switching or updating to a newer browser",
+  "support.non-safari-ios": "Apple prevents third-party browsers from accessing media devices.",
   "support.copy": "copy",
   "support.copied": "copied!",
   "support.details": "details",

--- a/src/support.js
+++ b/src/support.js
@@ -93,6 +93,12 @@ class Support extends React.Component {
                 <FormattedMessage
                   id={detectedOS === "iOS" ? "support.in-app-browser-ios" : "support.in-app-browser-android"}
                 />
+              ) : detectedOS === "Mac OS" && navigator.maxTouchPoints > 2 ? (
+                <div>
+                  <FormattedMessage id={"support.non-safari-ios"} />
+                  <br />
+                  <FormattedMessage id={"support.in-app-browser-ios"} />
+                </div>
               ) : (
                 <FormattedMessage id="support.update-browser" />
               )}


### PR DESCRIPTION
Fixes #3372 in a hacky way. 

If a device does not return 'supported' for all of the required features for Hubs, our error handling detects first for in-app browsers. If an in-app browser is detected, we detect if it is running on iOS or Android, and display an error message with a recommended browser accordingly (Safari if `detectOS` returns iOS; Chrome or Firefox if on Android). If we don't detect that the browser is an in-app browser, we just display the generic 'update your browser' assuming that the browser is out of date. 

However, `detectOS` returns `Mac OS` instead of `iOS` for iPads, which means we're going through the usual flow for generic error messages on iPad. This is (presumably) because user agent strings on iPad now report back as a Mac OS X device. UA for Firefox on iPad is `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15(KHTML, like Gecko) Version/13.1 Safari/605.1.15)` 

In absence of a better suggested way to differentiate between an iPad and Mac OS X desktop/laptop, I looked for touch points on Mac OS X to add the more detailed error string. This is not going to be 100% accurate given the possibility of touch-reporting peripherals, but my logic in deciding this was that the iPad case for Hubs would be significantly more likely than touch-friendly desktop Mac OS X browsers with unsupported features.  If someone wants to take a more in-depth look at `support.js` and refactor it to have better messaging across iOS devices too, please feel free. That was a bit more than I felt like I could take on given that I have no idea how React works. 🙂

Tested on iPhone - still uses existing behavior (displays existing error message)
Tested on Firefox/Safari on Mac - still uses existing behavior (works properly)
Tested on iPad - now has new error message 
Tested on older Firefox (Windows) - still uses existing behavior asking to upgrade

