### PR TITLE
fix button color on default theme settings

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 package.json
 *.gltf
 src/vendor/
+src/loaders/basis_transcoder.worker.js

--- a/src/react-components/styles/theme.js
+++ b/src/react-components/styles/theme.js
@@ -3,6 +3,8 @@ import PropTypes from "prop-types";
 
 let config = process.env.APP_CONFIG;
 
+// Note: duplicated logic in utils/theme.js
+
 // Storybook includes environment variables as a string
 // https://storybook.js.org/docs/react/configure/environment-variables
 if (!config && process.env.STORYBOOK_APP_CONFIG) {

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -22,17 +22,25 @@ const DEFAULT_COLORS = {
   "nametag-border-color-raised-hand": "#FFCD74"
 };
 
+// Note: duplicated logic in react-components/styles/theme.js
+const darkmodeQuery = window.matchMedia("(prefers-color-scheme: dark)");
+let isDarkMode = darkmodeQuery.matches;
+darkmodeQuery.addEventListener("change", event => {
+  isDarkMode = event.matches;
+});
+
 function getThemeColor(name) {
+  const themes = configs.APP_CONFIG?.theme?.themes;
+
   const themeId = window.APP?.store?.state?.preferences?.theme;
 
   const theme =
-    (themeId && configs.APP_CONFIG?.theme?.themes?.find(theme => theme.id === themeId)) ||
-    configs.APP_CONFIG?.theme?.themes?.find(theme => theme.default === true);
-  if (theme?.variables?.[name]) {
-    return theme.variables[name];
-  }
+    themes &&
+    ((themeId && themes.find(t => t.id === themeId)) ||
+      (isDarkMode && themes.find(t => t.darkModeDefault)) ||
+      themes.find(t => t.default === true));
 
-  return DEFAULT_COLORS[name];
+  return theme?.variables?.[name] || DEFAULT_COLORS[name];
 }
 
 function activateTheme() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -163,6 +163,9 @@ async function fetchAppConfigAndEnvironmentVars() {
   }
 
   const appConfig = await appConfigsResponse.json();
+  if (appConfig.theme?.themes) {
+    appConfig.theme.themes = JSON.parse(appConfig.theme.themes);
+  }
 
   // dev.reticulum.io doesn't run ita
   if (host === "dev.reticulum.io") {
@@ -320,6 +323,9 @@ module.exports = async (env, argv) => {
       inline: liveReload,
       historyApiFallback: {
         rewrites: [
+          { from: /^\/link/, to: "/link.html" },
+          { from: /^\/avatars/, to: "/avatar.html" },
+          { from: /^\/scenes/, to: "/scene.html" },
           { from: /^\/signin/, to: "/signin.html" },
           { from: /^\/discord/, to: "/discord.html" },
           { from: /^\/cloud/, to: "/cloud.html" },


### PR DESCRIPTION
- fix action button color: when user preference theme is 'default', the action button and action button highlight theme colors are not correctly applied on action buttons. Note that theme logic is duplicated in `utils/themes.json` and `react-components/styles/themes.js`. I did not find a good way to prevent this but I added a mention of this in both files.
- fixes for `webpack.config.json`:
  - fix localDev themes: themes JSON was not parsed
  - ~~fix remoteDev themes: moved theme from `appConfig.themes` to `appConfig.theme.themes`~~ (already fixed in master)
  - add `/link`, `/scenes` and `/avatars` paths for development
  - add `basis_transcoder.worker.js` to `.prettierignore` to prevent prettifying with `npm run prettier`

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/HUBS-792)
