### PR TITLE
Room UI Redesign: Fix Canvas Resize Handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15737,7 +15737,7 @@
       "dev": true
     },
     "aframe": {
-      "version": "github:mozillareality/aframe#05b980199e5e79e7dde1f6acb63ca74660ceee33",
+      "version": "github:mozillareality/aframe#64ec7c07170b71981a9ab7ae7617ee40b18c2f36",
       "from": "github:mozillareality/aframe#hubs/master",
       "requires": {
         "custom-event-polyfill": "^1.0.6",
@@ -38222,9 +38222,9 @@
       }
     },
     "webvr-polyfill-dpdb": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/webvr-polyfill-dpdb/-/webvr-polyfill-dpdb-1.0.17.tgz",
-      "integrity": "sha512-WOd4s0gSrb0fOlOtIpqFbwLBATax/ka7DFAB/u+C9KJBBJk1/x/FZlFynOqsNrUxMJniOdO7ViFJwVdMScMQzA=="
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/webvr-polyfill-dpdb/-/webvr-polyfill-dpdb-1.0.18.tgz",
+      "integrity": "sha512-O0S1ZGEWyPvyZEkS2VbyV7mtir/NM9MNK3EuhbHPoJ8EHTky2pTXehjIl+IiDPr+Lldgx129QGt3NGly7rwRPw=="
     },
     "well-known-symbols": {
       "version": "2.0.0",

--- a/src/hub.html
+++ b/src/hub.html
@@ -54,6 +54,7 @@
     <div id="support-root"></div>
 
     <a-scene
+        disable-resize
         embedded
         vr-mode-ui="enabled: false"
         loading-screen="enabled: false"

--- a/src/react-components/room/useResizeViewport.js
+++ b/src/react-components/room/useResizeViewport.js
@@ -43,20 +43,6 @@ export function useResizeViewport(viewportRef, store, scene) {
 
   useEffect(
     () => {
-      const oldResizeFunc = scene.resize;
-
-      // HACK: Override native AFRAME resize handler for our own.
-      scene.resize = () => {};
-
-      return () => {
-        scene.resize = oldResizeFunc;
-      };
-    },
-    [scene]
-  );
-
-  useEffect(
-    () => {
       function onStoreChanged() {
         const { maxResolutionWidth, maxResolutionHeight } = store.state.preferences;
 
@@ -107,6 +93,8 @@ export function useResizeViewport(viewportRef, store, scene) {
 
         // Resizing the canvas clears it, so render immediately after resize to prevent flicker.
         scene.renderer.render(scene.object3D, scene.camera);
+
+        scene.emit("rendererresize", null, false);
       });
 
       observer.observe(viewportRef.current);


### PR DESCRIPTION
The `useResizeViewport` hook I created defines it's own resize handler. AFrame has an early bound resize handler that uses an anonymous function to call it's own resize method. Previously I tried hacking my way around AFrame's resize handler by overwriting it with a no-op function in the hook. It didn't handle the resize event calling the anonymous function which in turn called the original resize handler.

This PR introduces a `disable-resize` attribute on the `a-scene` element ([commit here](https://github.com/MozillaReality/aframe/commit/64ec7c07170b71981a9ab7ae7617ee40b18c2f36)). When you add it, Aframe's resize handler is disabled and we can properly use the `useResizeViewport` hook.

Fixes #3534 