### PR TITLE
Fix: blank page when saved state is invalid

### DIFF
--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -212,7 +212,8 @@ export default class Store extends EventTarget {
   constructor() {
     super();
 
-    if (localStorage.getItem(LOCAL_STORE_KEY) === null) {
+    const savedState = localStorage.getItem(LOCAL_STORE_KEY)
+    if (savedState === null || !validator.validate(JSON.parse(savedState), SCHEMA).valid) {
       localStorage.setItem(LOCAL_STORE_KEY, JSON.stringify({}));
     }
 


### PR DESCRIPTION
When accessing the homepage or room page, if your saved state in local storage does not pass validation, you will see nothing but a blank page with the console error:

```
Uncaught Error: Write to store failed schema validation.
```

This probably only happens to devs who are switching between different versions of Hubs with different storage schemas, but, if it did happen to a user (say they visited a hubs cloud that later rolled back to an earlier version), it would be very difficult to figure how to restore access to the site (i.e. clear local storage)

This fix checks validation of the saved state in the store constructor and clears it if it does not pass. 