### PR TITLE
Browsers on mobile devices can return null for map.get("KeyQ")

### DIFF
--- a/src/react-components/room/TipContainer.js
+++ b/src/react-components/room/TipContainer.js
@@ -16,8 +16,8 @@ let turnRightKey = "E";
 if (window.navigator.keyboard !== undefined && window.navigator.keyboard.getLayoutMap) {
   window.navigator.keyboard.getLayoutMap().then(function(map) {
     moveKeys = `${map.get("KeyW")} ${map.get("KeyA")} ${map.get("KeyS")} ${map.get("KeyD")}`.toUpperCase();
-    turnLeftKey = map.get("KeyQ").toUpperCase();
-    turnRightKey = map.get("KeyE").toUpperCase();
+    turnLeftKey = map.get("KeyQ")?.toUpperCase();
+    turnRightKey = map.get("KeyE")?.toUpperCase();
   });
 }
 

--- a/src/react-components/room/TipContainer.js
+++ b/src/react-components/room/TipContainer.js
@@ -15,7 +15,7 @@ let turnRightKey = "E";
 // implimentation we may want to cook up our own polyfill based on observing key inputs
 if (window.navigator.keyboard !== undefined && window.navigator.keyboard.getLayoutMap) {
   window.navigator.keyboard.getLayoutMap().then(function(map) {
-    moveKeys = `${map.get("KeyW")} ${map.get("KeyA")} ${map.get("KeyS")} ${map.get("KeyD")}`.toUpperCase();
+    moveKeys = `${map.get("KeyW") || "W"} ${map.get("KeyA") || "A"} ${map.get("KeyS") || "S"} ${map.get("KeyD") || "D"}`.toUpperCase()
     turnLeftKey = map.get("KeyQ")?.toUpperCase();
     turnRightKey = map.get("KeyE")?.toUpperCase();
   });


### PR DESCRIPTION
Chrome 90.0.4430.82 on Android 10 returns null for calls like `map.get("KeyQ")`, presumably because there is no keyboard attached. The error doesn't appear to be fatal and the result is not used by TipContainer, but it leads to an unnecessary and distracting error message in the developer console:

<img width="644" alt="Screenshot 2021-04-22 at 09 29 42" src="https://user-images.githubusercontent.com/303516/115688672-43339880-a353-11eb-9c0a-da9871b2a538.png">
