### PR TITLE
Disable chrome AEC hack by default

### DIFF
--- a/src/assets/stylesheets/preferences-screen.scss
+++ b/src/assets/stylesheets/preferences-screen.scss
@@ -105,6 +105,13 @@ $semi-bold: 600;
   &:last-child {
     margin: 0px 16px 0px 16px;
   }
+  &.disabled {
+    opacity: 20%;
+    pointer-events: none;
+  }
+  &.indent {
+    padding-left: 15px;
+  }
 }
 :local(.column){
   display: flex;

--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -346,8 +346,8 @@ export class MaxResolutionPreferenceItem extends Component {
     );
   }
 }
-function ListItem({ children }) {
-  return <div className={styles.listItem}>{children}</div>;
+function ListItem({ children, disabled, indent }) {
+  return <div className={classNames(styles.listItem, { disabled, indent })}>{children}</div>;
 }
 ListItem.propTypes = {
   children: PropTypes.node.isRequired
@@ -381,6 +381,10 @@ const preferenceLabels = defineMessages({
   disableEchoCancellation: {
     id: "preferences-screen.preference.disable-echo-cancellation",
     defaultMessage: "Disable microphone echo cancellation"
+  },
+  enableAECHack: {
+    id: "preferences-screen.preference.enable-echo-cancellation-hack",
+    defaultMessage: "Enable agressive echo cancellation (significantly reduces audio quality)"
   },
   disableNoiseSuppression: {
     id: "preferences-screen.preference.disable-noise-suppression",
@@ -539,9 +543,15 @@ class PreferenceListItem extends Component {
     ) : (
       <ResetToDefaultButtonPlaceholder />
     );
+
+    const disabled =
+      (this.props.itemProps.disableIfTrue && this.props.store.state.preferences[this.props.itemProps.disableIfTrue]) ||
+      (this.props.itemProps.disableIfFalse && !this.props.store.state.preferences[this.props.itemProps.disableIfFalse]);
+    const indent = this.props.itemProps.disableIfTrue || this.props.itemProps.disableIfFalse;
+
     if (isCheckbox) {
       return (
-        <ListItem>
+        <ListItem disabled={disabled} indent={indent}>
           <div className={styles.row}>
             <Control itemProps={this.props.itemProps} store={this.props.store} setValue={this.props.setValue} />
             {label}
@@ -551,7 +561,7 @@ class PreferenceListItem extends Component {
       );
     } else if (isSmallScreen) {
       return (
-        <ListItem>
+        <ListItem disabled={disabled} indent={indent}>
           <div className={styles.column}>
             <div className={styles.row}>
               {<CheckboxPlaceholder />}
@@ -568,7 +578,7 @@ class PreferenceListItem extends Component {
       );
     }
     return (
-      <ListItem>
+      <ListItem disabled={disabled} indent={indent}>
         <div className={styles.row}>
           {<CheckboxPlaceholder />}
           {label}
@@ -967,6 +977,13 @@ class PreferencesScreen extends Component {
             prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX,
             defaultBool: false,
             promptForRefresh: true
+          },
+          {
+            key: "enableAECHack",
+            prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX,
+            defaultBool: false,
+            promptForRefresh: true,
+            disableIfTrue: "disableEchoCancellation"
           },
           {
             key: "disableNoiseSuppression",

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -124,6 +124,7 @@ export const SCHEMA = {
         disableEchoCancellation: { type: "bool" },
         disableNoiseSuppression: { type: "bool" },
         disableAutoGainControl: { type: "bool" },
+        enableAECHack: { type: "bool" },
         locale: { type: "string" },
         showRtcDebugPanel: { type: "bool" },
         theme: { type: "string" }

--- a/src/systems/audio-system.js
+++ b/src/systems/audio-system.js
@@ -162,7 +162,9 @@ export class AudioSystem {
 
     setTimeout(() => {
       if (this.audioContext.state === "running") {
-        if (!AFRAME.utils.device.isMobile() && /chrome/i.test(navigator.userAgent)) {
+        const disableAEC = window.APP.store.state.preferences.disableEchoCancellation;
+        const enableAECHack = window.APP.store.state.preferences.enableAECHack;
+        if (!AFRAME.utils.device.isMobile() && /chrome/i.test(navigator.userAgent) && !disableAEC && enableAECHack) {
           enableChromeAEC(this._sceneEl.audioListener.gain);
         }
 


### PR DESCRIPTION
This disables the workaround that was added to Chrome in https://github.com/mozilla/hubs/pull/2361 by default as it significantly reduces audio quality and largely breaks audio spatialization. It remains as a preference but we should plan to remove it once a fix lands upstream (which is slated for this year) https://bugs.chromium.org/p/chromium/issues/detail?id=687574

It is unclear if this was always an issue or something that changed in Chrome that caused this workaround to cause other issues... I am hoping for my own sanity that its the later, though it has been an issue since at least January since it was mentioned by a user on the original PR https://github.com/mozilla/hubs/pull/2361#issuecomment-766157504

Incidentally adds ability to the preference screen to have dependent properties:
![image](https://user-images.githubusercontent.com/130735/117216168-3469ce80-adb4-11eb-90bb-ef2014a56749.png)
