### PR TITLE
Google Fonts now recommends the use of a preconnect link

### DIFF
--- a/src/avatar.html
+++ b/src/avatar.html
@@ -9,6 +9,7 @@
 
     <link rel="shortcut icon" type="image/png" href="/favicon.ico">
     <title>Avatar</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
     <script>
     if (navigator.doNotTrack !== "1") {

--- a/src/cloud.html
+++ b/src/cloud.html
@@ -18,6 +18,7 @@
     <meta name="twitter:url" value="https://hubs.mozilla.com/cloud">
     <link rel="shortcut icon" type="image/png" href="/favicon.ico">
     <title>Get Hubs Cloud</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
     <!-- Google Analytics -->
     <!-- NOTE GA tracking is disabled by default. You'll need to set the GA_TRACKING_ID build variable to enable it. -->

--- a/src/discord.html
+++ b/src/discord.html
@@ -18,6 +18,7 @@
     <meta name="twitter:url" value="https://hubs.mozilla.com/discord">
     <link rel="shortcut icon" type="image/png" href="/favicon.ico">
     <title>Hubs by Mozilla for Discord</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
     <!-- Google Analytics -->
     <!-- NOTE GA tracking is disabled by default. You'll need to set the GA_TRACKING_ID build variable to enable it. -->

--- a/src/hub.html
+++ b/src/hub.html
@@ -13,6 +13,7 @@
     <!-- iOS (for "Add to Homescreen") -->
     <meta name="mobile-web-app-capable" content="yes">
     <title>Room | App by Company</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet"> 
     <!-- Google Analytics -->
     <!-- NOTE GA tracking is disabled by default. You'll need to set the GA_TRACKING_ID build variable to enable it. -->

--- a/src/index.html
+++ b/src/index.html
@@ -12,6 +12,7 @@
     <meta name="mobile-web-app-capable" content="yes">
     <!-- Web-App Manifest (https://w3c.github.io/manifest/) -->
     <link rel="manifest" href="/manifest.webmanifest">
+    <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
 
     <!-- Google Analytics -->

--- a/src/link.html
+++ b/src/link.html
@@ -12,6 +12,7 @@
     <meta name="mobile-web-app-capable" content="yes">
     <!-- Web-App Manifest (https://w3c.github.io/manifest/) -->
     <title>Enter Code</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <!-- Google Analytics -->

--- a/src/scene.html
+++ b/src/scene.html
@@ -9,6 +9,7 @@
 
     <link rel="shortcut icon" type="image/png" href="/favicon.ico">
     <title>Scene</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
     <!-- Google Analytics -->
     <!-- NOTE GA tracking is disabled by default. You'll need to set the GA_TRACKING_ID build variable to enable it. -->

--- a/src/signin.html
+++ b/src/signin.html
@@ -9,6 +9,7 @@
 
     <link rel="shortcut icon" type="image/png" href="/favicon.ico">
     <title>Sign In</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
     <script>
     if (navigator.doNotTrack !== "1") {

--- a/src/verify.html
+++ b/src/verify.html
@@ -9,6 +9,7 @@
 
     <link rel="shortcut icon" type="image/png" href="/favicon.ico">
     <title>Verify Email</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
     <script>
     if (navigator.doNotTrack !== "1") {

--- a/src/whats-new.html
+++ b/src/whats-new.html
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <link rel="shortcut icon" type="image/png" href="/favicon.ico"/>
     <title>What's New</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
     <!-- Google Analytics -->
     <!-- NOTE GA tracking is disabled by default. You'll need to set the GA_TRACKING_ID build variable to enable it. -->


### PR DESCRIPTION
The include code recommended by Google Fonts now includes this link:

`<link rel="preconnect" href="https://fonts.gstatic.com">
`

As you can see if you follow [this link](https://fonts.google.com/share?selection.family=Poppins:ital,wght@0,400;0,500;0,700;1,400) to the default Mozilla Hubs web fonts and click **Select all styles**.

There is some useful background information [here](https://dev.to/masakudamatsu/loading-google-fonts-and-any-other-web-fonts-as-fast-as-possible-in-early-2021-4f5o) and [here](https://csswizardry.com/2020/05/the-fastest-google-fonts/).

The latency saving may be overshadowed by other elements, but it all adds up.