### PR TITLE
Allow "text" component to be instantiated through GLTF extension

### DIFF
--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -449,3 +449,5 @@ AFRAME.GLTFModelPlus.registerComponent(
 );
 
 AFRAME.GLTFModelPlus.registerComponent("video-texture-source", "video-texture-source");
+
+AFRAME.GLTFModelPlus.registerComponent("text", "text");


### PR DESCRIPTION
Allowing text to be created from GLTF files opens up things like simple labels and signs without requiring image textures.

<img width="1250" alt="Screenshot 2021-05-05 at 12 52 00" src="https://user-images.githubusercontent.com/303516/117136746-b64ffc80-ada0-11eb-83ea-66eea58e469d.png">

The layout rules are a little quirky and it is subject to the [same character set restrictions](https://github.com/mozilla/hubs/issues/3934) as other text elements, but it does benefit from the high-quality SDF rendering.

[A complementary PR](https://github.com/MozillaReality/hubs-blender-exporter/pull/31) has been submitted for the Blender exporter add on.