### PR TITLE
Place media frame content in world space coordinates

### DIFF
--- a/src/systems/media-frames.js
+++ b/src/systems/media-frames.js
@@ -135,6 +135,7 @@ AFRAME.registerComponent("media-frame", {
   },
 
   init() {
+    this.tmpWorldPosition = new THREE.Vector3();
     //TODO these visuals need work
     this.el.setObject3D(
       "guide",
@@ -249,12 +250,9 @@ AFRAME.registerComponent("media-frame", {
   },
 
   snapObject(capturedEl) {
-    // TODO this assumes media frames are all in world space
-    const worldPosition = new THREE.Vector3();
-    this.el.object3D.getWorldPosition(worldPosition);
-    capturedEl.object3D.position.copy(worldPosition);
+    this.el.object3D.getWorldPosition(this.tmpWorldPosition);
+    capturedEl.object3D.position.copy(this.tmpWorldPosition);
     const worldQuat = new THREE.Quaternion();
-    this.el.object3D.updateWorldMatrix(true);
     this.el.object3D.getWorldQuaternion(worldQuat);
     capturedEl.object3D.setRotationFromQuaternion(worldQuat);
     capturedEl.object3D.matrixNeedsUpdate = true;

--- a/src/systems/media-frames.js
+++ b/src/systems/media-frames.js
@@ -250,8 +250,13 @@ AFRAME.registerComponent("media-frame", {
 
   snapObject(capturedEl) {
     // TODO this assumes media frames are all in world space
-    capturedEl.object3D.position.copy(this.el.object3D.position);
-    capturedEl.object3D.rotation.copy(this.el.object3D.rotation);
+    const worldPosition = new THREE.Vector3();
+    this.el.object3D.getWorldPosition(worldPosition);
+    capturedEl.object3D.position.copy(worldPosition);
+    const worldQuat = new THREE.Quaternion();
+    this.el.object3D.updateWorldMatrix(true);
+    this.el.object3D.getWorldQuaternion(worldQuat);
+    capturedEl.object3D.setRotationFromQuaternion(worldQuat);
     capturedEl.object3D.matrixNeedsUpdate = true;
     capturedEl.components["floaty-object"].setLocked(true);
   },
@@ -262,9 +267,13 @@ AFRAME.registerComponent("media-frame", {
         targetId: capturableEntity.id,
         originalTargetScale: new THREE.Vector3().copy(capturableEntity.object3D.scale)
       });
-      // TODO this assumes media frames are all in world space
-      capturableEntity.object3D.position.copy(this.el.object3D.position);
-      capturableEntity.object3D.rotation.copy(this.el.object3D.rotation);
+      const worldPosition = new THREE.Vector3();
+      this.el.object3D.getWorldPosition(worldPosition);
+      capturableEntity.object3D.position.copy(worldPosition);
+      const worldQuat = new THREE.Quaternion();
+      this.el.object3D.updateWorldMatrix(true);
+      this.el.object3D.getWorldQuaternion(worldQuat);
+      capturableEntity.object3D.setRotationFromQuaternion(worldQuat);
       capturableEntity.object3D.scale.setScalar(
         scaleForAspectFit(this.data.bounds, capturableEntity.getObject3D("mesh").scale)
       );


### PR DESCRIPTION
We are currently placing elements in `media-frame`s based on local coordinates so nested `media-frame`s don't place them correctly.

Test scene: https://hubs.mozilla.com/scenes/4zXCrZE