### PR TITLE
reexecute enableChromeAEC if network changed

### DIFF
--- a/src/systems/audio-system.js
+++ b/src/systems/audio-system.js
@@ -115,15 +115,12 @@ export class AudioSystem {
     this.analyserLevels = new Uint8Array(this.outboundAnalyser.fftSize);
     this.outboundGainNode.connect(this.outboundAnalyser);
     this.outboundAnalyser.connect(this.mediaStreamDestinationNode);
-    let alreadyExecuting = false;
 
     /**
      * Chrome and Safari will start Audio contexts in a "suspended" state.
      * A user interaction (touch/mouse event) is needed in order to resume the AudioContext.
      */
     const resume = () => {
-      if (alreadyExecuting) return;
-      alreadyExecuting = true;
       this.audioContext.resume();
 
       setTimeout(() => {

--- a/src/systems/audio-system.js
+++ b/src/systems/audio-system.js
@@ -6,7 +6,10 @@ function performDelayedReconnect(gainNode) {
 
   delayedReconnectTimeout = setTimeout(() => {
     delayedReconnectTimeout = null;
-    console.warn("enableChromeAEC: recreate RTCPeerConnection loopback because the local connection was disconnected for 10s");
+    console.warn(
+      "enableChromeAEC: recreate RTCPeerConnection loopback because the local connection was disconnected for 10s"
+    );
+    // eslint-disable-next-line no-use-before-define
     enableChromeAEC(gainNode);
   }, 10000);
 }
@@ -39,8 +42,10 @@ async function enableChromeAEC(gainNode) {
   outboundPeerConnection.addEventListener("icecandidate", e => {
     inboundPeerConnection.addIceCandidate(e.candidate).catch(onError);
   });
-  outboundPeerConnection.addEventListener("iceconnectionstatechange", e => {
-    console.warn("enableChromeAEC: outboundPeerConnection state changed to " + outboundPeerConnection.iceConnectionState);
+  outboundPeerConnection.addEventListener("iceconnectionstatechange", () => {
+    console.warn(
+      "enableChromeAEC: outboundPeerConnection state changed to " + outboundPeerConnection.iceConnectionState
+    );
     if (outboundPeerConnection.iceConnectionState === "disconnected") {
       performDelayedReconnect(gainNode);
     }
@@ -56,7 +61,7 @@ async function enableChromeAEC(gainNode) {
   inboundPeerConnection.addEventListener("icecandidate", e => {
     outboundPeerConnection.addIceCandidate(e.candidate).catch(onError);
   });
-  inboundPeerConnection.addEventListener("iceconnectionstatechange", e => {
+  inboundPeerConnection.addEventListener("iceconnectionstatechange", () => {
     console.warn("enableChromeAEC: inboundPeerConnection state changed to " + inboundPeerConnection.iceConnectionState);
     if (inboundPeerConnection.iceConnectionState === "disconnected") {
       performDelayedReconnect(gainNode);


### PR DESCRIPTION
When the network change from wired to Wi-Fi, the RTCPeerConnection loopback stays disconnected, recreate it after 10s if it didn't get back to connected.

![Capture d’écran de 2020-12-19 14-40-31](https://user-images.githubusercontent.com/112249/102691021-cdcf8400-4209-11eb-907c-20d04273b00b.png)

Note : this is only a partial fix. There is still an issue with the websocket and Send Transport that doesn't reconnect. It just stays disconnected on Chrome.