### PR TITLE
Fix issue that breaks the UI when you sign in after attempting to pin an object

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -788,7 +788,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   window.APP.mediaDevicesManager = new MediaDevicesManager(scene, store);
   window.APP.hubChannel = hubChannel;
 
-  const performConditionalSignIn = async (predicate, action, signInMessage, signInCompleteMessage, onFailure) => {
+  const performConditionalSignIn = async (predicate, action, signInMessage, onFailure) => {
     if (predicate()) return action();
 
     await handleExitTo2DInterstitial(true, () => remountUI({ showSignInDialog: false }));
@@ -796,7 +796,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     remountUI({
       showSignInDialog: true,
       signInMessage,
-      signInCompleteMessage,
       onContinueAfterSignIn: async () => {
         remountUI({ showSignInDialog: false });
         let actionError = null;

--- a/src/react-components/room/RoomSidebar.js
+++ b/src/react-components/room/RoomSidebar.js
@@ -76,10 +76,11 @@ function SceneAttribution({ attribution }) {
 // To assist with content control, we avoid displaying scene links to users who are not the scene
 // creator, unless the scene is remixable or promotable.
 function allowDisplayOfSceneLink(accountId, scene) {
-  return (accountId && scene.account_id === accountId) || scene.allow_promotion || scene.allow_remixing;
+  return scene && ((accountId && scene.account_id === accountId) || scene.allow_promotion || scene.allow_remixing);
 }
 
 export function SceneInfo({ accountId, scene, showAttributions, canChangeScene, onChangeScene }) {
+  if (!scene) return null;
   const showSceneLink = allowDisplayOfSceneLink(accountId, scene);
   const attributions = (scene.attributions && scene.attributions.content) || [];
   const creator = scene.attributions && scene.attributions.creator;

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -145,7 +145,6 @@ class UIRoot extends Component {
     initialIsFavorited: PropTypes.bool,
     showSignInDialog: PropTypes.bool,
     signInMessage: PropTypes.string,
-    signInCompleteMessage: PropTypes.string,
     onContinueAfterSignIn: PropTypes.func,
     showSafariMicDialog: PropTypes.bool,
     onMediaSearchResultEntrySelected: PropTypes.func,
@@ -378,7 +377,7 @@ class UIRoot extends Component {
   };
 
   showContextualSignInDialog = () => {
-    const { signInMessage, authChannel, signInCompleteMessage, onContinueAfterSignIn } = this.props;
+    const { signInMessage, authChannel, onContinueAfterSignIn } = this.props;
 
     this.showNonHistoriedDialog(RoomSignInModalContainer, {
       step: SignInStep.submit,
@@ -396,7 +395,6 @@ class UIRoot extends Component {
         this.setState({ signedIn: true });
         this.showNonHistoriedDialog(RoomSignInModalContainer, {
           step: SignInStep.complete,
-          message: signInCompleteMessage,
           onClose: onContinueAfterSignIn || this.closeDialog,
           onContinue: onContinueAfterSignIn || this.closeDialog
         });


### PR DESCRIPTION
We seem to have removed the concept of "sign-in complete message" with the redesign, but missed that it was still being passed around as a parameter. This happened to work in most cases, since most calls to `performConditionalSignIn` only passed in three parameters, except for the code path triggered by pinning objects, with used the `onFailure` parameter with a callback. https://github.com/mozilla/hubs/blob/master/src/scene-entry-manager.js#L251-L262

This PR removes the `signInCompleteMessage` parameter entirely since it's not actually in use.

I've also fixed null reference errors related to scene info UI, which I ran into while testing this on a fresh dev environment, where we load create rooms without a scene, and fallback to the loadingEnvironment.glb instead.

Fixes #3822 