### PR TITLE
Enable WebXR support for Windows Mixed Reality headsets in Google Chrome and Microsoft Edge

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -1,8 +1,8 @@
+import "./utils/debug-log";
 import "./webxr-bypass-hacks";
 import configs from "./utils/configs";
 import "./utils/theme";
 import "@babel/polyfill";
-import "./utils/debug-log";
 
 console.log(`App version: ${process.env.BUILD_VERSION || "?"}`);
 

--- a/src/systems/userinput/bindings/windows-mixed-reality-user.js
+++ b/src/systems/userinput/bindings/windows-mixed-reality-user.js
@@ -224,7 +224,7 @@ function characterAccelerationBindings() {
     {
       src: { value: paths.device.wmr.left.joystick.axisX },
       dest: { value: lJoyXDeadzoned },
-      xform: xforms.deadzone(0.1)
+      xform: xforms.deadzone(0.2)
     },
     {
       src: { value: lJoyXDeadzoned },
@@ -234,7 +234,7 @@ function characterAccelerationBindings() {
     {
       src: { value: paths.device.wmr.left.joystick.axisY },
       dest: { value: lJoyYDeadzoned },
-      xform: xforms.deadzone(0.1)
+      xform: xforms.deadzone(0.2)
     },
     {
       src: { value: lJoyYDeadzoned },

--- a/src/utils/vr-caps-detect.js
+++ b/src/utils/vr-caps-detect.js
@@ -50,6 +50,7 @@ export async function getAvailableVREntryTypes() {
   // This needs to be kept up-to-date with the latest browsers that can support VR and Hubs.
   // Checking for navigator.getVRDisplays always passes b/c of polyfill.
   const isWebVRCapableBrowser = window.hasNativeWebVRImplementation;
+  const isWebXRCapableBrowser = window.hasNativeWebXRImplementation;
 
   const isDaydreamCapableBrowser = !!(isWebVRCapableBrowser && browser.name === "chrome" && !isSamsungBrowser);
   const isIDevice = AFRAME.utils.device.isIOS();
@@ -130,6 +131,10 @@ export async function getAvailableVREntryTypes() {
       // If we didn't detect daydream in a daydream capable browser, we definitely can't run daydream at all.
       daydream = VR_DEVICE_AVAILABILITY.no;
     }
+  }
+
+  if (isWebXRCapableBrowser) {
+    generic = true;
   }
 
   return { screen, generic, gearvr, daydream, cardboard, safari };

--- a/src/webxr-bypass-hacks.js
+++ b/src/webxr-bypass-hacks.js
@@ -1,29 +1,29 @@
 import qsTruthy from "./utils/qs_truthy";
 
 const isOculusBrowser = /oculusbrowser/i.test(navigator.userAgent);
+const isMobileVR = /mobile vr/i.test(navigator.userAgent);
+const isFirefox = /firefox/i.test(navigator.userAgent);
+const hasWebVRapi = "getVRDisplays" in navigator;
 
 /*
 HACK: Our fork of aframe will read this global in src/utils/device.js to force the WebVR codepaths.
+For now we want to continue using WebVR in Firefox on desktop and Firefox Reality.
 */
-window.forceWebVR = !qsTruthy("no_force_webvr") && (!isOculusBrowser || "getVRDisplays" in navigator);
+const isNonFirefoxWebXR = !isFirefox && "xr" in navigator && "requestSession" in navigator.xr;
+window.forceWebVR = !qsTruthy("no_force_webvr") && (!isNonFirefoxWebXR || hasWebVRapi);
 
 /*
 HACK Fix a-frame's device detection in Chrome when WebXR or WebVR flags are enabled in
 chrome://flags. See https://github.com/mozilla/hubs/issues/892
 */
-if (
-  !/mobile vr/i.test(navigator.userAgent) &&
-  !isOculusBrowser &&
-  /Chrome/.test(navigator.userAgent) &&
-  navigator.xr &&
-  !navigator.xr.requestDevice
-) {
+if (!isMobileVR && !isNonFirefoxWebXR && navigator.xr && !navigator.xr.requestDevice) {
   navigator.xr.requestDevice = () => Promise.reject({ message: "Hubs: requestDevice not supported." });
 }
+
 /*
 HACK Call getVRDisplays to force Oculus Browser to use WebVR, which in turn disables the WebXR API.
 This should only take effect in older version of Oculus Browser that still have the getVRDisplays API.
 */
-if (isOculusBrowser && "getVRDisplays" in navigator) {
+if (isOculusBrowser && hasWebVRapi) {
   navigator.getVRDisplays();
 }


### PR DESCRIPTION
Enables WebXR support in Chrome and Edge. Both those browsers have support for Windows Mixed Reality headsets enabled by default. 

Tested with a WMR headset in Chrome, Edge. Regression tested in Firefox desktop, and Firefox Reality and Oculus Browser on the Quest

Support for Oculus and Vive/Valve/HTC (SteamVR/OpenVR/OpenXR) headsets seems to be unavailable in the latest versions of Chrome and Edge. Those devices will have to be worked on separately.

Closes #3076 