### PR TITLE
Fix scene and media failing to load for local dev against hubs cloud

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -177,15 +177,14 @@ async function fetchAppConfigAndEnvironmentVars() {
     throw new Error(`Error fetching Hubs Cloud config "${hubsConfigsResponse.statusText}"`);
   }
 
-  const { shortlink_domain, thumbnail_server } = hubsConfigs.general;
+  const { shortlink_domain, thumbnail_server, non_cors_proxy_domains } = hubsConfigs.general;
 
-  const localIp = process.env.HOST_IP || (await internalIp.v4()) || "localhost";
-
+  const localIp = "localhost";
   process.env.RETICULUM_SERVER = host;
   process.env.SHORTLINK_DOMAIN = shortlink_domain;
   process.env.CORS_PROXY_SERVER = `${localIp}:8080/cors-proxy`;
   process.env.THUMBNAIL_SERVER = thumbnail_server;
-  process.env.NON_CORS_PROXY_DOMAINS = `${localIp},hubs.local,localhost`;
+  process.env.NON_CORS_PROXY_DOMAINS = `${non_cors_proxy_domains},${localIp},hubs.local,localhost`;
 
   return appConfig;
 }


### PR DESCRIPTION
See also #3972 

Two issues disrupting local dev against hubs cloud since February:

1. Assets are loaded via `https://${local ip address}:8080/...` instead of localhost. Browsers see this as a different domain and won't transfer your certificate exception from localhost, so the requests get rejected and you get "Scene failed to load"
2. Internal domains (AWS recipe 2) are not included in non-cors-proxy list, so they attempt to proxy and fail. Images and videos from the selfie cam just show as broken links

This fixes both for me, but I doubt it is the correct solution as it is just removing that `localIp` logic that must serve some purpose. Looking for guidance on what that purpose is to find a solution that works for both

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/HUBS-802)
