### PR TITLE
Ensure Networked Aframe is on the correct version for the redesign launch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27753,8 +27753,8 @@
       "dev": true
     },
     "networked-aframe": {
-      "version": "github:mozillareality/networked-aframe#a1f1ec48caacadd6e4fcf13f413509d3bfe1aef6",
-      "from": "github:mozillareality/networked-aframe#fix/remote-clients-sending-invalid-data-cherry-picked",
+      "version": "github:mozillareality/networked-aframe#ae8ca30fcded2369c8702686b07cce46dfc16306",
+      "from": "github:mozillareality/networked-aframe#master",
       "requires": {
         "buffered-interpolation": "^0.2.5",
         "easyrtc": "1.1.0"

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "markdown-it": "^8.4.2",
     "moving-average": "^1.0.0",
     "naf-janus-adapter": "^4.0.1",
-    "networked-aframe": "github:mozillareality/networked-aframe#fix/remote-clients-sending-invalid-data-cherry-picked",
+    "networked-aframe": "github:mozillareality/networked-aframe#master",
     "nipplejs": "github:mozillareality/nipplejs#mr-social-client/master",
     "node-ensure": "0.0.0",
     "normalize.css": "^8.0.1",


### PR DESCRIPTION
This keeps getting reverted to the `fix/remote-clients-sending-invalid-data-cherry-picked` branch. It should be this one: https://github.com/mozilla/hubs/pull/3614