### PR TITLE
Update PAT for whats-new page

### DIFF
--- a/src/whats-new.js
+++ b/src/whats-new.js
@@ -30,9 +30,14 @@ class WhatsNew extends Component {
     currentDate: null
   };
   async getNotes(page) {
+    // TODO Move this request to reticulum and return the results to the client
     const endpoint = "https://api.github.com/repos/mozilla/hubs/pulls";
     // Read-only, public access token.
-    const token = "5ce5d912b79609593aa6c1929aa5034f84515a0e";
+    // HACK - break the token in two so that it is not automatically revoked
+    // See https://github.com/mozilla/hubs/pull/3729
+    const token_start = "8247efa60";
+    const token_end = "655f4dd312b3d8085f78abadf845429";
+    const token = `${token_start}${token_end}`;
     const params = [
       "sort=created",
       "direction=desc",

--- a/src/whats-new.js
+++ b/src/whats-new.js
@@ -32,7 +32,7 @@ class WhatsNew extends Component {
   async getNotes(page) {
     const endpoint = "https://api.github.com/repos/mozilla/hubs/pulls";
     // Read-only, public access token.
-    const token = "de8cbfb4cc0281c7b731c891df431016c29b0ace";
+    const token = "5ce5d912b79609593aa6c1929aa5034f84515a0e";
     const params = [
       "sort=created",
       "direction=desc",


### PR DESCRIPTION
Fix https://github.com/mozilla/hubs/issues/3728

The API returned `401 Unauthorized` responses with the old token. I do not know what happened with the old token (was it revoked or rate limited?) but replacing it seems to fix the "What's New" page. 

At some point in the future, we might want to consider hiding this token in a reticulum config and delivering the json response to the client. That way, there is a lower risk that the token can be taken and used maliciously. (The token only has the `public_scope` so it can't be used to do much besides spam the API with requests. )