### PR TITLE
Re-enable ability to hide lobby modal with spectate button

### DIFF
--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -809,9 +809,7 @@ class UIRoot extends Component {
           }}
           showEnterOnDevice={!this.state.waitingOnAudio && !this.props.entryDisallowed && !isMobileVR}
           onEnterOnDevice={() => this.attemptLink()}
-          showSpectate={
-            !this.state.waitingOnAudio && !this.props.entryDisallowed && configs.feature("enable_lobby_ghosts")
-          }
+          showSpectate={!this.state.waitingOnAudio && !this.props.entryDisallowed}
           onSpectate={() => this.setState({ watching: true })}
           showOptions={this.props.hubChannel.canOrWillIfCreator("update_hub")}
           onOptions={() => {

--- a/src/systems/ui-hotkeys.js
+++ b/src/systems/ui-hotkeys.js
@@ -60,9 +60,7 @@ AFRAME.registerSystem("ui-hotkeys", {
     }
 
     if (this.userinput.get(paths.actions.toggleUI)) {
-      if (this.el.sceneEl.is("entered")) {
-        this.el.emit("action_toggle_ui");
-      }
+      this.el.emit("action_toggle_ui");
     }
   },
 


### PR DESCRIPTION
This PR re-enables the ability to hide lobby modal with spectate button and makes it so you can toggle the UI visibility from anywhere in the app. Because `enable_lobby_ghosts` is checked when adding the `is-ghost` class, we can be sure that flying is disabled when `enable_lobby_ghosts` is not set.