### PR TITLE
Allow webxr gamepads that are not connected to update

### DIFF
--- a/src/systems/userinput/devices/webxr-controller.js
+++ b/src/systems/userinput/devices/webxr-controller.js
@@ -22,7 +22,7 @@ export class WebXRControllerDevice {
     this.orientation = new THREE.Quaternion();
   }
   write(frame, scene, referenceSpace) {
-    if (!referenceSpace || !this.gamepad || !this.gamepad.connected) return;
+    if (!referenceSpace || !this.gamepad) return;
 
     const hand = this.gamepad.hand || "right";
     const path = paths.device.webxr[hand];


### PR DESCRIPTION
It seems like devices from the [WebXR API Emulator](https://github.com/mozilla/hubs/compare/bug/webxr-extension?expand=1) do not identify as being `connected`. If we ignore this property, the extension works in hubs.
