### PR TITLE
Hotfix for video avatar regression

### DIFF
--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -397,14 +397,17 @@ export default class SceneEntryManager {
     let currentVideoShareEntity;
     let isHandlingVideoShare = false;
 
-    const shareSuccess = (isDisplayMedia, isVideoTrackAdded) => {
+    const shareSuccess = (isDisplayMedia, isVideoTrackAdded, target) => {
       isHandlingVideoShare = false;
 
       if (isVideoTrackAdded) {
-        currentVideoShareEntity = spawnMediaInfrontOfPlayer(this.mediaDevicesManager.mediaStream, undefined);
-
-        // Wire up custom removal event which will stop the stream.
-        currentVideoShareEntity.setAttribute("emit-scene-event-on-remove", "event:action_end_video_sharing");
+        if (target === "avatar") {
+          this.avatarRig.setAttribute("player-info", { isSharingAvatarCamera: true });
+        } else {
+          currentVideoShareEntity = spawnMediaInfrontOfPlayer(this.mediaDevicesManager.mediaStream, undefined);
+          // Wire up custom removal event which will stop the stream.
+          currentVideoShareEntity.setAttribute("emit-scene-event-on-remove", "event:action_end_video_sharing");
+        }
 
         this.scene.emit("share_video_enabled", { source: isDisplayMedia ? "screen" : "camera" });
         this.scene.addState("sharing_video");
@@ -417,7 +420,7 @@ export default class SceneEntryManager {
       this.scene.emit("share_video_failed");
     };
 
-    this.scene.addEventListener("action_share_camera", () => {
+    this.scene.addEventListener("action_share_camera", event => {
       if (isHandlingVideoShare) return;
       isHandlingVideoShare = true;
 
@@ -445,7 +448,7 @@ export default class SceneEntryManager {
           break;
       }
 
-      this.mediaDevicesManager.startVideoShare(constraints, false, shareSuccess, shareError);
+      this.mediaDevicesManager.startVideoShare(constraints, false, event.detail?.target, shareSuccess, shareError);
     });
 
     this.scene.addEventListener("action_share_screen", () => {
@@ -468,6 +471,7 @@ export default class SceneEntryManager {
           }
         },
         true,
+        null,
         shareSuccess,
         shareError
       );

--- a/src/utils/media-devices-manager.js
+++ b/src/utils/media-devices-manager.js
@@ -214,7 +214,7 @@ export default class MediaDevicesManager {
     await NAF.connection.adapter.setLocalMediaStream(this._mediaStream);
   }
 
-  async startVideoShare(constraints, isDisplayMedia, success, error) {
+  async startVideoShare(constraints, isDisplayMedia, target, success, error) {
     let newStream;
     let videoTrackAdded = false;
 
@@ -250,7 +250,7 @@ export default class MediaDevicesManager {
       return;
     }
 
-    success(isDisplayMedia, videoTrackAdded);
+    success(isDisplayMedia, videoTrackAdded, target);
   }
 
   async stopVideoShare() {


### PR DESCRIPTION
Bad merge in #3965 regressed video avatars ignoring the `target` and always spawning the video in world. This fixes the regression.

Code missed in merge here https://github.com/mozilla/hubs/commit/13a07359fae51ba86303e7a199c03125c8f51384#diff-0a28f27fbe324f80a32e2f54dd8cd1a48ba2825dc167547587ea618b8e843d1bL430