### PR TITLE
VRM support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36299,8 +36299,8 @@
       "dev": true
     },
     "three": {
-      "version": "github:mozillareality/three.js#494c88f493ca73c4521171bc849b2918f3a5c528",
-      "from": "github:mozillareality/three.js#hubs/master"
+      "version": "0.128.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.128.0.tgz"
     },
     "three-ammo": {
       "version": "1.0.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36302,9 +36302,8 @@
       "resolved": "https://registry.npmjs.org/three/-/three-0.128.0.tgz"
     },
     "three-ammo": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/three-ammo/-/three-ammo-1.0.12.tgz",
-      "integrity": "sha512-lGA0RmdqvFHb84Glc/VHnMlWSU+Bywu7tu6Sb3woQVt+2Qm8UGSws4VIfzW7aYmMk3Vf1SHBSQfbwW0LWK+HCA=="
+      "version": "github:takahirox/three-ammo#e7e991ed288277880a999c7f751338b6e7cf67dd",
+      "from": "github:takahirox/three-ammo#LatestThree"
     },
     "three-bmfont-text": {
       "version": "github:takahirox/three-bmfont-text#4d80acca312f7bdd2b333a8da3ec73a009fdc54c",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36328,9 +36328,9 @@
       }
     },
     "three-mesh-bvh": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.1.2.tgz",
-      "integrity": "sha512-ZwwpWalwKGUEp+APg2plFI5v2ws0h7ii++a/sKBom9tvAum6wNxF4oFDQrMr87MukzJT8XKnGJli4PeLZDKTcw=="
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.3.7.tgz",
+      "integrity": "sha512-veRJRj0mY2rBj9yRZVg/E98wd6e7AzqzTq/+6ispY6m50gYuGitUNih2dRQzbkMcwRECLURvuudb9BFW3/swAw=="
     },
     "three-pathfinding": {
       "version": "github:MozillaReality/three-pathfinding#9934636508ff8f445ac1b1bba5dd55c5a69266ff",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23378,6 +23378,11 @@
         }
       }
     },
+    "gl-matrix": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-2.8.1.tgz",
+      "integrity": "sha512-0YCjVpE3pS5XWlN3J4X7AiAx65+nqAI54LndtVFnQZB6G/FVLkZH8y8V6R3cIoOQR4pUdfwQGd1iwyoXHJ4Qfw=="
+    },
     "gl-preserve-state": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gl-preserve-state/-/gl-preserve-state-1.0.0.tgz",
@@ -38270,6 +38275,15 @@
       "version": "1.0.18",
       "resolved": "https://registry.npmjs.org/webvr-polyfill-dpdb/-/webvr-polyfill-dpdb-1.0.18.tgz",
       "integrity": "sha512-O0S1ZGEWyPvyZEkS2VbyV7mtir/NM9MNK3EuhbHPoJ8EHTky2pTXehjIl+IiDPr+Lldgx129QGt3NGly7rwRPw=="
+    },
+    "webxr-polyfill": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/webxr-polyfill/-/webxr-polyfill-2.0.3.tgz",
+      "integrity": "sha512-lgTKYVeD4HeTwWdJN+SeS6iflGx3epz/3dww9X4GyuuXmYGAV5p8l34jUM/HRGHn1jKS3oZNZRC/J9MlSk/Zhg==",
+      "requires": {
+        "cardboard-vr-display": "^1.0.19",
+        "gl-matrix": "^2.8.1"
+      }
     },
     "well-known-symbols": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15795,8 +15795,8 @@
       "dev": true
     },
     "aframe": {
-      "version": "github:mozillareality/aframe#6fdea0cdaae21eb6ad779c089eb005011191c29a",
-      "from": "github:mozillareality/aframe#hubs/master",
+      "version": "github:takahirox/aframe#67a760fccda167b91d50ec31bba81092a5fcdd2d",
+      "from": "github:takahirox/aframe#hubs/LatestThreeWIP",
       "requires": {
         "custom-event-polyfill": "^1.0.6",
         "debug": "github:ngokevin/debug#noTimestamp",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6897,6 +6897,10 @@
         }
       }
     },
