### PR TITLE
Restore the occupancy count lost in the new UI update

### DIFF
--- a/src/react-components/room/ContentMenu.js
+++ b/src/react-components/room/ContentMenu.js
@@ -6,6 +6,7 @@ import styles from "./ContentMenu.scss";
 import { ReactComponent as ObjectsIcon } from "../icons/Objects.svg";
 import { ReactComponent as PeopleIcon } from "../icons/People.svg";
 import { FormattedMessage } from "react-intl";
+import { useState, useEffect } from "react";
 
 export function ContentMenuButton({ active, children, ...props }) {
   return (
@@ -31,12 +32,25 @@ export function ObjectsMenuButton(props) {
   );
 }
 
+const OccupancyCountUpdateFrequencyMilliseconds = 500;
+
 export function PeopleMenuButton(props) {
+  const presences = props.presences;
+  const [peopleCount, setPeopleCount] = useState(0);
+  useEffect(() => {
+    let timeout;
+    function update() {
+      setPeopleCount(Object.entries(presences).length);
+      timeout = setTimeout(update, OccupancyCountUpdateFrequencyMilliseconds);
+    }
+    update();
+    return () => { clearTimeout(timeout); };
+});
   return (
     <ContentMenuButton {...props}>
       <PeopleIcon />
       <span>
-        <FormattedMessage id="content-menu.people-menu-button" defaultMessage="People" />
+        <FormattedMessage id="content-menu.people-menu-button" defaultMessage="People ({numPeople})" values={{ numPeople: peopleCount}} />
       </span>
     </ContentMenuButton>
   );

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1353,6 +1353,7 @@ class UIRoot extends Component {
                         )}
                         <PeopleMenuButton
                           active={this.state.sidebarId === "people"}
+                          presences={this.props.presences}
                           onClick={() => this.toggleSidebar("people")}
                         />
                       </ContentMenu>


### PR DESCRIPTION
I'm not sure if this was removed for a good reason or lost in the shuffle, but the number of occupants is the first thing I look at when entering a Hubs room. Same layout as before and the same as when you open the people list:

<img width="234" alt="Screenshot 2021-04-20 at 16 15 34" src="https://user-images.githubusercontent.com/303516/115421278-b8885780-a1f3-11eb-996b-cb4a19e2931a.png">

I based the implementation on the more sophisticated `PeopleSidebarContainer`, which uses a timer for regular updates rather than any event-based subscription, which would otherwise have been the more obvious choice. I'm learning React as I go along so apologies if I've missed something important.