### PR TITLE
add the min-line height needed to display letter "g" properly to dropdown

### DIFF
--- a/src/assets/stylesheets/shared.scss
+++ b/src/assets/stylesheets/shared.scss
@@ -368,6 +368,7 @@ $breakpoint-xxl: 1600px; // Extra Large Desktops
   position: relative;
   display: flex;
   align-items: center;
+  line-height: 20px;
 }
 %dropdown-select {
   @extend %rounded-border;


### PR DESCRIPTION
Adding the `min` `line-height` needed, `"g"` character can be rendered properly.

<img width="365" alt="Screenshot 2021-02-04 at 4 17 09" src="https://user-images.githubusercontent.com/20890308/106840301-28c91780-66a0-11eb-82fb-57d41a4bc457.png">
