### PR TITLE
Add null reference check to avatar morphs

### DIFF
--- a/src/components/audio-feedback.js
+++ b/src/components/audio-feedback.js
@@ -216,7 +216,7 @@ AFRAME.registerComponent("morph-audio-feedback", {
   },
 
   tick() {
-    if (!this.morphs.length) return;
+    if (!this.morphs || !this.morphs.length) return;
 
     if (!this.analyser) this.analyser = getAnalyser(this.el);
 


### PR DESCRIPTION
Custom GLB avatars can end up not having morphs and break the client when they are loaded.