### PR TITLE
Show safari mic modal if mic permissions denied

### DIFF
--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -203,10 +203,6 @@ class UIRoot extends Component {
   constructor(props) {
     super(props);
 
-    if (props.showSafariMicDialog) {
-      this.state.dialog = <SafariMicModal />;
-    }
-
     props.mediaSearchStore.setHistory(props.history);
 
     // An exit handler that discards event arguments and can be cleaned up.
@@ -954,9 +950,17 @@ class UIRoot extends Component {
       );
     }
 
+    if (this.props.showSafariMicDialog) {
+      return (
+        <div className={classNames(rootStyles)}>
+          <RoomLayoutContainer scene={this.props.scene} store={this.props.store} modal={<SafariMicModal />} />
+        </div>
+      );
+    }
+
     const preload = this.props.showPreload;
 
-    const isLoading = !preload && !this.state.hideLoader && !this.props.showSafariMicDialog;
+    const isLoading = !preload && !this.state.hideLoader;
 
     if (isLoading && this.state.showPrefs) {
       return (


### PR DESCRIPTION
Prior to the redesign we always showed the safari mic permissions modal when the user had denied microphone permissions. This PR re-enables that behavior. I do wonder if this hack is still needed or if there is a better behavior. Until that is properly researched and tested, I think we should move back to the old behavior and ensure that the user is properly notified when they have disallowed microphone access.