### PR TITLE
Bump Puppeteer to the latest one

### DIFF
--- a/scripts/bot/package.json
+++ b/scripts/bot/package.json
@@ -4,7 +4,7 @@
   "license": "MPL-2.0",
   "devDependencies": {
     "docopt": "^0.6.2",
-    "puppeteer": "7.0.1",
+    "puppeteer": "8.0.0",
     "query-string": "^5.0.1"
   }
 }


### PR DESCRIPTION
As I explained on Discord, `run-bot.js` no longer works on my Windows10 due to page crash error on Chromium. Somehow bumping Puppeteer to the latest one has resolved the problem.

Brian couldn't reproduce the problem on his Windows so I'm not sure you folks encounter this problem and I couldn't figure out the root issue but I think updating the dependencies is generally good.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/HUBS-812)
