### PR TITLE
fix object list not updating

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -597,6 +597,10 @@ AFRAME.registerComponent("gltf-model-plus", {
     this.loadTemplates();
   },
 
+  play() {
+    this.el.components["listed-media"] && this.el.sceneEl.emit("listed_media_changed");
+  },
+
   update() {
     this.applySrc(resolveAsset(this.data.src), this.data.contentType);
   },

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -378,6 +378,10 @@ AFRAME.registerComponent("media-video", {
     window.APP.store.addEventListener("statechanged", this.onPreferenceChanged);
   },
 
+  play() {
+    this.el.components["listed-media"] && this.el.sceneEl.emit("listed_media_changed");
+  },
+
   isMineOrLocal() {
     return !this.el.components.networked || (this.networkedEl && NAF.utils.isMine(this.networkedEl));
   },
@@ -1054,6 +1058,10 @@ AFRAME.registerComponent("media-image", {
     alphaCutoff: { type: "number" }
   },
 
+  play() {
+    this.el.components["listed-media"] && this.el.sceneEl.emit("listed_media_changed");
+  },
+
   remove() {
     if (this.data.batch && this.mesh) {
       this.el.sceneEl.systems["hubs-systems"].batchManagerSystem.removeObject(this.mesh);
@@ -1233,6 +1241,10 @@ AFRAME.registerComponent("media-pdf", {
     this.texture.minFilter = THREE.LinearFilter;
 
     this.el.addEventListener("pager-snap-clicked", () => this.snap());
+  },
+
+  play() {
+    this.el.components["listed-media"] && this.el.sceneEl.emit("listed_media_changed");
   },
 
   async snap() {


### PR DESCRIPTION
the listed media list (Objects) does not update: object type remains undefined (cube icon) and object name is `...` .
The list gets updated when adding new objects, except for the just-added object.

Steps to reproduce:
- add an image into the room - see that it is not resolved in listed media
- add another image - see that the first image is now resolved but not the second one
- etc.

Cause:
Object type detection is done by checking the presence of either of the components `media-video`, `media-image`, `media-pdf`, `gltf-model-plus` on the media element but these components are not yet present for new objects when `objects` is being set in `ObjectListProvider`.

Solution:
Emit `listed_media_changed` when these components are playing to trigger `objects` update in `ObjectListProvider`
I'm not sure if this approach makes sense in terms of dependency. I'm thinking that `listed_media_changed` event is not necessarily specifically bound to the media list component, but something like `media_ready` could work better.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/HUBS-793)
