### PR TITLE
Update networked aframe with transform validation checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13225,8 +13225,8 @@
       "dev": true
     },
     "networked-aframe": {
-      "version": "github:mozillareality/networked-aframe#f4b1f1ccc8871149be2e3aaa24ca665e481c716a",
-      "from": "github:mozillareality/networked-aframe#master",
+      "version": "github:mozillareality/networked-aframe#a1f1ec48caacadd6e4fcf13f413509d3bfe1aef6",
+      "from": "github:mozillareality/networked-aframe#fix/remote-clients-sending-invalid-data-cherry-picked",
       "requires": {
         "buffered-interpolation": "^0.2.5",
         "easyrtc": "1.1.0"

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "markdown-it": "^8.4.2",
     "moving-average": "^1.0.0",
     "naf-janus-adapter": "^4.0.1",
-    "networked-aframe": "github:mozillareality/networked-aframe#master",
+    "networked-aframe": "github:mozillareality/networked-aframe#fix/remote-clients-sending-invalid-data-cherry-picked",
     "nipplejs": "github:mozillareality/nipplejs#mr-social-client/master",
     "node-ensure": "0.0.0",
     "pdfjs-dist": "^2.1.266",


### PR DESCRIPTION
Updating networked-aframe to a specific branch which is based on https://github.com/MozillaReality/networked-aframe/commit/f4b1f1ccc8871149be2e3aaa24ca665e481c716a and includes https://github.com/MozillaReality/networked-aframe/pull/43

We need to point to a specific branch for now, since networked-aframe#master contains newer fixes that will be included with the redesign.