### PR TITLE
Bump into the latest glTF loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36299,8 +36299,8 @@
       "dev": true
     },
     "three": {
-      "version": "github:mozillareality/three.js#af08f523ef36c7fa30e0f32b6380a71cbca5a7ca",
-      "from": "github:mozillareality/three.js#hubs/master"
+      "version": "github:mozillareality/three.js#d4e3d72e7155e763e11a34dd4bf301ae1805b6d8",
+      "from": "github:mozillareality/three.js#hubs/r128devGLTFLoader"
     },
     "three-ammo": {
       "version": "1.0.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36299,8 +36299,8 @@
       "dev": true
     },
     "three": {
-      "version": "github:mozillareality/three.js#c0b148832c390bf045c5b4af15565b9abbc92ca8",
-      "from": "github:mozillareality/three.js#hubs/r128devGLTFLoader"
+      "version": "github:mozillareality/three.js#2915f3b6b978a70b966e4c504a1c1f9ef9e49a6b",
+      "from": "github:mozillareality/three.js#hubs/r128GLTFLoader"
     },
     "three-ammo": {
       "version": "1.0.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36299,8 +36299,8 @@
       "dev": true
     },
     "three": {
-      "version": "github:mozillareality/three.js#2915f3b6b978a70b966e4c504a1c1f9ef9e49a6b",
-      "from": "github:mozillareality/three.js#hubs/r128GLTFLoader"
+      "version": "github:mozillareality/three.js#494c88f493ca73c4521171bc849b2918f3a5c528",
+      "from": "github:mozillareality/three.js#hubs/master"
     },
     "three-ammo": {
       "version": "1.0.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36299,7 +36299,7 @@
       "dev": true
     },
     "three": {
-      "version": "github:mozillareality/three.js#d4e3d72e7155e763e11a34dd4bf301ae1805b6d8",
+      "version": "github:mozillareality/three.js#c0b148832c390bf045c5b4af15565b9abbc92ca8",
       "from": "github:mozillareality/three.js#hubs/r128devGLTFLoader"
     },
     "three-ammo": {

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "resize-observer-polyfill": "^1.5.1",
     "screenfull": "^4.0.1",
     "semver": "^7.3.2",
-    "three": "github:mozillareality/three.js#hubs/r128devGLTFLoader",
+    "three": "github:mozillareality/three.js#hubs/r128GLTFLoader",
     "three-ammo": "^1.0.12",
     "three-bmfont-text": "github:mozillareality/three-bmfont-text#hubs/master",
     "three-mesh-bvh": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "resize-observer-polyfill": "^1.5.1",
     "screenfull": "^4.0.1",
     "semver": "^7.3.2",
-    "three": "github:mozillareality/three.js#hubs/r128GLTFLoader",
+    "three": "github:mozillareality/three.js#hubs/master",
     "three-ammo": "^1.0.12",
     "three-bmfont-text": "github:mozillareality/three-bmfont-text#hubs/master",
     "three-mesh-bvh": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "resize-observer-polyfill": "^1.5.1",
     "screenfull": "^4.0.1",
     "semver": "^7.3.2",
-    "three": "github:mozillareality/three.js#hubs/master",
+    "three": "github:mozillareality/three.js#hubs/r128devGLTFLoader",
     "three-ammo": "^1.0.12",
     "three-bmfont-text": "github:mozillareality/three-bmfont-text#hubs/master",
     "three-mesh-bvh": "^0.1.2",

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -355,6 +355,7 @@ class GLTFHubsPlugin {
     // so we can use ImageBitmapLoader even for Firefox.
     // When we replace our Three.js fork with the latest official one
     // we need to revisit this workaround.
+    // GLTFLoader creates CanvasTexture from ImageBitmap if textureLoader is ImageBItmapLoader.
     if (!parser.textureLoader.isImageBitmapLoader && typeof createImageBitmap !== undefined) {
       parser.textureLoader = new THREE.ImageBitmapLoader(parser.options.manager);
     }

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -347,6 +347,18 @@ class GLTFHubsPlugin {
     this.parser = parser;
     this.jsonPreprocessor = jsonPreprocessor;
     this.fileMap = fileMap;
+
+    // The latest GLTFLoader doesn't use ImageBitmapLoader for Firefox
+    // because the latest ImageBitmapLoader passes an option parameter
+    // to createImageBitmap() but Firefox createImageBitmap() fails
+    // if an option parameter is passed (known bug and already reported to bugzilla).
+    // But our r111 based ImageBitmapLoader doesn't pass the option parameter yet
+    // so we can use ImageBitmapLoader even for Firefox.
+    // When we replace our Three.js fork with the latest official one
+    // we need to revisit this workaround.
+    if (!parser.textureLoader.isImageBitmapLoader && typeof createImageBitmap !== undefined) {
+      parser.textureLoader = new THREE.ImageBitmapLoader(parser.options.manager);
+    }
   }
 
   beforeRoot() {

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -356,7 +356,7 @@ class GLTFHubsPlugin {
     // When we replace our Three.js fork with the latest official one
     // we need to revisit this workaround.
     // GLTFLoader creates CanvasTexture from ImageBitmap if textureLoader is ImageBItmapLoader.
-    if (!parser.textureLoader.isImageBitmapLoader && typeof createImageBitmap !== undefined) {
+    if (!parser.textureLoader.isImageBitmapLoader && typeof createImageBitmap !== "undefined") {
       parser.textureLoader = new THREE.ImageBitmapLoader(parser.options.manager);
     }
   }

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -370,7 +370,7 @@ class GLTFHubsPlugin {
       parser.json = jsonPreprocessor(parser.json);
     }
 
-    //
+    // Ideally Hubs components stuffs should be handled in MozHubsComponents plugin?
     let version = 0;
     if (
       parser.json.extensions &&

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -343,10 +343,9 @@ function runMigration(version, json) {
 let ktxLoader;
 
 class GLTFHubsPlugin {
-  constructor(parser, jsonPreprocessor, fileMap) {
+  constructor(parser, jsonPreprocessor) {
     this.parser = parser;
     this.jsonPreprocessor = jsonPreprocessor;
-    this.fileMap = fileMap;
 
     // The latest GLTFLoader doesn't use ImageBitmapLoader for Firefox
     // because the latest ImageBitmapLoader passes an option parameter
@@ -444,12 +443,6 @@ class GLTFHubsPlugin {
     }
 
     //
-    if (this.fileMap) {
-      // The GLTF is now cached as a THREE object, we can get rid of the original blobs
-      Object.keys(this.fileMap).forEach(URL.revokeObjectURL);
-    }
-
-    //
     gltf.scene.animations = gltf.animations;
   }
 }
@@ -537,7 +530,7 @@ export async function loadGLTF(src, contentType, onProgress, jsonPreprocessor) {
   loadingManager.setURLModifier(getCustomGLTFParserURLResolver(gltfUrl));
   const gltfLoader = new THREE.GLTFLoader(loadingManager);
   gltfLoader
-    .register(parser => new GLTFHubsPlugin(parser, jsonPreprocessor, fileMap))
+    .register(parser => new GLTFHubsPlugin(parser, jsonPreprocessor))
     .register(parser => new GLTFHubsLightMapExtension(parser))
     .register(parser => new GLTFHubsTextureBasisExtension(parser));
 
@@ -554,6 +547,11 @@ export async function loadGLTF(src, contentType, onProgress, jsonPreprocessor) {
 
   return new Promise((resolve, reject) => {
     gltfLoader.load(gltfUrl, resolve, onProgress, reject);
+  }).finally(() => {
+    if (fileMap) {
+      // The GLTF is now cached as a THREE object, we can get rid of the original blobs
+      Object.keys(fileMap).forEach(URL.revokeObjectURL);
+    }
   });
 }
 

--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -56,7 +56,7 @@ class GLTFBinarySplitterPlugin {
 
   beforeRoot() {
     const parser = this.parser;
-    const {body} = parser.extensions.KHR_binary_glTF;
+    const { body } = parser.extensions.KHR_binary_glTF;
     const content = JSON.stringify(ensureAvatarMaterial(parser.json));
 
     // Inject hubs components on upload. Used to create base avatar
@@ -90,7 +90,7 @@ class GLTFBinarySplitterPlugin {
     // doesn't want to start the parse. But glTF loader plugin API
     // doesn't have an ability to cancel the parse. So overriding
     // parser.json with very light glTF data as workaround.
-    parser.json = {asset: {version: "2.0"}};
+    parser.json = { asset: { version: "2.0" } };
   }
 }
 
@@ -160,8 +160,9 @@ class AvatarEditor extends Component {
     e.preventDefault();
 
     if (this.inputFiles.glb && this.inputFiles.glb instanceof File) {
-      const gltfLoader = new THREE.GLTFLoader()
-        .register(parser => new GLTFBinarySplitterPlugin(parser, this.inputFiles));
+      const gltfLoader = new THREE.GLTFLoader().register(
+        parser => new GLTFBinarySplitterPlugin(parser, this.inputFiles)
+      );
       const gltfUrl = URL.createObjectURL(this.inputFiles.glb);
       const onProgress = console.log;
 

--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -59,26 +59,6 @@ class GLTFBinarySplitterPlugin {
     const { body } = parser.extensions.KHR_binary_glTF;
     const content = JSON.stringify(ensureAvatarMaterial(parser.json));
 
-    // Inject hubs components on upload. Used to create base avatar
-    // const gltf = parser.json;
-    // Object.assign(gltf.scenes[0], {
-    //   extensions: {
-    //     MOZ_hubs_components: {
-    //       "loop-animation": {
-    //         clip: "idle_eyes"
-    //       }
-    //     }
-    //   }
-    // });
-    // Object.assign(gltf.nodes.find(n => n.name === "Head"), {
-    //   extensions: {
-    //     MOZ_hubs_components: {
-    //       "scale-audio-feedback": ""
-    //     }
-    //   }
-    // });
-    // content = JSON.stringify(gltf);
-
     this.inputFiles.gltf = new File([content], "file.gltf", {
       type: "model/gltf"
     });

--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -147,19 +147,22 @@ class AvatarEditor extends Component {
     e.preventDefault();
 
     if (this.inputFiles.glb && this.inputFiles.glb instanceof File) {
-      const gltfLoader = new THREE.GLTFLoader().register(
-        parser => new GLTFBinarySplitterPlugin(parser)
-      );
+      const gltfLoader = new THREE.GLTFLoader().register(parser => new GLTFBinarySplitterPlugin(parser));
       const gltfUrl = URL.createObjectURL(this.inputFiles.glb);
       const onProgress = console.log;
 
       await new Promise((resolve, reject) => {
         // GLTFBinarySplitterPlugin saves gltf and bin in gltf.files
-        gltfLoader.load(gltfUrl, result => {
-          this.inputFiles.gltf = result.files.gltf;
-          this.inputFiles.bin = result.files.bin;
-          resolve(result);
-        }, onProgress, reject);
+        gltfLoader.load(
+          gltfUrl,
+          result => {
+            this.inputFiles.gltf = result.files.gltf;
+            this.inputFiles.bin = result.files.bin;
+            resolve(result);
+          },
+          onProgress,
+          reject
+        );
       });
 
       URL.revokeObjectURL(gltfUrl);


### PR DESCRIPTION
Requires: https://github.com/MozillaReality/three.js/pull/57
From: #4117

This PR replaces our Three.js glTF loader fork with the latest official Three.js one and updates `gltf-model-plus.js` and `avatar-editor.js` to follow the latest official Three.js `GLTFLoader` API.

Benefits

* Less cost for maintenance because we will no longer need to maintain our GLTFLoader fork
* We will be easily able to add or manage new and existing glTF related features with the official GLTFLoader plugin API for example LOD

Please refer to https://github.com/mozilla/hubs/issues/4117#issuecomment-818319656 for the changes.

Note that the changes in this PR is just for replacing the glTF loader. There may be a chance that they can be further cleaned up or optimized with the new API. But I would like to do them if needed in another PR because I don't want to make this PR bigger and the review harder.

TODO
- [x] merge https://github.com/MozillaReality/three.js/pull/57
- [x] update package.json to point back at hubs/master for three
- [x] update package-lock.json to point back at hubs/master and the merged commit sha