### PR TITLE
Add git hook to prevent accidental commits to protected branches

### DIFF
--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -10,6 +10,6 @@ then
   exit 1
 fi
 
-echo -e ">> pre-push git hook: Finished.\n==="
+echo -e "pre-push git hook: Finished."
 
 exit 0

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,15 @@
+#!/bin/bash
+echo -e "pre-push git hook: Checking to make sure you are not pushing to a protected branch."
+
+BRANCH=`git rev-parse --abbrev-ref HEAD`
+PROTECTED_BRANCHES="^(master|main|git-hook-pre-push-test)"
+
+if [[ "$BRANCH" =~ $PROTECTED_BRANCHES ]]
+then
+  echo -e "  🚫 error: The remote $BRANCH branch is protected. If this is not a mistake, disable this pre-push git hook (<hubs_dir>/.git/hooks/pre-push) and try again."
+  exit 1
+fi
+
+echo -e ">> pre-push git hook: Finished.\n==="
+
+exit 0

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -35,7 +35,7 @@ do
       timestamp="$(date +%F_%H-%M-%S)"
       backup="${dest_hook}.backup.${timestamp}"
       echo "    Warning: ${dest_hook} already exists."
-      echo "    Creating a backup so that it is permanently lost:"
+      echo "    Creating a backup so that it is not lost:"
       echo "      ${backup}"
       mv "${dest_hook}" ${backup}
   fi

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# Install git hooks from <hubs_dir>/hooks to <hubs_dir>/.git/hooks
+# If a hook already exists, it will create a backup in the <hubs_dir>.git/hooks directory so that nothing is destroyed.
+#
+# Instructions:
+#   - Make this script executable, e.g.
+#       chmod +x ./scripts/install-hooks.sh
+#   - Run this script:
+#       ./scripts/install-hooks.sh
+
+dot_git_hooks=".git/hooks/"
+if [[ ! -d "${dot_git_hooks}" ]];
+then
+    echo "Error: Could not find .git/hooks directory. ${dot_git_hooks}"
+    exit 1
+fi
+
+hooks_dir="./hooks/"
+if [[ ! -d "${hooks_dir}" ]];
+then
+    echo "Error: Could not find ./hooks directory. ${hooks_dir}"
+    exit 1
+fi
+
+echo "==="
+echo "Installing hooks..."
+for hook in $(find ${hooks_dir} -type f -exec basename {} \;);
+do
+  echo "  Installing ${hook} hook:"
+  src_hook="${hooks_dir}${hook}"
+  dest_hook="${dot_git_hooks}${hook}"
+  if [[ -f "${dest_hook}" ]];
+  then
+      timestamp="$(date +%F_%H-%M-%S)"
+      backup="${dest_hook}.backup.${timestamp}"
+      echo "    Warning: ${dest_hook} already exists."
+      echo "    Creating a backup so that it is permanently lost:"
+      echo "      ${backup}"
+      mv "${dest_hook}" ${backup}
+  fi
+
+  echo "    Copying ${src_hook} to ${dest_hook} ."
+  cp "${src_hook}" "${dest_hook}"
+
+  echo "    Marking ${dest_hook} as executable."
+  chmod +x "${dest_hook}"
+done
+
+
+echo "==="

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -23,8 +23,7 @@ then
     exit 1
 fi
 
-echo "==="
-echo "Installing hooks..."
+echo "Installing git hooks..."
 for hook in $(find ${hooks_dir} -type f -exec basename {} \;);
 do
   echo "  Installing ${hook} hook:"
@@ -46,6 +45,4 @@ do
   echo "    Marking ${dest_hook} as executable."
   chmod +x "${dest_hook}"
 done
-
-
-echo "==="
+echo "Finished installing hooks."


### PR DESCRIPTION
This morning I accidentally pushed a [commit](https://github.com/mozilla/reticulum/commit/7fa96b35296c45d142ec82c45b6e1e8194ef9268) to `reticulum`'s `master` branch. [Git hooks](https://git-scm.com/docs/githooks#_description) can be configured to prevent this from happening. 

This PR contains two files for bash users
- a [`pre-push`](https://git-scm.com/docs/githooks#_pre_push) git hook that prevents me from pushing to protected branches
- an install script that (non-destructively) copies the files from `<hubs>/hooks` into `<hubs>/.git/hooks`

```
[jomb@jlomb2 hubs]$ ./scripts/install-hooks.sh 
Installing git hooks...
  Installing pre-push hook:
    Warning: .git/hooks/pre-push already exists.
    Creating a backup so that it is not lost:
      .git/hooks/pre-push.backup.2021-01-20_14-25-12
    Copying ./hooks/pre-push to .git/hooks/pre-push .
    Marking .git/hooks/pre-push as executable.
Finished installing hooks.
```
Now if I try to push to a protected branch, the hook prevents it from happening:
```
[jomb@jlomb2 hubs]$ git push origin git-hook-pre-push-test
pre-push git hook: Checking to make sure you are not pushing to a protected branch...
  🚫 error: The remote git-hook-pre-push-test branch is protected. If this is not a mistake, disable this pre-push git hook (<hubs_dir>/.git/hooks/pre-push) and try again.
error: failed to push some refs to 'https://github.com/mozilla/hubs/'
```

Opportunities to improve this:
- Use platform-agnostic tools for the hooks and the install script (like node.js or python)
- Move the install script and hooks to hubs-ops to make it easier to install across multiple directories
- Find out how other teams manage git-hooks.