+    "@pixiv/three-vrm": {
+      "version": "github:takahirox/three-vrm#e3fef3f10ce03d3a49e512f0b2ac7e383dac0eee",
+      "from": "@pixiv/three-vrm@github:takahirox/three-vrm"
+    },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36337,8 +36337,8 @@
       "from": "github:takahirox/three-pathfinding#hubs/master3"
     },
     "three-to-ammo": {
-      "version": "github:infinitelee/three-to-ammo#92fd0e8300e693d4d48a603a8c446e520f9568ab",
-      "from": "github:infinitelee/three-to-ammo"
+      "version": "github:takahirox/three-to-ammo#501ad4eaa03232806d53d77781ede54ddb582ec6",
+      "from": "github:takahirox/three-to-ammo#LatestThree"
     },
     "throttle-debounce": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36307,8 +36307,8 @@
       "integrity": "sha512-lGA0RmdqvFHb84Glc/VHnMlWSU+Bywu7tu6Sb3woQVt+2Qm8UGSws4VIfzW7aYmMk3Vf1SHBSQfbwW0LWK+HCA=="
     },
     "three-bmfont-text": {
-      "version": "github:mozillareality/three-bmfont-text#3cbce0b90403d7ca6e690e9174c650f4606b53d8",
-      "from": "github:mozillareality/three-bmfont-text#hubs/master",
+      "version": "github:takahirox/three-bmfont-text#4d80acca312f7bdd2b333a8da3ec73a009fdc54c",
+      "from": "github:takahirox/three-bmfont-text#hubs/LatestThree",
       "requires": {
         "array-shuffle": "^1.0.1",
         "inherits": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36333,8 +36333,8 @@
       "integrity": "sha512-veRJRj0mY2rBj9yRZVg/E98wd6e7AzqzTq/+6ispY6m50gYuGitUNih2dRQzbkMcwRECLURvuudb9BFW3/swAw=="
     },
     "three-pathfinding": {
-      "version": "github:MozillaReality/three-pathfinding#9934636508ff8f445ac1b1bba5dd55c5a69266ff",
-      "from": "github:MozillaReality/three-pathfinding#hubs/master2"
+      "version": "github:takahirox/three-pathfinding#f7c3b8fbc777983081e6db2ffadd118bd5122afc",
+      "from": "github:takahirox/three-pathfinding#hubs/master3"
     },
     "three-to-ammo": {
       "version": "github:infinitelee/three-to-ammo#92fd0e8300e693d4d48a603a8c446e520f9568ab",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19308,9 +19308,8 @@
       "dev": true
     },
     "buffered-interpolation": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/buffered-interpolation/-/buffered-interpolation-0.2.5.tgz",
-      "integrity": "sha512-LauOWiVXZppapDpc8y2yzcf3/pKU1Exal/+H0EZeNVxttnWHqtyhEaJ2J4U5yia71FWqZvywnhx8xneh073xbA=="
+      "version": "github:takahirox/buffered-interpolation#a419211f62d15acc67e50e8af383d012a2dd4c99",
+      "from": "github:takahirox/buffered-interpolation#LatestThree"
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -27746,7 +27745,7 @@
       "version": "github:mozillareality/networked-aframe#ae8ca30fcded2369c8702686b07cce46dfc16306",
       "from": "github:mozillareality/networked-aframe#master",
       "requires": {
-        "buffered-interpolation": "^0.2.5",
+        "buffered-interpolation": "github:takahirox/buffered-interpolation#a419211f62d15acc67e50e8af383d012a2dd4c99",
         "easyrtc": "1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "screenfull": "^4.0.1",
     "semver": "^7.3.2",
     "three": "^0.128.0",
-    "three-ammo": "^1.0.12",
+    "three-ammo": "github:takahirox/three-ammo#LatestThree",
     "three-bmfont-text": "github:takahirox/three-bmfont-text#hubs/LatestThree",
     "three-mesh-bvh": "^0.3.7",
     "three-pathfinding": "github:takahirox/three-pathfinding#hubs/master3",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "semver": "^7.3.2",
     "three": "^0.128.0",
     "three-ammo": "^1.0.12",
-    "three-bmfont-text": "github:mozillareality/three-bmfont-text#hubs/master",
+    "three-bmfont-text": "github:takahirox/three-bmfont-text#hubs/LatestThree",
     "three-mesh-bvh": "^0.3.7",
     "three-pathfinding": "github:takahirox/three-pathfinding#hubs/master3",
     "three-to-ammo": "github:takahirox/three-to-ammo#LatestThree",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "three-ammo": "^1.0.12",
     "three-bmfont-text": "github:mozillareality/three-bmfont-text#hubs/master",
     "three-mesh-bvh": "^0.3.7",
-    "three-pathfinding": "github:MozillaReality/three-pathfinding#hubs/master2",
+    "three-pathfinding": "github:takahirox/three-pathfinding#hubs/master3",
     "three-to-ammo": "github:infinitelee/three-to-ammo",
     "use-clipboard-copy": "^0.1.2",
     "uuid": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "three-bmfont-text": "github:mozillareality/three-bmfont-text#hubs/master",
     "three-mesh-bvh": "^0.3.7",
     "three-pathfinding": "github:takahirox/three-pathfinding#hubs/master3",
-    "three-to-ammo": "github:infinitelee/three-to-ammo",
+    "three-to-ammo": "github:takahirox/three-to-ammo#LatestThree",
     "use-clipboard-copy": "^0.1.2",
     "uuid": "^3.2.1",
     "webrtc-adapter": "^7.7.0",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "three": "^0.128.0",
     "three-ammo": "^1.0.12",
     "three-bmfont-text": "github:mozillareality/three-bmfont-text#hubs/master",
-    "three-mesh-bvh": "^0.1.2",
+    "three-mesh-bvh": "^0.3.7",
     "three-pathfinding": "github:MozillaReality/three-pathfinding#hubs/master2",
     "three-to-ammo": "github:infinitelee/three-to-ammo",
     "use-clipboard-copy": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@fortawesome/react-fontawesome": "^0.1.0",
     "@mozillareality/easing-functions": "^0.1.1",
     "@mozillareality/three-batch-manager": "github:mozillareality/three-batch-manager#master",
+    "@pixiv/three-vrm": "github:takahirox/three-vrm",
     "@popperjs/core": "^2.4.4",
     "aframe": "github:takahirox/aframe#hubs/LatestThreeWIP",
     "aframe-rounded": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "ammo-debug-drawer": "github:infinitelee/ammo-debug-drawer",
     "ammo.js": "github:mozillareality/ammo.js#hubs/master",
     "animejs": "github:mozillareality/anime#hubs/master",
-    "buffered-interpolation": "^0.2.5",
+    "buffered-interpolation": "github:takahirox/buffered-interpolation#LatestThree",
     "classnames": "^2.2.5",
     "color": "^3.1.2",
     "copy-to-clipboard": "^3.0.8",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "use-clipboard-copy": "^0.1.2",
     "uuid": "^3.2.1",
     "webrtc-adapter": "^7.7.0",
+    "webxr-polyfill": "^2.0.3",
     "zip-loader": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "resize-observer-polyfill": "^1.5.1",
     "screenfull": "^4.0.1",
     "semver": "^7.3.2",
-    "three": "github:mozillareality/three.js#hubs/master",
+    "three": "^0.128.0",
     "three-ammo": "^1.0.12",
     "three-bmfont-text": "github:mozillareality/three-bmfont-text#hubs/master",
     "three-mesh-bvh": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@mozillareality/easing-functions": "^0.1.1",
     "@mozillareality/three-batch-manager": "github:mozillareality/three-batch-manager#master",
     "@popperjs/core": "^2.4.4",
-    "aframe": "github:mozillareality/aframe#hubs/master",
+    "aframe": "github:takahirox/aframe#hubs/LatestThreeWIP",
     "aframe-rounded": "^1.0.3",
     "aframe-slice9-component": "^1.0.0",
     "ammo-debug-drawer": "github:infinitelee/ammo-debug-drawer",

--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -634,10 +634,10 @@ AFRAME.registerComponent("camera-tool", {
           boneVisibilitySystem.tick();
         }
 
-        const tmpVRFlag = renderer.vr.enabled;
+        const tmpVRFlag = renderer.xr.enabled;
         const tmpOnAfterRender = sceneEl.object3D.onAfterRender;
         delete sceneEl.object3D.onAfterRender;
-        renderer.vr.enabled = false;
+        renderer.xr.enabled = false;
 
         if (allowVideo && this.videoRecorder && !this.videoRenderTarget) {
           // Create a separate render target for video becuase we need to flip and (sometimes) downscale it before
@@ -659,7 +659,7 @@ AFRAME.registerComponent("camera-tool", {
         renderer.render(sceneEl.object3D, this.camera);
         renderer.setRenderTarget(null);
 
-        renderer.vr.enabled = tmpVRFlag;
+        renderer.xr.enabled = tmpVRFlag;
         sceneEl.object3D.onAfterRender = tmpOnAfterRender;
         if (playerHead) {
           playerHead.visible = false;

--- a/src/components/ik-controller.js
+++ b/src/components/ik-controller.js
@@ -242,10 +242,9 @@ AFRAME.registerComponent("ik-controller", {
         if (yDelta > this.data.maxLerpAngle) {
           avatar.quaternion.copy(cameraYQuaternion);
         } else {
-          Quaternion.slerp(
+          avatar.quaternion.slerpQuaternions(
             avatar.quaternion,
             cameraYQuaternion,
-            avatar.quaternion,
             (this.data.rotationSpeed * dt) / 1000
           );
         }

--- a/src/components/ik-controller.js
+++ b/src/components/ik-controller.js
@@ -160,7 +160,7 @@ AFRAME.registerComponent("ik-controller", {
     this.middleEyePosition.addVectors(this.leftEye.position, this.rightEye.position);
     this.middleEyePosition.divideScalar(2);
     this.middleEyeMatrix.makeTranslation(this.middleEyePosition.x, this.middleEyePosition.y, this.middleEyePosition.z);
-    this.invMiddleEyeToHead = this.middleEyeMatrix.getInverse(this.middleEyeMatrix);
+    this.invMiddleEyeToHead = this.middleEyeMatrix.copy(this.middleEyeMatrix).invert();
 
     this.invHipsToHeadVector
       .addVectors(this.chest.position, this.neck.position)
@@ -262,7 +262,7 @@ AFRAME.registerComponent("ik-controller", {
 
       avatar.updateMatrix();
       rootToChest.multiplyMatrices(avatar.matrix, chest.matrix);
-      invRootToChest.getInverse(rootToChest);
+      invRootToChest.copy(rootToChest).invert();
 
       root.matrixNeedsUpdate = true;
       neck.matrixNeedsUpdate = true;

--- a/src/components/ik-controller.js
+++ b/src/components/ik-controller.js
@@ -257,7 +257,7 @@ AFRAME.registerComponent("ik-controller", {
 
       // Take the head orientation computed from the hmd, remove the Y rotation already applied to it by the hips,
       // and apply it to the head
-      invHipsQuaternion.copy(avatar.quaternion).inverse();
+      invHipsQuaternion.copy(avatar.quaternion).invert();
       head.quaternion.setFromRotationMatrix(headTransform).premultiply(invHipsQuaternion);
 
       avatar.updateMatrix();

--- a/src/components/ik-controller.js
+++ b/src/components/ik-controller.js
@@ -323,7 +323,7 @@ AFRAME.registerComponent("ik-controller", {
     const cameraWorld = new THREE.Vector3();
     const isInViewOfCamera = (screenCamera, pos) => {
       frustumMatrix.multiplyMatrices(screenCamera.projectionMatrix, screenCamera.matrixWorldInverse);
-      frustum.setFromMatrix(frustumMatrix);
+      frustum.setFromProjectionMatrix(frustumMatrix);
       return frustum.containsPoint(pos);
     };
 

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -18,6 +18,7 @@ import { refreshMediaMirror, getCurrentMirroredMedia } from "../utils/mirror-uti
 import { detect } from "detect-browser";
 import semver from "semver";
 import { createPlaneBufferGeometry } from "../utils/three-utils";
+import HubsTextureLoader from "../loaders/HubsTextureLoader";
 
 import qsTruthy from "../utils/qs_truthy";
 
@@ -39,7 +40,7 @@ const TYPE_IMG_PNG = { type: "image/png" };
 const parseGIF = promisifyWorker(new GIFWorker());
 
 const isIOS = AFRAME.utils.device.isIOS();
-const audioIconTexture = new THREE.TextureLoader().load(audioIcon);
+const audioIconTexture = new HubsTextureLoader().load(audioIcon);
 
 export const VOLUME_LABELS = [];
 for (let i = 0; i <= 20; i++) {

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -17,6 +17,7 @@ import { applyPersistentSync } from "../utils/permissions-utils";
 import { refreshMediaMirror, getCurrentMirroredMedia } from "../utils/mirror-utils";
 import { detect } from "detect-browser";
 import semver from "semver";
+import { createPlaneBufferGeometry } from "../utils/three-utils";
 
 import qsTruthy from "../utils/qs_truthy";
 
@@ -1163,7 +1164,7 @@ AFRAME.registerComponent("media-image", {
           }
         }
       } else {
-        geometry = new THREE.PlaneBufferGeometry(1, 1, 1, 1, texture.flipY);
+        geometry = createPlaneBufferGeometry(1, 1, 1, 1, texture.flipY);
         material.side = THREE.DoubleSide;
       }
 
@@ -1304,7 +1305,7 @@ AFRAME.registerComponent("media-pdf", {
 
     if (!this.mesh) {
       const material = new THREE.MeshBasicMaterial();
-      const geometry = new THREE.PlaneBufferGeometry(1, 1, 1, 1, texture.flipY);
+      const geometry = createPlaneBufferGeometry(1, 1, 1, 1, texture.flipY);
       material.side = THREE.DoubleSide;
 
       this.mesh = new THREE.Mesh(geometry, material);

--- a/src/components/particle-emitter.js
+++ b/src/components/particle-emitter.js
@@ -57,9 +57,7 @@ AFRAME.registerComponent("particle-emitter", {
       accessibleUrl = proxiedUrlFor(canonicalUrl);
     }
 
-    const texture = new THREE.Texture();
-
-    await textureLoader.loadTextureAsync(texture, accessibleUrl);
+    const texture = await textureLoader.loadAsync(accessibleUrl);
 
     // Guard against src changing while request was in flight
     if (this.data.src !== src) {

--- a/src/components/pitch-yaw-rotator.js
+++ b/src/components/pitch-yaw-rotator.js
@@ -28,7 +28,7 @@ const rotatePitchAndYaw = (function() {
     q.copy(owq)
       .premultiply(pq)
       .premultiply(yq)
-      .premultiply(opq.inverse());
+      .premultiply(opq.invert());
     v.set(0, 1, 0).applyQuaternion(q);
     const newUpDot = v.dot(UP);
     v.set(0, 0, 1).applyQuaternion(q);

--- a/src/components/scene-preview-camera.js
+++ b/src/components/scene-preview-camera.js
@@ -80,7 +80,7 @@ AFRAME.registerComponent("scene-preview-camera", {
       const fromRot = this.backwards ? this.targetRotation : this.startRotation;
       const toRot = this.backwards ? this.startRotation : this.targetRotation;
 
-      THREE.Quaternion.slerp(fromRot, toRot, newRot, t);
+      newRot.slerpQuaternions(fromRot, toRot, t);
 
       this.el.object3D.position.set(lerp(from.x, to.x, t), lerp(from.y, to.y, t), lerp(from.z, to.z, t));
 

--- a/src/components/simple-water.js
+++ b/src/components/simple-water.js
@@ -1,5 +1,6 @@
 import { SimplexNoise } from "three/examples/jsm/math/SimplexNoise";
 import waterNormalsUrl from "../assets/waternormals.jpg";
+import HubsTextureLoader from "../loaders/HubsTextureLoader";
 
 const {
   Mesh,
@@ -7,7 +8,6 @@ const {
   MeshStandardMaterial,
   MeshPhongMaterial,
   Vector2,
-  TextureLoader,
   RepeatWrapping
 } = THREE;
 
@@ -287,7 +287,7 @@ AFRAME.registerComponent("simple-water", {
 
   init() {
     if (!waterNormalMap) {
-      waterNormalMap = new TextureLoader().load(waterNormalsUrl);
+      waterNormalMap = new HubsTextureLoader().load(waterNormalsUrl);
     }
 
     const usePhongShader = window.APP.store.materialQualitySetting !== "high";

--- a/src/components/simple-water.js
+++ b/src/components/simple-water.js
@@ -2,14 +2,7 @@ import { SimplexNoise } from "three/examples/jsm/math/SimplexNoise";
 import waterNormalsUrl from "../assets/waternormals.jpg";
 import HubsTextureLoader from "../loaders/HubsTextureLoader";
 
-const {
-  Mesh,
-  PlaneBufferGeometry,
-  MeshStandardMaterial,
-  MeshPhongMaterial,
-  Vector2,
-  RepeatWrapping
-} = THREE;
+const { Mesh, PlaneBufferGeometry, MeshStandardMaterial, MeshPhongMaterial, Vector2, RepeatWrapping } = THREE;
 
 /**
  * SimpleWater

--- a/src/components/skybox.js
+++ b/src/components/skybox.js
@@ -12,7 +12,6 @@ const {
   Mesh,
   Object3D,
   PMREMGenerator,
-  PMREMCubeUVPacker,
   RGBAFormat,
   Scene,
   ShaderMaterial,
@@ -365,12 +364,16 @@ export default class Sky extends Object3D {
     const skyScene = new Scene();
     skyScene.add(this.sky);
 
-    const cubeCamera = new CubeCamera(1, 100000, new WebGLCubeRenderTarget(512, {
-      format: RGBAFormat,
-      magFilter: LinearFilter,
-      minFilter: LinearFilter,
-      encoding: sRGBEncoding
-    }));
+    const cubeCamera = new CubeCamera(
+      1,
+      100000,
+      new WebGLCubeRenderTarget(512, {
+        format: RGBAFormat,
+        magFilter: LinearFilter,
+        minFilter: LinearFilter,
+        encoding: sRGBEncoding
+      })
+    );
     skyScene.add(cubeCamera);
     skyScene.add(this.sky);
     cubeCamera.update(renderer, skyScene);

--- a/src/components/skybox.js
+++ b/src/components/skybox.js
@@ -3,18 +3,24 @@ import qsTruthy from "../utils/qs_truthy";
 const isBotMode = qsTruthy("bot");
 
 const {
-  Scene,
-  CubeCamera,
-  Object3D,
-  Vector3,
-  BoxBufferGeometry,
-  ShaderMaterial,
-  UniformsUtils,
+  AmbientLight,
   BackSide,
+  BoxBufferGeometry,
+  CubeCamera,
+  LightProbeGenerator,
+  LinearFilter,
   Mesh,
-  UniformsLib,
+  Object3D,
   PMREMGenerator,
-  PMREMCubeUVPacker
+  PMREMCubeUVPacker,
+  RGBAFormat,
+  Scene,
+  ShaderMaterial,
+  sRGBEncoding,
+  UniformsLib,
+  UniformsUtils,
+  Vector3,
+  WebGLCubeRenderTarget
 } = THREE;
 
 /**
@@ -369,7 +375,7 @@ export default class Sky extends Object3D {
     skyScene.add(this.sky);
     cubeCamera.update(renderer, skyScene);
     this.add(this.sky);
-    const lightProbe = THREE.LightProbeGenerator.fromRenderTargetCube(renderer, cubeCamera.renderTarget);
+    const lightProbe = LightProbeGenerator.fromCubeRenderTarget(renderer, cubeCamera.renderTarget);
     cubeCamera.renderTarget.dispose();
     return lightProbe;
   }
@@ -482,7 +488,7 @@ AFRAME.registerComponent("skybox", {
       // Without it, objects are significantly darker in brighter environments.
       // It's kept to a low value to not wash out objects in very dark environments.
       // This is a hack, but the results are much better than they are without it.
-      this.el.setObject3D("ambient-light", new THREE.AmbientLight(0xffffff, 0.3));
+      this.el.setObject3D("ambient-light", new AmbientLight(0xffffff, 0.3));
       this.el.setObject3D("light-probe", this.sky.generateLightProbe(renderer));
     }
   },

--- a/src/components/skybox.js
+++ b/src/components/skybox.js
@@ -345,13 +345,13 @@ export default class Sky extends Object3D {
     skyScene.add(this.sky);
     cubeCamera.update(renderer, skyScene);
     this.add(this.sky);
-    const vrEnabled = renderer.vr.enabled;
-    renderer.vr.enabled = false;
+    const vrEnabled = renderer.xr.enabled;
+    renderer.xr.enabled = false;
     const pmremGenerator = new PMREMGenerator(cubeCamera.renderTarget.texture);
     pmremGenerator.update(renderer);
     const pmremCubeUVPacker = new PMREMCubeUVPacker(pmremGenerator.cubeLods);
     pmremCubeUVPacker.update(renderer);
-    renderer.vr.enabled = vrEnabled;
+    renderer.xr.enabled = vrEnabled;
     pmremGenerator.dispose();
     pmremCubeUVPacker.dispose();
     cubeCamera.renderTarget.dispose();

--- a/src/components/skybox.js
+++ b/src/components/skybox.js
@@ -340,7 +340,7 @@ export default class Sky extends Object3D {
 
   generateEnvironmentMap(renderer) {
     const skyScene = new Scene();
-    const cubeCamera = new CubeCamera(1, 100000, 512);
+    const cubeCamera = new CubeCamera(1, 100000, new WebGLCubeRenderTarget(512));
     skyScene.add(cubeCamera);
     skyScene.add(this.sky);
     cubeCamera.update(renderer, skyScene);
@@ -362,12 +362,12 @@ export default class Sky extends Object3D {
     const skyScene = new Scene();
     skyScene.add(this.sky);
 
-    const cubeCamera = new THREE.CubeCamera(1, 100000, 512, {
-      format: THREE.RGBAFormat,
-      magFilter: THREE.LinearFilter,
-      minFilter: THREE.LinearFilter
-    });
-    cubeCamera.renderTarget.texture.encoding = THREE.sRGBEncoding;
+    const cubeCamera = new CubeCamera(1, 100000, new WebGLCubeRenderTarget(512, {
+      format: RGBAFormat,
+      magFilter: LinearFilter,
+      minFilter: LinearFilter,
+      encoding: sRGBEncoding
+    }));
     skyScene.add(cubeCamera);
     skyScene.add(this.sky);
     cubeCamera.update(renderer, skyScene);

--- a/src/components/skybox.js
+++ b/src/components/skybox.js
@@ -1,4 +1,8 @@
-import "three/examples/js/lights/LightProbeGenerator";
+// It seems we need to use require to import modules
+// under the three/examples/js to avoid tree shaking
+// in webpack production mode.
+require("three/examples/js/lights/LightProbeGenerator");
+
 import qsTruthy from "../utils/qs_truthy";
 const isBotMode = qsTruthy("bot");
 

--- a/src/components/skybox.js
+++ b/src/components/skybox.js
@@ -347,15 +347,12 @@ export default class Sky extends Object3D {
     this.add(this.sky);
     const vrEnabled = renderer.xr.enabled;
     renderer.xr.enabled = false;
-    const pmremGenerator = new PMREMGenerator(cubeCamera.renderTarget.texture);
-    pmremGenerator.update(renderer);
-    const pmremCubeUVPacker = new PMREMCubeUVPacker(pmremGenerator.cubeLods);
-    pmremCubeUVPacker.update(renderer);
+    const pmremGenerator = new PMREMGenerator(renderer);
+    const envMap = pmremGenerator.fromCubemap(cubeCamera.renderTarget.texture).texture;
     renderer.xr.enabled = vrEnabled;
     pmremGenerator.dispose();
-    pmremCubeUVPacker.dispose();
     cubeCamera.renderTarget.dispose();
-    return pmremCubeUVPacker.CubeUVRenderTarget.texture;
+    return envMap;
   }
 
   generateLightProbe(renderer) {

--- a/src/components/skybox.js
+++ b/src/components/skybox.js
@@ -1,5 +1,3 @@
-import "three/examples/js/pmrem/PMREMGenerator";
-import "three/examples/js/pmrem/PMREMCubeUVPacker";
 import "three/examples/js/lights/LightProbeGenerator";
 import qsTruthy from "../utils/qs_truthy";
 const isBotMode = qsTruthy("bot");

--- a/src/components/teleporter.js
+++ b/src/components/teleporter.js
@@ -24,7 +24,6 @@ const RayCurve = function(numPoints, width) {
   });
 
   this.mesh = new THREE.Mesh(this.geometry, this.material);
-  this.mesh.drawMode = THREE.TriangleStripDrawMode;
 
   this.mesh.frustumCulled = false;
   this.mesh.vertices = this.vertices;

--- a/src/components/teleporter.js
+++ b/src/components/teleporter.js
@@ -12,8 +12,7 @@ function easeOutIn(t) {
 
 const RayCurve = function(numPoints, width) {
   this.geometry = new THREE.BufferGeometry();
-  this.vertices = new Float32Array(numPoints * 3 * 2);
-  this.uvs = new Float32Array(numPoints * 2 * 2);
+  this.vertices = new Float32Array(numPoints * 3 * 6);
   this.width = width;
 
   this.geometry.setAttribute("position", new THREE.BufferAttribute(this.vertices, 3).setUsage(THREE.DynamicDrawUsage));
@@ -32,9 +31,9 @@ const RayCurve = function(numPoints, width) {
   this.numPoints = numPoints;
 };
 
+const UP = new THREE.Vector3(0, 1, 0);
 RayCurve.prototype = {
   setDirection: function(direction) {
-    const UP = new THREE.Vector3(0, 1, 0);
     this.direction
       .copy(direction)
       .cross(UP)
@@ -47,21 +46,63 @@ RayCurve.prototype = {
   },
 
   setPoint: (function() {
-    const posA = new THREE.Vector3();
-    const posB = new THREE.Vector3();
+    const A = new THREE.Vector3();
+    const B = new THREE.Vector3();
+    const C = new THREE.Vector3();
+    const D = new THREE.Vector3();
 
-    return function(i, point) {
-      posA.copy(point).add(this.direction);
-      posB.copy(point).sub(this.direction);
+    return function(i, P) {
+      let idx = 3 * 6 * i;
 
-      let idx = 2 * 3 * i;
-      this.vertices[idx++] = posA.x;
-      this.vertices[idx++] = posA.y;
-      this.vertices[idx++] = posA.z;
+      A.copy(P).add(this.direction);
+      B.copy(P).sub(this.direction);
+      C.set(
+        // Previous A
+        i === 0 ? A.x : this.vertices[idx - 3],
+        i === 0 ? A.y : this.vertices[idx - 2],
+        i === 0 ? A.z : this.vertices[idx - 1]
+      );
+      D.set(
+        // Previous B
+        i === 0 ? B.x : this.vertices[idx - 6],
+        i === 0 ? B.y : this.vertices[idx - 5],
+        i === 0 ? B.z : this.vertices[idx - 4]
+      );
 
-      this.vertices[idx++] = posB.x;
-      this.vertices[idx++] = posB.y;
-      this.vertices[idx++] = posB.z;
+      //   A---P---B
+      //   | \     |
+      //   |  \    |
+      //   |   \   |
+      //   |    \  |
+      //   |     \ |
+      //   |      \|
+      //   C-------D
+      //   A'--P'--B' Previous P
+      //   | \     |
+
+      this.vertices[idx++] = A.x;
+      this.vertices[idx++] = A.y;
+      this.vertices[idx++] = A.z;
+
+      this.vertices[idx++] = C.x;
+      this.vertices[idx++] = C.y;
+      this.vertices[idx++] = C.z;
+
+      this.vertices[idx++] = D.x;
+      this.vertices[idx++] = D.y;
+      this.vertices[idx++] = D.z;
+
+      this.vertices[idx++] = D.x;
+      this.vertices[idx++] = D.y;
+      this.vertices[idx++] = D.z;
+
+      this.vertices[idx++] = B.x;
+      this.vertices[idx++] = B.y;
+      this.vertices[idx++] = B.z;
+
+      this.vertices[idx++] = A.x;
+      this.vertices[idx++] = A.y;
+      this.vertices[idx++] = A.z;
 
       this.geometry.attributes.position.needsUpdate = true;
     };

--- a/src/components/transform-object-button.js
+++ b/src/components/transform-object-button.js
@@ -142,7 +142,7 @@ AFRAME.registerSystem("transform-selected-object", {
         if (qAlmostEquals(q, this.startQ)) {
           q.multiply(PI_AROUND_Y);
           this.target.parent.getWorldQuaternion(pInv);
-          pInv.inverse();
+          pInv.invert();
           this.target.quaternion.copy(pInv).multiply(q);
           this.target.matrixNeedsUpdate = true;
         }
@@ -216,7 +216,7 @@ AFRAME.registerSystem("transform-selected-object", {
     if (this.mode === TRANSFORM_MODE.PUPPET) {
       this.target.getWorldQuaternion(this.puppet.initialObjectOrientation);
       this.hand.getWorldQuaternion(this.puppet.initialControllerOrientation);
-      this.puppet.initialControllerOrientation_inverse.copy(this.puppet.initialControllerOrientation).inverse();
+      this.puppet.initialControllerOrientation_inverse.copy(this.puppet.initialControllerOrientation).invert();
       return;
     }
 
@@ -276,7 +276,7 @@ AFRAME.registerSystem("transform-selected-object", {
     finalProjectedVec
       .copy(deltaOnPlane)
       .projectOnPlane(normal)
-      .applyQuaternion(q.copy(plane.quaternion).inverse())
+      .applyQuaternion(q.copy(plane.quaternion).invert())
       .multiplyScalar(SENSITIVITY / cameraToPlaneDistance);
     if (this.mode === TRANSFORM_MODE.CURSOR) {
       const modify = AFRAME.scenes[0].systems.userinput.get(paths.actions.transformModifier);

--- a/src/components/water.js
+++ b/src/components/water.js
@@ -1,6 +1,7 @@
 import { Layers } from "./layers";
 import "../vendor/Water";
 import waterNormalMap from "../assets/waternormals.jpg";
+import HubsTextureLoader from "../loaders/HubsTextureLoader";
 
 /**
  * @author jbouny / https://github.com/jbouny
@@ -141,7 +142,7 @@ MobileWater.prototype.constructor = THREE.Water;
 
 async function loadWaterNormals(url) {
   const texture = await new Promise((resolve, reject) =>
-    new THREE.TextureLoader().load(url, resolve, undefined, reject)
+    new HubsTextureLoader().load(url, resolve, undefined, reject)
   );
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
   texture.needsUpdate = true;

--- a/src/components/water.js
+++ b/src/components/water.js
@@ -141,9 +141,7 @@ MobileWater.prototype = Object.create(THREE.Mesh.prototype);
 MobileWater.prototype.constructor = THREE.Water;
 
 async function loadWaterNormals(url) {
-  const texture = await new Promise((resolve, reject) =>
-    new HubsTextureLoader().load(url, resolve, undefined, reject)
-  );
+  const texture = await new Promise((resolve, reject) => new HubsTextureLoader().load(url, resolve, undefined, reject));
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
   texture.needsUpdate = true;
   return texture;

--- a/src/hub.js
+++ b/src/hub.js
@@ -27,7 +27,11 @@ import "./utils/logging";
 import { patchWebGLRenderingContext } from "./utils/webgl";
 patchWebGLRenderingContext();
 
-import "three/examples/js/loaders/GLTFLoader";
+// It seems we need to use require to import modules
+// under the three/examples/js to avoid tree shaking
+// in webpack production mode.
+require("three/examples/js/loaders/GLTFLoader");
+
 import "networked-aframe/src/index";
 import "aframe-rounded";
 import "webrtc-adapter";

--- a/src/hub.js
+++ b/src/hub.js
@@ -2,7 +2,7 @@ import WebXRPolyfill from "webxr-polyfill";
 
 // WebXR Polyfill for platforms only supporting WebVR API. e.g. Desktop Firefox
 // WebVR API is deprecated. We may drop such platforms support at some point.
-if (!('xr' in navigator) && ('getVRDisplays' in navigator)) {
+if (!("xr" in navigator) && "getVRDisplays" in navigator) {
   new WebXRPolyfill({
     cardboard: false
   });

--- a/src/hub.js
+++ b/src/hub.js
@@ -1,3 +1,13 @@
+import WebXRPolyfill from "webxr-polyfill";
+
+// WebXR Polyfill for platforms only supporting WebVR API. e.g. Desktop Firefox
+// WebVR API is deprecated. We may drop such platforms support at some point.
+if (!('xr' in navigator) && ('getVRDisplays' in navigator)) {
+  new WebXRPolyfill({
+    cardboard: false
+  });
+}
+
 import "./utils/debug-log";
 import "./webxr-bypass-hacks";
 import configs from "./utils/configs";

--- a/src/loaders/HubsTextureLoader.js
+++ b/src/loaders/HubsTextureLoader.js
@@ -1,7 +1,3 @@
-function loadAsync(loader, url, onProgress) {
-  return new Promise((resolve, reject) => loader.load(url, resolve, onProgress, reject));
-}
-
 // Disable ImageBitmap for Firefox so far because
 // createImageBitmap() with option fails on Firefox due to the bug.
 // Three.js ImageBitmapLoader passes {colorSpaceConversion: 'none'} option.
@@ -10,43 +6,15 @@ function loadAsync(loader, url, onProgress) {
 const HAS_IMAGE_BITMAP = window.createImageBitmap !== undefined && /Firefox/.test(navigator.userAgent) === false;
 export const TEXTURES_FLIP_Y = !HAS_IMAGE_BITMAP;
 
-export default class HubsTextureLoader {
-  constructor(manager = THREE.DefaultLoadingManager) {
-    this.manager = manager;
-    this.crossOrigin = "anonymous";
+export default class HubsTextureLoader extends THREE.TextureLoader {
+  constructor(manager) {
+    super(manager);
   }
 
   load(url, onLoad, onProgress, onError) {
-    const texture = new THREE.Texture();
-
-    this.loadTextureAsync(texture, url, onProgress)
-      .then(onLoad)
-      .catch(onError);
-
-    return texture;
-  }
-
-  async loadTextureAsync(texture, src, onProgress) {
-    let imageLoader;
-
-    if (HAS_IMAGE_BITMAP) {
-      imageLoader = new THREE.ImageBitmapLoader(this.manager);
-      texture.flipY = false;
-    } else {
-      imageLoader = new THREE.ImageLoader(this.manager);
-    }
-
-    imageLoader.setCrossOrigin(this.crossOrigin);
-    imageLoader.setPath(this.path);
-
-    const resolvedUrl = this.manager.resolveURL(src);
-
-    texture.image = await loadAsync(imageLoader, resolvedUrl, onProgress);
-
-    // Image was just added to cache before this function gets called, disable caching by immediatly removing it
-    THREE.Cache.remove(resolvedUrl);
-
-    texture.needsUpdate = true;
+    const texture = HAS_IMAGE_BITMAP
+      ? this.loadImageBitmapTexture(url, onLoad, onProgress, onError)
+      : super.load(url, onLoad, onProgress, onError);
 
     texture.onUpdate = function() {
       // Delete texture data once it has been uploaded to the GPU
@@ -57,13 +25,34 @@ export default class HubsTextureLoader {
     return texture;
   }
 
-  setCrossOrigin(value) {
-    this.crossOrigin = value;
-    return this;
+  async loadAsync(url, onProgress) {
+    return new Promise((resolve, reject) => {
+      this.load(url, resolve, onProgress, reject);
+    });
   }
 
-  setPath(value) {
-    this.path = value;
-    return this;
+  loadImageBitmapTexture(url, onLoad, onProgress, onError) {
+    const texture = new THREE.Texture();
+    const loader = new THREE.ImageBitmapLoader(this.manager);
+    loader.setCrossOrigin(this.crossOrigin);
+    loader.setPath(this.path);
+
+    loader.load(url, bitmap => {
+      texture.image = bitmap;
+      texture.needsUpdate = true;
+
+      // We close the image bitmap when it's uploaded to texture.
+      // Closed image bitmap can't be reused so we remove the cache
+      // added in ImageBitmapLoader.
+      // You can remove this line once we entirely disable THREE.Cache.
+      THREE.Cache.remove(this.manager.resolveURL(url));
+
+      if (onLoad !== undefined) {
+        onLoad(texture);
+      }
+    }, onProgress, onError);
+
+    texture.flipY = false;
+    return texture;
   }
 }

--- a/src/loaders/HubsTextureLoader.js
+++ b/src/loaders/HubsTextureLoader.js
@@ -2,7 +2,12 @@ function loadAsync(loader, url, onProgress) {
   return new Promise((resolve, reject) => loader.load(url, resolve, onProgress, reject));
 }
 
-const HAS_IMAGE_BITMAP = window.createImageBitmap !== undefined;
+// Disable ImageBitmap for Firefox so far because
+// createImageBitmap() with option fails on Firefox due to the bug.
+// Three.js ImageBitmapLoader passes {colorSpaceConversion: 'none'} option.
+// Without the option, the rendering result can be wrong if image file has ICC profiles.
+// See https://github.com/mrdoob/three.js/pull/21336
+const HAS_IMAGE_BITMAP = window.createImageBitmap !== undefined && /Firefox/.test(navigator.userAgent) === false;
 export const TEXTURES_FLIP_Y = !HAS_IMAGE_BITMAP;
 
 export default class HubsTextureLoader {

--- a/src/loaders/HubsTextureLoader.js
+++ b/src/loaders/HubsTextureLoader.js
@@ -37,20 +37,25 @@ export default class HubsTextureLoader extends THREE.TextureLoader {
     loader.setCrossOrigin(this.crossOrigin);
     loader.setPath(this.path);
 
-    loader.load(url, bitmap => {
-      texture.image = bitmap;
-      texture.needsUpdate = true;
+    loader.load(
+      url,
+      bitmap => {
+        texture.image = bitmap;
+        texture.needsUpdate = true;
 
-      // We close the image bitmap when it's uploaded to texture.
-      // Closed image bitmap can't be reused so we remove the cache
-      // added in ImageBitmapLoader.
-      // You can remove this line once we entirely disable THREE.Cache.
-      THREE.Cache.remove(this.manager.resolveURL(url));
+        // We close the image bitmap when it's uploaded to texture.
+        // Closed image bitmap can't be reused so we remove the cache
+        // added in ImageBitmapLoader.
+        // You can remove this line once we entirely disable THREE.Cache.
+        THREE.Cache.remove(this.manager.resolveURL(url));
 
-      if (onLoad !== undefined) {
-        onLoad(texture);
-      }
-    }, onProgress, onError);
+        if (onLoad !== undefined) {
+          onLoad(texture);
+        }
+      },
+      onProgress,
+      onError
+    );
 
     texture.flipY = false;
     return texture;

--- a/src/react-components/avatar-preview.js
+++ b/src/react-components/avatar-preview.js
@@ -34,8 +34,7 @@ function createRenderer(canvas, alpha = false, useDevicePixelRatio = true) {
   });
 
   const renderer = new THREE.WebGLRenderer({ alpha, canvas, context, forceWebVR: true });
-  renderer.gammaOutput = true;
-  renderer.gammaFactor = 2.2;
+  renderer.outputEncoding = THREE.sRGBEncoding;
   renderer.physicallyCorrectLights = true;
   if (useDevicePixelRatio) {
     renderer.setPixelRatio(window.devicePixelRatio);

--- a/src/react-components/avatar-preview.js
+++ b/src/react-components/avatar-preview.js
@@ -2,7 +2,11 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { injectIntl, FormattedMessage } from "react-intl";
 import classNames from "classnames";
-import "three/examples/js/controls/OrbitControls";
+
+// It seems we need to use require to import modules
+// under the three/examples/js to avoid tree shaking
+// in webpack production mode.
+require("three/examples/js/controls/OrbitControls");
 
 import { createDefaultEnvironmentMap } from "../components/environment-map";
 import { loadGLTF } from "../components/gltf-model-plus";

--- a/src/react-components/chat-message.js
+++ b/src/react-components/chat-message.js
@@ -7,8 +7,9 @@ import html2canvas from "html2canvas";
 import { coerceToUrl } from "../utils/media-utils";
 import { formatMessageBody } from "../utils/chat-message";
 import { createPlaneBufferGeometry } from "../utils/three-utils";
+import HubsTextureLoader from "../loaders/HubsTextureLoader";
 
-const textureLoader = new THREE.TextureLoader();
+const textureLoader = new HubsTextureLoader();
 
 const CHAT_MESSAGE_TEXTURE_SIZE = 1024;
 

--- a/src/react-components/chat-message.js
+++ b/src/react-components/chat-message.js
@@ -6,6 +6,7 @@ import classNames from "classnames";
 import html2canvas from "html2canvas";
 import { coerceToUrl } from "../utils/media-utils";
 import { formatMessageBody } from "../utils/chat-message";
+import { createPlaneBufferGeometry } from "../utils/three-utils";
 
 const textureLoader = new THREE.TextureLoader();
 
@@ -130,7 +131,7 @@ export async function createInWorldLogMessage({ name, type, body }) {
     material.generateMipmaps = false;
     material.needsUpdate = true;
 
-    const geometry = new THREE.PlaneBufferGeometry(1, 1, 1, 1, texture.flipY);
+    const geometry = createPlaneBufferGeometry(1, 1, 1, 1, texture.flipY);
     const mesh = new THREE.Mesh(geometry, material);
     meshEntity.setObject3D("mesh", mesh);
     meshEntity.meshMaterial = material;

--- a/src/react-components/room/useResizeViewport.js
+++ b/src/react-components/room/useResizeViewport.js
@@ -66,8 +66,8 @@ export function useResizeViewport(viewportRef, store, scene) {
   useEffect(
     () => {
       const observer = new ResizeObserver(entries => {
-        const isPresenting = scene.renderer.vr.isPresenting();
-        const isVRPresenting = scene.renderer.vr.enabled && isPresenting;
+        const isPresenting = scene.renderer.xr.isPresenting;
+        const isVRPresenting = scene.renderer.xr.enabled && isPresenting;
 
         // Do not update renderer, if a camera or a canvas have not been injected.
         // In VR mode, three handles canvas resize based on the dimensions returned by

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -232,8 +232,22 @@ class UIRoot extends Component {
         window.setTimeout(() => {
           if (!this.props.isBotMode) {
             try {
-              this.props.scene.renderer.compileAndUploadMaterials(this.props.scene.object3D, this.props.scene.camera);
-            } catch {
+              this.props.scene.renderer.compile(this.props.scene.object3D, this.props.scene.camera);
+              this.props.scene.object3D.traverse(obj => {
+                if (!obj.material) {
+                  return;
+                }
+                const materials = Array.isArray(obj.material) ? obj.material : [obj.material];
+                for (const material of materials) {
+                  for (const prop in material) {
+                    if (material[prop] && material[prop].isTexture) {
+                      this.props.scene.renderer.initTexture(material[prop]);
+                    }
+                  }
+                }
+              });
+            } catch (e) {
+              console.error(e);
               this.props.exitScene(ExitReason.sceneError); // https://github.com/mozilla/hubs/issues/1950
             }
           }

--- a/src/scene.js
+++ b/src/scene.js
@@ -13,7 +13,10 @@ import "./utils/threejs-world-update";
 import { patchWebGLRenderingContext } from "./utils/webgl";
 patchWebGLRenderingContext();
 
-import "three/examples/js/loaders/GLTFLoader";
+// It seems we need to use require to import modules
+// under the three/examples/js to avoid tree shaking
+// in webpack production mode.
+require("three/examples/js/loaders/GLTFLoader");
 
 import "./components/scene-components";
 import "./components/debug";

--- a/src/systems/camera-system.js
+++ b/src/systems/camera-system.js
@@ -64,7 +64,7 @@ const orbit = (function() {
     if (!target.parent) {
       // add dummy object to the scene, if this is the first time we call this function
       AFRAME.scenes[0].object3D.add(target);
-      target.applyMatrix(IDENTITY); // make sure target gets updated at least once for our matrix optimizations
+      target.applyMatrix4(IDENTITY); // make sure target gets updated at least once for our matrix optimizations
     }
     pivot.updateMatrices();
     decompose(pivot.matrixWorld, owp, owq);
@@ -107,7 +107,7 @@ const moveRigSoCameraLooksAtPivot = (function() {
     if (!target.parent) {
       // add dummy object to the scene, if this is the first time we call this function
       AFRAME.scenes[0].object3D.add(target);
-      target.applyMatrix(IDENTITY); // make sure target gets updated at least once for our matrix optimizations
+      target.applyMatrix4(IDENTITY); // make sure target gets updated at least once for our matrix optimizations
     }
 
     pivot.updateMatrices();

--- a/src/systems/media-frames.js
+++ b/src/systems/media-frames.js
@@ -1,6 +1,7 @@
 import { MediaType } from "../utils/media-utils";
 import { TEXTURES_FLIP_Y } from "../loaders/HubsTextureLoader";
 import { applyPersistentSync } from "../utils/permissions-utils";
+import { createPlaneBufferGeometry } from "../utils/three-utils";
 
 // TODO better handling for 3d objects
 function scaleForAspectFit(containerSize, itemSize) {
@@ -181,7 +182,7 @@ AFRAME.registerComponent("media-frame", {
     previewMaterial.transparent = true;
     previewMaterial.opacity = 0.5;
 
-    const geometry = new THREE.PlaneBufferGeometry(1, 1, 1, 1, TEXTURES_FLIP_Y);
+    const geometry = createPlaneBufferGeometry(1, 1, 1, 1, TEXTURES_FLIP_Y);
     const previewMesh = new THREE.Mesh(geometry, previewMaterial);
     previewMesh.visible = false;
     this.el.setObject3D("preview", previewMesh);

--- a/src/systems/nav.js
+++ b/src/systems/nav.js
@@ -126,7 +126,7 @@ AFRAME.registerSystem("nav", {
     }
     const geometry = fromBufferGeometry(new THREE.Geometry(), mesh.geometry);
     mesh.updateMatrices();
-    geometry.applyMatrix(mesh.matrixWorld);
+    geometry.applyMatrix4(mesh.matrixWorld);
     this.pathfinder.setZoneData(zone, Pathfinding.createZone(geometry));
     this.mesh = mesh;
     this.el.sceneEl.emit("nav-mesh-loaded");

--- a/src/systems/nav.js
+++ b/src/systems/nav.js
@@ -1,11 +1,6 @@
 const { Pathfinding } = require("three-pathfinding");
 import qsTruthy from "../utils/qs_truthy";
 
-const Vector3 = THREE.Vector3;
-const Vector2 = THREE.Vector2;
-const Face3 = THREE.Face3;
-const Color = THREE.Color;
-
 AFRAME.registerSystem("nav", {
   init: function() {
     this.pathfinder = new Pathfinding();

--- a/src/systems/nav.js
+++ b/src/systems/nav.js
@@ -6,111 +6,6 @@ const Vector2 = THREE.Vector2;
 const Face3 = THREE.Face3;
 const Color = THREE.Color;
 
-// TODO this is backported from a later version of THREE.
-// Geometry is going to be dropped from ThreeJS anyway so just copying here for now.
-// Ideally three-pathfinding will just use BufferGeometry in the future
-// https://github.com/donmccurdy/three-pathfinding/issues/74
-function fromBufferGeometry(scope, geometry) {
-  const index = geometry.index !== null ? geometry.index : undefined;
-  const attributes = geometry.attributes;
-
-  if (attributes.position === undefined) {
-    console.error("THREE.Geometry.fromBufferGeometry(): Position attribute required for conversion.");
-    return scope;
-  }
-
-  const position = attributes.position;
-  const normal = attributes.normal;
-  const color = attributes.color;
-  const uv = attributes.uv;
-  const uv2 = attributes.uv2;
-
-  if (uv2 !== undefined) scope.faceVertexUvs[1] = [];
-
-  for (let i = 0; i < position.count; i++) {
-    scope.vertices.push(new Vector3().fromBufferAttribute(position, i));
-
-    if (color !== undefined) {
-      scope.colors.push(new Color().fromBufferAttribute(color, i));
-    }
-  }
-
-  function addFace(a, b, c, materialIndex) {
-    const vertexColors =
-      color === undefined ? [] : [scope.colors[a].clone(), scope.colors[b].clone(), scope.colors[c].clone()];
-
-    const vertexNormals =
-      normal === undefined
-        ? []
-        : [
-            new Vector3().fromBufferAttribute(normal, a),
-            new Vector3().fromBufferAttribute(normal, b),
-            new Vector3().fromBufferAttribute(normal, c)
-          ];
-
-    const face = new Face3(a, b, c, vertexNormals, vertexColors, materialIndex);
-
-    scope.faces.push(face);
-
-    if (uv !== undefined) {
-      scope.faceVertexUvs[0].push([
-        new Vector2().fromBufferAttribute(uv, a),
-        new Vector2().fromBufferAttribute(uv, b),
-        new Vector2().fromBufferAttribute(uv, c)
-      ]);
-    }
-
-    if (uv2 !== undefined) {
-      scope.faceVertexUvs[1].push([
-        new Vector2().fromBufferAttribute(uv2, a),
-        new Vector2().fromBufferAttribute(uv2, b),
-        new Vector2().fromBufferAttribute(uv2, c)
-      ]);
-    }
-  }
-
-  const groups = geometry.groups;
-
-  if (groups.length > 0) {
-    for (let i = 0; i < groups.length; i++) {
-      const group = groups[i];
-
-      const start = group.start;
-      const count = group.count;
-
-      for (let j = start, jl = start + count; j < jl; j += 3) {
-        if (index !== undefined) {
-          addFace(index.getX(j), index.getX(j + 1), index.getX(j + 2), group.materialIndex);
-        } else {
-          addFace(j, j + 1, j + 2, group.materialIndex);
-        }
-      }
-    }
-  } else {
-    if (index !== undefined) {
-      for (let i = 0; i < index.count; i += 3) {
-        addFace(index.getX(i), index.getX(i + 1), index.getX(i + 2));
-      }
-    } else {
-      for (let i = 0; i < position.count; i += 3) {
-        addFace(i, i + 1, i + 2);
-      }
-    }
-  }
-
-  scope.computeFaceNormals();
-
-  if (geometry.boundingBox !== null) {
-    scope.boundingBox = geometry.boundingBox.clone();
-  }
-
-  if (geometry.boundingSphere !== null) {
-    scope.boundingSphere = geometry.boundingSphere.clone();
-  }
-
-  return scope;
-}
-
 AFRAME.registerSystem("nav", {
   init: function() {
     this.pathfinder = new Pathfinding();
@@ -124,7 +19,7 @@ AFRAME.registerSystem("nav", {
       console.error("tried to load multiple nav meshes");
       this.removeNavMeshData();
     }
-    const geometry = fromBufferGeometry(new THREE.Geometry(), mesh.geometry);
+    const geometry = mesh.geometry;
     mesh.updateMatrices();
     geometry.applyMatrix4(mesh.matrixWorld);
     this.pathfinder.setZoneData(zone, Pathfinding.createZone(geometry));

--- a/src/systems/physics-system.js
+++ b/src/systems/physics-system.js
@@ -166,7 +166,7 @@ export class PhysicsSystem {
                 index * BUFFER_CONFIG.BODY_DATA_SIZE + BUFFER_CONFIG.MATRIX_OFFSET
               );
               object3D.parent.updateMatrices();
-              inverse.getInverse(object3D.parent.matrixWorld);
+              inverse.copy(object3D.parent.matrixWorld).invert();
               transform.multiplyMatrices(inverse, matrix);
               transform.decompose(object3D.position, object3D.quaternion, scale);
               object3D.matrixNeedsUpdate = true;

--- a/src/systems/render-manager-system.js
+++ b/src/systems/render-manager-system.js
@@ -5,8 +5,7 @@
 // We may revert and update it when we will enable again.
 
 export class BatchManagerSystem {
-  constructor(scene, renderer) {
-  }
+  constructor(/*scene, renderer*/) {}
 
   get batchingEnabled() {
     return false;
@@ -16,15 +15,15 @@ export class BatchManagerSystem {
     // Ignore
   }
 
-  addObject(rootObject) {
+  addObject(/*rootObject*/) {
     return 0;
   }
 
-  removeObject(rootObject) {
+  removeObject(/*rootObject*/) {
     return;
   }
 
-  tick(time) {
+  tick(/*time*/) {
     return;
   }
 }

--- a/src/systems/render-manager-system.js
+++ b/src/systems/render-manager-system.js
@@ -1,79 +1,30 @@
-import { BatchManager } from "@mozillareality/three-batch-manager";
-
-import HubsBatchRawUniformGroup from "./render-manager/hubs-batch-raw-uniform-group";
-import { sizeofInstances } from "./render-manager/hubs-batch-raw-uniform-group";
-import unlitBatchVert from "./render-manager/unlit-batch.vert";
-import unlitBatchFrag from "./render-manager/unlit-batch.frag";
-import qsTruthy from "../utils/qs_truthy";
-
-const MAX_INSTANCES = 500;
-const UBO_BYTE_LENGTH = sizeofInstances(MAX_INSTANCES);
+// We disable batching manager because of some problems.
+// BatchManagerSystem has some dependencies with our Three.js fork.
+// Build errors with the upstreaming official Three.js.
+// So replacing BatchManagerSystem with a stub so far.
+// We may revert and update it when we will enable again.
 
 export class BatchManagerSystem {
   constructor(scene, renderer) {
-    this.meshToEl = new WeakMap();
-    const gl = renderer.getContext();
+  }
 
-    if (qsTruthy("disableBatching")) {
-      console.warn("Batching disabled by user via disableBatching. Disabling batching.");
-      return;
-    }
+  get batchingEnabled() {
+    return false;
+  }
 
-    if (!(window.WebGL2RenderingContext && gl instanceof WebGL2RenderingContext)) {
-      console.warn("Batching requires WebGL 2. Disabling batching.");
-      return;
-    }
-
-    if (UBO_BYTE_LENGTH > gl.getParameter(gl.MAX_UNIFORM_BLOCK_SIZE)) {
-      console.warn("Insufficient MAX_UNIFORM_BLOCK_SIZE, Disabling batching.");
-      return;
-    }
-
-    this.batchingEnabled = qsTruthy("forceMeshBatching") || qsTruthy("forceImageBatching");
-
-    if (!this.batchingEnabled) {
-      console.warn("Batching must be forced on with forceMeshBatching or forceImageBatching. Disabling batching.");
-      return;
-    }
-
-    this.ubo = new HubsBatchRawUniformGroup(MAX_INSTANCES, this.meshToEl);
-    this.batchManager = new BatchManager(scene, renderer, {
-      maxInstances: MAX_INSTANCES,
-      ubo: this.ubo,
-      shaders: {
-        unlit: {
-          vertexShader: unlitBatchVert,
-          fragmentShader: unlitBatchFrag
-        }
-      }
-    });
+  set batchingEnabled(enabled) {
+    // Ignore
   }
 
   addObject(rootObject) {
-    if (!this.batchingEnabled) return 0;
-
-    let batchedCount = 0;
-    rootObject.traverse(object => {
-      if (object.isMesh) {
-        if (this.batchManager.addMesh(object)) batchedCount++;
-      }
-    });
-    return batchedCount;
+    return 0;
   }
 
   removeObject(rootObject) {
-    if (!this.batchingEnabled) return;
-
-    rootObject.traverse(object => {
-      if (object.isMesh) {
-        this.batchManager.removeMesh(object);
-      }
-    });
+    return;
   }
 
   tick(time) {
-    if (!this.batchingEnabled) return;
-
-    this.batchManager.update(time);
+    return;
   }
 }

--- a/src/systems/shadow-system.js
+++ b/src/systems/shadow-system.js
@@ -64,7 +64,7 @@ function resizeShadowCameraFrustum(light, boundingBox) {
   verts[7].set(max.x, max.y, max.z);
 
   light.updateMatrices();
-  inverseLightMatrixWorld.getInverse(light.matrixWorld);
+  inverseLightMatrixWorld.copy(light.matrixWorld).invert();
 
   for (let i = 0; i < verts.length; i++) {
     verts[i].applyMatrix4(inverseLightMatrixWorld);

--- a/src/systems/sprites.js
+++ b/src/systems/sprites.js
@@ -224,11 +224,11 @@ export class SpriteSystem {
     }
 
     const vertexShader = String.prototype.concat(
-      scene.renderer.vr.multiview ? multiviewVertPrefix : nonmultiviewVertPrefix,
+      scene.renderer.xr.multiview ? multiviewVertPrefix : nonmultiviewVertPrefix,
       vert
     );
     const fragmentShader = String.prototype.concat(
-      scene.renderer.vr.multiview ? multiviewFragPrefix : nonmultiviewFragPrefix,
+      scene.renderer.xr.multiview ? multiviewFragPrefix : nonmultiviewFragPrefix,
       frag
     );
 

--- a/src/utils/auto-box-collider.js
+++ b/src/utils/auto-box-collider.js
@@ -16,7 +16,7 @@ export const computeLocalBoundingBox = (function() {
   return function computeLocalBoundingBox(root, box, excludeInvisible) {
     box.makeEmpty();
     root.updateMatrices();
-    rootInverse.getInverse(root.matrixWorld);
+    rootInverse.copy(root.matrixWorld).invert();
     root.traverse(node => {
       if (excludeInvisible && !isVisibleUpToRoot(node, root)) {
         return;

--- a/src/utils/auto-box-collider.js
+++ b/src/utils/auto-box-collider.js
@@ -32,7 +32,7 @@ export const computeLocalBoundingBox = (function() {
           }
         } else if (node.geometry.isBufferGeometry && node.geometry.attributes.position) {
           const array = node.geometry.attributes.position.array;
-          const itemSize = node.geometry.attributes.position._itemSize;
+          const itemSize = node.geometry.attributes.position.itemSize;
           for (let i = 0; i < node.geometry.attributes.position.count; i++) {
             if (itemSize === 2) {
               vertex.set(array[2 * i], array[2 * i + 1], 0);

--- a/src/utils/material-utils.js
+++ b/src/utils/material-utils.js
@@ -107,17 +107,20 @@ class HubsMeshBasicMaterial extends THREE.MeshBasicMaterial {
     shader.fragmentShader = shader.fragmentShader.replace(
       "#include <envmap_fragment>",
       `#include <envmap_fragment>
-      vec3 totalEmissiveRadiance = emissive;
 
-      vec4 emissiveColor = vec4(0.0, 0.0, 0.0, 0.0);
+      #ifdef USE_EMISSIVEMAP
+        vec3 totalEmissiveRadiance = emissive;
 
-      #ifdef USE_UV
-        emissiveColor = texture2D( emissiveMap, vUv );
+        vec4 emissiveColor = vec4(0.0, 0.0, 0.0, 0.0);
+
+        #ifdef USE_UV
+          emissiveColor = texture2D( emissiveMap, vUv );
+        #endif
+
+        emissiveColor.rgb = emissiveMapTexelToLinear( emissiveColor ).rgb;
+        totalEmissiveRadiance *= emissiveColor.rgb;
+        outgoingLight += totalEmissiveRadiance;
       #endif
-
-      emissiveColor.rgb = emissiveMapTexelToLinear( emissiveColor ).rgb;
-      totalEmissiveRadiance *= emissiveColor.rgb;
-      outgoingLight += totalEmissiveRadiance;
       `
     );
   };

--- a/src/utils/material-utils.js
+++ b/src/utils/material-utils.js
@@ -108,19 +108,10 @@ class HubsMeshBasicMaterial extends THREE.MeshBasicMaterial {
       "#include <envmap_fragment>",
       `#include <envmap_fragment>
 
-      #ifdef USE_EMISSIVEMAP
-        vec3 totalEmissiveRadiance = emissive;
+      vec3 totalEmissiveRadiance = emissive;
+      #include <emissivemap_fragment>
+      outgoingLight += totalEmissiveRadiance;
 
-        vec4 emissiveColor = vec4(0.0, 0.0, 0.0, 0.0);
-
-        #ifdef USE_UV
-          emissiveColor = texture2D( emissiveMap, vUv );
-        #endif
-
-        emissiveColor.rgb = emissiveMapTexelToLinear( emissiveColor ).rgb;
-        totalEmissiveRadiance *= emissiveColor.rgb;
-        outgoingLight += totalEmissiveRadiance;
-      #endif
       `
     );
   };

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -440,10 +440,8 @@ export async function createImageTexture(url, filter) {
 
     texture = new THREE.CanvasTexture(canvas);
   } else {
-    texture = new THREE.Texture();
-
     try {
-      await textureLoader.loadTextureAsync(texture, url);
+      texture = await textureLoader.loadAsync(url);
     } catch (e) {
       throw new Error(`'${url}' could not be fetched (Error code: ${e.status}; Response: ${e.statusText})`);
     }

--- a/src/utils/physics-utils.js
+++ b/src/utils/physics-utils.js
@@ -22,6 +22,9 @@ function exceedsDensityThreshold(count, subtree) {
 }
 
 function isHighDensity(subtree) {
+  if (subtree.continueGeneration) {
+    subtree.continueGeneration();
+  }
   if (subtree.count) {
     const result = exceedsDensityThreshold(subtree.count, subtree);
     return result === true ? true : subtree.count;

--- a/src/utils/three-utils.js
+++ b/src/utils/three-utils.js
@@ -54,7 +54,7 @@ export function disposeNode(node) {
 const IDENTITY = new THREE.Matrix4().identity();
 export function setMatrixWorld(object3D, m) {
   if (!object3D.matrixIsModified) {
-    object3D.applyMatrix(IDENTITY); // hack around our matrix optimizations
+    object3D.applyMatrix4(IDENTITY); // hack around our matrix optimizations
   }
   object3D.matrixWorld.copy(m);
   if (object3D.parent) {

--- a/src/utils/three-utils.js
+++ b/src/utils/three-utils.js
@@ -357,3 +357,17 @@ export function traverseAnimationTargets(rootObject, animations, callback) {
     }
   }
 }
+
+export function createPlaneBufferGeometry(width, height, widthSegments, heightSegments, flipY = true) {
+  const geometry = new THREE.PlaneBufferGeometry(width, height, widthSegments, heightSegments);
+  // Three.js seems to assume texture flipY is true for all its built in geometry
+  // but we turn this off on our texture loader since createImageBitmap in Firefox
+  // does not support flipping. Then we flip the uv for flipY = false texture.
+  if (flipY === false) {
+    const uv = geometry.getAttribute('uv');
+    for (let i = 0; i < uv.count; i++) {
+      uv.setY(i, 1.0 - uv.getY(i));
+    }
+  }
+  return geometry;
+}

--- a/src/utils/three-utils.js
+++ b/src/utils/three-utils.js
@@ -59,7 +59,10 @@ export function setMatrixWorld(object3D, m) {
   object3D.matrixWorld.copy(m);
   if (object3D.parent) {
     object3D.parent.updateMatrices();
-    object3D.matrix = object3D.matrix.copy(object3D.parent.matrixWorld).invert().multiply(object3D.matrixWorld);
+    object3D.matrix = object3D.matrix
+      .copy(object3D.parent.matrixWorld)
+      .invert()
+      .multiply(object3D.matrixWorld);
   } else {
     object3D.matrix.copy(object3D.matrixWorld);
   }
@@ -287,7 +290,10 @@ export const calculateCameraTransformForWaypoint = (function() {
   const detachFromWorldUp = new THREE.Matrix4();
   return function calculateCameraTransformForWaypoint(cameraTransform, waypointTransform, outMat4) {
     affixToWorldUp(cameraTransform, upAffixedCameraTransform);
-    detachFromWorldUp.copy(upAffixedCameraTransform).invert().multiply(cameraTransform);
+    detachFromWorldUp
+      .copy(upAffixedCameraTransform)
+      .invert()
+      .multiply(cameraTransform);
     affixToWorldUp(waypointTransform, upAffixedWaypointTransform);
     outMat4.copy(upAffixedWaypointTransform).multiply(detachFromWorldUp);
   };
@@ -364,7 +370,7 @@ export function createPlaneBufferGeometry(width, height, widthSegments, heightSe
   // but we turn this off on our texture loader since createImageBitmap in Firefox
   // does not support flipping. Then we flip the uv for flipY = false texture.
   if (flipY === false) {
-    const uv = geometry.getAttribute('uv');
+    const uv = geometry.getAttribute("uv");
     for (let i = 0; i < uv.count; i++) {
       uv.setY(i, 1.0 - uv.getY(i));
     }

--- a/src/utils/three-utils.js
+++ b/src/utils/three-utils.js
@@ -59,7 +59,7 @@ export function setMatrixWorld(object3D, m) {
   object3D.matrixWorld.copy(m);
   if (object3D.parent) {
     object3D.parent.updateMatrices();
-    object3D.matrix = object3D.matrix.getInverse(object3D.parent.matrixWorld).multiply(object3D.matrixWorld);
+    object3D.matrix = object3D.matrix.copy(object3D.parent.matrixWorld).invert().multiply(object3D.matrixWorld);
   } else {
     object3D.matrix.copy(object3D.matrixWorld);
   }
@@ -287,7 +287,7 @@ export const calculateCameraTransformForWaypoint = (function() {
   const detachFromWorldUp = new THREE.Matrix4();
   return function calculateCameraTransformForWaypoint(cameraTransform, waypointTransform, outMat4) {
     affixToWorldUp(cameraTransform, upAffixedCameraTransform);
-    detachFromWorldUp.getInverse(upAffixedCameraTransform).multiply(cameraTransform);
+    detachFromWorldUp.copy(upAffixedCameraTransform).invert().multiply(cameraTransform);
     affixToWorldUp(waypointTransform, upAffixedWaypointTransform);
     outMat4.copy(upAffixedWaypointTransform).multiply(detachFromWorldUp);
   };
@@ -330,10 +330,10 @@ export const childMatch = (function() {
   // transform the parent such that its child matches the target
   return function childMatch(parent, child, target) {
     parent.updateMatrices();
-    inverseParentWorld.getInverse(parent.matrixWorld);
+    inverseParentWorld.copy(parent.matrixWorld).invert();
     child.updateMatrices();
     childRelativeToParent.multiplyMatrices(inverseParentWorld, child.matrixWorld);
-    childInverse.getInverse(childRelativeToParent);
+    childInverse.copy(childRelativeToParent).invert();
     newParentMatrix.multiplyMatrices(target, childInverse);
     setMatrixWorld(parent, newParentMatrix);
   };

--- a/src/utils/threejs-world-update.js
+++ b/src/utils/threejs-world-update.js
@@ -252,7 +252,7 @@ THREE.Object3D.prototype.lookAt = (function() {
     if (parent) {
       m1.extractRotation(parent.matrixWorld);
       q1.setFromRotationMatrix(m1);
-      this.quaternion.premultiply(q1.inverse());
+      this.quaternion.premultiply(q1.invert());
     }
     this.matrixNeedsUpdate = true;
   };

--- a/src/utils/threejs-world-update.js
+++ b/src/utils/threejs-world-update.js
@@ -110,9 +110,9 @@ THREE.Object3D.prototype.updateMatrix = function() {
   handleMatrixModification(this);
 };
 
-const applyMatrix = THREE.Object3D.prototype.applyMatrix;
-THREE.Object3D.prototype.applyMatrix = function() {
-  applyMatrix.apply(this, arguments);
+const applyMatrix4 = THREE.Object3D.prototype.applyMatrix4;
+THREE.Object3D.prototype.applyMatrix4 = function() {
+  applyMatrix4.apply(this, arguments);
   handleMatrixModification(this);
 };
 


### PR DESCRIPTION
This PR is a draft PR for supporting VRM in Hubs. Still under the experiment and very beginning of the implementation but I want to share the progress and want the feedbacks.

## What is VRM?

VRM is a 3D model format extending glTF, primarily designed for humanoid character avatar.

**Features**

* Looking like Anime/Game characters with cartoon material
* Physics engine independent secondary animation for hair, cloths, and others
* Copyright information meta data
* Standard bone sets (so we can apply the same skinning key frame animation)
* Standard morph sets
* First person information (e.g. which node camera should be bound to)
* There are lot of downloadable VRM models for example at https://hub.vroid.com/en/

Refer to https://vrm.dev/en/vrm/ for more details

We Hubs team often got VRM support requests from users especially who are keen to VR and/or Animes/Games.

## Screenshot

https://user-images.githubusercontent.com/7637832/122448785-fb4b7f00-cf59-11eb-8403-b969d87876b6.mp4

## Changes

I'm working with the newer Three.js based on #4321 because older Three.js + VRM seems a bit problematic (in animation? according to @netpro2k)

For VRM specific feature handling, I'm trying three-vrm so far.

https://github.com/pixiv/three-vrm

If their API or behavior doesn't greatly fit to Hubs, we may need to send feature request to them, hack it, or write our own.

Importing VRM itself may not be so difficult (see the diff of `gltf-model-plus.js`). But we may need some works for animation and optimization stuffs as you see in the next section.

Note that the current implementation is very beginning of VRM support and some of them are hacky. There are lot of remaining tasks. Please see `@TODO: ` in `gltf-model-plus.js` for the details.

## Remaining tasks and challengings

**More proper implement**

* The secondary animation should be handled in the existing animation system or a new VRM animation system. 

**VR**

* Map VR controller inputs to hands of VRM standard bone set.

**bugs or limitations**

* I succeeded in placing a VRM model but didn't do to in uploading as an avatar yet due to some errors.
* The secondary animation with three-vrm doesn't seem to work correctly if model's scale is not one. (If a model is placed it is resized.) We may need to hack it or send feature request.
* The secondary animation with three-vrm doesn't work for cloned VRM objects. We may need to create THREE.VRM objects for each cloned model.

**Skinning model avatars**

* networked-aframe needs to send skeleton transforms for avatars (unless each client applies an animation on its end)
* Support IK for Arms.
* Apply walking animation if VRM model avatars are moved. 

**Optimization**

* Material optimization for low quality material preference. Maybe we can just use `MeshBasicMaterial` instead.
* Optimize raycasting. The FPS number significantly drops if I point the VRM model. I speculate it's because raycasting of high poly models. (Humanoid models are often high poly.)
* Evaluate Runtime and download time because humanoid models are often high poly. LOD may be a good optimization if they are slow.
* Evaluate the secondary animation performance. If it's slow, consider to load off from the main thread to workers.
* Consider that only the owner handles the secondary animation and sends transforms to other peers rather than handling it in all peers especially if it's slow
* Consider to load off IK from main thread to workers if we will start to support Arm IK

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/HUBS-790)
