### PR TITLE
Remove hottentot-teal from duck breed list

### DIFF
--- a/src/utils/identity.js
+++ b/src/utils/identity.js
@@ -38,7 +38,6 @@ const names = [
   "Harlequin",
   "Hartlaubs",
   "Hooded-Merganser",
-  "Hottentot-Teal",
   "Kelp-Goose",
   "King-Eider",
   "Lake-Duck",


### PR DESCRIPTION
A community member flagged that a term used in our duck breeds list is a racial term. Removing this entry from the default names list.