### PR TITLE
Ammo.js debug visualization is broken

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -283,7 +283,9 @@ module.exports = async (env, argv) => {
       useLocalIp: true,
       allowedHosts: [host, "hubs.local"],
       headers: {
-        "Access-Control-Allow-Origin": "*"
+        "Access-Control-Allow-Origin": "*",
+        "Cross-Origin-Opener-Policy": "same-origin",
+        "Cross-Origin-Embedder-Policy": "require-corp"
       },
       hot: liveReload,
       inline: liveReload,


### PR DESCRIPTION
The `/debug` command used to enable the very useful ammo.js wireframes and other debug visualizations. This code relies on [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer), which must now run in a secure context, without which you get the following console warning:

> Physics debug rendering only available in browsers that support SharedArrayBuffers.

I'm not confident about the functional or security implications of making this available on a production server, but it looks safe to enable it on the local dev server by adding the required HTTP headers.

Alternative suggestions welcome.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/HUBS-800)
