### PR TITLE
Fix echo cancelation hack quality issues, re-enable by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "react-use-css-breakpoints": "^1.0.3",
     "resize-observer-polyfill": "^1.5.1",
     "screenfull": "^4.0.1",
+    "sdp-transform": "^2.14.1",
     "semver": "^7.3.2",
     "three": "github:mozillareality/three.js#hubs/master",
     "three-ammo": "^1.0.12",

--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -384,10 +384,6 @@ const preferenceLabels = defineMessages({
     id: "preferences-screen.preference.disable-echo-cancellation",
     defaultMessage: "Disable microphone echo cancellation"
   },
-  enableAECHack: {
-    id: "preferences-screen.preference.enable-echo-cancellation-hack",
-    defaultMessage: "Enable aggressive echo cancellation (significantly reduces audio quality)"
-  },
   disableNoiseSuppression: {
     id: "preferences-screen.preference.disable-noise-suppression",
     defaultMessage: "Disable microphone noise supression"
@@ -979,13 +975,6 @@ class PreferencesScreen extends Component {
             prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX,
             defaultBool: false,
             promptForRefresh: true
-          },
-          {
-            key: "enableAECHack",
-            prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX,
-            defaultBool: false,
-            promptForRefresh: true,
-            disableIfTrue: "disableEchoCancellation"
           },
           {
             key: "disableNoiseSuppression",

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -89,7 +89,8 @@ export const SCHEMA = {
 
     preferences: {
       type: "object",
-      additionalProperties: false,
+      // Allow removed preferences to pass validation
+      additionalProperties: true,
       properties: {
         shouldPromptForRefresh: { type: "bool" },
         preferredMic: { type: "string" },
@@ -124,7 +125,6 @@ export const SCHEMA = {
         disableEchoCancellation: { type: "bool" },
         disableNoiseSuppression: { type: "bool" },
         disableAutoGainControl: { type: "bool" },
-        enableAECHack: { type: "bool" },
         locale: { type: "string" },
         showRtcDebugPanel: { type: "bool" },
         theme: { type: "string" }

--- a/src/systems/audio-system.js
+++ b/src/systems/audio-system.js
@@ -16,6 +16,8 @@ function performDelayedReconnect(gainNode) {
   }, 10000);
 }
 
+import * as sdpTransform from "sdp-transform";
+
 async function enableChromeAEC(gainNode) {
   /**
    *  workaround for: https://bugs.chromium.org/p/chromium/issues/detail?id=687574
@@ -92,6 +94,16 @@ async function enableChromeAEC(gainNode) {
     await inboundPeerConnection.setRemoteDescription(offer);
 
     const answer = await inboundPeerConnection.createAnswer();
+
+    // Rewrite SDP to be stereo and (variable) max bitrate
+    const parsedSdp = sdpTransform.parse(answer.sdp);
+    for (let i = 0; i < parsedSdp.media.length; i++) {
+      for (let j = 0; j < parsedSdp.media[i].fmtp.length; j++) {
+        parsedSdp.media[i].fmtp[j].config += `;stereo=1;cbr=0;maxaveragebitrate=510000;`;
+      }
+    }
+    answer.sdp = sdpTransform.write(parsedSdp);
+
     inboundPeerConnection.setLocalDescription(answer);
     outboundPeerConnection.setRemoteDescription(answer);
 
@@ -163,8 +175,7 @@ export class AudioSystem {
     setTimeout(() => {
       if (this.audioContext.state === "running") {
         const disableAEC = window.APP.store.state.preferences.disableEchoCancellation;
-        const enableAECHack = window.APP.store.state.preferences.enableAECHack;
-        if (!AFRAME.utils.device.isMobile() && /chrome/i.test(navigator.userAgent) && !disableAEC && enableAECHack) {
+        if (!AFRAME.utils.device.isMobile() && /chrome/i.test(navigator.userAgent) && !disableAEC) {
           enableChromeAEC(this._sceneEl.audioListener.gain);
         }
 


### PR DESCRIPTION
I had noticed that the previous hack we had in place to fix echo cancellation in Chrome **significantly** reduced audio quality and broke stereo audio panning, so I disabled it by default #4227 and added an additional preference for "aggressive echo cancellation". 

This PR fixes the quality issues with the hack and gets stereo working, so I am comfortable re-enabling it by default in Chrome. Don't think we need a separate preference anymore either (though it is still only enabled if you actually have echo cancellation enabled, which is different from the state prior to #4227). 

We should still monitor the upstream bug (https://bugs.chromium.org/p/chromium/issues/detail?id=687574), and strip this out once a fix lands (to avoid the extra work of encoding another audio stream), but this should help a lot with echo in the meantime (unless most of the benefit in echo reduction we were actually seeing was a result of crushing the outbound audio so much that it just picked up less..)

The recommendation still remains, **wear headphones** and disable echo cancellation!