### PR TITLE
Limit dropdown horizontal size to prevent long text overlap on arrow

### DIFF
--- a/src/assets/stylesheets/shared.scss
+++ b/src/assets/stylesheets/shared.scss
@@ -381,6 +381,7 @@ $breakpoint-xxl: 1600px; // Extra Large Desktops
   padding: 6px;
   font-weight: bold;
   padding-right: 30px;
+  max-width: 170px;
 }
 %dropdown-arrow {
   pointer-events: none;


### PR DESCRIPTION
- After providing a `max` width to the `select` element:


<img width="771" alt="Screenshot 2021-02-04 at 5 17 36" src="https://user-images.githubusercontent.com/20890308/106844419-c9233a00-66a8-11eb-901b-03022de03de1.png">
<img width="370" alt="Screenshot 2021-02-04 at 5 17 41" src="https://user-images.githubusercontent.com/20890308/106844422-cb859400-66a8-11eb-922f-228a3907f506.png">
