### PR TITLE
Fix waypoint teleport height

### DIFF
--- a/src/systems/character-controller-system.js
+++ b/src/systems/character-controller-system.js
@@ -125,8 +125,16 @@ export class CharacterControllerSystem {
         inPosition.setFromMatrixPosition(inMat4Copy);
         this.findPositionOnNavMesh(inPosition, inPosition, outPosition, true);
         finalPOV.setPosition(outPosition);
+        translation.makeTranslation(0, getCurrentPlayerHeight(), -0.15);
+      } else {
+        // If we are not snapping to the nav mesh, align the user's
+        // perspective exactly to the robot eyes as they appear in the
+        // waypoint indicator. (1.6 meters up and 0.15 meters forward)
+        // This does _not_ require taking the player's height into account
+        // on this line because we are only interested in where the
+        // camera will end up.
+        translation.makeTranslation(0, 1.6, -0.15);
       }
-      translation.makeTranslation(0, getCurrentPlayerHeight(), -0.15);
       finalPOV.multiply(translation);
       if (willMaintainInitialOrientation) {
         initialOrientation.extractRotation(this.avatarPOV.object3D.matrixWorld);


### PR DESCRIPTION
In a previous PR https://github.com/mozilla/hubs/pull/2226 , I changed how the camera height was calculated when traveling to a `waypoint`. I cited this behavior as a bug:

> when we spawned at a waypoint that was not snapped to the nav mesh, we used a default height of 1.6 meters. If the current player height was different than that, we would end up above or below the floor. 

But I believe this diagnosis was incorrect, and only the second thing listed in the PR was a problem:
> we need to delay spawning at the waypoint

My "fix" made it impossible to create vr-enabled `waypoint` "seats" like those pictured below:
![image](https://user-images.githubusercontent.com/4072106/105258113-e3ec9f00-5b3d-11eb-8c33-400cbde25c61.png)
(Credit Discord user Dreamwriter#8148 . These should be lowered so that the robots are in the car, and `"Snap to floor plan"` should be disabled.)

If a `waypoint` does not have `"Snap to floor plan"` enabled, then:
- fly mode should be enabled (with `shouldLandWhenPossible` enabled too)
- the `avatar POV node` should be aligned with the robot's eyes. (I am referring to the robot that appears when the `waypoint` icon is hovered or appears in Spoke when you place a `waypoint` in a scene.)

This second objective is achieved by using the hard-coded value of 1.6 meters (the height of the robot's eyes above the waypoint transform) when calculating the `finalPOV`. Note that this is wrong for waypoints that are not at unit scale `(1,1,1)`, but I did not want to address scale issues in this PR. There is a separate issue tracking problems with waypoint scaling https://github.com/mozilla/hubs/issues/3724

If a waypoint author wants to align people based on the floor position, they need to use `"Snap to floor plan"`. There is no option to create a waypoint that is not snapped to the floor plan that will align people by their "floor point".

Thanks @j-conrad and Discord user Dreamwriter#8148 for bringing this to my attention.

