### PR TITLE
Fix closed room cleanup

### DIFF
--- a/src/components/tools/networked-drawing.js
+++ b/src/components/tools/networked-drawing.js
@@ -111,7 +111,7 @@ AFRAME.registerComponent("networked-drawing", {
   },
 
   play() {
-    AFRAME.scenes[0].systems["hubs-systems"].drawingMenuSystem.registerDrawingMenu(this.el);
+    this.el.sceneEl.systems["hubs-systems"].drawingMenuSystem.registerDrawingMenu(this.el);
   },
 
   remove() {
@@ -124,7 +124,7 @@ AFRAME.registerComponent("networked-drawing", {
     const drawingManager = this.el.sceneEl.querySelector("#drawing-manager").components["drawing-manager"];
     drawingManager.destroyDrawing(this);
 
-    AFRAME.scenes[0].systems["hubs-systems"].drawingMenuSystem.unregisterDrawingMenu(this.el);
+    this.el.sceneEl.systems["hubs-systems"].drawingMenuSystem.unregisterDrawingMenu(this.el);
   },
 
   tick(t) {

--- a/src/components/tools/pen.js
+++ b/src/components/tools/pen.js
@@ -494,8 +494,8 @@ AFRAME.registerComponent("pen", {
 
   remove() {
     this.observer.disconnect();
-    AFRAME.scenes[0].removeEventListener("object3dset", this.setDirty);
-    AFRAME.scenes[0].removeEventListener("object3dremove", this.setDirty);
+    this.el.sceneEl.removeEventListener("object3dset", this.setDirty);
+    this.el.sceneEl.removeEventListener("object3dremove", this.setDirty);
     this.penSystem.deregister(this.el);
   }
 });

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -148,6 +148,9 @@ export default class SceneEntryManager {
     if (this.scene.renderer) {
       this.scene.renderer.setAnimationLoop(null); // Stop animation loop, TODO A-Frame should do this
     }
+    document.querySelectorAll("[media-video]").forEach(el => {
+      el.components["media-video"].removeAudio();
+    });
     this.scene.parentNode.removeChild(this.scene);
   };
 

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -115,7 +115,7 @@ export default class SceneEntryManager {
     })();
 
     // Bump stored entry count after 30s
-    setTimeout(() => this.store.bumpEntryCount(), 30000);
+    this.entryCountTimeout = setTimeout(() => this.store.bumpEntryCount(), 30000);
 
     this.scene.addState("entered");
 
@@ -137,6 +137,7 @@ export default class SceneEntryManager {
   };
 
   exitScene = () => {
+    clearTimeout(this.entryCountTimeout);
     this.scene.exitVR();
     if (APP.dialog && APP.dialog.localMediaStream) {
       APP.dialog.localMediaStream.getTracks().forEach(t => t.stop());

--- a/src/systems/camera-tools.js
+++ b/src/systems/camera-tools.js
@@ -24,6 +24,12 @@ AFRAME.registerSystem("camera-tools", {
   deregister(el) {
     this.cameraEls.splice(this.cameraEls.indexOf(el), 1);
     el.removeEventListener("ownership-changed", this.updateMyCamera);
+
+    if (!AFRAME.scenes[0]) {
+      // Aframe Scene was removed. Avoid other side effects.
+      return;
+    }
+
     this.updateMyCamera();
   },
 

--- a/src/systems/cursor-targetting-system.js
+++ b/src/systems/cursor-targetting-system.js
@@ -19,7 +19,8 @@ AFRAME.registerComponent("overwrite-raycast-as-noop", {
 });
 
 export class CursorTargettingSystem {
-  constructor() {
+  constructor(scene) {
+    this.scene = scene;
     this.targets = [];
     this.dirty = true;
     this.onMutation = this.onMutation.bind(this);
@@ -70,7 +71,7 @@ export class CursorTargettingSystem {
   populateEntities(targets) {
     targets.length = 0;
     // TODO: Do not querySelectorAll on the entire scene every time anything changes!
-    const els = AFRAME.scenes[0].querySelectorAll(
+    const els = this.scene.querySelectorAll(
       ".collidable, .interactable, .ui, .drawing, .occupiable-waypoint-icon, .teleport-waypoint-icon, .avatar-inspect-collider"
     );
     for (let i = 0; i < els.length; i++) {
@@ -82,7 +83,7 @@ export class CursorTargettingSystem {
 
   remove() {
     this.observer.disconnect();
-    AFRAME.scenes[0].removeEventListener("object3dset", this.onObject3DSet);
-    AFRAME.scenes[0].removeEventListener("object3dremove", this.onObject3DRemove);
+    AFRAME.scenes[0]?.removeEventListener("object3dset", this.onObject3DSet);
+    AFRAME.scenes[0]?.removeEventListener("object3dremove", this.onObject3DRemove);
   }
 }

--- a/src/systems/hubs-systems.js
+++ b/src/systems/hubs-systems.js
@@ -42,7 +42,7 @@ AFRAME.registerSystem("hubs-systems", {
     this.cursorTogglingSystem = new CursorTogglingSystem();
     this.interactionSfxSystem = new InteractionSfxSystem();
     this.superSpawnerSystem = new SuperSpawnerSystem();
-    this.cursorTargettingSystem = new CursorTargettingSystem();
+    this.cursorTargettingSystem = new CursorTargettingSystem(this.el);
     this.positionAtBorderSystem = new PositionAtBorderSystem();
     this.physicsSystem = new PhysicsSystem(this.el.object3D);
     this.constraintsSystem = new ConstraintsSystem(this.physicsSystem);

--- a/src/systems/pen-tools.js
+++ b/src/systems/pen-tools.js
@@ -20,6 +20,12 @@ AFRAME.registerSystem("pen-tools", {
   deregister(el) {
     this.penEls.splice(this.penEls.indexOf(el), 1);
     el.removeEventListener("ownership-changed", this.updateMyPen);
+
+    if (!AFRAME.scenes[0]) {
+      // Aframe Scene was removed. Avoid other side effects.
+      return;
+    }
+
     this.updateMyPen();
   },
 


### PR DESCRIPTION
This PR address multiple places where we are relying on invalid state when exiting the room and removing the scene.

The main culprit is using `AFRAME.scenes[0]` which will be null after it is removed. The pen and camera system also fail to properly deregister objects because dependent elements such as the avatar rig are already removed. Finally, Networked Aframe will not have a network adapter set when joining an already closed room, so I added a guard for that.

Fixes https://github.com/mozilla/hubs/issues/3743

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/HUBS-818)
