### PR TITLE
Warn instead of fail on missing loop-animation clips

### DIFF
--- a/src/components/loop-animation.js
+++ b/src/components/loop-animation.js
@@ -53,7 +53,16 @@ AFRAME.registerComponent("loop-animation", {
     } else {
       // Support for old Spoke->Hubs { clipName, activeClipIndex } struct. Still used for Blender imports.
       if (clipName !== "") {
-        clips = clipName.split(",").map(n => animations.find(({ name }) => name === n));
+        const clipNames = clipName.split(",");
+        for (let i = 0; i < clipNames.length; i++) {
+          const n = clipNames[i];
+          const a = animations.find(({ name }) => name === n);
+          if (a) {
+            clips.push(a);
+          } else {
+            console.warn(`Could not find animation named '${n}' in ${this.el.className}`);
+          }
+        }
       } else {
         clips = [animations[activeClipIndex]];
       }


### PR DESCRIPTION
Currently miss-configured `loop-animation` components will cause the model to fail to load. It seems better to warn about this instead and then continue loading.

![image](https://user-images.githubusercontent.com/130735/113214221-ff56e300-922d-11eb-9ab3-f86a5802cc4c.png)