### PR TITLE
Room UI Redesign: Invite Link Popover and Fixes

### DIFF
--- a/src/react-components/popover/Popover.js
+++ b/src/react-components/popover/Popover.js
@@ -80,12 +80,12 @@ export function Popover({
       };
 
       if (visible) {
-        window.addEventListener("click", onClick);
+        window.addEventListener("mousedown", onClick);
         window.addEventListener("keydown", onKeyDown);
       }
 
       return () => {
-        window.removeEventListener("click", onClick);
+        window.removeEventListener("mousedown", onClick);
         window.removeEventListener("keydown", onKeyDown);
       };
     },

--- a/src/react-components/room/InviteLinkInputField.js
+++ b/src/react-components/room/InviteLinkInputField.js
@@ -1,0 +1,61 @@
+import React, { useState, useCallback } from "react";
+import PropTypes from "prop-types";
+import styles from "./RoomSettingsSidebar.scss";
+import { IconButton } from "../input/IconButton";
+import { FormattedMessage } from "react-intl";
+import { CopyableTextInputField } from "../input/CopyableTextInputField";
+
+export function InviteLinkInputField({ fetchingInvite, inviteUrl, onRevokeInvite }) {
+  const [showRevokeConfirmation, setShowRevokeConfirmation] = useState(false);
+
+  const revokeInvite = useCallback(() => {
+    setShowRevokeConfirmation(true);
+  }, []);
+
+  const cancelConfirmRevokeInvite = useCallback(() => {
+    setShowRevokeConfirmation(false);
+  }, []);
+
+  const confirmRevokeInvite = useCallback(
+    () => {
+      onRevokeInvite();
+      setShowRevokeConfirmation(false);
+    },
+    [onRevokeInvite]
+  );
+
+  return (
+    <CopyableTextInputField
+      label="Invite link"
+      disabled={fetchingInvite}
+      value={fetchingInvite ? "Generating invite..." : inviteUrl}
+      buttonPreset="blue"
+      description={
+        !fetchingInvite &&
+        (showRevokeConfirmation ? (
+          <>
+            <FormattedMessage id="room-settings.revoke-confirm" />{" "}
+            <IconButton className={styles.confirmRevokeButton} onClick={confirmRevokeInvite}>
+              <FormattedMessage id="room-settings.revoke-confirm-yes" />
+            </IconButton>{" "}
+            /{" "}
+            <IconButton className={styles.confirmRevokeButton} onClick={cancelConfirmRevokeInvite}>
+              <FormattedMessage id="room-settings.revoke-confirm-no" />
+            </IconButton>
+          </>
+        ) : (
+          <IconButton className={styles.confirmRevokeButton} onClick={revokeInvite}>
+            <FormattedMessage id="room-settings.revoke" />
+          </IconButton>
+        ))
+      }
+      fullWidth
+    />
+  );
+}
+
+InviteLinkInputField.propTypes = {
+  fetchingInvite: PropTypes.bool,
+  inviteUrl: PropTypes.string,
+  onRevokeInvite: PropTypes.func.isRequired
+};

--- a/src/react-components/room/InvitePopover.js
+++ b/src/react-components/room/InvitePopover.js
@@ -6,13 +6,22 @@ import { Popover } from "../popover/Popover";
 import { ToolbarButton } from "../input/ToolbarButton";
 import { ReactComponent as InviteIcon } from "../icons/Invite.svg";
 import { Column } from "../layout/Column";
+import { InviteLinkInputField } from "./InviteLinkInputField";
 
