### PR TITLE
Handle XR controller disconnect and session end

### DIFF
--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -413,19 +413,15 @@ AFRAME.registerSystem("userinput", {
     }
 
     const retrieveXRGamepads = ({ added, removed }) => {
-      if (removed) {
-        for (const inputSource of removed) {
-          gamepadDisconnected(inputSource);
-        }
+      for (const inputSource of removed) {
+        gamepadDisconnected(inputSource);
       }
-      if (added) {
-        for (const inputSource of added) {
-          inputSource.gamepad.isWebXRGamepad = true;
-          inputSource.gamepad.targetRaySpace = inputSource.targetRaySpace;
-          inputSource.gamepad.primaryProfile = inputSource.profiles[0];
-          inputSource.gamepad.hand = inputSource.handedness;
-          gamepadConnected(inputSource);
-        }
+      for (const inputSource of added) {
+        inputSource.gamepad.isWebXRGamepad = true;
+        inputSource.gamepad.targetRaySpace = inputSource.targetRaySpace;
+        inputSource.gamepad.primaryProfile = inputSource.profiles[0];
+        inputSource.gamepad.hand = inputSource.handedness;
+        gamepadConnected(inputSource);
       }
     };
 
@@ -437,14 +433,8 @@ AFRAME.registerSystem("userinput", {
           this.xrReferenceSpace = referenceSpace;
         });
         xrSession.addEventListener("end", e => {
-          const xrDevices = this.activeDevices.items.filter(d => d.gamepad && d.gamepad.isWebXRGamepad);
-          for (const device of xrDevices) {
-            if (device.gamepad && device.gamepad.isWebXRGamepad) {
-              gamepadDisconnected(device);
-            }
-          }
+          this.activeDevices.items.filter(d => d.gamepad && d.gamepad.isWebXRGamepad).forEach(gamepadDisconnected);
         });
-        retrieveXRGamepads({ session: xrSession });
       }
       updateBindingsForVRMode();
     });


### PR DESCRIPTION
Exiting VR mode in Oculus browser now ends the XR Session (without triggering a `inputsourcechange` or `gamepaddisconnected` event. This PR correctly handles the `end` event on session to clean up controllers form the input system.

Also fixes the handling for the `inputsourcechange` event to correctly handle devices being lost not just added (this can happen for example if a controller runs out of batteries).

fixes #4134
fixes #4196 