### PR TITLE
Wrongly displayed mobile icon on VR

### DIFF
--- a/src/react-components/room/PeopleSidebar.js
+++ b/src/react-components/room/PeopleSidebar.js
@@ -17,12 +17,12 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 function getDeviceLabel(ctx, intl) {
   if (ctx) {
-    if (ctx.mobile) {
-      return intl.formatMessage({ id: "people-sidebar.device-label.mobile", defaultMessage: "Mobile" });
+    if (ctx.hmd) {
+      return intl.formatMessage({ id: "people-sidebar.device-label.vr", defaultMessage: "VR" });
     } else if (ctx.discord) {
       return intl.formatMessage({ id: "people-sidebar.device-label.discord", defaultMessage: "Discord Bot" });
-    } else if (ctx.hmd) {
-      return intl.formatMessage({ id: "people-sidebar.device-label.vr", defaultMessage: "VR" });
+    } else if (ctx.mobile) {
+      return intl.formatMessage({ id: "people-sidebar.device-label.mobile", defaultMessage: "Mobile" });
     }
   }
 
@@ -31,12 +31,12 @@ function getDeviceLabel(ctx, intl) {
 
 function getDeviceIconComponent(ctx) {
   if (ctx) {
-    if (ctx.mobile) {
-      return PhoneIcon;
+    if (ctx.hmd) {
+      return VRIcon;
     } else if (ctx.discord) {
       return DiscordIcon;
-    } else if (ctx.hmd) {
-      return VRIcon;
+    } else if (ctx.mobile) {
+      return PhoneIcon;
     }
   }
 


### PR DESCRIPTION
Inside `hub.js` starting from `L:1086` `params` object is initialized. Given that `isMobileVR` is true, `mobile: true` and `hmd: true` as well.

```js
context: {
     mobile: true,
     ...,
     hmd: true
  }
```

The `if` statement in `PeopleSidebar` component, first `checks` whether `mobile` is `true` as it's first `condition`. It was always true when `isMobileVR` is true. It `returned` with the `mobile icon` leaving no chance for `ctx.hmd` to be evaluated to `true`.

I was thinking of removing the `||` operator and its `right hand` operand `isMobileVR` from `hub.js` on `L:1092` but not sure about the outcome, how many components depend on this `context` etc... Discarded the `idea`.

```js
context: {
        mobile: isMobile || isMobileVR, // <- this bad boy
        embed: isEmbed
      },
```

With the above solution, not breaking anything but for VR the correct icon gets rendered.