-function InvitePopoverContent({ url, code, embed }) {
+function InvitePopoverContent({ url, code, embed, inviteRequired, fetchingInvite, inviteUrl, revokeInvite }) {
   return (
     <Column center padding className={styles.invitePopover}>
-      <CopyableTextInputField label="Room Link" value={url} buttonPreset="green" />
-      <CopyableTextInputField label="Room Code" value={code} buttonPreset="blue" />
-      <CopyableTextInputField label="Embed Code" value={embed} buttonPreset="purple" />
+      {inviteRequired ? (
+        <>
+          <InviteLinkInputField fetchingInvite={fetchingInvite} inviteUrl={inviteUrl} onRevokeInvite={revokeInvite} />
+        </>
+      ) : (
+        <>
+          <CopyableTextInputField label="Room Link" value={url} buttonPreset="green" />
+          <CopyableTextInputField label="Room Code" value={code} buttonPreset="blue" />
+          <CopyableTextInputField label="Embed Code" value={embed} buttonPreset="purple" />
+        </>
+      )}
     </Column>
   );
 }
@@ -20,14 +29,39 @@ function InvitePopoverContent({ url, code, embed }) {
 InvitePopoverContent.propTypes = {
   url: PropTypes.string.isRequired,
   code: PropTypes.string.isRequired,
-  embed: PropTypes.string.isRequired
+  embed: PropTypes.string.isRequired,
+  inviteRequired: PropTypes.bool,
+  fetchingInvite: PropTypes.bool,
+  inviteUrl: PropTypes.string,
+  revokeInvite: PropTypes.func
 };
 
-export function InvitePopoverButton({ url, code, embed, initiallyVisible, popoverApiRef, ...rest }) {
+export function InvitePopoverButton({
+  url,
+  code,
+  embed,
+  initiallyVisible,
+  popoverApiRef,
+  inviteRequired,
+  fetchingInvite,
+  inviteUrl,
+  revokeInvite,
+  ...rest
+}) {
   return (
     <Popover
       title="Invite"
-      content={() => <InvitePopoverContent url={url} code={code} embed={embed} />}
+      content={() => (
+        <InvitePopoverContent
+          url={url}
+          code={code}
+          embed={embed}
+          inviteRequired={inviteRequired}
+          fetchingInvite={fetchingInvite}
+          inviteUrl={inviteUrl}
+          revokeInvite={revokeInvite}
+        />
+      )}
       placement="top-start"
       offsetDistance={28}
       initiallyVisible={initiallyVisible}

--- a/src/react-components/room/InvitePopover.stories.js
+++ b/src/react-components/room/InvitePopover.stories.js
@@ -3,7 +3,10 @@ import { RoomLayout } from "../layout/RoomLayout";
 import { InvitePopoverButton } from "./InvitePopover";
 
 export default {
-  title: "InvitePopover"
+  title: "InvitePopover",
+  parameters: {
+    layout: "fullscreen"
+  }
 };
 
 const room = {
@@ -19,6 +22,10 @@ export const Base = () => (
   />
 );
 
-Base.parameters = {
-  layout: "fullscreen"
-};
+export const InviteLink = () => (
+  <RoomLayout
+    toolbarCenter={
+      <InvitePopoverButton inviteRequired initiallyVisible inviteUrl="https://hubs.mozilla.com/123?hub_invite_id=123" />
+    }
+  />
+);

--- a/src/react-components/room/InvitePopoverContainer.js
+++ b/src/react-components/room/InvitePopoverContainer.js
@@ -3,8 +3,9 @@ import PropTypes from "prop-types";
 import configs from "../../utils/configs";
 import { InvitePopoverButton } from "./InvitePopover";
 import { handleExitTo2DInterstitial } from "../../utils/vr-interstitial";
+import { useInviteUrl } from "./useInviteUrl";
 
-export function InvitePopoverContainer({ hub, scene, ...rest }) {
+export function InvitePopoverContainer({ hub, hubChannel, scene, ...rest }) {
   // TODO: Move to Hub class
   const shortLink = `https://${configs.SHORTLINK_DOMAIN}/${hub.hub_id}`;
   const embedUrl = `${location.protocol}//${location.host}${location.pathname}?embed_token=${hub.embed_token}`;
@@ -30,10 +31,35 @@ export function InvitePopoverContainer({ hub, scene, ...rest }) {
     [scene, popoverApiRef]
   );
 
-  return <InvitePopoverButton url={shortLink} code={code} embed={embedText} popoverApiRef={popoverApiRef} {...rest} />;
+  const inviteRequired = hub.entry_mode === "invite";
+  const canGenerateInviteUrl = hubChannel.can("update_hub");
+
+  const { fetchingInvite, inviteUrl, revokeInvite } = useInviteUrl(
+    hubChannel,
+    !inviteRequired || !canGenerateInviteUrl
+  );
+
+  if (inviteRequired && !canGenerateInviteUrl) {
+    return null;
+  }
+
+  return (
+    <InvitePopoverButton
+      inviteRequired={inviteRequired}
+      fetchingInvite={fetchingInvite}
+      inviteUrl={inviteUrl}
+      revokeInvite={revokeInvite}
+      url={shortLink}
+      code={code}
+      embed={embedText}
+      popoverApiRef={popoverApiRef}
+      {...rest}
+    />
+  );
 }
 
 InvitePopoverContainer.propTypes = {
-  hub: PropTypes.object,
-  scene: PropTypes.object
+  hub: PropTypes.object.isRequired,
+  scene: PropTypes.object.isRequired,
+  hubChannel: PropTypes.object.isRequired
 };

--- a/src/react-components/room/MoreMenuPopover.js
+++ b/src/react-components/room/MoreMenuPopover.js
@@ -6,11 +6,11 @@ import { Popover } from "../popover/Popover";
 import { ToolbarButton } from "../input/ToolbarButton";
 import { ReactComponent as MoreIcon } from "../icons/More.svg";
 
-function MoreMenuItem({ item }) {
+function MoreMenuItem({ item, closePopover }) {
   const Icon = item.icon;
 
   return (
-    <li>
+    <li onClick={closePopover}>
       {item.href ? (
         <a
           className={styles.moreMenuItemTarget}
@@ -38,32 +38,37 @@ MoreMenuItem.propTypes = {
     icon: PropTypes.elementType.isRequired,
     label: PropTypes.node.isRequired,
     onClick: PropTypes.func
-  }).isRequired
+  }).isRequired,
+  closePopover: PropTypes.func.isRequired
 };
 
-function MoreMenuGroup({ group }) {
+function MoreMenuGroup({ group, closePopover }) {
   return (
     <li>
       <h1 className={styles.moreMenuGroupLabel}>{group.label}</h1>
-      <ul className={styles.moreMenuItemList}>{group.items.map(item => <MoreMenuItem key={item.id} item={item} />)}</ul>
+      <ul className={styles.moreMenuItemList}>
+        {group.items.map(item => <MoreMenuItem key={item.id} item={item} closePopover={closePopover} />)}
+      </ul>
     </li>
   );
 }
 
 MoreMenuGroup.propTypes = {
-  group: PropTypes.object.isRequired
+  group: PropTypes.object.isRequired,
+  closePopover: PropTypes.func.isRequired
 };
 
-function MoreMenuPopoverContent({ menu }) {
+function MoreMenuPopoverContent({ menu, closePopover }) {
   return (
     <div className={styles.moreMenuPopover}>
-      <ul>{menu.map(group => <MoreMenuGroup key={group.id} group={group} />)}</ul>
+      <ul>{menu.map(group => <MoreMenuGroup key={group.id} group={group} closePopover={closePopover} />)}</ul>
     </div>
   );
 }
 
 MoreMenuPopoverContent.propTypes = {
-  menu: PropTypes.array.isRequired
+  menu: PropTypes.array.isRequired,
+  closePopover: PropTypes.func.isRequired
 };
 
 // The MoreMenuContext allows us to control the more menu popover visibility from the MoreMenuPopoverButton
@@ -86,7 +91,7 @@ export function MoreMenuPopoverButton({ menu }) {
   return (
     <Popover
       title="More"
-      content={() => <MoreMenuPopoverContent menu={menu} />}
+      content={props => <MoreMenuPopoverContent menu={menu} {...props} />}
       placement="top-end"
       offsetDistance={28}
       isVisible={visible}

--- a/src/react-components/room/RoomSettingsSidebar.js
+++ b/src/react-components/room/RoomSettingsSidebar.js
@@ -1,11 +1,10 @@
-import React, { useState, useCallback, useEffect } from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { useForm } from "react-hook-form";
 import styles from "./RoomSettingsSidebar.scss";
 import { Sidebar } from "../sidebar/Sidebar";
 import { CloseButton } from "../input/CloseButton";
 import { InputField } from "../input/InputField";
-import { IconButton } from "../input/IconButton";
 import { FormattedMessage } from "react-intl";
 import { Button } from "../input/Button";
 import { TextInputField } from "../input/TextInputField";
@@ -13,10 +12,10 @@ import { TextAreaInputField } from "../input/TextAreaInputField";
 import { ToggleInput } from "../input/ToggleInput";
 import { RadioInputField, RadioInputOption } from "../input/RadioInputField";
 import { NumericInputField } from "../input/NumericInputField";
-import { CopyableTextInputField } from "../input/CopyableTextInputField";
 import { BackButton } from "../input/BackButton";
 import { SceneInfo } from "./RoomSidebar";
 import { Column } from "../layout/Column";
+import { InviteLinkInputField } from "./InviteLinkInputField";
 
 export function RoomSettingsSidebar({
   showBackButton,
@@ -35,21 +34,6 @@ export function RoomSettingsSidebar({
   const { handleSubmit, register, watch, errors, setValue } = useForm({
     defaultValues: room
   });
-
-  const [showRevokeConfirmation, setShowRevokeConfirmation] = useState(false);
-  const revokeInvite = useCallback(() => {
-    setShowRevokeConfirmation(true);
-  }, []);
-  const cancelConfirmRevokeInvite = useCallback(() => {
-    setShowRevokeConfirmation(false);
-  }, []);
-  const confirmRevokeInvite = useCallback(
-    () => {
-      onRevokeInvite();
-      setShowRevokeConfirmation(false);
-    },
-    [onRevokeInvite]
-  );
 
   const entryMode = watch("entry_mode");
   const spawnAndMoveMedia = watch("member_permissions.spawn_and_move_media");
@@ -129,32 +113,7 @@ export function RoomSettingsSidebar({
           />
         </RadioInputField>
         {entryMode === "invite" && (
-          <CopyableTextInputField
-            label="Invite link"
-            disabled={fetchingInvite}
-            value={fetchingInvite ? "..." : inviteUrl}
-            buttonPreset="blue"
-            description={
-              !fetchingInvite &&
-              (showRevokeConfirmation ? (
-                <>
-                  <FormattedMessage id="room-settings.revoke-confirm" />{" "}
-                  <IconButton className={styles.confirmRevokeButton} onClick={confirmRevokeInvite}>
-                    <FormattedMessage id="room-settings.revoke-confirm-yes" />
-                  </IconButton>{" "}
-                  /{" "}
-                  <IconButton className={styles.confirmRevokeButton} onClick={cancelConfirmRevokeInvite}>
-                    <FormattedMessage id="room-settings.revoke-confirm-no" />
-                  </IconButton>
-                </>
-              ) : (
-                <IconButton className={styles.confirmRevokeButton} onClick={revokeInvite}>
-                  <FormattedMessage id="room-settings.revoke" />
-                </IconButton>
-              ))
-            }
-            fullWidth
-          />
+          <InviteLinkInputField fetchingInvite={fetchingInvite} inviteUrl={inviteUrl} onRevokeInvite={onRevokeInvite} />
         )}
         {showPublicRoomSetting && (
           <ToggleInput

--- a/src/react-components/room/RoomSettingsSidebarContainer.js
+++ b/src/react-components/room/RoomSettingsSidebarContainer.js
@@ -1,61 +1,8 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback } from "react";
 import PropTypes from "prop-types";
 import { RoomSettingsSidebar } from "./RoomSettingsSidebar";
 import configs from "../../utils/configs";
-import { hubUrl } from "../../utils/phoenix-utils";
-
-function useInviteUrl(hubChannel) {
-  const [inviteId, setInviteId] = useState();
-
-  useEffect(
-    () => {
-      setInviteId(undefined);
-
-      hubChannel
-        .fetchInvite()
-        .then(({ hub_invite_id }) => {
-          setInviteId(hub_invite_id);
-        })
-        .catch(error => {
-          console.error("Error fetching invite", error);
-        });
-    },
-    [hubChannel]
-  );
-
-  const revokeInvite = useCallback(
-    () => {
-      setInviteId(undefined);
-
-      hubChannel
-        .revokeInvite(inviteId)
-        .then(({ hub_invite_id }) => {
-          setInviteId(hub_invite_id);
-        })
-        .catch(error => {
-          console.error("Error revoking invite", error);
-        });
-    },
-    [inviteId, hubChannel]
-  );
-
-  const inviteUrl = useMemo(
-    () => {
-      if (inviteId) {
-        const url = hubUrl();
-        url.searchParams.set("hub_invite_id", inviteId);
-        return url.toString();
-      }
-
-      return undefined;
-    },
-    [inviteId]
-  );
-
-  const fetchingInvite = !inviteId;
-
-  return { fetchingInvite, inviteUrl, revokeInvite };
-}
+import { useInviteUrl } from "./useInviteUrl";
 
 export function RoomSettingsSidebarContainer({ showBackButton, room, hubChannel, onChangeScene, onClose }) {
   const maxRoomSize = configs.feature("max_room_size");

--- a/src/react-components/room/useInviteUrl.js
+++ b/src/react-components/room/useInviteUrl.js
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { hubUrl } from "../../utils/phoenix-utils";
+
+export function useInviteUrl(hubChannel, disabled = false) {
+  const [inviteId, setInviteId] = useState();
+
+  useEffect(
+    () => {
+      setInviteId(undefined);
+
+      if (disabled) {
+        return;
+      }
+
+      hubChannel
+        .fetchInvite()
+        .then(({ hub_invite_id }) => {
+          if (disabled) {
+            return;
+          }
+
+          setInviteId(hub_invite_id);
+        })
+        .catch(error => {
+          console.error("Error fetching invite", error);
+        });
+    },
+    [hubChannel, disabled]
+  );
+
+  const revokeInvite = useCallback(
+    () => {
+      setInviteId(undefined);
+
+      if (disabled) {
+        return;
+      }
+
+      hubChannel
+        .revokeInvite(inviteId)
+        .then(({ hub_invite_id }) => {
+          if (disabled) {
+            return;
+          }
+
+          setInviteId(hub_invite_id);
+        })
+        .catch(error => {
+          console.error("Error revoking invite", error);
+        });
+    },
+    [inviteId, hubChannel, disabled]
+  );
+
+  const inviteUrl = useMemo(
+    () => {
+      if (inviteId && !disabled) {
+        const url = hubUrl();
+        url.searchParams.set("hub_invite_id", inviteId);
+        return url.toString();
+      }
+
+      return undefined;
+    },
+    [inviteId, disabled]
+  );
+
+  const fetchingInvite = !inviteId && !disabled;
+
+  return { fetchingInvite, inviteUrl, revokeInvite };
+}

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1593,7 +1593,13 @@ class UIRoot extends Component {
                         accountId={this.props.sessionId}
                         room={this.props.hub}
                         canEdit={this.props.hubChannel.canOrWillIfCreator("update_hub")}
-                        onEdit={() => this.setSidebar("room-info-settings")}
+                        onEdit={() => {
+                          this.props.performConditionalSignIn(
+                            () => this.props.hubChannel.can("update_hub"),
+                            () => this.setSidebar("room-info-settings"),
+                            "room-settings"
+                          );
+                        }}
                         onClose={() => this.setSidebar(null)}
                         onChangeScene={this.onChangeScene}
                       />
@@ -1622,7 +1628,13 @@ class UIRoot extends Component {
                 )
               }
               modal={this.state.dialog || (renderEntryFlow && entryDialog)}
-              toolbarLeft={<InvitePopoverContainer hub={this.props.hub} scene={this.props.scene} />}
+              toolbarLeft={
+                <InvitePopoverContainer
+                  hub={this.props.hub}
+                  hubChannel={this.props.hubChannel}
+                  scene={this.props.scene}
+                />
+              }
               toolbarCenter={
                 <>
                   {watching && (


### PR DESCRIPTION
Fixes: https://github.com/mozilla/hubs/issues/3459

The invite popover shows the redesign link when it is required and if you have permission to retrieve it via the Hub Channel. If it is required but you don't have permission, the invite popover button will be hidden. I made it so we can reuse the `InviteLinkInputField` and `useInviteUrl` code between the `RoomSettingsSidebar` and `InvitePopover` components.

In the process I noticed that the "Edit" button at the top of the `RoomSidebar` component was visible when you didn't have permission to edit the room. I've fixed that bug. I also noticed that the revoke invite link button closed the popover component because it changed the content of the popover before the `click` event fired. So I moved the event to use `mousedown`. This exposed a bug with the `MoreMenuSidebar` where clicking on items wouldn't close the popover so I added an explicit call to `closePopover`.