### PR TITLE
Always allow mic selection in the entry flow

### DIFF
--- a/src/react-components/room/MicSetupModal.js
+++ b/src/react-components/room/MicSetupModal.js
@@ -115,16 +115,14 @@ export function MicSetupModal({
             large
           />
         </div>
-        {microphoneEnabled && (
-          <>
-            <SelectInputField value={selectedMicrophone} options={microphoneOptions} onChange={onChangeMicrophone} />
-            <ToggleInput
-              label={<FormattedMessage id="mic-setup-modal.mute-mic-toggle" defaultMessage="Mute My Microphone" />}
-              checked={microphoneMuted}
-              onChange={onChangeMicrophoneMuted}
-            />
-          </>
-        )}
+        <>
+          <SelectInputField value={selectedMicrophone} options={microphoneOptions} onChange={onChangeMicrophone} />
+          <ToggleInput
+            label={<FormattedMessage id="mic-setup-modal.mute-mic-toggle" defaultMessage="Mute My Microphone" />}
+            checked={microphoneMuted}
+            onChange={onChangeMicrophoneMuted}
+          />
+        </>
         <Button preset="accept" onClick={onEnterRoom}>
           <FormattedMessage id="mic-setup-modal.enter-room-button" defaultMessage="Enter Room" />
         </Button>


### PR DESCRIPTION
If you have a saved mic input that is no longer available (you connected last time with Bluetooth headset that is not connected anymore) we skip the mic selection dialog in the entry flow so the user ends up connected to the room without microphone.

I've removed the microphone enabled check in the entry flow show it always shows the mic chooser. This will help in this case and also helps the user review the current setup.