### PR TITLE
Allow billboard component in gltfs

### DIFF
--- a/src/components/scene-components.js
+++ b/src/components/scene-components.js
@@ -2,6 +2,7 @@ import "./animation";
 import "./ambient-light";
 import "./animation-mixer";
 import "./audio-feedback";
+import "./billboard";
 import "./css-class";
 import "./directional-light";
 import "./duck";

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -70,7 +70,7 @@ AFRAME.GLTFModelPlus.registerComponent("directional-light", "directional-light")
 AFRAME.GLTFModelPlus.registerComponent("hemisphere-light", "hemisphere-light");
 AFRAME.GLTFModelPlus.registerComponent("point-light", "point-light");
 AFRAME.GLTFModelPlus.registerComponent("spot-light", "spot-light");
-
+AFRAME.GLTFModelPlus.registerComponent("billboard", "billboard");
 AFRAME.GLTFModelPlus.registerComponent("simple-water", "simple-water");
 AFRAME.GLTFModelPlus.registerComponent("skybox", "skybox");
 AFRAME.GLTFModelPlus.registerComponent("layers", "layers");

--- a/src/hub.js
+++ b/src/hub.js
@@ -109,7 +109,6 @@ import "./components/replay";
 import "./components/visibility-by-path";
 import "./components/tags";
 import "./components/hubs-text";
-import "./components/billboard";
 import "./components/periodic-full-syncs";
 import "./components/inspect-button";
 import "./components/inspect-pivot-child-selector";


### PR DESCRIPTION
This PR is a dependency of https://github.com/mozilla/Spoke/pull/1087

This adds the billboard gltf component mapping and moves the billboard component registration to `scene-components.js` so that it appears properly on the scene page.