### PR TITLE
Add support for rendering in world cameras to textures

### DIFF
--- a/src/components/video-texture-target.js
+++ b/src/components/video-texture-target.js
@@ -1,18 +1,86 @@
 import { disposeTexture } from "../utils/material-utils";
 import { createVideoOrAudioEl } from "../utils/media-utils";
+import { findNode } from "../utils/three-utils";
+
+/**
+ * @component video-texture-source
+ * This component is intended to be used on entities with a Camera Object3D as a child.
+ * That camera is used to render the scene to a WebGLRenderTarget of the specified resolution
+ * at a maximum of the specified frame rate. It will only render a frame if something sets
+ * it's textureNeedsUpdate property to true. Currently video-texture-target does this
+ * whenever its material is used during the primary camera render (as in, its in view).
+ */
+AFRAME.registerComponent("video-texture-source", {
+  schema: {
+    resolution: { type: "vec2", default: [1280, 720] },
+    fps: { default: 15 }
+  },
+
+  init() {
+    this.camera = findNode(this.el.object3D, n => n.isCamera);
+    this.camera.aspect = this.data.resolution[0] / this.data.resolution[1];
+
+    // TODO currently if a video-texture-source tries to render itself it will fail with a warning.
+    // If we want to support this we will need 2 render targets to swap back and forth.
+    this.renderTarget = new THREE.WebGLRenderTarget(this.data.resolution[0], this.data.resolution[1], {
+      format: THREE.RGBAFormat,
+      minFilter: THREE.LinearFilter,
+      magFilter: THREE.NearestFilter,
+      encoding: THREE.GammaEncoding,
+      depth: false,
+      stencil: false
+    });
+
+    const texture = this.renderTarget.texture;
+    texture.matrixAutoUpdate = false;
+    texture.matrix.scale(1, -1);
+    texture.matrix.translate(0, 1);
+
+    this.textureNeedsUpdate = false;
+  },
+
+  tock(time) {
+    if (!this.textureNeedsUpdate) return;
+
+    if (time < this.lastRenderTime + 1000 / this.data.fps) return;
+
+    // TODO handle hiding UI and showing first person head
+    // Once thats done also rework camrea-tool to use this to do its actual rendering
+
+    const sceneEl = this.el.sceneEl;
+    const renderer = this.renderer || sceneEl.renderer;
+
+    const tmpVRFlag = renderer.vr.enabled;
+    const tmpOnAfterRender = sceneEl.object3D.onAfterRender;
+    delete sceneEl.object3D.onAfterRender;
+    renderer.vr.enabled = false;
+
+    renderer.setRenderTarget(this.renderTarget);
+    renderer.render(sceneEl.object3D, this.camera);
+    renderer.setRenderTarget(null);
+
+    renderer.vr.enabled = tmpVRFlag;
+    sceneEl.object3D.onAfterRender = tmpOnAfterRender;
+
+    this.lastRenderTime = time;
+    this.textureNeedsUpdate = false;
+  }
+});
 
 /**
  * @component video-texture-target
  * This component is intended to be used on entities with a mesh/skinned mesh Object3D
  * The component swaps the base color map on the mesh's material with a video texture
- * Currently the video texture can only be a Webcam stream, but this component could be easily modified
- * to work with normal urls, screensharing, etc.
+ * Currently the video texture can come from a webcam stream or a camera entity with
+ * a video-texture-src component on it.
  */
 AFRAME.registerComponent("video-texture-target", {
   schema: {
     src: { type: "string" },
     targetBaseColorMap: { type: "boolean", default: true },
-    targetEmissiveMap: { type: "boolean", default: false }
+    targetEmissiveMap: { type: "boolean", default: false },
+    // TODO having both src and target is a bit odd
+    target: { type: "selector" }
   },
 
   getMaterial() {
@@ -43,11 +111,11 @@ AFRAME.registerComponent("video-texture-target", {
 
     const src = this.data.src;
 
-    if (prevData.src === src) {
-      return;
-    }
-
     if (src && src.startsWith("hubs://")) {
+      if (prevData.src === src) {
+        return;
+      }
+
       const streamClientId = src.substring(7).split("/")[1]; // /clients/<client id>/video is only URL for now
 
       NAF.connection.adapter.getMediaStream(streamClientId, "video").then(stream => {
@@ -64,38 +132,56 @@ AFRAME.registerComponent("video-texture-target", {
         texture.minFilter = THREE.LinearFilter;
         texture.encoding = THREE.sRGBEncoding;
 
-        // Copy texture settings from the original texture so that things like texture wrap settings are applied
-        const originalTexture = this.originalMap || this.originalEmissiveMap;
-
-        if (originalTexture) {
-          texture.wrapS = originalTexture.wrapS;
-          texture.wrapT = originalTexture.wrapT;
-        }
-
-        if (this.data.targetBaseColorMap) {
-          material.map = texture;
-        }
-
-        if (this.data.targetEmissiveMap) {
-          material.emissiveMap = texture;
-        }
-
-        material.needsUpdate = true;
+        this.applyTexture(texture);
       });
     } else {
-      if (material.map && material.map !== this.originalMap) {
-        disposeTexture(material.map);
+      if (this.data.target) {
+        const videoTextureSource = this.data.target.components["video-texture-source"];
+        const texture = videoTextureSource.renderTarget.texture;
+        this.applyTexture(texture);
+
+        // Bit of a hack here to only update the renderTarget when the screens are in view
+        material.map.isVideoTexture = true;
+        material.map.update = () => {
+          videoTextureSource.textureNeedsUpdate = true;
+        };
+      } else {
+        if (material.map && material.map !== this.originalMap) {
+          disposeTexture(material.map);
+        }
+
+        if (material.emissiveMap && material.emissiveMap !== this.originalEmissiveMap) {
+          disposeTexture(material.emissiveMap);
+        }
+
+        material.map = this.originalMap;
+        material.emissiveMap = this.originalEmissiveMap;
+
+        material.needsUpdate = true;
       }
-
-      if (material.emissiveMap && material.emissiveMap !== this.originalEmissiveMap) {
-        disposeTexture(material.emissiveMap);
-      }
-
-      material.map = this.originalMap;
-      material.emissiveMap = this.originalEmissiveMap;
-
-      material.needsUpdate = true;
     }
+  },
+
+  applyTexture(texture) {
+    const material = this.getMaterial();
+
+    // Copy texture settings from the original texture so that things like texture wrap settings are applied
+    const originalTexture = this.originalMap || this.originalEmissiveMap;
+
+    if (originalTexture) {
+      texture.wrapS = originalTexture.wrapS;
+      texture.wrapT = originalTexture.wrapT;
+    }
+
+    if (this.data.targetBaseColorMap) {
+      material.map = texture;
+    }
+
+    if (this.data.targetEmissiveMap) {
+      material.emissiveMap = texture;
+    }
+
+    material.needsUpdate = true;
   },
 
   remove() {

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -427,20 +427,23 @@ AFRAME.GLTFModelPlus.registerComponent(
   "video-texture-target",
   "video-texture-target",
   (el, componentName, componentData, _components, indexToEntityMap) => {
-    const { targetBaseColorMap, targetEmissiveMap, src } = componentData;
+    const { targetBaseColorMap, targetEmissiveMap, srcNode } = componentData;
 
-    const target = indexToEntityMap[src];
-    if (!target) {
-      console.warn(
-        `Error inflating gltf component "video-texture-target": Couldn't find target entity with index ${src}`
-      );
-      return;
+    let srcEl;
+    if (srcNode !== undefined) {
+      srcEl = indexToEntityMap[srcNode];
+      if (!srcEl) {
+        console.warn(
+          `Error inflating gltf component "video-texture-srcEl": Couldn't find srcEl entity with index ${src}`
+        );
+      }
     }
 
     el.setAttribute(componentName, {
+      src: srcEl ? "el" : "",
       targetBaseColorMap,
       targetEmissiveMap,
-      target
+      srcEl
     });
   }
 );

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -434,7 +434,7 @@ AFRAME.GLTFModelPlus.registerComponent(
       srcEl = indexToEntityMap[srcNode];
       if (!srcEl) {
         console.warn(
-          `Error inflating gltf component "video-texture-srcEl": Couldn't find srcEl entity with index ${src}`
+          `Error inflating gltf component "video-texture-srcEl": Couldn't find srcEl entity with index ${srcNode}`
         );
       }
     }

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -423,4 +423,26 @@ AFRAME.GLTFModelPlus.registerComponent("audio-settings", "audio-settings", (el, 
   el.sceneEl.systems["hubs-systems"].audioSettingsSystem.updateAudioSettings(componentData);
 });
 
-AFRAME.GLTFModelPlus.registerComponent("video-texture-target", "video-texture-target");
+AFRAME.GLTFModelPlus.registerComponent(
+  "video-texture-target",
+  "video-texture-target",
+  (el, componentName, componentData, _components, indexToEntityMap) => {
+    const { targetBaseColorMap, targetEmissiveMap, src } = componentData;
+
+    const target = indexToEntityMap[src];
+    if (!target) {
+      console.warn(
+        `Error inflating gltf component "video-texture-target": Couldn't find target entity with index ${src}`
+      );
+      return;
+    }
+
+    el.setAttribute(componentName, {
+      targetBaseColorMap,
+      targetEmissiveMap,
+      target
+    });
+  }
+);
+
+AFRAME.GLTFModelPlus.registerComponent("video-texture-source", "video-texture-source");


### PR DESCRIPTION
This PR builds on the `video-texture-target` component used for video avatars by adding a new `video-texture-source` component. This component is to be placed on a `Camera` entity. The `video-texture-target` can then specify that entity as its `target` to pull "video" from that camera onto its texture. This allows creating things like "jumbotron" screens and mirrors. This should be considered "beta" for now and may change depending on what we find trying it out in some scenes.

![image](https://user-images.githubusercontent.com/130735/113921510-f40a3700-979a-11eb-9d42-eabc0aefbf0d.png)

Blender exporter support for these new components is here: https://github.com/MozillaReality/hubs-blender-exporter/pull/28

Still a few TODOs in the code that can be dealt with later. Ideally we would also rework the camera-tool component/system to use this new component to do its actual rendering to remove any duplicate code.