### PR TITLE
document.body can be null when setLocale is first called

### DIFF
--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -489,11 +489,11 @@ class PreferenceListItem extends Component {
   };
   componentDidMount() {
     this.props.store.addEventListener("statechanged", this.storeUpdated);
-    document.body.addEventListener("locale-updated", this.storeUpdated);
+    window.addEventListener("locale-updated", this.storeUpdated);
   }
   componentWillUnmount() {
     this.props.store.removeEventListener("statechanged", this.storeUpdated);
-    document.body.removeEventListener("locale-updated", this.storeUpdated);
+    window.removeEventListener("locale-updated", this.storeUpdated);
   }
 
   storeUpdated = () => {

--- a/src/react-components/wrapped-intl-provider.js
+++ b/src/react-components/wrapped-intl-provider.js
@@ -24,11 +24,11 @@ export class WrappedIntlProvider extends React.Component {
 
   componentDidMount() {
     this.updateLocale();
-    document.body.addEventListener("locale-updated", this.updateLocale);
+    window.addEventListener("locale-updated", this.updateLocale);
   }
 
   componentWillUnmount() {
-    document.body.removeEventListener("locale-updated", this.updateLocale);
+    window.removeEventListener("locale-updated", this.updateLocale);
   }
 
   render() {

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -64,16 +64,16 @@ export function setLocale(locale) {
   if (resolvedLocale === DEFAULT_LOCALE) {
     _locale = resolvedLocale;
     _localeData = defaultLocaleData;
-    document.body.dispatchEvent(new CustomEvent("locale-updated"));
+    document.body?.dispatchEvent(new CustomEvent("locale-updated"));
   } else {
     if (cachedMessages.has(resolvedLocale)) {
       _locale = resolvedLocale;
-      document.body.dispatchEvent(new CustomEvent("locale-updated"));
+      document.body?.dispatchEvent(new CustomEvent("locale-updated"));
     } else {
       import(`../assets/locales/${resolvedLocale}.json`).then(({ default: localeData }) => {
         _locale = resolvedLocale;
         _localeData = localeData;
-        document.body.dispatchEvent(new CustomEvent("locale-updated"));
+        document.body?.dispatchEvent(new CustomEvent("locale-updated"));
       });
     }
   }

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -64,16 +64,16 @@ export function setLocale(locale) {
   if (resolvedLocale === DEFAULT_LOCALE) {
     _locale = resolvedLocale;
     _localeData = defaultLocaleData;
-    document.body?.dispatchEvent(new CustomEvent("locale-updated"));
+    window.dispatchEvent(new CustomEvent("locale-updated"));
   } else {
     if (cachedMessages.has(resolvedLocale)) {
       _locale = resolvedLocale;
-      document.body?.dispatchEvent(new CustomEvent("locale-updated"));
+      window.dispatchEvent(new CustomEvent("locale-updated"));
     } else {
       import(`../assets/locales/${resolvedLocale}.json`).then(({ default: localeData }) => {
         _locale = resolvedLocale;
         _localeData = localeData;
-        document.body?.dispatchEvent(new CustomEvent("locale-updated"));
+        window.dispatchEvent(new CustomEvent("locale-updated"));
       });
     }
   }


### PR DESCRIPTION
A common, but non-deterministic, console error is being thrown in `setLocale` because document.body can be null.

<img width="601" alt="Screenshot 2021-04-22 at 09 31 30" src="https://user-images.githubusercontent.com/303516/115689896-6f9be480-a354-11eb-8bdd-d44f6aeab7c4.png">

It should be safe to skip raising the event with `?.` in this situation because at best it was throwing an exception before.

A common pattern elsewhere in the codebase is to hang these events off `window` (which is guaranteed to be non-null) rather than `document.body`, and that would appear to be preferable in this case as well, but there may be something special about events on the `document.body` that I'm missing.