### PR TITLE
Fix webcam sharing

### DIFF
--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -467,7 +467,7 @@ export default class SceneEntryManager {
           break;
       }
 
-      shareVideoMediaStream(constraints, false, event.detail.target);
+      shareVideoMediaStream(constraints, false, event.detail?.target);
     });
 
     this.scene.addEventListener("action_share_screen", () => {


### PR DESCRIPTION
I forgot to add a null check for the share camera event's target field which can be null if no event detail object is provided.