### PR TITLE
Add workaround for Firefox video play performance issue

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -731,6 +731,16 @@ AFRAME.registerComponent("media-video", {
         texture.minFilter = THREE.LinearFilter;
         texture.encoding = THREE.sRGBEncoding;
 
+        // Firefox seems to have video play (or decode) performance issue.
+        // Somehow setting RGBA format improves the performance very well.
+        // Some tickets have been opened for the performance issue but
+        // I don't think it will be fixed soon. So we set RGBA format for Firefox
+        // as workaround so far.
+        // See https://github.com/mozilla/hubs/issues/3470
+        if (/firefox/i.test(navigator.userAgent)) {
+          texture.format = THREE.RGBAFormat;
+        }
+
         isReady = () => {
           if (texture.hls && texture.hls.streamController.audioOnly) {
             audioEl = videoEl;


### PR DESCRIPTION
From https://github.com/mozilla/hubs/issues/3470#issuecomment-829421706 and the following comments.

Firefox seems to have video play (or decode) performance issue. The FPS number becomes very bad if videos are played in viewport on Firefox.

[In Three.js repo, it has been reported that somehow setting RGBA format to video texture improves the performance very well.](https://github.com/mrdoob/three.js/pull/21746) (I guess it can avoid slow decoding in browser?).

[The ticket has been opened for the performance issue in bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1708491) but I don't think it can be resolved soon. So I would like to suggest to set RGBA format for Firefox as workaround so far.

11.2MB mp4 video + desktop Windows + NVIDIA GeForce GTX 1080.

| | RGB | RGBA |
|----|----|----|
| Firefox | 15fps | 60fps |
| Chrome | 60fps | 60fps |

Ideally we should test on more platforms (Mac, Mobile, other graphics boards and so on). I would be happy if you test on your end, too.
