### PR TITLE
Simulcast support

### DIFF
--- a/src/components/mute-mic.js
+++ b/src/components/mute-mic.js
@@ -80,9 +80,9 @@ AFRAME.registerComponent("mute-mic", {
 
   onStoreUpdated: function() {
     const micMuted = this.store.state.settings["micMuted"];
-    const isMicSelected = window.APP.mediaDevicesManager?.isMicDeviceSelected;
+    const isMicShared = window.APP.mediaDevicesManager?.isMicShared;
     if (micMuted !== undefined) {
-      if (isMicSelected) {
+      if (isMicShared) {
         if (micMuted) {
           this.el.addState("muted");
         } else {

--- a/src/hub.js
+++ b/src/hub.js
@@ -682,7 +682,7 @@ async function runBotMode(scene, entryManager) {
   };
 
   while (!NAF.connection.isConnected()) await nextTick();
-  entryManager.enterSceneWhenLoaded(new MediaStream(), false);
+  entryManager.enterSceneWhenLoaded(false);
 }
 
 function checkForAccountRequired() {
@@ -785,7 +785,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   const entryManager = new SceneEntryManager(hubChannel, authChannel, history);
 
   window.APP.scene = scene;
-  window.APP.mediaDevicesManager = new MediaDevicesManager(scene, store);
+  const audioSystem = scene.systems["hubs-systems"].audioSystem;
+  window.APP.mediaDevicesManager = new MediaDevicesManager(scene, store, audioSystem);
   window.APP.hubChannel = hubChannel;
 
   const performConditionalSignIn = async (predicate, action, signInMessage, signInCompleteMessage, onFailure) => {

--- a/src/react-components/debug-panel/Prop.js
+++ b/src/react-components/debug-panel/Prop.js
@@ -9,8 +9,13 @@ export function CreatePropsFromData(data) {
     let value = data[property];
     if (typeof value === "number" && !!(value % 1)) {
       value = value.toFixed(2);
+      props.push(<Prop key={property} propKey={property} propValue={value} />);
+    } else if (typeof value === "object") {
+      props.push(<Prop key={property} propKey={property} propValue={"-"} />);
+      props.push(CreatePropsFromData(value));
+    } else {
+      props.push(<Prop key={property} propKey={property} propValue={value} />);
     }
-    props.push(<Prop key={property} propKey={property} propValue={value} />);
   }
 
   return props;

--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -775,7 +775,11 @@ class PreferencesScreen extends Component {
   }
 
   onMicSelectionChanged = deviceId => {
-    this.mediaDevicesManager.selectMicDevice(deviceId === "none" ? null : deviceId).then(this.updateMediaDevices);
+    if (deviceId === "none") {
+      this.mediaDevicesManager.stopMicShare().then(this.updateMediaDevices);
+    } else {
+      this.mediaDevicesManager.startMicShare(deviceId).then(this.updateMediaDevices);
+    }
   };
 
   onMediaDevicesUpdated = () => {
@@ -837,8 +841,9 @@ class PreferencesScreen extends Component {
   };
 
   storeUpdated = () => {
-    if (!this.props.store?.state?.preferences?.preferredMic) {
-      this.mediaDevicesManager.selectMicDevice(null);
+    const deviceId = this.props.store?.state?.preferences?.preferredMic;
+    if (!deviceId && this.mediaDevicesManager.isMicShared) {
+      this.mediaDevicesManager.stopMicShare();
     }
   };
 
@@ -846,7 +851,11 @@ class PreferencesScreen extends Component {
     this.props.store.addEventListener("statechanged", this.storeUpdated);
     this.props.scene.addEventListener("devicechange", this.onMediaDevicesUpdated);
 
-    this.mediaDevicesManager.fetchMediaDevices().then(this.updateMediaDevices);
+    if (!this.mediaDevicesManager.isMicShared) {
+      this.mediaDevicesManager.startMicShare().then(this.updateMediaDevices);
+    } else {
+      this.mediaDevicesManager.fetchMediaDevices().then(this.updateMediaDevices);
+    }
   }
 
   componentWillUnmount() {

--- a/src/utils/media-devices-manager.js
+++ b/src/utils/media-devices-manager.js
@@ -13,14 +13,15 @@ const isFirefoxReality = isMobileVR && navigator.userAgent.match(/Firefox/);
 const HMD_MIC_REGEXES = [/\Wvive\W/i, /\Wrift\W/i];
 
 export default class MediaDevicesManager {
-  constructor(scene, store) {
+  constructor(scene, store, audioSystem) {
     this._scene = scene;
     this._store = store;
     this._micDevices = [];
     this._videoDevices = [];
     this._deviceId = null;
     this._audioTrack = null;
-    this._mediaStream = null;
+    this.audioSystem = audioSystem;
+    this._mediaStream = audioSystem.outboundStream;
 
     navigator.mediaDevices.addEventListener("devicechange", this.onDeviceChange);
   }
@@ -78,8 +79,12 @@ export default class MediaDevicesManager {
     return lastUsedMicDeviceId;
   }
 
-  get isMicDeviceSelected() {
+  get isMicShared() {
     return this.audioTrack !== null;
+  }
+
+  get isVideoShared() {
+    return this._mediaStream?.getVideoTracks().length > 0;
   }
 
   onDeviceChange = () => {
@@ -88,46 +93,52 @@ export default class MediaDevicesManager {
     });
   };
 
-  async selectMicDevice(deviceId) {
+  async fetchMediaDevices() {
+    return new Promise(resolve => {
+      navigator.mediaDevices.enumerateDevices().then(mediaDevices => {
+        this.micDevices = mediaDevices
+          .filter(d => d.kind === "audioinput")
+          .map(d => ({ value: d.deviceId, label: d.label || `Mic Device (${d.deviceId.substr(0, 9)})` }));
+        this.videoDevices = mediaDevices
+          .filter(d => d.kind === "videoinput")
+          .map(d => ({ value: d.deviceId, label: d.label || `Camera Device (${d.deviceId.substr(0, 9)})` }));
+        resolve();
+      });
+    });
+  }
+
+  async startMicShare(deviceId) {
+    let constraints = { audio: {} };
     if (deviceId) {
-      const constraints = { audio: { deviceId: { exact: [deviceId] } } };
-      const result = await this.fetchAudioTrack(constraints);
-      await this.setupNewMediaStream();
-      NAF.connection.adapter.enableMicrophone(true);
-
-      return result;
-    } else if (this.isMicDeviceSelected) {
-      const audioSystem = this._scene.systems["hubs-systems"].audioSystem;
-      audioSystem.removeStreamFromOutboundAudio("microphone");
-      this.audioTrack?.stop();
-      this.audioTrack = null;
-      this.mediaStream = null;
-      NAF.connection.adapter.enableMicrophone(false);
-
-      return null;
+      constraints = { audio: { deviceId: { exact: [deviceId] } } };
     }
-  }
 
-  async setMediaStreamToDeviceId(deviceId) {
-    let hasAudio = false;
+    const result = await this._startMicShare(constraints);
 
-    // Try to fetch last used mic, if there was one.
-    if (this.lastUsedMicDeviceId) {
-      hasAudio = await this.fetchAudioTrack({ audio: { deviceId } });
+    await this.fetchMediaDevices();
+
+    // we should definitely have an audioTrack at this point unless they denied mic access
+    if (this.audioTrack) {
+      const micDeviceId = this.micDeviceIdForMicLabel(this.micLabelForAudioTrack(this.audioTrack));
+      if (micDeviceId) {
+        this._store.update({ settings: { lastUsedMicDeviceId: micDeviceId } });
+        console.log(`Selected input device: ${this.micLabelForDeviceId(micDeviceId)}`);
+      }
+      this._scene.emit("local-media-stream-created");
     } else {
-      hasAudio = await this.fetchAudioTrack({ audio: {} });
+      console.log("No available audio tracks");
     }
 
-    await this.setupNewMediaStream();
+    NAF.connection.adapter.enableMicrophone(true);
 
-    return { hasAudio };
+    return result;
   }
 
-  async setMediaStreamToDefault() {
-    return await this.setMediaStreamToDeviceId(this.lastUsedMicDeviceId);
+  async startLastUsedMicShare() {
+    return await this.startMicShare(this.lastUsedMicDeviceId);
   }
 
-  async fetchAudioTrack(constraints = { audio: {} }) {
+  async _startMicShare(constraints = { audio: {} }) {
     if (this.audioTrack) {
       this.audioTrack.stop();
     }
@@ -155,11 +166,11 @@ export default class MediaDevicesManager {
 
     try {
       const newStream = await navigator.mediaDevices.getUserMedia(constraints);
-
-      const audioSystem = this._scene.systems["hubs-systems"].audioSystem;
-      audioSystem.addStreamToOutboundAudio("microphone", newStream);
-      this.mediaStream = audioSystem.outboundStream;
+      this.audioSystem.addStreamToOutboundAudio("microphone", newStream);
       this.audioTrack = newStream.getAudioTracks()[0];
+      this.audioTrack.addEventListener("ended", () => {
+        this._scene.emit("action_end_mic_sharing");
+      });
 
       if (/Oculus/.test(navigator.userAgent)) {
         // HACK Oculus Browser 6 seems to randomly end the microphone audio stream. This re-creates it.
@@ -172,7 +183,7 @@ export default class MediaDevicesManager {
           const newStream = await navigator.mediaDevices.getUserMedia(constraints);
           this.audioTrack = newStream.getAudioTracks()[0];
 
-          audioSystem.addStreamToOutboundAudio("microphone", newStream);
+          this.audioSystem.addStreamToOutboundAudio("microphone", newStream);
 
           this._scene.emit("local-media-stream-created");
 
@@ -191,34 +202,68 @@ export default class MediaDevicesManager {
     }
   }
 
-  async setupNewMediaStream() {
-    await this.fetchMediaDevices();
+  async stopMicShare() {
+    this.audioSystem.removeStreamFromOutboundAudio("microphone");
 
-    // we should definitely have an audioTrack at this point unless they denied mic access
-    if (this.audioTrack) {
-      const micDeviceId = this.micDeviceIdForMicLabel(this.micLabelForAudioTrack(this.audioTrack));
-      if (micDeviceId) {
-        this._store.update({ settings: { lastUsedMicDeviceId: micDeviceId } });
-        console.log(`Selected input device: ${this.micLabelForDeviceId(micDeviceId)}`);
-      }
-      this._scene.emit("local-media-stream-created");
-    } else {
-      console.log("No available audio tracks");
-    }
+    this.audioTrack?.stop();
+    this.audioTrack = null;
+
+    this._scene.emit("action_mute");
+
+    NAF.connection.adapter.enableMicrophone(false);
+    await NAF.connection.adapter.setLocalMediaStream(this._mediaStream);
   }
 
-  async fetchMediaDevices() {
-    return new Promise(resolve => {
-      navigator.mediaDevices.enumerateDevices().then(mediaDevices => {
-        this.micDevices = mediaDevices
-          .filter(d => d.kind === "audioinput")
-          .map(d => ({ value: d.deviceId, label: d.label || `Mic Device (${d.deviceId.substr(0, 9)})` }));
-        this.videoDevices = mediaDevices
-          .filter(d => d.kind === "videoinput")
-          .map(d => ({ value: d.deviceId, label: d.label || `Camera Device (${d.deviceId.substr(0, 9)})` }));
-        resolve();
-      });
-    });
+  async startVideoShare(constraints, isDisplayMedia, success, error) {
+    let newStream;
+    let videoTrackAdded = false;
+
+    try {
+      if (isDisplayMedia) {
+        newStream = await navigator.mediaDevices.getDisplayMedia(constraints);
+      } else {
+        newStream = await navigator.mediaDevices.getUserMedia(constraints);
+      }
+
+      const videoTracks = newStream ? newStream.getVideoTracks() : [];
+      if (videoTracks.length > 0) {
+        videoTrackAdded = true;
+
+        newStream.getVideoTracks().forEach(track => {
+          // Ideally we would use track.contentHint but it seems to be read-only in Chrome so we just add a custom property
+          track["_hubs_contentHint"] = isDisplayMedia ? "share" : "camera";
+          track.addEventListener("ended", () => {
+            this._scene.emit("action_end_video_sharing");
+          });
+          this._mediaStream.addTrack(track);
+        });
+
+        if (newStream && newStream.getAudioTracks().length > 0) {
+          this.audioSystem.addStreamToOutboundAudio("screenshare", newStream);
+        }
+
+        await NAF.connection.adapter.setLocalMediaStream(this._mediaStream);
+      }
+    } catch (e) {
+      error(e);
+      this._scene.emit("action_end_video_sharing");
+      return;
+    }
+
+    success(isDisplayMedia, videoTrackAdded);
+  }
+
+  async stopVideoShare() {
+    if (!this._mediaStream) return;
+
+    for (const track of this._mediaStream.getVideoTracks()) {
+      track.stop(); // Stop video track to remove the "Stop screen sharing" bar right away.
+      this._mediaStream.removeTrack(track);
+    }
+
+    this.audioSystem.removeStreamFromOutboundAudio("screenshare");
+
+    await NAF.connection.adapter.setLocalMediaStream(this._mediaStream);
   }
 
   async shouldShowHmdMicWarning() {


### PR DESCRIPTION
Related https://github.com/mozilla/hubs/pull/3543

This PR ad adds support for simulcast and refactors some media manager related code required for supporting simulcast. It adds three layers for webcam sharing and two for screen sharing. It also exposes layers and downlink info in the RTC panel.

It also addresses the lack of support for handling sharing permissions at the browser level. Now when stopping sharing mic/video from the browser site permissions we should remove the related media and stop producing for those sources.