### PR TITLE
Disable THREE.Cache to reduce heap memory consumption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15795,7 +15795,7 @@
       "dev": true
     },
     "aframe": {
-      "version": "github:mozillareality/aframe#6fdea0cdaae21eb6ad779c089eb005011191c29a",
+      "version": "github:mozillareality/aframe#91574ba28f04b4002c6354ee834ff26a6b283d5c",
       "from": "github:mozillareality/aframe#hubs/master",
       "requires": {
         "custom-event-polyfill": "^1.0.6",

--- a/src/hub.js
+++ b/src/hub.js
@@ -13,6 +13,13 @@ import initialBatchImage from "./assets/images/warning_icon.png";
 import loadingEnvironment from "./assets/models/LoadingEnvironment.glb";
 
 import "aframe";
+
+// A-Frame hardcodes THREE.Cache.enabled = true
+// But we don't want to use THREE.Cache because
+// web browser cache should work well.
+// So we disable it here.
+THREE.Cache.enabled = false;
+
 import "./utils/logging";
 import { patchWebGLRenderingContext } from "./utils/webgl";
 patchWebGLRenderingContext();


### PR DESCRIPTION
Fixes #4258 

Our A-Frame fork uses (and the upstreaming will use soon) proper Three.js Cache API, add() and remove(). So now we can disable Three.js Cache just with `THREE.Cache.enabled = false` on our ends.

Another option to disable it would be that we remove `THREE.Cache.enabled = true` line in our A-Frame fork (`Three.Cache.enabled` is `false` by default in Three.js). But I think we should avoid to apply such a special patch if possible because it could cause future potential problems.

It seems we rarely import the A-Frame upstreaming change now but I still think we should avoid to apply a special patch just in case especially if we can easily resolve on our ends.