### PR TITLE
Audio zone fixes

### DIFF
--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -235,7 +235,7 @@ AFRAME.registerComponent("zone-audio-source", {
         const playerInfo = playerInfos[i];
         const avatar = playerInfo.el;
 
-        if (this.data.onlyMods && !playerInfo.isOwner) continue;
+        if (this.data.onlyMods && !playerInfo.can("amplify_audio")) continue;
 
         const distanceSquared = avatar.object3D.position.distanceToSquared(tmpWorldPos);
         if (distanceSquared < this.boundingRadiusSquared) {

--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -165,6 +165,8 @@ function createWhiteNoise(audioContext, gain) {
   return whiteNoise;
 }
 
+const tmpWorldPos = new THREE.Vector3();
+
 /**
  * @component zone-audio-source
  * This component looks for audio sources that get near it, keeping track
@@ -220,8 +222,9 @@ AFRAME.registerComponent("zone-audio-source", {
   },
 
   tick() {
+    this.el.object3D.getWorldPosition(tmpWorldPos);
     if (this.trackingEl) {
-      const distanceSquared = this.trackingEl.object3D.position.distanceToSquared(this.el.object3D.position);
+      const distanceSquared = this.trackingEl.object3D.position.distanceToSquared(tmpWorldPos);
       if (distanceSquared > this.boundingRadiusSquared) {
         this.trackingEl = null;
         this.setInput(this.whiteNoise);
@@ -234,7 +237,7 @@ AFRAME.registerComponent("zone-audio-source", {
 
         if (this.data.onlyMods && !playerInfo.isOwner) continue;
 
-        const distanceSquared = avatar.object3D.position.distanceToSquared(this.el.object3D.position);
+        const distanceSquared = avatar.object3D.position.distanceToSquared(tmpWorldPos);
         if (distanceSquared < this.boundingRadiusSquared) {
           this.trackingEl = avatar;
           if (this.data.muteSelf && this.trackingEl.id === "avatar-rig") {

--- a/src/components/player-info.js
+++ b/src/components/player-info.js
@@ -128,7 +128,7 @@ AFRAME.registerComponent("player-info", {
     this.applyDisplayName();
   },
   can(perm) {
-    return !!this.permissiosn[perm];
+    return !!this.permissions && this.permissiosn[perm];
   },
   applyDisplayName() {
     const store = window.APP.store;

--- a/src/components/player-info.js
+++ b/src/components/player-info.js
@@ -120,11 +120,15 @@ AFRAME.registerComponent("player-info", {
     this.updateDisplayNameFromPresenceMeta(e.detail);
   },
   updateDisplayNameFromPresenceMeta(presenceMeta) {
+    this.permissions = presenceMeta.permissions;
     this.displayName = presenceMeta.profile.displayName;
     this.identityName = presenceMeta.profile.identityName;
     this.isRecording = !!(presenceMeta.streaming || presenceMeta.recording);
     this.isOwner = !!(presenceMeta.roles && presenceMeta.roles.owner);
     this.applyDisplayName();
+  },
+  can(perm) {
+    return !!this.permissiosn[perm];
   },
   applyDisplayName() {
     const store = window.APP.store;

--- a/src/components/player-info.js
+++ b/src/components/player-info.js
@@ -62,7 +62,7 @@ AFRAME.registerComponent("player-info", {
         this.playerSessionId = NAF.utils.getCreator(networkedEntity);
         const playerPresence = window.APP.hubChannel.presence.state[this.playerSessionId];
         if (playerPresence) {
-          this.updateDisplayNameFromPresenceMeta(playerPresence.metas[0]);
+          this.updateFromPresenceMeta(playerPresence.metas[0]);
         }
       });
     }
@@ -117,9 +117,9 @@ AFRAME.registerComponent("player-info", {
     if (!this.playerSessionId) return;
     if (this.playerSessionId !== e.detail.sessionId) return;
 
-    this.updateDisplayNameFromPresenceMeta(e.detail);
+    this.updateFromPresenceMeta(e.detail);
   },
-  updateDisplayNameFromPresenceMeta(presenceMeta) {
+  updateFromPresenceMeta(presenceMeta) {
     this.permissions = presenceMeta.permissions;
     this.displayName = presenceMeta.profile.displayName;
     this.identityName = presenceMeta.profile.identityName;

--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -22,7 +22,8 @@ const HUB_CREATOR_PERMISSIONS = [
   "update_roles",
   "close_hub",
   "mute_users",
-  "kick_users"
+  "kick_users",
+  "amplify_audio"
 ];
 const VALID_PERMISSIONS = HUB_CREATOR_PERMISSIONS.concat([
   "tweet",

--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -24,9 +24,15 @@ const HUB_CREATOR_PERMISSIONS = [
   "mute_users",
   "kick_users"
 ];
-const VALID_PERMISSIONS =
-  HUB_CREATOR_PERMISSIONS +
-  ["tweet", "spawn_camera", "spawn_drawing", "spawn_and_move_media", "pin_objects", "spawn_emoji", "fly"];
+const VALID_PERMISSIONS = HUB_CREATOR_PERMISSIONS.concat([
+  "tweet",
+  "spawn_camera",
+  "spawn_drawing",
+  "spawn_and_move_media",
+  "pin_objects",
+  "spawn_emoji",
+  "fly"
+]);
 
 export default class HubChannel extends EventTarget {
   constructor(store, hubId) {


### PR DESCRIPTION
- Fixes #4276 by taking into account the world space position of zone audio sources when doing distances checks
- Uses the new `amplify_audio` permission added in https://github.com/mozilla/reticulum/pull/499 to enforce `modOnly` on zone audio sources. Previously this was using "owner" but this does not work well for bound rooms.
- Fixed an unrelated bug I noticed in hub-channel.js that was incorrectly concatenating arrays using the + operator.. It turned out this mostly just "worked" anyway since the arrays were contacted into a big string, and strings also have an `includes` method which happened to also be correct for this case. Oh javascript.