### PR TITLE
#3149 fix waypoint link reloads room

### DIFF
--- a/src/components/open-media-button.js
+++ b/src/components/open-media-button.js
@@ -57,7 +57,8 @@ AFRAME.registerComponent("open-media-button", {
       } else if ((hubId = await isHubsRoomUrl(this.src))) {
         const url = new URL(this.src);
         if (url.hash && APP.hub.hub_id === hubId) {
-          location.hash = url.hash;
+          // move to waypoint w/o writing to history
+          window.history.replaceState(null, null, window.location.href.split("#")[0] + url.hash);
         } else {
           await exitImmersive();
           location.href = this.src;

--- a/src/components/open-media-button.js
+++ b/src/components/open-media-button.js
@@ -21,13 +21,14 @@ AFRAME.registerComponent("open-media-button", {
       if (visible) {
         let label = "open link";
         if (!this.data.onlyOpenLink) {
+          let hubId;
           if (await isLocalHubsAvatarUrl(src)) {
             label = "use avatar";
           } else if ((await isLocalHubsSceneUrl(src)) && mayChangeScene) {
             label = "use scene";
-          } else if (await isHubsRoomUrl(src)) {
-            const url = new URL(this.src);
-            if (url.hash && window.location.pathname === url.pathname) {
+          } else if ((hubId = await isHubsRoomUrl(src))) {
+            const url = new URL(src);
+            if (url.hash && APP.hub.hub_id === hubId) {
               label = "go to";
             } else {
               label = "visit room";
@@ -43,6 +44,7 @@ AFRAME.registerComponent("open-media-button", {
 
       const exitImmersive = async () => await handleExitTo2DInterstitial(false, () => {}, true);
 
+      let hubId;
       if (this.data.onlyOpenLink) {
         await exitImmersive();
         window.open(this.src);
@@ -52,9 +54,14 @@ AFRAME.registerComponent("open-media-button", {
         this.el.sceneEl.emit("avatar_updated");
       } else if ((await isLocalHubsSceneUrl(this.src)) && mayChangeScene) {
         this.el.sceneEl.emit("scene_media_selected", this.src);
-      } else if (await isHubsRoomUrl(this.src)) {
-        await exitImmersive();
-        location.href = this.src;
+      } else if ((hubId = await isHubsRoomUrl(this.src))) {
+        const url = new URL(this.src);
+        if (url.hash && APP.hub.hub_id === hubId) {
+          location.hash = url.hash;
+        } else {
+          await exitImmersive();
+          location.href = this.src;
+        }
       } else {
         await exitImmersive();
         window.open(this.src);

--- a/src/systems/waypoint-system.js
+++ b/src/systems/waypoint-system.js
@@ -330,7 +330,7 @@ export class WaypointSystem {
       const waypoint = this.ready.find(c => c.el.object3D.name === waypointName);
       if (waypoint) {
         this.moveToWaypoint(waypoint, this.previousWaypointHash === null);
-        window.location.hash = ""; // Reset so you can re-activate the same waypoint
+        window.history.replaceState(null, null, window.location.href.split("#")[0]); // Reset so you can re-activate the same waypoint
       }
       this.previousWaypointHash = window.location.hash;
     }

--- a/src/utils/media-url-utils.js
+++ b/src/utils/media-url-utils.js
@@ -180,9 +180,9 @@ async function isHubsServer(url) {
   return isHubsServer;
 }
 
-const hubsSceneRegex = /https?:\/\/[^/]+\/scenes\/(\w+)\/?\S*/;
-const hubsAvatarRegex = /https?:\/\/[^/]+\/avatars\/(?<id>\w+)\/?\S*/;
-const hubsRoomRegex = /(https?:\/\/)?[^/]+\/([a-zA-Z0-9]{7})\/?\S*/;
+const hubsSceneRegex = /https?:\/\/[^/]+\/scenes\/[a-zA-Z0-9]{7}(?:\/|$)/;
+const hubsAvatarRegex = /https?:\/\/[^/]+\/avatars\/(?<id>[a-zA-Z0-9]{7})(?:\/|$)/;
+const hubsRoomRegex = /(https?:\/\/)?[^/]+\/(?<id>[a-zA-Z0-9]{7})(?:\/|$)/;
 
 export const isLocalHubsUrl = async url =>
   (await isHubsServer(url)) && new URL(url).origin === document.location.origin;
@@ -194,7 +194,10 @@ export const isHubsAvatarUrl = async url => (await isHubsServer(url)) && hubsAva
 export const isLocalHubsAvatarUrl = async url => (await isHubsAvatarUrl(url)) && (await isLocalHubsUrl(url));
 
 export const isHubsRoomUrl = async url =>
-  (await isHubsServer(url)) && !(await isHubsAvatarUrl(url)) && !(await isHubsSceneUrl(url)) && hubsRoomRegex.test(url);
+  (await isHubsServer(url)) &&
+  !(await isHubsAvatarUrl(url)) &&
+  !(await isHubsSceneUrl(url)) &&
+  url.match(hubsRoomRegex)?.groups.id;
 
 export const isHubsDestinationUrl = async url =>
   (await isHubsServer(url)) && ((await isHubsSceneUrl(url)) || (await isHubsRoomUrl(url)));


### PR DESCRIPTION
Fixes links pointing to waypoint hashes reloading the room.
Clicking on a link with a hash does not compare full urls anymore, instead it checks if the link's domain and room ID match those of the current room. As a side effect, waypoint links now also work on a local client.

Fixes back button sending to last waypoint: when using a waypoint link, the url with hash and the url with cleared hash was added to history. Now uses replaceState() instead.

Fixes RegEx for room/avatar/scene links to NOT match when IDs have more than 7 letters/numbers.