### PR TITLE
Fix issues with audio-targets

### DIFF
--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -288,7 +288,11 @@ AFRAME.registerComponent("audio-target", {
 
   init() {
     this.createAudio();
-    this.connectAudio();
+    // TODO this is to ensure targets and sources loaded at the same time don't have
+    // an order depndancy but this should be done in a more robust way
+    setTimeout(() => {
+      this.connectAudio();
+    }, 0);
   },
 
   remove: function() {
@@ -321,7 +325,7 @@ AFRAME.registerComponent("audio-target", {
 
   connectAudio() {
     const srcEl = this.data.srcEl;
-    const srcZone = srcEl.components["zone-audio-source"];
+    const srcZone = srcEl && srcEl.components["zone-audio-source"];
     const node = srcZone && srcZone.getAudioOutput();
     if (node) {
       this.audio.setNodeSource(node);

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -467,7 +467,7 @@ AFRAME.GLTFModelPlus.registerComponent(
       }
     }
 
-    el.setAttribute(componentName, { srcEl });
+    el.setAttribute(componentName, { ...componentData, srcEl });
   }
 );
 AFRAME.GLTFModelPlus.registerComponent("zone-audio-source", "zone-audio-source");


### PR DESCRIPTION
After deploying 2 issues were found:
- There was an order dependancy in `audio-target` and `zone-audio-source`, fixing this the dead simple setTemout(0) way for now
- Most properties of `audio-target` were being ignored.