### PR TITLE
Use qsVREntryType as forcedVREntryType when remounting UI for mobileVR if it is available

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -1070,7 +1070,11 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   availableVREntryTypesPromise.then(async availableVREntryTypes => {
     if (isMobileVR) {
-      remountUI({ availableVREntryTypes, forcedVREntryType: "vr", checkingForDeviceAvailability: false });
+      remountUI({
+        availableVREntryTypes,
+        forcedVREntryType: qsVREntryType || "vr",
+        checkingForDeviceAvailability: false
+      });
 
       if (/Oculus/.test(navigator.userAgent) && "getVRDisplays" in navigator) {
         // HACK - The polyfill reports Cardboard as the primary VR display on startup out ahead of


### PR DESCRIPTION
**Background**

I opened Hubs with `vr_entry_type=2d_now` for automatic testing purpose because I want to shortcut the dialogs and automatically enter a room. But on VR headsets (I used Oculus Quest), the audio setup dialog is displayed.

The reason seems that `forcedVREntryType` is overridden with "vr" for mobileVR.

https://github.com/mozilla/hubs/blob/9ea70d174202679da664904456866c5570a984c8/src/hub.js#L1065

**Suggestion**

I think using `qsVREntryType` if it's available (`forcedVREntryType: qsVREntryType || "vr"`) as it's done for non-mobileVR sounds reasonable.

But I haven't followed all the related code yet. Please let me know if this change can cause any problems in certain scenarios.