### PR TITLE
Fix ICE reconnect flashings

### DIFF
--- a/src/components/audio-feedback.js
+++ b/src/components/audio-feedback.js
@@ -68,7 +68,7 @@ AFRAME.registerComponent("networked-audio-analyser", {
         this.levels = new Uint8Array(this.analyser.fftSize);
         event.detail.soundSource.connect(this.analyser);
       },
-      { once: false }
+      { once: true }
     );
 
     this.playerSessionId = findAncestorWithComponent(this.el, "player-info").components["player-info"].playerSessionId;

--- a/src/components/audio-feedback.js
+++ b/src/components/audio-feedback.js
@@ -68,7 +68,7 @@ AFRAME.registerComponent("networked-audio-analyser", {
         this.levels = new Uint8Array(this.analyser.fftSize);
         event.detail.soundSource.connect(this.analyser);
       },
-      { once: true }
+      { once: false }
     );
 
     this.playerSessionId = findAncestorWithComponent(this.el, "player-info").components["player-info"].playerSessionId;

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -696,19 +696,18 @@ AFRAME.registerComponent("media-video", {
         const stream = await NAF.connection.adapter.getMediaStream(streamClientId, "video");
         // We subscribe to video stream notifications for this peer to update the video element
         // This could happen in case there is an ICE failure that requires a transport recreation.
-        NAF.connection.adapter.addEventListener(streamClientId, "video", {
-          onStreamUpdated: async (peerId, kind) => {
-            if (peerId === streamClientId && kind === "video") {
-              // The video stream for this peer has been updated
-              const stream = await NAF.connection.adapter.getMediaStream(peerId, "video").catch(e => {
-                console.error(`Error getting video stream for ${peerId}`, e);
-              });
-              if (stream) {
-                videoEl.srcObject = new MediaStream(stream);
-              }
+        this._onStreamUpdated = async (peerId, kind) => {
+          if (peerId === streamClientId && kind === "video") {
+            // The video stream for this peer has been updated
+            const stream = await NAF.connection.adapter.getMediaStream(peerId, "video").catch(e => {
+              console.error(`Error getting video stream for ${peerId}`, e);
+            });
+            if (stream) {
+              videoEl.srcObject = new MediaStream(stream);
             }
           }
-        });
+        };
+        NAF.connection.adapter.on("stream_updated", this._onStreamUpdated, this);
         videoEl.srcObject = new MediaStream(stream.getVideoTracks());
         // If hls.js is supported we always use it as it gives us better events
       } else if (contentType.startsWith("application/dash")) {
@@ -959,6 +958,7 @@ AFRAME.registerComponent("media-video", {
     if (this.video) {
       this.video.removeEventListener("pause", this.onPauseStateChange);
       this.video.removeEventListener("play", this.onPauseStateChange);
+      NAF.connection.adapter.off("stream_updated", this._onStreamUpdated);
     }
 
     if (this.hoverMenu) {

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -696,6 +696,9 @@ AFRAME.registerComponent("media-video", {
         const stream = await NAF.connection.adapter.getMediaStream(streamClientId, "video");
         // We subscribe to video stream notifications for this peer to update the video element
         // This could happen in case there is an ICE failure that requires a transport recreation.
+        if (this._onStreamUpdated) {
+          NAF.connection.adapter.off("stream_updated", this._onStreamUpdated);
+        }
         this._onStreamUpdated = async (peerId, kind) => {
           if (peerId === streamClientId && kind === "video") {
             // The video stream for this peer has been updated

--- a/src/naf-dialog-adapter.js
+++ b/src/naf-dialog-adapter.js
@@ -208,7 +208,7 @@ export default class DialogAdapter extends EventEmitter {
   /**
    * Restart ICE in the underlying send peerconnection.
    */
-  async restartSendICE(force = true) {
+  async restartSendICE() {
     // Do not restart ICE if Signaling is disconnected. We are not in the meeting room if that's the case.
     if (this._closed) {
       return;
@@ -216,15 +216,7 @@ export default class DialogAdapter extends EventEmitter {
 
     try {
       if (!this._sendTransport?._closed) {
-        // Renegotiate ICE in case ICE state is "failed".
-        // We also try to renegotiate in case we got stuck in a new state after an ICE failure.
-        if (
-          force ||
-          this._sendTransport.connectionState === "failed" ||
-          (this._sendTransport.connectionState === "new" && this._lastSendConnectionState === "failed")
-        ) {
-          await this.iceRestart(this._sendTransport);
-        }
+        await this.iceRestart(this._sendTransport);
       } else {
         // If the transport is closed but the signaling is connected, we try to recreate
         const { host, port, turn } = await window.APP.hubChannel.getHost();
@@ -244,7 +236,7 @@ export default class DialogAdapter extends EventEmitter {
   checkSendIceStatus(connectionState) {
     // If the ICE connection state is failed, we force an ICE restart
     if (connectionState === "failed") {
-      this.restartSendICE(false);
+      this.restartSendICE();
     }
 
     this._lastSendConnectionState = connectionState;
@@ -261,7 +253,7 @@ export default class DialogAdapter extends EventEmitter {
    * Restart ICE in the underlying receive peerconnection.
    * @param {boolean} force Forces the execution of the reconnect.
    */
-  async restartRecvICE(force = true) {
+  async restartRecvICE() {
     // Do not restart ICE if Signaling is disconnected. We are not in the meeting room if that's the case.
     if (this._closed) {
       return;
@@ -269,16 +261,7 @@ export default class DialogAdapter extends EventEmitter {
 
     try {
       if (!this._recvTransport?._closed) {
-        // Renegotiate ICE in case ICE state is "failed".
-        // We also try to renegotiate in case we got stuck in a new state after an ICE failure.
-        if (
-          force ||
-          this._recvTransport.connectionState === "failed" ||
-          (this._recvTransport.connectionState === "new" && this._lastRecvConnectionState === "failed")
-        ) {
-          // If the transport is closed but the signaling is connected, we try to recreate
-          await this.iceRestart(this._recvTransport);
-        }
+        await this.iceRestart(this._recvTransport);
       } else {
         // If the transport is closed but the signaling is connected, we try to recreate
         const { host, port, turn } = await window.APP.hubChannel.getHost();
@@ -298,7 +281,7 @@ export default class DialogAdapter extends EventEmitter {
   checkRecvIceStatus(connectionState) {
     // If the ICE connection state is failed, we force an ICE restart
     if (connectionState === "failed") {
-      this.restartRecvICE(false);
+      this.restartRecvICE();
     }
 
     this._lastRecvConnectionState = connectionState;

--- a/src/naf-dialog-adapter.js
+++ b/src/naf-dialog-adapter.js
@@ -32,6 +32,7 @@ const PC_PROPRIETARY_CONSTRAINTS = {
 
 const ICE_RECONNECT_INTERVAL = 2000;
 const INITIAL_ROOM_RECONNECTION_INTERVAL = 2000;
+const DISCONNECT_RETRY_DELAY = 2000;
 
 const isFirefox = navigator.userAgent.toLowerCase().indexOf("firefox") > -1;
 
@@ -68,6 +69,9 @@ export default class DialogAdapter {
     this._recvTaskId = null;
     this._closed = true;
     this.scene = document.querySelector("a-scene");
+    this._listeners = new Map();
+    this._isRecreatingSendTransport = false;
+    this._isRecreatingRecvTransport = false;
   }
 
   get serverUrl() {
@@ -146,6 +150,24 @@ export default class DialogAdapter {
     this._onOccupantMessage = messageListener;
   }
 
+  // Add an event listener for a peer and an event type
+  addEventListener(peerId, eventType, listener) {
+    if (!this._listeners.has(peerId)) {
+      this._listeners.set(peerId, {
+        [eventType]: listener
+      });
+    } else {
+      this._listeners.get(peerId)[eventType] = listener;
+    }
+  }
+
+  // Removes an event listener for a peer and an event type
+  removeEventListener(peerId, eventType) {
+    if (this._listeners.has(peerId)) {
+      delete this._listeners.get(peerId)[eventType];
+    }
+  }
+
   /**
    * Gets transport/consumer/producer stats on the server side.
    */
@@ -202,36 +224,91 @@ export default class DialogAdapter {
    * https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/setConfiguration
    * So we recreate the transports/consumer/producers through reconnect to force setting
    * new ICE servers for both send and receive transports.
+   * If we are not using TURN at all we can just restart ICE in any navigator
+   * and avoid the server refresh part.
    */
+
+  async iceRestart(transport) {
+    // Force an ICE restart to gather new candidates and trigger a reconnection
+    this.emitRTCEvent(
+      "log",
+      "RTC",
+      () => `Restarting ${transport.id === this._sendTransport.id ? "send" : "receive"} transport ICE`
+    );
+    const iceParameters = await this._protoo.request("restartIce", { transportId: transport.id });
+    await transport.restartIce({ iceParameters });
+  }
+
+  async tryIceRestart(transport) {
+    // FF automatically attempts to connect after a disconnect but that doesn't happen in Chome/Safari so we retry after 2 secs
+    if (!isFirefox && transport.connectionState === "disconnected") {
+      setTimeout(async () => {
+        if (transport.connectionState === "disconnected") {
+          await this.iceRestart(transport);
+        }
+      }, DISCONNECT_RETRY_DELAY);
+    } else {
+      await this.iceRestart(transport);
+    }
+  }
+
+  async recreateSendTransport(iceServers) {
+    this.emitRTCEvent("log", "RTC", () => `Recreating send transport ICE`);
+    await this.closeSendTransport();
+    await this.createSendTransport(iceServers);
+  }
 
   /**
    * Restart ICE in the underlying send peerconnection.
    */
   async restartSendICE(force = true) {
-    if (!this._sendTransport?._closed) {
-      // Renegotiate ICE in case ICE state is "failed".
-      // Chrome doesn't seem to automatically reconnect after a "disconnected" so we renegotiate in that case.
-      // We also try to renegotiate in case we got stuck in a new state after an ICE failure.
-      if (
-        force ||
-        this._sendTransport.connectionState === "failed" ||
-        (!isFirefox && this._sendTransport.connectionState === "disconnected") ||
-        (this._sendTransport.connectionState === "new" && this._lastSendConnectionState === "failed")
-      ) {
-        this.emitRTCEvent("log", "RTC", () => `Restarting send transport ICE`);
-        if (this._protoo.connected) {
-          if (isFirefox) {
-            this.reconnect();
-          } else if (!this._sendTransport.closed) {
+    // Do not restart ICE if Signaling is disconnected. We are not in the meeting room if that's the case.
+    if (this._closed || this._isRecreatingSendTransport) {
+      return;
+    }
+
+    this._isRecreatingSendTransport = true;
+    try {
+      if (!this._sendTransport?._closed) {
+        // Renegotiate ICE in case ICE state is "failed".
+        // Chrome note: Chrome doesn't seem to automatically reconnect after a "disconnected" so
+        // we renegotiate in that case.
+        // This can be tested taking down the network connection or the TURN server if using TURN, Chrome
+        // recovers fine from the former but not the later.
+        // We also try to renegotiate in case we got stuck in a new state after an ICE failure.
+        if (
+          force ||
+          this._sendTransport.connectionState === "failed" ||
+          (!isFirefox && this._sendTransport.connectionState === "disconnected") ||
+          (this._sendTransport.connectionState === "new" && this._lastSendConnectionState === "failed")
+        ) {
+          if (this._forceTurn || this._forceTcp) {
+            // In casen case we are using the TURN server we need to update the ICE servers as the credentials have probably expired
             const { host, port, turn } = await window.APP.hubChannel.getHost();
             const iceServers = this.getIceServers(host, port, turn);
-            await this._sendTransport.updateIceServers({ iceServers });
-            const iceParameters = await this._protoo.request("restartIce", { transportId: this._sendTransport.id });
-            await this._sendTransport.restartIce({ iceParameters });
+            if (isFirefox) {
+              // FF doesn't support hot updating the ICE servers so we need to recreate
+              await this.recreateSendTransport(iceServers);
+            } else {
+              // For other browsers we can just update them preserving the current transport
+              await this._sendTransport.updateIceServers({ iceServers });
+              await this.tryIceRestart(this._sendTransport);
+            }
+          } else {
+            // If we are using STUN, we can just restart ICE
+            await this.tryIceRestart(this._sendTransport);
           }
         }
+      } else {
+        // If the transport is closed but the signaling is connected, we try to recreate
+        const { host, port, turn } = await window.APP.hubChannel.getHost();
+        const iceServers = this.getIceServers(host, port, turn);
+        await this.recreateSendTransport(iceServers);
       }
+    } catch (err) {
+      this.emitRTCEvent("error", "RTC", () => `Send transport [recreate] failed: ${err}`);
     }
+    this._isRecreatingSendTransport = false;
   }
 
   /**
@@ -240,7 +317,7 @@ export default class DialogAdapter {
    * @param {boolean} connectionState The transport connnection state (ICE connection state)
    */
   checkSendIceStatus(connectionState) {
-    // If the ICE connection state failed we force an ICE negotiation
+    // If the ICE connection state is failed or disconnected, we force an ICE restart
     if (connectionState === "failed" || connectionState === "disconnected") {
       this.restartSendICE(false);
     } else if (connectionState === "connected") {
@@ -253,17 +330,12 @@ export default class DialogAdapter {
 
   /**
    * Starts a watchdog to monitorize the state of the Send Transport ICE connection state.
-   * @param {boolean} force Forces the execution of the reconnect.
    */
-  startSendIceConnectionStateWd(force = false) {
-    if (force) {
-      this.reconnect();
-    } else {
-      if (!this._sendTaskId) {
-        this._sendTaskId = setInterval(() => {
-          this.restartSendICE(false);
-        }, ICE_RECONNECT_INTERVAL);
-      }
+  startSendIceConnectionStateWd() {
+    if (!this._sendTaskId) {
+      this._sendTaskId = setInterval(() => {
+        this.restartSendICE(false);
+      }, ICE_RECONNECT_INTERVAL);
     }
   }
 
@@ -275,44 +347,74 @@ export default class DialogAdapter {
     this._sendTaskId = null;
   }
 
+  async recreateRecvTransport(iceServers) {
+    this.emitRTCEvent("log", "RTC", () => `Recreating receive transport ICE`);
+    await this.closeRecvTransport();
+    await this.createRecvTransport(iceServers);
+    await this.createMissingConsumers();
+  }
+
   /**
    * Restart ICE in the underlying receive peerconnection.
    * @param {boolean} force Forces the execution of the reconnect.
    */
   async restartRecvICE(force = true) {
-    // Renegotiate ICE in case ICE state is "failed".
-    // Chrome doesn't seem to automatically reconnect after a "disconnected" so we renegotiate in that case.
-    // We also try to renegotiate in case we got stuck in a new state after an ICE failure.
-    if (!this._recvTransport?._closed) {
-      if (
-        force ||
-        this._recvTransport.connectionState === "failed" ||
-        (!isFirefox && this._recvTransport.connectionState === "disconnected") ||
-        (this._recvTransport.connectionState === "new" && this._lastRecvConnectionState === "failed")
-      ) {
-        this.emitRTCEvent("log", "RTC", () => `Restarting receive transport ICE`);
-        if (this._protoo.connected) {
-          if (isFirefox) {
-            this.reconnect();
-          } else if (!this._recvTransport.closed) {
+    // Do not restart ICE if Signaling is disconnected. We are not in the meeting room if that's the case.
+    if (this._closed || this._isRecreatingRecvTransport) {
+      return;
+    }
+
+    this._isRecreatingRecvTransport = true;
+    try {
+      if (!this._recvTransport?._closed) {
+        // Renegotiate ICE in case ICE state is "failed".
+        // Chrome note: Chrome doesn't seem to automatically reconnect after a "disconnected" so
+        // we renegotiate in that case.
+        // This can be tested taking down the network connection or the TURN server if using TURN, Chrome
+        // recovers fine from the former but not the later.
+        // We also try to renegotiate in case we got stuck in a new state after an ICE failure.
+        if (
+          force ||
+          this._recvTransport.connectionState === "failed" ||
+          (!isFirefox && this._recvTransport.connectionState === "disconnected") ||
+          (this._recvTransport.connectionState === "new" && this._lastRecvConnectionState === "failed")
+        ) {
+          if (this._forceTurn || this._forceTcp) {
+            // In casen case we are using the TURN server we need to update the ICE servers as the credentials have probably expired
             const { host, port, turn } = await window.APP.hubChannel.getHost();
             const iceServers = this.getIceServers(host, port, turn);
-            await this._recvTransport.updateIceServers({ iceServers });
-            const iceParameters = await this._protoo.request("restartIce", { transportId: this._recvTransport.id });
-            await this._recvTransport.restartIce({ iceParameters });
+            if (isFirefox) {
+              // FF doesn't support hot updating the ICE servers so we need to recreate
+              await this.recreateRecvTransport(iceServers);
+            } else {
+              // For other browsers we can just update them preserving the current transport
+              await this._recvTransport.updateIceServers({ iceServers });
+              await this.tryIceRestart(this._recvTransport);
+            }
+          } else {
+            // If we are using STUN, we can just restart ICE.
+            await this.tryIceRestart(this._recvTransport);
           }
         }
+      } else {
+        // If the transport is closed but the signaling is connected, we try to recreate
+        const { host, port, turn } = await window.APP.hubChannel.getHost();
+        const iceServers = this.getIceServers(host, port, turn);
+        await this.recreateRecvTransport(iceServers);
       }
+    } catch (err) {
+      this.emitRTCEvent("error", "RTC", () => `Receive transport [recreate] failed: ${err}`);
     }
+    this._isRecreatingRecvTransport = false;
   }
 
   /**
-   * Checks the Send Transport ICE status and restarts it in case is in failed or disconnected states.
-   * This is called by the Send Transport "connectionstatechange" event listener.
+   * Checks the ReeceiveReeceive Transport ICE status and restarts it in case is in failed or disconnected states.
+   * This is called by the Reeceive Transport "connectionstatechange" event listener.
    * @param {boolean} connectionState The transport connection state (ICE connection state)
    */
   checkRecvIceStatus(connectionState) {
-    // If the ICE connection state failed we force an ICE negotiation
+    // If the ICE connection state is failed or disconnected, we force an ICE restart
     if (connectionState === "failed" || connectionState === "disconnected") {
       this.restartRecvICE(false);
     } else if (connectionState === "connected") {
@@ -325,17 +427,12 @@ export default class DialogAdapter {
 
   /**
    * Starts a watchdog to monitorize the state of the Receive Transport ICE connection state.
-   * @param {boolean} force Forces the execution of the reconnect.
    */
-  startRecvIceConnectionStateWd(force = false) {
-    if (force) {
-      this.reconnect();
-    } else {
-      if (!this._recvTaskId) {
-        this._recvTaskId = setInterval(() => {
-          this.restartRecvICE(false);
-        }, ICE_RECONNECT_INTERVAL);
-      }
+  startRecvIceConnectionStateWd() {
+    if (!this._recvTaskId) {
+      this._recvTaskId = setInterval(() => {
+        this.restartRecvICE(false);
+      }, ICE_RECONNECT_INTERVAL);
     }
   }
 
@@ -421,6 +518,11 @@ export default class DialogAdapter {
                 this._initialAudioConsumerResolvers.delete(peerId);
               }
             }
+
+            // Notify of an stream update event of type (audio/video)
+            if (this._listeners.has(peerId) && this._listeners.get(peerId)[kind]) {
+              this._listeners.get(peerId)[kind].onStreamUpdated(peerId, kind);
+            }
           } catch (err) {
             this.emitRTCEvent("error", "Adapter", () => `Error: ${err}`);
             error('"newConsumer" request failed:%o', err);
@@ -439,51 +541,14 @@ export default class DialogAdapter {
       switch (notification.method) {
         case "newPeer": {
           const peer = notification.data;
-          this._onOccupantConnected(peer.id);
-          this.occupants[peer.id] = peer;
-
-          if (this._onOccupantsChanged) {
-            this._onOccupantsChanged(this.occupants);
-          }
+          this.newPeer(peer);
 
           break;
         }
 
         case "peerClosed": {
           const { peerId } = notification.data;
-          this._onOccupantDisconnected(peerId);
-
-          const pendingMediaRequests = this._pendingMediaRequests.get(peerId);
-
-          if (pendingMediaRequests) {
-            const msg = "The user disconnected before the media stream was resolved.";
-            info(msg);
-
-            if (pendingMediaRequests.audio) {
-              pendingMediaRequests.audio.resolve(null);
-            }
-
-            if (pendingMediaRequests.video) {
-              pendingMediaRequests.video.resolve(null);
-            }
-
-            this._pendingMediaRequests.delete(peerId);
-          }
-
-          // Resolve initial audio resolver since this person left.
-          const initialAudioResolver = this._initialAudioConsumerResolvers.get(peerId);
-
-          if (initialAudioResolver) {
-            initialAudioResolver();
-
-            this._initialAudioConsumerResolvers.delete(peerId);
-          }
-
-          delete this.occupants[peerId];
-
-          if (this._onOccupantsChanged) {
-            this._onOccupantsChanged(this.occupants);
-          }
+          this.closePeer(peerId);
 
           break;
         }
@@ -519,9 +584,60 @@ export default class DialogAdapter {
     await Promise.all([this.updateTimeOffset(), this._initialAudioConsumerPromise]);
   }
 
+  newPeer(peer) {
+    this._onOccupantConnected(peer.id);
+    this.occupants[peer.id] = peer;
+
+    if (this._onOccupantsChanged) {
+      this._onOccupantsChanged(this.occupants);
+    }
+  }
+
+  closePeer(peerId) {
+    this._onOccupantDisconnected(peerId);
+
+    const pendingMediaRequests = this._pendingMediaRequests.get(peerId);
+
+    if (pendingMediaRequests) {
+      const msg = "The user disconnected before the media stream was resolved.";
+      info(msg);
+
+      if (pendingMediaRequests.audio) {
+        pendingMediaRequests.audio.resolve(null);
+      }
+
+      if (pendingMediaRequests.video) {
+        pendingMediaRequests.video.resolve(null);
+      }
+
+      this._pendingMediaRequests.delete(peerId);
+    }
+
+    // Resolve initial audio resolver since this person left.
+    const initialAudioResolver = this._initialAudioConsumerResolvers.get(peerId);
+
+    if (initialAudioResolver) {
+      initialAudioResolver();
+
+      this._initialAudioConsumerResolvers.delete(peerId);
+    }
+
+    delete this.occupants[peerId];
+
+    if (this._onOccupantsChanged) {
+      this._onOccupantsChanged(this.occupants);
+    }
+
+    // Remove all the event listeners for the peer
+    if (this._listeners.has(peerId)) {
+      this._listeners.remove(peerId);
+    }
+  }
+
   shouldStartConnectionTo() {
     return true;
   }
+
   startStreamConnection() {}
 
   closeStreamConnection() {}
@@ -613,6 +729,182 @@ export default class DialogAdapter {
     // Not implemented
   }
 
+  async createSendTransport(iceServers) {
+    // Create mediasoup Transport for sending (unless we don't want to produce).
+    const sendTransportInfo = await this._protoo.request("createWebRtcTransport", {
+      producing: true,
+      consuming: false,
+      sctpCapabilities: undefined
+    });
+
+    this._sendTransport = this._mediasoupDevice.createSendTransport({
+      id: sendTransportInfo.id,
+      iceParameters: sendTransportInfo.iceParameters,
+      iceCandidates: sendTransportInfo.iceCandidates,
+      dtlsParameters: sendTransportInfo.dtlsParameters,
+      sctpParameters: sendTransportInfo.sctpParameters,
+      iceServers,
+      iceTransportPolicy: this._iceTransportPolicy,
+      proprietaryConstraints: PC_PROPRIETARY_CONSTRAINTS
+    });
+
+    this._sendTransport.on("connect", (
+      { dtlsParameters },
+      callback,
+      errback // eslint-disable-line no-shadow
+    ) => {
+      this.emitRTCEvent("info", "RTC", () => `Send transport [connect]`);
+      this._sendTransport.observer.on("close", () => {
+        this.emitRTCEvent("info", "RTC", () => `Send transport [close]`);
+        !this._sendTransport?._closed && this._sendTransport.close();
+      });
+      this._sendTransport.observer.on("newproducer", producer => {
+        this.emitRTCEvent("info", "RTC", () => `Send transport [newproducer]: ${producer.id}`);
+      });
+      this._sendTransport.observer.on("newconsumer", consumer => {
+        this.emitRTCEvent("info", "RTC", () => `Send transport [newconsumer]: ${consumer.id}`);
+      });
+
+      this._protoo
+        .request("connectWebRtcTransport", {
+          transportId: this._sendTransport.id,
+          dtlsParameters
+        })
+        .then(callback)
+        .catch(errback);
+    });
+
+    this._sendTransport.on("connectionstatechange", connectionState => {
+      let level = "info";
+      if (connectionState === "failed" || connectionState === "disconnected") {
+        level = "error";
+      }
+      this.emitRTCEvent(level, "RTC", () => `Send transport [connectionstatechange]: ${connectionState}`);
+
+      this.checkSendIceStatus(connectionState);
+    });
+
+    this._sendTransport.on("produce", async ({ kind, rtpParameters, appData }, callback, errback) => {
+      this.emitRTCEvent("info", "RTC", () => `Send transport [produce]: ${kind}`);
+      try {
+        // eslint-disable-next-line no-shadow
+        const { id } = await this._protoo.request("produce", {
+          transportId: this._sendTransport.id,
+          kind,
+          rtpParameters,
+          appData
+        });
+
+        callback({ id });
+      } catch (error) {
+        this.emitRTCEvent("error", "Signaling", () => `[produce] error: ${error}`);
+        errback(error);
+      }
+    });
+
+    if (this._localMediaStream) {
+      this.createMissingProducers(this._localMediaStream);
+    }
+  }
+
+  async closeSendTransport() {
+    if (this._micProducer) {
+      this._micProducer.close();
+      this._protoo.connected && this._protoo.request("closeProducer", { producerId: this._micProducer.id });
+      this._micProducer = null;
+    }
+
+    if (this._videoProducer) {
+      this._videoProducer.close();
+      this._protoo.connected && this._protoo.request("closeProducer", { producerId: this._videoProducer.id });
+      this._videoProducer = null;
+    }
+
+    if (!this._sendTransport?._closed) {
+      this._sendTransport.close();
+    }
+
+    if (this._protoo.connected) {
+      try {
+        await this._protoo.request("closeWebRtcTransport", { transportId: this._sendTransport?.id });
+      } catch (err) {
+        error(err);
+      }
+    }
+  }
+
+  async createRecvTransport(iceServers) {
+    // Create mediasoup Transport for sending (unless we don't want to consume).
+    const recvTransportInfo = await this._protoo.request("createWebRtcTransport", {
+      producing: false,
+      consuming: true,
+      sctpCapabilities: undefined
+    });
+
+    this._recvTransport = this._mediasoupDevice.createRecvTransport({
+      id: recvTransportInfo.id,
+      iceParameters: recvTransportInfo.iceParameters,
+      iceCandidates: recvTransportInfo.iceCandidates,
+      dtlsParameters: recvTransportInfo.dtlsParameters,
+      sctpParameters: recvTransportInfo.sctpParameters,
+      iceServers,
+      iceTransportPolicy: this._iceTransportPolicy
+    });
+
+    this._recvTransport.on("connect", (
+      { dtlsParameters },
+      callback,
+      errback // eslint-disable-line no-shadow
+    ) => {
+      this.emitRTCEvent("info", "RTC", () => `Receive transport [connect]`);
+      this._recvTransport.observer.on("close", () => {
+        this.emitRTCEvent("info", "RTC", () => `Receive transport [close]`);
+        !this._recvTransport?._closed && this._recvTransport.close();
+      });
+      this._recvTransport.observer.on("newproducer", producer => {
+        this.emitRTCEvent("info", "RTC", () => `Receive transport [newproducer]: ${producer.id}`);
+      });
+      this._recvTransport.observer.on("newconsumer", consumer => {
+        this.emitRTCEvent("info", "RTC", () => `Receive transport [newconsumer]: ${consumer.id}`);
+      });
+
+      this._protoo
+        .request("connectWebRtcTransport", {
+          transportId: this._recvTransport.id,
+          dtlsParameters
+        })
+        .then(callback)
+        .catch(errback);
+    });
+
+    this._recvTransport.on("connectionstatechange", connectionState => {
+      let level = "info";
+      if (connectionState === "failed" || connectionState === "disconnected") {
+        level = "error";
+      }
+      this.emitRTCEvent(level, "RTC", () => `Receive transport [connectionstatechange]: ${connectionState}`);
+
+      this.checkRecvIceStatus(connectionState);
+    });
+  }
+
+  async closeRecvTransport() {
+    if (!this._recvTransport?._closed) {
+      this._recvTransport.close();
+    }
+    if (this._protoo.connected) {
+      try {
+        await this._protoo.request("closeWebRtcTransport", { transportId: this._recvTransport?.id });
+      } catch (err) {
+        error(err);
+      }
+    }
+  }
+
+  async createMissingConsumers() {
+    await this._protoo.request("getPeers");
+  }
+
   async _joinRoom() {
     debug("_joinRoom()");
 
@@ -626,128 +918,8 @@ export default class DialogAdapter {
       const { host, port, turn } = await window.APP.hubChannel.getHost();
       const iceServers = this.getIceServers(host, port, turn);
 
-      // Create mediasoup Transport for sending (unless we don't want to produce).
-      const sendTransportInfo = await this._protoo.request("createWebRtcTransport", {
-        producing: true,
-        consuming: false,
-        sctpCapabilities: undefined
-      });
-
-      this._sendTransport = this._mediasoupDevice.createSendTransport({
-        id: sendTransportInfo.id,
-        iceParameters: sendTransportInfo.iceParameters,
-        iceCandidates: sendTransportInfo.iceCandidates,
-        dtlsParameters: sendTransportInfo.dtlsParameters,
-        sctpParameters: sendTransportInfo.sctpParameters,
-        iceServers,
-        iceTransportPolicy: this._iceTransportPolicy,
-        proprietaryConstraints: PC_PROPRIETARY_CONSTRAINTS
-      });
-
-      this._sendTransport.on("connect", (
-        { dtlsParameters },
-        callback,
-        errback // eslint-disable-line no-shadow
-      ) => {
-        this.emitRTCEvent("info", "RTC", () => `Send transport [connect]`);
-        this._sendTransport.observer.on("close", () => {
-          this.emitRTCEvent("info", "RTC", () => `Send transport [close]`);
-        });
-        this._sendTransport.observer.on("newproducer", producer => {
-          this.emitRTCEvent("info", "RTC", () => `Send transport [newproducer]: ${producer.id}`);
-        });
-        this._sendTransport.observer.on("newconsumer", consumer => {
-          this.emitRTCEvent("info", "RTC", () => `Send transport [newconsumer]: ${consumer.id}`);
-        });
-
-        this._protoo
-          .request("connectWebRtcTransport", {
-            transportId: this._sendTransport.id,
-            dtlsParameters
-          })
-          .then(callback)
-          .catch(errback);
-      });
-
-      this._sendTransport.on("connectionstatechange", connectionState => {
-        let level = "info";
-        if (connectionState === "failed" || connectionState === "disconnected") {
-          level = "error";
-        }
-        this.emitRTCEvent(level, "RTC", () => `Send transport [connectionstatechange]: ${connectionState}`);
-
-        this.checkSendIceStatus(connectionState);
-      });
-
-      this._sendTransport.on("produce", async ({ kind, rtpParameters, appData }, callback, errback) => {
-        this.emitRTCEvent("info", "RTC", () => `Send transport [produce]: ${kind}`);
-        try {
-          // eslint-disable-next-line no-shadow
-          const { id } = await this._protoo.request("produce", {
-            transportId: this._sendTransport.id,
-            kind,
-            rtpParameters,
-            appData
-          });
-
-          callback({ id });
-        } catch (error) {
-          this.emitRTCEvent("error", "Signaling", () => `[produce] error: ${error}`);
-          errback(error);
-        }
-      });
-
-      // Create mediasoup Transport for sending (unless we don't want to consume).
-      const recvTransportInfo = await this._protoo.request("createWebRtcTransport", {
-        producing: false,
-        consuming: true,
-        sctpCapabilities: undefined
-      });
-
-      this._recvTransport = this._mediasoupDevice.createRecvTransport({
-        id: recvTransportInfo.id,
-        iceParameters: recvTransportInfo.iceParameters,
-        iceCandidates: recvTransportInfo.iceCandidates,
-        dtlsParameters: recvTransportInfo.dtlsParameters,
-        sctpParameters: recvTransportInfo.sctpParameters,
-        iceServers,
-        iceTransportPolicy: this._iceTransportPolicy
-      });
-
-      this._recvTransport.on("connect", (
-        { dtlsParameters },
-        callback,
-        errback // eslint-disable-line no-shadow
-      ) => {
-        this.emitRTCEvent("info", "RTC", () => `Receive transport [connect]`);
-        this._recvTransport.observer.on("close", () => {
-          this.emitRTCEvent("info", "RTC", () => `Receive transport [close]`);
-        });
-        this._recvTransport.observer.on("newproducer", producer => {
-          this.emitRTCEvent("info", "RTC", () => `Receive transport [newproducer]: ${producer.id}`);
-        });
-        this._recvTransport.observer.on("newconsumer", consumer => {
-          this.emitRTCEvent("info", "RTC", () => `Receive transport [newconsumer]: ${consumer.id}`);
-        });
-
-        this._protoo
-          .request("connectWebRtcTransport", {
-            transportId: this._recvTransport.id,
-            dtlsParameters
-          })
-          .then(callback)
-          .catch(errback);
-      });
-
-      this._recvTransport.on("connectionstatechange", connectionState => {
-        let level = "info";
-        if (connectionState === "failed" || connectionState === "disconnected") {
-          level = "error";
-        }
-        this.emitRTCEvent(level, "RTC", () => `Receive transport [connectionstatechange]: ${connectionState}`);
-
-        this.checkRecvIceStatus(connectionState);
-      });
+      await this.createSendTransport(iceServers);
+      await this.createRecvTransport(iceServers);
 
       const { peers } = await this._protoo.request("join", {
         displayName: this._clientId,
@@ -775,10 +947,6 @@ export default class DialogAdapter {
 
       if (this._onOccupantsChanged) {
         this._onOccupantsChanged(this.occupants);
-      }
-
-      if (this._localMediaStream) {
-        this.createMissingProducers(this._localMediaStream);
       }
     } catch (err) {
       this.emitRTCEvent("error", "Adapter", () => `Join room failed: ${error}`);
@@ -937,8 +1105,8 @@ export default class DialogAdapter {
     }
 
     // Close mediasoup Transports.
-    if (!this._sendTransport?._closed) this._sendTransport.close();
-    if (!this._recvTransport?._closed) this._recvTransport.close();
+    this.closeSendTransport();
+    this.closeRecvTransport();
 
     // Stop the ICE connection state watchdogs.
     this.stopSendIceConnectionStateWd();

--- a/src/naf-dialog-adapter.js
+++ b/src/naf-dialog-adapter.js
@@ -879,7 +879,7 @@ export default class DialogAdapter extends EventEmitter {
   }
 
   async createMissingConsumers() {
-    await this._protoo.request("getPeers");
+    await this._protoo.request("refreshConsumers");
   }
 
   async _joinRoom() {

--- a/src/react-components/debug-panel/RtcDebugPanel.js
+++ b/src/react-components/debug-panel/RtcDebugPanel.js
@@ -304,7 +304,7 @@ export default class RtcDebugPanel extends Component {
     const opened = (transport && !transport._closed && true) || false;
     result["opened"] = opened;
     if (transport) {
-      result["state"] = transport._connectionState;
+      result["state"] = opened ? transport._connectionState : "closed";
       result["id"] = transport._id;
       result[PRODUCERS_KEY] = [];
       result[CONSUMERS_KEY] = [];
@@ -846,10 +846,7 @@ export default class RtcDebugPanel extends Component {
                   candidates={this.createCandidates(transportsData?.[TransportType.SEND]?.candidates)}
                   producers={this.createProducers(transportsData?.[TransportType.SEND]?.producers, statsData)}
                   onRestart={this.restartSendICE}
-                  isButtonEnabled={
-                    transportsData?.[TransportType.SEND]?.opened &&
-                    transportsData?.[TransportType.SEND]?.state === "connected"
-                  }
+                  isButtonEnabled={transportsData?.[TransportType.SEND]?.opened}
                 />
               </div>
               <div style={{ display: "flex", flexFlow: "column" }}>
@@ -868,10 +865,7 @@ export default class RtcDebugPanel extends Component {
                   candidates={this.createCandidates(transportsData?.[TransportType.RECEIVE]?.candidates)}
                   consumers={this.createConsumers(transportsData?.[TransportType.RECEIVE]?.consumers, statsData)}
                   onRestart={this.restartRecvICE}
-                  isButtonEnabled={
-                    transportsData?.[TransportType.RECEIVE]?.opened &&
-                    transportsData?.[TransportType.RECEIVE]?.state === "connected"
-                  }
+                  isButtonEnabled={transportsData?.[TransportType.RECEIVE]?.opened}
                 />
               </div>
             </CollapsiblePanel>


### PR DESCRIPTION
This PR adds support for better ICE failures recovery. Now instead of rejoining in case of an ICE failure we:
- Restart ICE for browser that support it
- Recreate the transports and recreate producers/consumers for browser that don't support ICE `updateIceServers`

This PR adds a couple of methods in the Dialog side for closing a transport and getting the consumers.

This has to be merged at the same time as: https://github.com/mozilla/dialog/pull/12