### PR TITLE
Fix race condition in reconnect on reticulum deploy

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -1121,8 +1121,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     let attempt = 0;
     while (!didMatchMeta && attempt < maxAttempts && !shouldAbandonMigration()) {
       try {
-        // Add randomness to avoid flooding reticulum.
-        const delayMS = attempt * backoffMS + Math.random() * randomMS;
+        // Add randomness to the first request avoid flooding reticulum.
+        const delayMS = attempt * backoffMS + (attempt === 0 ? Math.random() * randomMS : 0);
         console.log(
           `[reconnect] Getting reticulum meta in ${Math.ceil(delayMS / 1000)} seconds.${
             attempt ? ` (Attempt ${attempt + 1} of ${maxAttempts})` : ""

--- a/src/utils/async-utils.js
+++ b/src/utils/async-utils.js
@@ -11,3 +11,9 @@ export const waitForDOMContentLoaded = function() {
     return waitForEvent("DOMContentLoaded", window);
   }
 };
+
+export const sleep = function(milliseconds) {
+  return new Promise(resolve => {
+    setTimeout(resolve, milliseconds);
+  });
+};


### PR DESCRIPTION
If `getReticulumMeta` does not resolve for more than 5 seconds, or if reticulum issues multiple `ret-deploy` events for some reason, the previous `retDeployReconnectInterval` would call `tryReconnect` multiple times, resulting in a race condition in the subsequent block. 

This change avoids the race condition. On the off-chance we receive multiple `ret-deploy` events in rapid succession, the handler for the first event can be interrupted so that the most recent event can be processed as soon as possible.

