### PR TITLE
Recreate the mic stream in iOS in case it's muted/unmuted externally

### DIFF
--- a/src/naf-dialog-adapter.js
+++ b/src/naf-dialog-adapter.js
@@ -1044,6 +1044,10 @@ export default class DialogAdapter extends EventEmitter {
     });
   }
 
+  get micEnabled() {
+    return this._micEnabled;
+  }
+
   setWebRtcOptions() {
     // Not implemented
   }

--- a/src/utils/media-devices-manager.js
+++ b/src/utils/media-devices-manager.js
@@ -229,6 +229,7 @@ export default class MediaDevicesManager {
   _muteStateChanged() {
     if (this._audioTrack && this._audioTrack.muted) {
       if (!this.reconnectIfUnmuted) {
+        this.wasMicEnabledBeforeMute = NAF.connection.adapter.micEnabled;
         NAF.connection.adapter.enableMicrophone(false);
       }
       this.reconnectIfUnmuted = true;
@@ -236,7 +237,9 @@ export default class MediaDevicesManager {
       if (this.reconnectIfUnmuted) {
         this.reconnectIfUnmuted = false;
         this.setMediaStreamToDefault();
-        NAF.connection.adapter.enableMicrophone(true);
+        if (this.wasMicEnabledBeforeMute) {
+          NAF.connection.adapter.enableMicrophone(true);
+        }
       }
     }
   }

--- a/src/utils/media-devices-manager.js
+++ b/src/utils/media-devices-manager.js
@@ -192,7 +192,7 @@ export default class MediaDevicesManager {
 
           this._iOSTrackMutedHack();
 
-          audioSystem.addStreamToOutboundAudio("microphone", newStream);
+          this.audioSystem.addStreamToOutboundAudio("microphone", newStream);
 
           this._scene.emit("local-media-stream-created");
 


### PR DESCRIPTION
PR based on this contribution from @vincentfretin https://github.com/mozilla/hubs/issues/2643#issuecomment-765398974

In iOS devices when another app tab uses the mic, the track transitions to a muted state and never recovers: https://bugs.webkit.org/show_bug.cgi?id=213853

This PR listen to mute state changes on the mic track and recreates the track if it transitions unmuted->muted->unmuted state.

This need testing in Safari mobile as I don't have an iOS device and I couldn't reproduce in any other environments.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/HUBS-819)
