### PR TITLE
Remove DynamicsCompressor audio node from AudioNormalizer to reduce the noise

### DIFF
--- a/src/components/avatar-volume-controls.js
+++ b/src/components/avatar-volume-controls.js
@@ -10,7 +10,6 @@ class AudioNormalizer {
   constructor(audio) {
     this.audio = audio;
     this.analyser = audio.context.createAnalyser();
-    this.compressor = audio.context.createDynamicsCompressor();
     this.connected = false;
 
     // To analyse volume, 32 fftsize may be good enough
@@ -19,10 +18,6 @@ class AudioNormalizer {
     this.timeData = new Uint8Array(this.analyser.frequencyBinCount);
     this.volumes = [];
     this.volumeSum = 0;
-
-    // To protect user's ears, we insert compressor in case of misguessing the volume.
-    // Threshold -30 is just an arbitary number so far.
-    this.compressor.threshold.setValueAtTime(-30, audio.context.currentTime);
   }
 
   apply() {
@@ -77,7 +72,7 @@ class AudioNormalizer {
       this.audio.disconnect();
     }
     const filters = this.audio.getFilters();
-    filters.unshift(this.analyser, this.gain, this.compressor);
+    filters.unshift(this.analyser, this.gain);
     this.audio.setFilters(filters);
     if (this.audio.source && !this.audio.isPlaying) {
       this.audio.connect();
@@ -89,7 +84,7 @@ class AudioNormalizer {
     if (this.audio.source && !this.audio.isPlaying) {
       this.audio.disconnect();
     }
-    const filters = [this.analyser, this.gain, this.compressor];
+    const filters = [this.analyser, this.gain];
     this.audio.setFilters(this.audio.getFilters().filter(filter => !filters.includes(filter)));
     if (this.audio.source && !this.audio.isPlaying) {
       this.audio.connect();


### PR DESCRIPTION
Related issue: #3252 

**Description**

I figured out that one of the main factors which amplify the background noise if Dynamic Audio Normalization is turned on is Dynamics compressor audio node.

The compressor node has been originally inserted as limiter in case the AudioNormalizer misestimates the audio volume, it unexpectedly the audio volume much louder, and it breaks user's ears or audio devices.

I'd like to remove the compressor node for now because I first want to evaluate the simplest normalization and I haven't heard such misestimation (yet). I may think of the limiter later if needed.

This PR reduces the noise but still another noise reduction may be necessary. Because the AudioNormalizer just controls the gain so it doesn't change the noise ratio. For example if a speaker speaks quietly and a mic has noise, the noise ratio may be big. If the AudioNormalizer increases the gain, the noise can be annoying. I would like to think of further reduction later if needed.