### PR TITLE
Room UI Redesign: Add setting to hide/show FPS counter

### DIFF
--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -316,6 +316,7 @@
   "preferences.locale": "Language",
   "preferences.onlyShowNametagsInFreeze": "Only show nametags while frozen",
   "preferences.animateWaypointTransitions": "Animate waypoint transitions",
+  "preferences.showFPSCounter": "Show FPS Counter",
   "preferences.maxResolution": "Max Resolution",
   "preferences.materialQualitySetting": "Material quality",
   "preferences.enableDynamicShadows": "Enable Dynamic Shadows",

--- a/src/assets/locales/es.json
+++ b/src/assets/locales/es.json
@@ -316,6 +316,7 @@
   "preferences.locale": "Idioma",
   "preferences.onlyShowNametagsInFreeze": "Mostrar etiquetas de nombre solo mientras estás congelado",
   "preferences.animateWaypointTransitions": "Animar transiciones de puntos de referencia",
+  "preferences.showFPSCounter": "Show FPS Counter",
   "preferences.maxResolution": "Resolución máxima",
   "preferences.materialQualitySetting": "Calidad del material",
   "preferences.enableDynamicShadows": "Activar sombras dinámicas",

--- a/src/assets/locales/jp.json
+++ b/src/assets/locales/jp.json
@@ -316,6 +316,7 @@
   "preferences.locale": "言語",
   "preferences.onlyShowNametagsInFreeze": "フリーズ中の名前タグのみを表示",
   "preferences.animateWaypointTransitions": "ウェイポイントトランジションをアニメーション化",
+  "preferences.showFPSCounter": "Show FPS Counter",
   "preferences.maxResolution": "最大解像度",
   "preferences.materialQualitySetting": "マテリアル品質",
   "preferences.enableDynamicShadows": "ダイナミックシャドウを有効にする",

--- a/src/assets/locales/pt-br.json
+++ b/src/assets/locales/pt-br.json
@@ -316,6 +316,7 @@
   "preferences.locale": "Idioma",
   "preferences.onlyShowNametagsInFreeze": "Mostrar nomes de usuário apenas quando congelado",
   "preferences.animateWaypointTransitions": "Transições de pontos de referência animados",
+  "preferences.showFPSCounter": "Show FPS Counter",
   "preferences.maxResolution": "Resolução máxima",
   "preferences.materialQualitySetting": "Qualidade do material",
   "preferences.enableDynamicShadows": "Habilitar Sombras Dinâmicas",

--- a/src/assets/locales/zh.json
+++ b/src/assets/locales/zh.json
@@ -316,6 +316,7 @@
   "preferences.locale": "Language",
   "preferences.onlyShowNametagsInFreeze": "当停止不动时只显示用户标签",
   "preferences.animateWaypointTransitions": "Animate waypoint transitions",
+  "preferences.showFPSCounter": "Show FPS Counter",
   "preferences.maxResolution": "最大分辨率 (宽 x 高 以像素为单位)",
   "preferences.materialQualitySetting": "材质质量 (需要重启)",
   "preferences.enableDynamicShadows": "Enable Dynamic Shadows",

--- a/src/components/stats-plus.css
+++ b/src/components/stats-plus.css
@@ -14,10 +14,11 @@
   font-family: monospace;
   cursor: pointer;
   position: absolute;
-  bottom: 0px;
+  bottom: 96px;
   right: 2px;
   padding: 4px 8px;
-  color: #aaa;
+  color: #ffffff;
+  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.5);
   font-size: 10px;
   -moz-user-select: none;
   -webkit-user-select: none;

--- a/src/components/stats-plus.js
+++ b/src/components/stats-plus.js
@@ -130,6 +130,13 @@ AFRAME.registerComponent("stats-plus", {
   tick(time) {
     const stats = this.stats;
     if (!this.statsEl) return;
+    if (this.showFPSCounter !== window.APP.store.state.preferences.showFPSCounter) {
+      this.showFPSCounter = window.APP.store.state.preferences.showFPSCounter;
+      this.fpsEl.style.display = this.showFPSCounter ? "block" : "none";
+    }
+    if (!this.showFPSCounter) {
+      return;
+    }
     if (this.data || this.vrStatsEnabled) {
       // Update rStats
       stats("rAF").tick();
@@ -180,10 +187,6 @@ AFRAME.registerComponent("stats-plus", {
         ].join("\n")
       );
       this.lastUpdate = time;
-    }
-    if (this.showFPSCounter !== window.APP.store.state.preferences.showFPSCounter) {
-      this.showFPSCounter = window.APP.store.state.preferences.showFPSCounter;
-      this.fpsEl.style.display = this.showFPSCounter ? "block" : "none";
     }
   },
   onEnterVr() {

--- a/src/components/stats-plus.js
+++ b/src/components/stats-plus.js
@@ -66,6 +66,8 @@ AFRAME.registerComponent("stats-plus", {
     this.lastFps = 0;
     this.frameCount = 0;
     this.inVR = scene.is("vr-mode");
+    this.showFPSCounter = window.APP.store.state.preferences.showFPSCounter;
+    this.fpsEl.style.display = this.showFPSCounter ? "block" : "none";
 
     if (scene.isMobile) {
       this.statsEl.classList.add("rs-mobile");
@@ -178,6 +180,10 @@ AFRAME.registerComponent("stats-plus", {
         ].join("\n")
       );
       this.lastUpdate = time;
+    }
+    if (this.showFPSCounter !== window.APP.store.state.preferences.showFPSCounter) {
+      this.showFPSCounter = window.APP.store.state.preferences.showFPSCounter;
+      this.fpsEl.style.display = this.showFPSCounter ? "block" : "none";
     }
   },
   onEnterVr() {

--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -618,7 +618,8 @@ const DEFINITIONS = new Map([
       { key: "allowMultipleHubsInstances", prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX, defaultBool: false },
       { key: "disableIdleDetection", prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX, defaultBool: false },
       { key: "preferMobileObjectInfoPanel", prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX, defaultBool: false },
-      { key: "animateWaypointTransitions", prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX, defaultBool: true }
+      { key: "animateWaypointTransitions", prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX, defaultBool: true },
+      { key: "showFPSCounter", prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX, defaultBool: false }
     ]
   ]
 ]);

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -100,6 +100,7 @@ export const SCHEMA = {
         enableOnScreenJoystickRight: { type: "bool" },
         onlyShowNametagsInFreeze: { type: "bool" },
         animateWaypointTransitions: { type: "bool" },
+        showFPSCounter: { type: "bool" },
         allowMultipleHubsInstances: { type: "bool" },
         disableIdleDetection: { type: "bool" },
         preferMobileObjectInfoPanel: { type: "bool" },


### PR DESCRIPTION
The FPS counter was stuck in the bottom right corner of the screen, inside the toolbar. This PR moves it into the bottom right corner of the viewport and also makes it a preference. This means you can turn it off on mobile and prevent yourself from accidentally pressing it. It's also just not something that should be important for a majority of users so it is hidden by default.