### PR TITLE
Fix forward and backward motion when using on-screen touch joysticks.

### DIFF
--- a/src/components/virtual-gamepad-controls.js
+++ b/src/components/virtual-gamepad-controls.js
@@ -160,7 +160,7 @@ AFRAME.registerComponent("virtual-gamepad-controls", {
     if (window.APP.preferenceScreenIsVisible) return;
     const angle = joystick.angle.radian;
     const force = joystick.force < 1 ? joystick.force : 1;
-    this.displacement.set(Math.cos(angle), 0, Math.sin(angle)).multiplyScalar(force * 1.85);
+    this.displacement.set(Math.cos(angle), 0, -Math.sin(angle)).multiplyScalar(force * 1.85);
     this.moving = true;
   },
 

--- a/src/systems/character-controller-system.js
+++ b/src/systems/character-controller-system.js
@@ -71,7 +71,6 @@ export class CharacterControllerSystem {
     this.waypoints.push({ transform: getPooledMatrix4().copy(inTransform), isInstant, waypointComponentData }); //TODO: don't create new object
   }
   enqueueRelativeMotion(motion) {
-    motion.z *= -1;
     this.relativeMotion.add(motion);
   }
   enqueueInPlaceRotationAroundWorldUp(dXZ) {


### PR DESCRIPTION
The on-screen joysticks "stutter" when you try and go forward and back. This is caused by the Z component of velocity being inverted in order to map _joystick-up_ to _world-forward_, but `this.displacement` is passed by reference so the Z component gets inverted back-and-forth every frame, the net effect of which is zero forward motion. Wiggling the joystick means that `this.displacement` is set correctly every frame and overrides the inversion, so it's not immediately obvious there's a problem, but movement feels "sticky".

Inverting the value when it was calculated seemed the most appropriate fix as the code is already making joystick-to-world-coordinate mapping assumptions there anyway.