### PR TITLE
Separate NAF and Dialog with a phoenix adapter

### DIFF
--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -33,7 +33,7 @@ async function getMediaStream(el) {
     console.error(INFO_INIT_FAILED, INFO_NO_OWNER);
     return null;
   }
-  const stream = await NAF.connection.adapter.getMediaStream(peerId).catch(e => {
+  const stream = await APP.dialog.getMediaStream(peerId).catch(e => {
     console.error(INFO_INIT_FAILED, `Error getting media stream for ${peerId}`, e);
   });
   if (!stream) {
@@ -106,7 +106,7 @@ AFRAME.registerComponent("avatar-audio-source", {
     this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem.registerAvatarAudioSource(this);
     // We subscribe to audio stream notifications for this peer to update the audio source
     // This could happen in case there is an ICE failure that requires a transport recreation.
-    NAF.connection.adapter?.on("stream_updated", this._onStreamUpdated, this);
+    APP.dialog.on("stream_updated", this._onStreamUpdated, this);
     this.createAudio();
   },
 
@@ -119,7 +119,7 @@ AFRAME.registerComponent("avatar-audio-source", {
     getOwnerId(this.el).then(async ownerId => {
       if (ownerId === peerId && kind === "audio") {
         // The audio stream for this peer has been updated
-        const newStream = await NAF.connection.adapter.getMediaStream(peerId, "audio").catch(e => {
+        const newStream = await APP.dialog.getMediaStream(peerId, "audio").catch(e => {
           console.error(INFO_INIT_FAILED, `Error getting media stream for ${peerId}`, e);
         });
 
@@ -149,7 +149,7 @@ AFRAME.registerComponent("avatar-audio-source", {
 
   remove: function() {
     this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem.unregisterAvatarAudioSource(this);
-    NAF.connection.adapter.off("stream_updated", this._onStreamUpdated);
+    APP.dialog.off("stream_updated", this._onStreamUpdated);
     this.destroyAudio();
   }
 });

--- a/src/components/bone-mute-state-indicator.js
+++ b/src/components/bone-mute-state-indicator.js
@@ -3,6 +3,7 @@
  * @namespace avatar
  * @component bone-mute-state-indicator
  */
+// TODO: Remove this
 AFRAME.registerComponent("bone-mute-state-indicator", {
   schema: {
     unmutedBoneName: { default: "Watch_Joint_MicON" },
@@ -20,26 +21,23 @@ AFRAME.registerComponent("bone-mute-state-indicator", {
 
       this.updateMuteState();
     });
+
+    this.onMicStateChanged = () => {
+      this.updateMuteState();
+    };
   },
 
   play() {
-    this.el.sceneEl.addEventListener("stateadded", this.onStateToggled);
-    this.el.sceneEl.addEventListener("stateremoved", this.onStateToggled);
+    APP.dialog.on("mic-state-changed", this.onMicStateChanged);
   },
 
   pause() {
-    this.el.sceneEl.removeEventListener("stateadded", this.onStateToggled);
-    this.el.sceneEl.removeEventListener("stateremoved", this.onStateToggled);
-  },
-
-  onStateToggled(e) {
-    if (!e.detail.state === "muted") return;
-    this.updateMuteState();
+    APP.dialog.off("mic-state-changed", this.onMicStateChanged);
   },
 
   updateMuteState() {
     if (!this.modelLoaded) return;
-    const muted = this.el.sceneEl.is("muted");
+    const muted = !APP.dialog.isMicEnabled;
     this.mutedBone.position.y = muted ? this.data.onPos : this.data.offPos;
     this.unmutedBone.position.y = !muted ? this.data.onPos : this.data.offPos;
     this.mutedBone.matrixNeedsUpdate = true;

--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -389,7 +389,7 @@ AFRAME.registerComponent("camera-tool", {
     };
 
     if (this.data.captureAudio) {
-      const selfAudio = await NAF.connection.adapter.getMediaStream(NAF.clientId, "audio");
+      const selfAudio = await APP.dialog.getMediaStream(NAF.clientId, "audio");
 
       // NOTE: if we don't have a self audio track, we can end up generating an empty video (browser bug?)
       // if no audio comes through on the listener source. (Eg the room is otherwise silent.)

--- a/src/components/in-world-hud.js
+++ b/src/components/in-world-hud.js
@@ -13,8 +13,13 @@ AFRAME.registerComponent("in-world-hud", {
     this.inviteBtn = this.el.querySelector(".invite-btn");
     this.background = this.el.querySelector(".bg");
 
+    this.onMicStateChanged = () => {
+      this.mic.setAttribute("mic-button", "active", APP.dialog.isMicEnabled);
+    };
+    APP.dialog.on("mic-state-changed", this.onMicStateChanged);
+
     this.updateButtonStates = () => {
-      this.mic.setAttribute("mic-button", "active", this.el.sceneEl.is("muted"));
+      this.mic.setAttribute("mic-button", "active", APP.dialog.isMicEnabled);
       this.pen.setAttribute("icon-button", "active", this.el.sceneEl.is("pen"));
       this.cameraBtn.setAttribute("icon-button", "active", this.el.sceneEl.is("camera"));
       if (window.APP.hubChannel) {
@@ -25,13 +30,12 @@ AFRAME.registerComponent("in-world-hud", {
     };
 
     this.onStateChange = evt => {
-      if (!(evt.detail === "muted" || evt.detail === "frozen" || evt.detail === "pen" || evt.detail === "camera"))
-        return;
+      if (!(evt.detail === "frozen" || evt.detail === "pen" || evt.detail === "camera")) return;
       this.updateButtonStates();
     };
 
     this.onMicClick = () => {
-      this.el.emit("action_mute");
+      APP.dialog.toggleMicrophone();
     };
 
     this.onSpawnClick = () => {

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -752,16 +752,16 @@ AFRAME.registerComponent("media-video", {
       // Set src on video to begin loading.
       if (url.startsWith("hubs://")) {
         const streamClientId = url.substring(7).split("/")[1]; // /clients/<client id>/video is only URL for now
-        const stream = await NAF.connection.adapter.getMediaStream(streamClientId, "video");
+        const stream = await APP.dialog.getMediaStream(streamClientId, "video");
         // We subscribe to video stream notifications for this peer to update the video element
         // This could happen in case there is an ICE failure that requires a transport recreation.
         if (this._onStreamUpdated) {
-          NAF.connection.adapter.off("stream_updated", this._onStreamUpdated);
+          APP.dialog.off("stream_updated", this._onStreamUpdated);
         }
         this._onStreamUpdated = async (peerId, kind) => {
           if (peerId === streamClientId && kind === "video") {
             // The video stream for this peer has been updated
-            const stream = await NAF.connection.adapter.getMediaStream(peerId, "video").catch(e => {
+            const stream = await APP.dialog.getMediaStream(peerId, "video").catch(e => {
               console.error(`Error getting video stream for ${peerId}`, e);
             });
             if (stream) {
@@ -769,7 +769,7 @@ AFRAME.registerComponent("media-video", {
             }
           }
         };
-        NAF.connection.adapter.on("stream_updated", this._onStreamUpdated, this);
+        APP.dialog.on("stream_updated", this._onStreamUpdated, this);
         videoEl.srcObject = new MediaStream(stream.getVideoTracks());
         // If hls.js is supported we always use it as it gives us better events
       } else if (contentType.startsWith("application/dash")) {
@@ -1006,7 +1006,7 @@ AFRAME.registerComponent("media-video", {
     if (this.video) {
       this.video.removeEventListener("pause", this.onPauseStateChange);
       this.video.removeEventListener("play", this.onPauseStateChange);
-      NAF.connection.adapter.off("stream_updated", this._onStreamUpdated);
+      APP.dialog.off("stream_updated", this._onStreamUpdated);
     }
 
     if (this.hoverMenu) {

--- a/src/components/mute-mic.js
+++ b/src/components/mute-mic.js
@@ -35,8 +35,6 @@ AFRAME.registerComponent("mute-mic", {
     this.onToggle = this.onToggle.bind(this);
     this.onMute = this.onMute.bind(this);
     this.onUnmute = this.onUnmute.bind(this);
-    this.store = window.APP.store;
-    this.store.addEventListener("statechanged", this.onStoreUpdated.bind(this));
   },
 
   play: function() {
@@ -54,43 +52,16 @@ AFRAME.registerComponent("mute-mic", {
   },
 
   onToggle: function() {
-    if (!NAF.connection.adapter) return;
+    APP.dialog.toggleMicrophone();
     if (!this.el.sceneEl.is("entered")) return;
-
     this.el.sceneEl.systems["hubs-systems"].soundEffectsSystem.playSoundOneShot(SOUND_TOGGLE_MIC);
-    if (this.el.is("muted")) {
-      NAF.connection.adapter.enableMicrophone(true);
-    } else {
-      NAF.connection.adapter.enableMicrophone(false);
-    }
   },
 
   onMute: function() {
-    if (!NAF.connection.adapter) return;
-    if (!this.el.is("muted")) {
-      NAF.connection.adapter.enableMicrophone(false);
-    }
+    APP.dialog.enableMicrophone(false);
   },
 
   onUnmute: function() {
-    if (this.el.is("muted")) {
-      NAF.connection.adapter.enableMicrophone(true);
-    }
-  },
-
-  onStoreUpdated: function() {
-    const micMuted = this.store.state.settings["micMuted"];
-    const isMicShared = window.APP.mediaDevicesManager?.isMicShared;
-    if (micMuted !== undefined) {
-      if (isMicShared) {
-        if (micMuted) {
-          this.el.addState("muted");
-        } else {
-          this.el.removeState("muted");
-        }
-      } else {
-        this.el.addState("muted");
-      }
-    }
+    APP.dialog.enableMicrophone(true);
   }
 });

--- a/src/components/player-info.js
+++ b/src/components/player-info.js
@@ -51,8 +51,7 @@ AFRAME.registerComponent("player-info", {
     this.handleModelError = this.handleModelError.bind(this);
     this.handleRemoteModelError = this.handleRemoteModelError.bind(this);
     this.update = this.update.bind(this);
-    this.localStateAdded = this.localStateAdded.bind(this);
-    this.localStateRemoved = this.localStateRemoved.bind(this);
+    this.onMicStateChanged = this.onMicStateChanged.bind(this);
 
     this.isLocalPlayerInfo = this.el.id === "avatar-rig";
     this.playerSessionId = null;
@@ -85,8 +84,7 @@ AFRAME.registerComponent("player-info", {
     this.el.sceneEl.addEventListener("stateremoved", this.update);
 
     if (this.isLocalPlayerInfo) {
-      this.el.sceneEl.addEventListener("stateadded", this.localStateAdded);
-      this.el.sceneEl.addEventListener("stateremoved", this.localStateRemoved);
+      APP.dialog.on("mic-state-changed", this.onMicStateChanged);
     }
   },
   pause() {
@@ -102,8 +100,7 @@ AFRAME.registerComponent("player-info", {
     window.APP.store.removeEventListener("statechanged", this.update);
 
     if (this.isLocalPlayerInfo) {
-      this.el.sceneEl.removeEventListener("stateadded", this.localStateAdded);
-      this.el.sceneEl.removeEventListener("stateremoved", this.localStateRemoved);
+      APP.dialog.off("mic-state-changed", this.onMicStateChanged);
     }
   },
 
@@ -197,14 +194,7 @@ AFRAME.registerComponent("player-info", {
     this.data.avatarSrc = defaultAvatar;
     this.applyProperties();
   },
-  localStateAdded(e) {
-    if (e.detail === "muted") {
-      this.el.setAttribute("player-info", { muted: true });
-    }
-  },
-  localStateRemoved(e) {
-    if (e.detail === "muted") {
-      this.el.setAttribute("player-info", { muted: false });
-    }
+  onMicStateChanged({ enabled }) {
+    this.el.setAttribute("player-info", { muted: !enabled });
   }
 });

--- a/src/components/video-texture-target.js
+++ b/src/components/video-texture-target.js
@@ -152,7 +152,7 @@ AFRAME.registerComponent("video-texture-target", {
 
         const streamClientId = src.substring(7).split("/")[1]; // /clients/<client id>/video is only URL for now
 
-        NAF.connection.adapter.getMediaStream(streamClientId, "video").then(stream => {
+        APP.dialog.getMediaStream(streamClientId, "video").then(stream => {
           if (src !== this.data.src) {
             // Prevent creating and loading video texture if the src changed while we were fetching the video stream.
             return;

--- a/src/emitter.js
+++ b/src/emitter.js
@@ -1,0 +1,28 @@
+export function emitter() {
+  let bindings = [];
+  let bindingRef = 0;
+  const on = (event, callback) => {
+    const ref = bindingRef++;
+    bindings.push({ event, ref, callback });
+    return ref;
+  };
+  const off = (event, ref) => {
+    bindings = bindings.filter(bind => {
+      return !(bind.event === event && (typeof ref === "undefined" || ref === bind.ref));
+    });
+  };
+  const trigger = (event, payload) => {
+    bindings.filter(bind => bind.event === event).forEach(bind => {
+      bind.callback(payload);
+    });
+  };
+  const getBindings = () => {
+    return bindings;
+  };
+  return {
+    on,
+    off,
+    trigger,
+    getBindings
+  };
+}

--- a/src/freeze.js
+++ b/src/freeze.js
@@ -1,0 +1,3 @@
+export function freeze(a) {
+  return JSON.parse(JSON.stringify(a || "undefined"));
+}

--- a/src/phoenix-adapter.js
+++ b/src/phoenix-adapter.js
@@ -1,0 +1,258 @@
+import { transportForChannel } from "./transport-for-channel";
+import { authorizeOrSanitizeMessage } from "./utils/permissions-utils";
+
+// TODO: Use the websocket connection, not HEAD requests
+const getTimeOffsetToServer = async () => {
+  const precision = 1000;
+  const clientSentTime = Date.now();
+  const serverReceivedTime =
+    new Date(
+      (await fetch(document.location.href, {
+        method: "HEAD",
+        cache: "no-cache"
+      })).headers.get("Date")
+    ).getTime() +
+    precision / 2;
+  const clientReceivedTime = Date.now();
+  const serverTime = serverReceivedTime + (clientReceivedTime - clientSentTime) / 2;
+  const offset = serverTime - clientReceivedTime;
+  return offset;
+};
+
+const getAverageTimeOffset = (() => {
+  let average = 0;
+  const numOffsetsToGather = 10;
+  const offsets = [];
+  let n = 0;
+
+  const update = async () => {
+    offsets[n % numOffsetsToGather] = await getTimeOffsetToServer();
+    n = n + 1;
+    average = offsets.reduce((acc, offset) => (acc += offset), 0) / offsets.length;
+    if (offsets.length == numOffsetsToGather) {
+      setTimeout(update, 5 * 60 * 1000);
+    } else {
+      update();
+    }
+  };
+
+  update();
+
+  return () => {
+    return average;
+  };
+})();
+
+export default class PhoenixAdapter {
+  constructor() {
+    this.refs = new Map();
+    // TODO: Frozen messages can be handled outside this class.
+    this.frozenUpdates = new Map();
+    this._blockedClients = new Map();
+  }
+  setServerUrl() {}
+  setApp() {}
+  setRoom() {}
+  setWebRtcOptions() {}
+  setServerConnectListeners(nafConnectSuccess, nafConnectFailed) {
+    this.nafConnectSuccess = nafConnectSuccess;
+    this.nafConnectFailed = nafConnectFailed;
+  }
+  setRoomOccupantListener() {}
+  setDataChannelListeners(nafOccupantJoined, nafOccupantLeave, nafMessageReceived) {
+    this.nafOccupantJoined = nafOccupantJoined;
+    this.nafOccupantLeave = nafOccupantLeave;
+    this.nafMessageReceived = nafMessageReceived;
+  }
+  async connect() {
+    this.refs.set("naf", this.hubChannel.channel.on("naf", this.handleIncomingNAF));
+    this.refs.set("nafr", this.hubChannel.channel.on("nafr", this.handleIncomingNAFR));
+
+    this.nafConnectSuccess(this.session_id);
+    this.reliableTransport = transportForChannel(this.hubChannel.channel, true);
+    this.unreliableTransport = transportForChannel(this.hubChannel.channel, false);
+
+    this.hubChannel.presence.list(key => key).forEach(this.nafOccupantJoined);
+    this.refs.set("hub:join", this.events.on(`hub:join`, ({ key }) => this.nafOccupantJoined(key)));
+    this.refs.set("hub:leave", this.events.on(`hub:leave`, ({ key }) => this.nafOccupantLeave(key)));
+  }
+  shouldStartConnectionTo() {}
+  startStreamConnection() {}
+  closeStreamConnection() {}
+  getConnectStatus() {}
+
+  getMediaStream() {
+    return Promise.reject("getMediaStream not implemented in phoenix-adapter");
+  }
+
+  getServerTime() {
+    return Date.now() + getAverageTimeOffset();
+  }
+
+  sendData(clientId, dataType, data) {
+    this.unreliableTransport(clientId, dataType, data);
+  }
+  sendDataGuaranteed(clientId, dataType, data) {
+    this.reliableTransport(clientId, dataType, data);
+  }
+  broadcastData(dataType, data) {
+    this.unreliableTransport(undefined, dataType, data);
+  }
+  broadcastDataGuaranteed(dataType, data) {
+    this.reliableTransport(undefined, dataType, data);
+  }
+
+  disconnect() {
+    this.hubChannel.presence.list(key => key).forEach(this.nafOccupantLeave);
+
+    this.events.off("naf", this.refs.get("naf"));
+    this.events.off("nafr", this.refs.get("nafr"));
+    this.events.off("hub:join", this.refs.get("hub:join"));
+    this.events.off("hub:leave", this.refs.get("hub:leave"));
+    this.refs.delete("naf");
+    this.refs.delete("nafr");
+    this.refs.delete("hub:join");
+    this.refs.delete("hub:leave");
+  }
+
+  toggleFreeze() {
+    if (this.frozen) {
+      this.unfreeze();
+    } else {
+      this.freeze();
+    }
+  }
+
+  freeze() {
+    this.frozen = true;
+  }
+
+  unfreeze() {
+    this.frozen = false;
+    this.flushPendingUpdates();
+  }
+
+  flushPendingUpdates() {
+    for (const [networkId, message] of this.frozenUpdates) {
+      const data = this.getPendingData(networkId, message);
+      if (!data) continue;
+
+      // Override the data type on "um" messages types, since we extract entity updates from "um" messages into
+      // individual frozenUpdates in storeSingleMessage.
+      const dataType = message.dataType === "um" ? "u" : message.dataType;
+
+      this.nafMessageReceived(null, dataType, data, message.source);
+    }
+    this.frozenUpdates.clear();
+  }
+
+  getPendingData(networkId, message) {
+    if (!message) return null;
+
+    const data = message.dataType === "um" ? this.dataForUpdateMultiMessage(networkId, message) : message.data;
+
+    // Ignore messages from users that we may have blocked while frozen.
+    if (data.owner && this._blockedClients.has(data.owner)) return null;
+
+    return data;
+  }
+
+  // Used externally
+  getPendingDataForNetworkId(networkId) {
+    return this.getPendingData(networkId, this.frozenUpdates.get(networkId));
+  }
+
+  handleIncomingNAF = data => {
+    const message = authorizeOrSanitizeMessage(data);
+    const source = "phx-reliable";
+    if (!message.dataType) return;
+
+    message.source = source;
+
+    //TODO: Handle frozen
+    if (this.frozen) {
+      this.storeMessage(message);
+    } else {
+      this.nafMessageReceived(null, message.dataType, message.data, message.source);
+    }
+  };
+  handleIncomingNAFR = ({ from_session_id, naf: unparsedData }) => {
+    // Server optimization: server passes through unparsed NAF message, we must now parse it.
+    const data = JSON.parse(unparsedData);
+    data.from_session_id = from_session_id;
+    this.handleIncomingNAF(data);
+  };
+
+  storeMessage(message) {
+    if (message.dataType === "um") {
+      // UpdateMulti
+      for (let i = 0, l = message.data.d.length; i < l; i++) {
+        this.storeSingleMessage(message, i);
+      }
+    } else {
+      this.storeSingleMessage(message);
+    }
+  }
+
+  storeSingleMessage(message, index) {
+    const data = index !== undefined ? message.data.d[index] : message.data;
+    const dataType = message.dataType;
+
+    const networkId = data.networkId;
+
+    if (!this.frozenUpdates.has(networkId)) {
+      this.frozenUpdates.set(networkId, message);
+    } else {
+      const storedMessage = this.frozenUpdates.get(networkId);
+      const storedData =
+        storedMessage.dataType === "um" ? this.dataForUpdateMultiMessage(networkId, storedMessage) : storedMessage.data;
+
+      // Avoid updating components if the entity data received did not come from the current owner.
+      const isOutdatedMessage = data.lastOwnerTime < storedData.lastOwnerTime;
+      const isContemporaneousMessage = data.lastOwnerTime === storedData.lastOwnerTime;
+      if (isOutdatedMessage || (isContemporaneousMessage && storedData.owner > data.owner)) {
+        return;
+      }
+
+      if (dataType === "r") {
+        const createdWhileFrozen = storedData && storedData.isFirstSync;
+        if (createdWhileFrozen) {
+          // If the entity was created and deleted while frozen, don't bother conveying anything to the consumer.
+          this.frozenUpdates.delete(networkId);
+        } else {
+          // Delete messages override any other messages for this entity
+          this.frozenUpdates.set(networkId, message);
+        }
+      } else {
+        // merge in component updates
+        if (storedData.components && data.components) {
+          Object.assign(storedData.components, data.components);
+        }
+      }
+    }
+  }
+  dataForUpdateMultiMessage(networkId, message) {
+    // "d" is an array of entity datas, where each item in the array represents a unique entity and contains
+    // metadata for the entity, and an array of components that have been updated on the entity.
+    // This method finds the data corresponding to the given networkId.
+    for (let i = 0, l = message.data.d.length; i < l; i++) {
+      const data = message.data.d[i];
+
+      if (data.networkId === networkId) {
+        return data;
+      }
+    }
+
+    return null;
+  }
+
+  block(clientId) {
+    this._blockedClients.set(clientId, true);
+  }
+
+  unblock(clientId) {
+    this._blockedClients.delete(clientId);
+  }
+}
+
+NAF.adapters.register("phoenix", PhoenixAdapter);

--- a/src/react-components/debug-panel/RtcDebugPanel.js
+++ b/src/react-components/debug-panel/RtcDebugPanel.js
@@ -262,7 +262,7 @@ export default class RtcDebugPanel extends Component {
 
   getDeviceData() {
     let result = {};
-    const device = NAF.connection.adapter._mediasoupDevice;
+    const device = APP.dialog._mediasoupDevice;
     if (device) {
       result["loaded"] = !device._closed ? true : false;
       result["codecs"] = device._recvRtpCapabilities?.codecs.map(
@@ -270,7 +270,7 @@ export default class RtcDebugPanel extends Component {
       );
       result = {
         ...result,
-        ...NAF.connection.adapter.downlinkBwe
+        ...APP.dialog.downlinkBwe
       };
     }
     return result;
@@ -314,9 +314,9 @@ export default class RtcDebugPanel extends Component {
     const result = {};
     let transport;
     if (type === TransportType.SEND) {
-      transport = NAF.connection.adapter._sendTransport;
+      transport = APP.dialog._sendTransport;
     } else if (type === TransportType.RECEIVE) {
-      transport = NAF.connection.adapter._recvTransport;
+      transport = APP.dialog._recvTransport;
     }
     const opened = (transport && !transport._closed && true) || false;
     result["opened"] = opened;
@@ -364,7 +364,7 @@ export default class RtcDebugPanel extends Component {
       result["name"] = profile ? profile.displayName : "N/A";
       result["peerId"] = peer._appData.peerId;
 
-      const stats = NAF.connection.adapter.consumerStats[peer._id];
+      const stats = APP.dialog.consumerStats[peer._id];
       if (result["kind"] === "video" && stats) {
         result["spatialLayer"] = stats["spatialLayer"];
         result["temporalLayer"] = stats["temporalLayer"];
@@ -385,11 +385,11 @@ export default class RtcDebugPanel extends Component {
   }
 
   getSignalingData() {
-    return { connected: !NAF.connection.adapter._closed };
+    return { connected: !APP.dialog._closed };
   }
 
   async getServerData() {
-    return await NAF.connection.adapter.getServerStats();
+    return await APP.dialog.getServerStats();
   }
 
   async getRtpStatsData(peer, type) {
@@ -486,9 +486,9 @@ export default class RtcDebugPanel extends Component {
 
             // Populate graph, speed and stats data
             const statsData = {};
-            if (NAF.connection.adapter._micProducer) {
-              const id = NAF.connection.adapter._micProducer.id;
-              const peer = NAF.connection.adapter._micProducer;
+            if (APP.dialog._micProducer) {
+              const id = APP.dialog._micProducer.id;
+              const peer = APP.dialog._micProducer;
               const speedData = this.getPeerSpeed(id, "bytesSent");
               const rtpStatsData = await this.getRtpStatsData(peer, StatsType.OUTBOUND_RTP);
               const { lastStats, graphData } = this.getGraphData(id, rtpStatsData);
@@ -498,9 +498,9 @@ export default class RtcDebugPanel extends Component {
               statsData[id]["last"] = lastStats;
               statsData[id]["rtpStats"] = rtpStatsData;
             }
-            if (NAF.connection.adapter._cameraProducer) {
-              const id = NAF.connection.adapter._cameraProducer.id;
-              const peer = NAF.connection.adapter._cameraProducer;
+            if (APP.dialog._cameraProducer) {
+              const id = APP.dialog._cameraProducer.id;
+              const peer = APP.dialog._cameraProducer;
               const speedData = this.getPeerSpeed(id, "bytesSent");
               const rtpStatsData = await this.getRtpStatsData(peer, StatsType.OUTBOUND_RTP);
               const { lastStats, graphData } = this.getGraphData(id, rtpStatsData);
@@ -510,9 +510,9 @@ export default class RtcDebugPanel extends Component {
               statsData[id]["last"] = lastStats;
               statsData[id]["rtpStats"] = rtpStatsData;
             }
-            if (NAF.connection.adapter._shareProducer) {
-              const id = NAF.connection.adapter._shareProducer.id;
-              const peer = NAF.connection.adapter._shareProducer;
+            if (APP.dialog._shareProducer) {
+              const id = APP.dialog._shareProducer.id;
+              const peer = APP.dialog._shareProducer;
               const speedData = this.getPeerSpeed(id, "bytesSent");
               const rtpStatsData = await this.getRtpStatsData(peer, StatsType.OUTBOUND_RTP);
               const { lastStats, graphData } = this.getGraphData(id, rtpStatsData);
@@ -522,7 +522,7 @@ export default class RtcDebugPanel extends Component {
               statsData[id]["last"] = lastStats;
               statsData[id]["rtpStats"] = rtpStatsData;
             }
-            for (const consumer of NAF.connection.adapter._consumers) {
+            for (const consumer of APP.dialog._consumers) {
               const id = consumer[0];
               const peer = consumer[1];
               const speedData = this.getPeerSpeed(id, "bytesReceived");
@@ -555,19 +555,19 @@ export default class RtcDebugPanel extends Component {
   }
 
   restartSendICE = () => {
-    NAF.connection.adapter.restartSendICE();
+    APP.dialog.restartSendICE();
   };
 
   restartRecvICE = () => {
-    NAF.connection.adapter.restartRecvICE();
+    APP.dialog.restartRecvICE();
   };
 
   connectSignaling = () => {
-    NAF.connection.adapter.connect();
+    APP.dialog.connect();
   };
 
   disconnectSignaling = () => {
-    NAF.connection.adapter.disconnect();
+    APP.dialog.disconnect();
   };
 
   colorForLevel = level => {

--- a/src/react-components/input/SelectInputField.js
+++ b/src/react-components/input/SelectInputField.js
@@ -110,7 +110,7 @@ SelectInputField.propTypes = {
       PropTypes.string,
       PropTypes.number,
       PropTypes.shape({
-        id: PropTypes.string.isRequired,
+        // id: PropTypes.string.isRequired,
         label: PropTypes.string,
         value: PropTypes.any.isRequired
       })

--- a/src/react-components/room/ContentMenu.js
+++ b/src/react-components/room/ContentMenu.js
@@ -36,13 +36,13 @@ export function PeopleMenuButton(props) {
     <ContentMenuButton {...props}>
       <PeopleIcon />
       <span>
-        <FormattedMessage id="content-menu.people-menu-button" defaultMessage="People" />({props.presenceCount})
+        <FormattedMessage id="content-menu.people-menu-button" defaultMessage="People" />({`${props.presencecount}`})
       </span>
     </ContentMenuButton>
   );
 }
 PeopleMenuButton.propTypes = {
-  presenceCount: PropTypes.number
+  presencecount: PropTypes.number
 };
 
 export function ContentMenu({ children }) {

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -454,7 +454,7 @@ class UIRoot extends Component {
   };
 
   toggleMute = () => {
-    this.props.scene.emit("action_mute");
+    APP.dialog.toggleMicrophone();
   };
 
   shareVideo = mediaSource => {
@@ -571,7 +571,6 @@ class UIRoot extends Component {
   };
 
   beginOrSkipAudioSetup = () => {
-    console.log(this.props.forcedVREntryType);
     const skipAudioSetup = this.props.forcedVREntryType && this.props.forcedVREntryType.endsWith("_now");
 
     if (skipAudioSetup) {
@@ -600,9 +599,6 @@ class UIRoot extends Component {
     clearHistoryState(this.props.history);
 
     const muteOnEntry = this.props.store.state.preferences["muteMicOnEntry"] || false;
-    this.props.store.update({
-      settings: { micMuted: false }
-    });
     await this.props.enterScene(this.state.enterInVR, muteOnEntry);
 
     this.setState({ entered: true, entering: false, showShareDialog: false });
@@ -1356,7 +1352,7 @@ class UIRoot extends Component {
                         <PeopleMenuButton
                           active={this.state.sidebarId === "people"}
                           onClick={() => this.toggleSidebar("people")}
-                          presenceCount={this.state.presenceCount}
+                          presencecount={this.state.presenceCount}
                         />
                       </ContentMenu>
                     )}

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -96,10 +96,6 @@ export default class SceneEntryManager {
       return;
     }
 
-    if (this.mediaDevicesManager.mediaStream) {
-      await NAF.connection.adapter.setLocalMediaStream(this.mediaDevicesManager.mediaStream);
-    }
-
     this.scene.classList.remove("hand-cursor");
     this.scene.classList.add("no-cursor");
 
@@ -123,9 +119,7 @@ export default class SceneEntryManager {
 
     this.scene.addState("entered");
 
-    if (muteOnEntry) {
-      this.scene.emit("action_mute");
-    }
+    APP.dialog.enableMicrophone(!muteOnEntry);
   };
 
   whenSceneLoaded = callback => {
@@ -142,8 +136,8 @@ export default class SceneEntryManager {
 
   exitScene = () => {
     this.scene.exitVR();
-    if (NAF.connection.adapter && NAF.connection.adapter.localMediaStream) {
-      NAF.connection.adapter.localMediaStream.getTracks().forEach(t => t.stop());
+    if (APP.dialog && NAF.connection.adapter.localMediaStream) {
+      APP.dialog.localMediaStream.getTracks().forEach(t => t.stop());
     }
     if (this.hubChannel) {
       this.hubChannel.disconnect();
@@ -497,7 +491,6 @@ export default class SceneEntryManager {
 
     this.scene.addEventListener("action_end_mic_sharing", async () => {
       await this.mediaDevicesManager.stopMicShare();
-      this.scene.emit("action_mute");
     });
 
     this.scene.addEventListener("action_selected_media_result_entry", async e => {
@@ -630,7 +623,7 @@ export default class SceneEntryManager {
       this.mediaDevicesManager.mediaStream.addTrack(audioDestination.stream.getAudioTracks()[0]);
     }
 
-    await NAF.connection.adapter.setLocalMediaStream(this.mediaDevicesManager.mediaStream);
+    await APP.dialog.setLocalMediaStream(this.mediaDevicesManager.mediaStream);
     audioEl.play();
   };
 }

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -136,7 +136,7 @@ export default class SceneEntryManager {
 
   exitScene = () => {
     this.scene.exitVR();
-    if (APP.dialog && NAF.connection.adapter.localMediaStream) {
+    if (APP.dialog && APP.dialog.localMediaStream) {
       APP.dialog.localMediaStream.getTracks().forEach(t => t.stop());
     }
     if (this.hubChannel) {

--- a/src/transport-for-channel.js
+++ b/src/transport-for-channel.js
@@ -1,0 +1,40 @@
+export function transportForChannel(channel, reliable = true) {
+  return (clientId, dataType, data) => {
+    const payload = { dataType, data };
+
+    if (clientId) {
+      payload.clientId = clientId;
+    }
+
+    const isOpen = channel.socket.connectionState() === "open";
+
+    if (isOpen || reliable) {
+      const hasFirstSync =
+        payload.dataType === "um" ? payload.data.d.find(r => r.isFirstSync) : payload.data.isFirstSync;
+
+      if (hasFirstSync) {
+        if (isOpen) {
+          channel.push("naf", payload);
+        } else {
+          // Memory is re-used, so make a copy
+          channel.push("naf", AFRAME.utils.clone(payload));
+        }
+      } else {
+        // Optimization: Strip isFirstSync and send payload as a string to reduce server parsing.
+        // The server will not parse messages without isFirstSync keys when sent to the nafr event.
+        //
+        // The client must assume any payload that does not have a isFirstSync key is not a first sync.
+        const nafrPayload = AFRAME.utils.clone(payload);
+        if (nafrPayload.dataType === "um") {
+          for (let i = 0; i < nafrPayload.data.d.length; i++) {
+            delete nafrPayload.data.d[i].isFirstSync;
+          }
+        } else {
+          delete nafrPayload.data.isFirstSync;
+        }
+
+        channel.push("nafr", { naf: JSON.stringify(nafrPayload) });
+      }
+    }
+  };
+}

--- a/src/utils/media-devices-manager.js
+++ b/src/utils/media-devices-manager.js
@@ -129,8 +129,7 @@ export default class MediaDevicesManager {
       console.log("No available audio tracks");
     }
 
-    await NAF.connection.adapter.setLocalMediaStream(this._mediaStream);
-    NAF.connection.adapter.enableMicrophone(this._scene.is("muted"));
+    await APP.dialog.setLocalMediaStream(this._mediaStream);
 
     return result;
   }
@@ -209,8 +208,8 @@ export default class MediaDevicesManager {
     this.audioTrack?.stop();
     this.audioTrack = null;
 
-    await NAF.connection.adapter.setLocalMediaStream(this._mediaStream);
-    NAF.connection.adapter.enableMicrophone(false);
+    await APP.dialog.setLocalMediaStream(this._mediaStream);
+    APP.dialog.enableMicrophone(false);
   }
 
   async startVideoShare(constraints, isDisplayMedia, target, success, error) {
@@ -241,7 +240,7 @@ export default class MediaDevicesManager {
           this.audioSystem.addStreamToOutboundAudio("screenshare", newStream);
         }
 
-        await NAF.connection.adapter.setLocalMediaStream(this._mediaStream);
+        await APP.dialog.setLocalMediaStream(this._mediaStream);
       }
     } catch (e) {
       error(e);
@@ -262,7 +261,7 @@ export default class MediaDevicesManager {
 
     this.audioSystem.removeStreamFromOutboundAudio("screenshare");
 
-    await NAF.connection.adapter.setLocalMediaStream(this._mediaStream);
+    await APP.dialog.setLocalMediaStream(this._mediaStream);
   }
 
   async shouldShowHmdMicWarning() {

--- a/src/utils/permissions-utils.js
+++ b/src/utils/permissions-utils.js
@@ -232,9 +232,8 @@ export function authorizeOrSanitizeMessage(message) {
   }
 }
 
-const PHOENIX_RELIABLE_NAF = "phx-reliable";
 export function applyPersistentSync(networkId) {
   if (!persistentSyncs[networkId]) return;
-  NAF.connection.adapter.onData(authorizeOrSanitizeMessage(persistentSyncs[networkId]), PHOENIX_RELIABLE_NAF);
+  NAF.connection.adapter.handleIncomingNAF(persistentSyncs[networkId]);
   delete persistentSyncs[networkId];
 }

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -336,3 +336,37 @@ export function hasEmbedPresences(presences) {
 
   return false;
 }
+
+export function denoisePresence({ onJoin, onLeave, onChange }) {
+  return {
+    rawOnJoin: (key, beforeJoin, afterJoin) => {
+      if (beforeJoin === undefined) {
+        onJoin(key, afterJoin.metas[0]);
+      }
+    },
+    rawOnLeave: (key, remaining, removed) => {
+      if (remaining.metas.length === 0) {
+        onLeave(key, removed.metas[0]);
+      } else {
+        onChange(key, removed.metas[removed.metas.length - 1], remaining.metas[remaining.metas.length - 1]);
+      }
+    }
+  };
+}
+
+export function presenceEventsForHub(events) {
+  const onJoin = (key, meta) => {
+    events.trigger(`hub:join`, { key, meta });
+  };
+  const onLeave = (key, meta) => {
+    events.trigger(`hub:leave`, { key, meta });
+  };
+  const onChange = (key, previous, current) => {
+    events.trigger(`hub:change`, { key, previous, current });
+  };
+  return {
+    onJoin,
+    onLeave,
+    onChange
+  };
+}


### PR DESCRIPTION
This PR changes a few things.

- There is a new `NAF` adapter called `PhoenixAdapter`. The `PhoenixAdapter` handles `naf` and `nafr` events on the `hub:${hubId}` phoenix channel, and tells `NAF` when participants join and leave the hub room. (It uses `Presence` to know about the other participants.)
- The `DialogAdapter` does not have to care about `NAF` anymore, so it doesn't. We give dialog only the information it needs (`serverParams`, `hubId`, `turn` info etc) to join the `protoo` room and establish `WebRTC` connections with the help of `mediasoup`.
- Mic state is simpler:
  - The source of truth is [`APP.dialog.isMicEnabled`](https://github.com/mozilla/hubs/blob/feature/phoenix-adapter/src/naf-dialog-adapter.js#L937-L939). 
  - The mic state is not stored in `localStorage` or in a `muted` css class on the `scene`. 
  - We do not toggle the microphone when selecting a new input device from the preference menu.
- Hub channel presence events are handled by various event handlers, rather than having a small number of event handlers do a bunch of work.
- The control flow in `hub.js` is mostly the same. The biggest difference is that we now need to explicitly tell dialog to connect because it's no longer tied to networked aframe. We should further simplify `hub.js` in a future PR. I tried to keep this diff manageable by postponing some changes that seem like improvements.