### PR TITLE
Add navigation buttons to exited room screen

### DIFF
--- a/src/react-components/room/ExitedRoomScreen.js
+++ b/src/react-components/room/ExitedRoomScreen.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { defineMessages, FormattedMessage, useIntl } from "react-intl";
 import { LoadingScreenLayout } from "../layout/LoadingScreenLayout";
+import { Button } from "../input/Button";
 
 export const ExitReason = {
   exited: "exited",
@@ -104,6 +105,10 @@ export function ExitedRoomScreen({ reason, showTerms, termsUrl, logoSrc, showSou
             />
           </p>
         )}
+
+        <Button as="a" preset="accept" href="/">
+          <FormattedMessage id="exited-room-screen.home-button" defaultMessage="Back to Home" />
+        </Button>
       </>
     );
   } else {
@@ -140,6 +145,10 @@ export function ExitedRoomScreen({ reason, showTerms, termsUrl, logoSrc, showSou
             />
           </p>
         )}
+
+        <Button as="a" preset="accept" href={window.location.href}>
+          <FormattedMessage id="exited-room-screen.refresh-page-button" defaultMessage="Refresh Page" />
+        </Button>
       </>
     );
   }


### PR DESCRIPTION
This PR adds buttons to refresh the page when disconnected/exited or a link to the home page when the room was closed.

Thanks @mrsVelena and @MuditJain5 for the original PRs! https://github.com/mozilla/hubs/pull/3678 https://github.com/mozilla/hubs/pull/3936

Fixes #2140
