### PR TITLE
"Change Scene" button is missing once the scene is set from a GLB

### DIFF
--- a/src/react-components/room/RoomSidebar.js
+++ b/src/react-components/room/RoomSidebar.js
@@ -80,7 +80,12 @@ function allowDisplayOfSceneLink(accountId, scene) {
 }
 
 export function SceneInfo({ accountId, scene, showAttributions, canChangeScene, onChangeScene }) {
-  if (!scene) return null;
+  const changeSceneButton = canChangeScene && (
+    <Button preset="primary" onClick={onChangeScene}>
+      <FormattedMessage id="room-sidebar.scene-info.change-scene-button" defaultMessage="Change Scene" />
+    </Button>
+  )
+  if (!scene) return changeSceneButton;
   const showSceneLink = allowDisplayOfSceneLink(accountId, scene);
   const attributions = (scene.attributions && scene.attributions.content) || [];
   const creator = scene.attributions && scene.attributions.creator;
@@ -129,11 +134,7 @@ export function SceneInfo({ accountId, scene, showAttributions, canChangeScene, 
             <ul className={styles.attributions}>{filteredAttributionElements}</ul>
           </InputField>
         )}
-      {canChangeScene && (
-        <Button preset="primary" onClick={onChangeScene}>
-          <FormattedMessage id="room-sidebar.scene-info.change-scene-button" defaultMessage="Change Scene" />
-        </Button>
-      )}
+      {changeSceneButton}
     </>
   );
 }
@@ -160,15 +161,13 @@ export function RoomSidebar({ room, accountId, onClose, canEdit, onEdit, onChang
             {room.description}
           </InputField>
         )}
-        {room.scene && (
-          <SceneInfo
-            accountId={accountId}
-            scene={room.scene}
-            showAttributions
-            canChangeScene={canEdit}
-            onChangeScene={onChangeScene}
-          />
-        )}
+        <SceneInfo
+          accountId={accountId}
+          scene={room.scene}
+          showAttributions
+          canChangeScene={canEdit}
+          onChangeScene={onChangeScene}
+        />
       </Column>
     </Sidebar>
   );


### PR DESCRIPTION
Once a custom GLB URL is used to set the scene for a room, the scene cannot be set again to either an existing scene or another GLB URL.

This is particularly restrictive when rapidly iterating new scene files as you have to create a new room for each scene version.

**Initial Room Info Dialog**
<img width="477" alt="Screenshot 2021-05-06 at 15 30 31" src="https://user-images.githubusercontent.com/303516/117316159-3f8a3080-ae80-11eb-8b49-c952841c38f5.png">

**Room Dialog After Using Custom Scene File**
<img width="470" alt="Screenshot 2021-05-06 at 15 30 50" src="https://user-images.githubusercontent.com/303516/117316184-444ee480-ae80-11eb-9efe-576e38041a7b.png">

**Room Edit Dialog After Using Custom SceneFile**
<img width="469" alt="Screenshot 2021-05-06 at 15 30 57" src="https://user-images.githubusercontent.com/303516/117316194-4618a800-ae80-11eb-8274-a02309481f4f.png">


