### PR TITLE
Switch colors of the close room dialogue buttons so "Cancel" is highlighted

### DIFF
--- a/src/assets/stylesheets/close-room-dialog.scss
+++ b/src/assets/stylesheets/close-room-dialog.scss
@@ -1,12 +1,12 @@
 @import 'shared';
 
 :local(.confirm-button) {
-  @extend %action-button;
+  @extend %action-button-secondary;
   margin-top: 8px;
 }
 
 :local(.cancel-button) {
-  @extend %action-button-secondary;
+  @extend %action-button;
   margin-top: 8px;
 }
 

--- a/src/assets/stylesheets/promote-client-dialog.scss
+++ b/src/assets/stylesheets/promote-client-dialog.scss
@@ -1,6 +1,6 @@
 @import 'shared';
 
-:local(.confirm-button) {
+:local(.promote-button) {
   @extend %action-button;
   margin-top: 8px;
   flex-direction: row;

--- a/src/react-components/promote-client-dialog.js
+++ b/src/react-components/promote-client-dialog.js
@@ -19,7 +19,7 @@ export default class PromoteClientDialog extends Component {
           <FormattedMessage id="promote.message" />
         </div>
         <button
-          className={styles.confirmButton}
+          className={styles.promoteButton}
           onClick={() => {
             this.props.onConfirm();
             this.props.onClose();


### PR DESCRIPTION
We occasionally get emails from people who have accidentally closed their rooms (see https://github.com/mozilla/hubs/issues/2060) - this update makes the "cancel" button brighter so people will hopefully be less likely to quickly click through and shut their room down by mistake.  