### PR TITLE
Add NAF Phoenix Adapter

### DIFF
--- a/src/change-hub.js
+++ b/src/change-hub.js
@@ -27,7 +27,7 @@ function loadRoomObjects(hubId) {
 
 export async function changeHub(hubId, addToHistory = true) {
   // Suppress on-screen join and leave messages until we receive a sync.
-  APP.suppressPresenceMessages = true;
+  APP.hideHubPresenceEvents = true;
   const scene = AFRAME.scenes[0];
 
   let data;

--- a/src/change-hub.js
+++ b/src/change-hub.js
@@ -26,6 +26,10 @@ function loadRoomObjects(hubId) {
 }
 
 export async function changeHub(hubId, addToHistory = true) {
+  if (hubId === APP.hub.hub_id) {
+    console.log("Change hub called with the current hub id. This is a noop.");
+    return;
+  }
   // Suppress on-screen join and leave messages until we receive a sync.
   APP.hideHubPresenceEvents = true;
   const scene = AFRAME.scenes[0];

--- a/src/change-hub.js
+++ b/src/change-hub.js
@@ -110,7 +110,7 @@ export async function changeHub(hubId, addToHistory = true) {
 window.changeHub = changeHub;
 
 // TODO see if there is a better way to do this with react router
-window.addEventListener("popstate", function(e) {
+window.addEventListener("popstate", function() {
   if (!APP.store.state.preferences.fastRoomSwitching) return;
   const qs = new URLSearchParams(location.search);
   const newHubId = qs.get("hub_id") || document.location.pathname.substring(1).split("/")[0];

--- a/src/change-hub.js
+++ b/src/change-hub.js
@@ -59,6 +59,7 @@ export async function changeHub(hubId, addToHistory = true) {
   await APP.mediaDevicesManager.stopMicShare();
   NAF.entities.removeRemoteEntities();
   await NAF.connection.adapter.disconnect();
+  const micState = APP.dialog.isMicEnabled;
   await APP.dialog.disconnect();
   unloadRoomObjects();
   NAF.connection.connectedClients = {};
@@ -89,7 +90,8 @@ export async function changeHub(hubId, addToHistory = true) {
     NAF.connection.adapter.connect()
   ]);
 
-  APP.mediaDevicesManager.startMicShare();
+  await APP.mediaDevicesManager.startMicShare();
+  APP.dialog.enableMicrophone(micState);
   loadRoomObjects(hubId);
 
   APP.hubChannel.sendEnteredEvent();

--- a/src/change-hub.js
+++ b/src/change-hub.js
@@ -80,11 +80,16 @@ export async function changeHub(hubId, addToHistory = true) {
   await Promise.all([
     APP.dialog.connect({
       serverUrl: `wss://${hub.host}:${hub.port}`,
-      hubId: hub.hub_id,
+      roomId: hub.hub_id,
       joinToken: data.perms_token,
       serverParams: { host: hub.host, port: hub.port, turn: hub.turn },
-      scene
+      scene,
+      clientId: APP.dialog._clientId,
+      forceTcp: APP.dialog._forceTcp,
+      forceTurn: APP.dialog._forceTurn,
+      iceTransportPolicy: APP.dialog._iceTransportPolicy
     }),
+
     NAF.connection.adapter.connect()
   ]);
 

--- a/src/change-hub.js
+++ b/src/change-hub.js
@@ -56,10 +56,8 @@ export async function changeHub(hubId, addToHistory = true) {
     initialIsFavorited: data.subscriptions.favorites
   });
 
-  await APP.mediaDevicesManager.stopMicShare();
   NAF.entities.removeRemoteEntities();
   await NAF.connection.adapter.disconnect();
-  const micState = APP.dialog.isMicEnabled;
   await APP.dialog.disconnect();
   unloadRoomObjects();
   NAF.connection.connectedClients = {};
@@ -90,8 +88,6 @@ export async function changeHub(hubId, addToHistory = true) {
     NAF.connection.adapter.connect()
   ]);
 
-  await APP.mediaDevicesManager.startMicShare();
-  APP.dialog.enableMicrophone(micState);
   loadRoomObjects(hubId);
 
   APP.hubChannel.sendEnteredEvent();

--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -33,7 +33,7 @@ async function getMediaStream(el) {
     console.error(INFO_INIT_FAILED, INFO_NO_OWNER);
     return null;
   }
-  const stream = await NAF.connection.adapter.getMediaStream(peerId).catch(e => {
+  const stream = await APP.dialog.getMediaStream(peerId).catch(e => {
     console.error(INFO_INIT_FAILED, `Error getting media stream for ${peerId}`, e);
   });
   if (!stream) {
@@ -106,7 +106,7 @@ AFRAME.registerComponent("avatar-audio-source", {
     this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem.registerAvatarAudioSource(this);
     // We subscribe to audio stream notifications for this peer to update the audio source
     // This could happen in case there is an ICE failure that requires a transport recreation.
-    NAF.connection.adapter?.on("stream_updated", this._onStreamUpdated, this);
+    APP.dialog.on("stream_updated", this._onStreamUpdated, this);
     this.createAudio();
   },
 
@@ -119,7 +119,7 @@ AFRAME.registerComponent("avatar-audio-source", {
     getOwnerId(this.el).then(async ownerId => {
       if (ownerId === peerId && kind === "audio") {
         // The audio stream for this peer has been updated
-        const newStream = await NAF.connection.adapter.getMediaStream(peerId, "audio").catch(e => {
+        const newStream = await APP.dialog.getMediaStream(peerId, "audio").catch(e => {
           console.error(INFO_INIT_FAILED, `Error getting media stream for ${peerId}`, e);
         });
 
@@ -149,7 +149,7 @@ AFRAME.registerComponent("avatar-audio-source", {
 
   remove: function() {
     this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem.unregisterAvatarAudioSource(this);
-    NAF.connection.adapter.off("stream_updated", this._onStreamUpdated);
+    APP.dialog.off("stream_updated", this._onStreamUpdated);
     this.destroyAudio();
   }
 });

--- a/src/components/bone-mute-state-indicator.js
+++ b/src/components/bone-mute-state-indicator.js
@@ -3,6 +3,7 @@
  * @namespace avatar
  * @component bone-mute-state-indicator
  */
+// TODO: Remove this
 AFRAME.registerComponent("bone-mute-state-indicator", {
   schema: {
     unmutedBoneName: { default: "Watch_Joint_MicON" },
@@ -20,26 +21,23 @@ AFRAME.registerComponent("bone-mute-state-indicator", {
 
       this.updateMuteState();
     });
+
+    this.onMicStateChanged = () => {
+      this.updateMuteState();
+    };
   },
 
   play() {
-    this.el.sceneEl.addEventListener("stateadded", this.onStateToggled);
-    this.el.sceneEl.addEventListener("stateremoved", this.onStateToggled);
+    APP.dialog.on("mic-state-changed", this.onMicStateChanged);
   },
 
   pause() {
-    this.el.sceneEl.removeEventListener("stateadded", this.onStateToggled);
-    this.el.sceneEl.removeEventListener("stateremoved", this.onStateToggled);
-  },
-
-  onStateToggled(e) {
-    if (!e.detail.state === "muted") return;
-    this.updateMuteState();
+    APP.dialog.off("mic-state-changed", this.onMicStateChanged);
   },
 
   updateMuteState() {
     if (!this.modelLoaded) return;
-    const muted = this.el.sceneEl.is("muted");
+    const muted = !APP.dialog.isMicEnabled;
     this.mutedBone.position.y = muted ? this.data.onPos : this.data.offPos;
     this.unmutedBone.position.y = !muted ? this.data.onPos : this.data.offPos;
     this.mutedBone.matrixNeedsUpdate = true;

--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -389,7 +389,7 @@ AFRAME.registerComponent("camera-tool", {
     };
 
     if (this.data.captureAudio) {
-      const selfAudio = await NAF.connection.adapter.getMediaStream(NAF.clientId, "audio");
+      const selfAudio = await APP.dialog.getMediaStream(NAF.clientId, "audio");
 
       // NOTE: if we don't have a self audio track, we can end up generating an empty video (browser bug?)
       // if no audio comes through on the listener source. (Eg the room is otherwise silent.)

--- a/src/components/in-world-hud.js
+++ b/src/components/in-world-hud.js
@@ -13,8 +13,13 @@ AFRAME.registerComponent("in-world-hud", {
     this.inviteBtn = this.el.querySelector(".invite-btn");
     this.background = this.el.querySelector(".bg");
 
+    this.onMicStateChanged = () => {
+      this.mic.setAttribute("mic-button", "active", APP.dialog.isMicEnabled);
+    };
+    APP.dialog.on("mic-state-changed", this.onMicStateChanged);
+
     this.updateButtonStates = () => {
-      this.mic.setAttribute("mic-button", "active", this.el.sceneEl.is("muted"));
+      this.mic.setAttribute("mic-button", "active", APP.dialog.isMicEnabled);
       this.pen.setAttribute("icon-button", "active", this.el.sceneEl.is("pen"));
       this.cameraBtn.setAttribute("icon-button", "active", this.el.sceneEl.is("camera"));
       if (window.APP.hubChannel) {
@@ -25,13 +30,12 @@ AFRAME.registerComponent("in-world-hud", {
     };
 
     this.onStateChange = evt => {
-      if (!(evt.detail === "muted" || evt.detail === "frozen" || evt.detail === "pen" || evt.detail === "camera"))
-        return;
+      if (!(evt.detail === "frozen" || evt.detail === "pen" || evt.detail === "camera")) return;
       this.updateButtonStates();
     };
 
     this.onMicClick = () => {
-      this.el.emit("action_mute");
+      APP.dialog.toggleMicrophone();
     };
 
     this.onSpawnClick = () => {

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -752,16 +752,16 @@ AFRAME.registerComponent("media-video", {
       // Set src on video to begin loading.
       if (url.startsWith("hubs://")) {
         const streamClientId = url.substring(7).split("/")[1]; // /clients/<client id>/video is only URL for now
-        const stream = await NAF.connection.adapter.getMediaStream(streamClientId, "video");
+        const stream = await APP.dialog.getMediaStream(streamClientId, "video");
         // We subscribe to video stream notifications for this peer to update the video element
         // This could happen in case there is an ICE failure that requires a transport recreation.
         if (this._onStreamUpdated) {
-          NAF.connection.adapter.off("stream_updated", this._onStreamUpdated);
+          APP.dialog.off("stream_updated", this._onStreamUpdated);
         }
         this._onStreamUpdated = async (peerId, kind) => {
           if (peerId === streamClientId && kind === "video") {
             // The video stream for this peer has been updated
-            const stream = await NAF.connection.adapter.getMediaStream(peerId, "video").catch(e => {
+            const stream = await APP.dialog.getMediaStream(peerId, "video").catch(e => {
               console.error(`Error getting video stream for ${peerId}`, e);
             });
             if (stream) {
@@ -769,7 +769,7 @@ AFRAME.registerComponent("media-video", {
             }
           }
         };
-        NAF.connection.adapter.on("stream_updated", this._onStreamUpdated, this);
+        APP.dialog.on("stream_updated", this._onStreamUpdated, this);
         videoEl.srcObject = new MediaStream(stream.getVideoTracks());
         // If hls.js is supported we always use it as it gives us better events
       } else if (contentType.startsWith("application/dash")) {
@@ -1006,7 +1006,7 @@ AFRAME.registerComponent("media-video", {
     if (this.video) {
       this.video.removeEventListener("pause", this.onPauseStateChange);
       this.video.removeEventListener("play", this.onPauseStateChange);
-      NAF.connection.adapter.off("stream_updated", this._onStreamUpdated);
+      APP.dialog.off("stream_updated", this._onStreamUpdated);
     }
 
     if (this.hoverMenu) {

--- a/src/components/mute-mic.js
+++ b/src/components/mute-mic.js
@@ -35,8 +35,6 @@ AFRAME.registerComponent("mute-mic", {
     this.onToggle = this.onToggle.bind(this);
     this.onMute = this.onMute.bind(this);
     this.onUnmute = this.onUnmute.bind(this);
-    this.store = window.APP.store;
-    this.store.addEventListener("statechanged", this.onStoreUpdated.bind(this));
   },
 
   play: function() {
@@ -54,43 +52,16 @@ AFRAME.registerComponent("mute-mic", {
   },
 
   onToggle: function() {
-    if (!NAF.connection.adapter) return;
+    APP.dialog.toggleMicrophone();
     if (!this.el.sceneEl.is("entered")) return;
-
     this.el.sceneEl.systems["hubs-systems"].soundEffectsSystem.playSoundOneShot(SOUND_TOGGLE_MIC);
-    if (this.el.is("muted")) {
-      NAF.connection.adapter.enableMicrophone(true);
-    } else {
-      NAF.connection.adapter.enableMicrophone(false);
-    }
   },
 
   onMute: function() {
-    if (!NAF.connection.adapter) return;
-    if (!this.el.is("muted")) {
-      NAF.connection.adapter.enableMicrophone(false);
-    }
+    APP.dialog.enableMicrophone(false);
   },
 
   onUnmute: function() {
-    if (this.el.is("muted")) {
-      NAF.connection.adapter.enableMicrophone(true);
-    }
-  },
-
-  onStoreUpdated: function() {
-    const micMuted = this.store.state.settings["micMuted"];
-    const isMicShared = window.APP.mediaDevicesManager?.isMicShared;
-    if (micMuted !== undefined) {
-      if (isMicShared) {
-        if (micMuted) {
-          this.el.addState("muted");
-        } else {
-          this.el.removeState("muted");
-        }
-      } else {
-        this.el.addState("muted");
-      }
-    }
+    APP.dialog.enableMicrophone(true);
   }
 });

--- a/src/components/player-info.js
+++ b/src/components/player-info.js
@@ -51,8 +51,7 @@ AFRAME.registerComponent("player-info", {
     this.handleModelError = this.handleModelError.bind(this);
     this.handleRemoteModelError = this.handleRemoteModelError.bind(this);
     this.update = this.update.bind(this);
-    this.localStateAdded = this.localStateAdded.bind(this);
-    this.localStateRemoved = this.localStateRemoved.bind(this);
+    this.onMicStateChanged = this.onMicStateChanged.bind(this);
 
     this.isLocalPlayerInfo = this.el.id === "avatar-rig";
     this.playerSessionId = null;
@@ -85,8 +84,7 @@ AFRAME.registerComponent("player-info", {
     this.el.sceneEl.addEventListener("stateremoved", this.update);
 
     if (this.isLocalPlayerInfo) {
-      this.el.sceneEl.addEventListener("stateadded", this.localStateAdded);
-      this.el.sceneEl.addEventListener("stateremoved", this.localStateRemoved);
+      APP.dialog.on("mic-state-changed", this.onMicStateChanged);
     }
   },
   pause() {
@@ -102,8 +100,7 @@ AFRAME.registerComponent("player-info", {
     window.APP.store.removeEventListener("statechanged", this.update);
 
     if (this.isLocalPlayerInfo) {
-      this.el.sceneEl.removeEventListener("stateadded", this.localStateAdded);
-      this.el.sceneEl.removeEventListener("stateremoved", this.localStateRemoved);
+      APP.dialog.off("mic-state-changed", this.onMicStateChanged);
     }
   },
 
@@ -197,14 +194,7 @@ AFRAME.registerComponent("player-info", {
     this.data.avatarSrc = defaultAvatar;
     this.applyProperties();
   },
-  localStateAdded(e) {
-    if (e.detail === "muted") {
-      this.el.setAttribute("player-info", { muted: true });
-    }
-  },
-  localStateRemoved(e) {
-    if (e.detail === "muted") {
-      this.el.setAttribute("player-info", { muted: false });
-    }
+  onMicStateChanged({ enabled }) {
+    this.el.setAttribute("player-info", { muted: !enabled });
   }
 });

--- a/src/components/video-texture-target.js
+++ b/src/components/video-texture-target.js
@@ -152,7 +152,7 @@ AFRAME.registerComponent("video-texture-target", {
 
         const streamClientId = src.substring(7).split("/")[1]; // /clients/<client id>/video is only URL for now
 
-        NAF.connection.adapter.getMediaStream(streamClientId, "video").then(stream => {
+        APP.dialog.getMediaStream(streamClientId, "video").then(stream => {
           if (src !== this.data.src) {
             // Prevent creating and loading video texture if the src changed while we were fetching the video stream.
             return;

--- a/src/emitter.js
+++ b/src/emitter.js
@@ -1,0 +1,28 @@
+export function emitter() {
+  let bindings = [];
+  let bindingRef = 0;
+  const on = (event, callback) => {
+    const ref = bindingRef++;
+    bindings.push({ event, ref, callback });
+    return ref;
+  };
+  const off = (event, ref) => {
+    bindings = bindings.filter(bind => {
+      return !(bind.event === event && (typeof ref === "undefined" || ref === bind.ref));
+    });
+  };
+  const trigger = (event, payload) => {
+    bindings.filter(bind => bind.event === event).forEach(bind => {
+      bind.callback(payload);
+    });
+  };
+  const getBindings = () => {
+    return bindings;
+  };
+  return {
+    on,
+    off,
+    trigger,
+    getBindings
+  };
+}

--- a/src/freeze.js
+++ b/src/freeze.js
@@ -1,0 +1,3 @@
+export function freeze(a) {
+  return JSON.parse(JSON.stringify(a || "undefined"));
+}

--- a/src/hub.js
+++ b/src/hub.js
@@ -1,3 +1,4 @@
+import { getCurrentHubId } from "./utils/hub-utils";
 import "./utils/debug-log";
 import "./webxr-bypass-hacks";
 import configs from "./utils/configs";
@@ -678,14 +679,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   const defaultRoomId = configs.feature("default_room_id");
-
-  const hubId =
-    qs.get("hub_id") ||
-    (document.location.pathname === "/" && defaultRoomId
-      ? defaultRoomId
-      : document.location.pathname.substring(1).split("/")[0]);
+  const hubId = getCurrentHubId();
   console.log(`Hub ID: ${hubId}`);
-
   if (!defaultRoomId) {
     // Default room won't work if account is required to access
     checkForAccountRequired();

--- a/src/hub.js
+++ b/src/hub.js
@@ -685,23 +685,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   const subscriptions = new Subscriptions(hubId);
   APP.subscriptions = subscriptions;
-
-  if (navigator.serviceWorker) {
-    try {
-      navigator.serviceWorker
-        .register("/hub.service.js")
-        .then(() => {
-          navigator.serviceWorker.ready
-            .then(registration => subscriptions.setRegistration(registration))
-            .catch(() => subscriptions.setRegistrationFailed());
-        })
-        .catch(() => subscriptions.setRegistrationFailed());
-    } catch (e) {
-      subscriptions.setRegistrationFailed();
-    }
-  } else {
-    subscriptions.setRegistrationFailed();
-  }
+  subscriptions.register();
 
   const scene = document.querySelector("a-scene");
   scene.renderer.debug.checkShaderErrors = false;

--- a/src/hub.js
+++ b/src/hub.js
@@ -1101,36 +1101,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
   });
 
-  const presenceLogEntries = [];
-  const addToPresenceLog = entry => {
-    entry.key = Date.now().toString();
-
-    presenceLogEntries.push(entry);
-    remountUI({ presenceLogEntries });
-    if (entry.type === "chat" && scene.is("loaded")) {
-      scene.systems["hubs-systems"].soundEffectsSystem.playSoundOneShot(SOUND_CHAT_MESSAGE);
-    }
-
-    // Fade out and then remove
-    setTimeout(() => {
-      entry.expired = true;
-      remountUI({ presenceLogEntries });
-
-      setTimeout(() => {
-        presenceLogEntries.splice(presenceLogEntries.indexOf(entry), 1);
-        remountUI({ presenceLogEntries });
-      }, 5000);
-    }, 20000);
-  };
-
-  const messageDispatch = new MessageDispatch(
-    scene,
-    entryManager,
-    hubChannel,
-    addToPresenceLog,
-    remountUI,
-    mediaSearchStore
-  );
+  const messageDispatch = new MessageDispatch(scene, entryManager, hubChannel, remountUI, mediaSearchStore);
   APP.messageDispatch = messageDispatch;
   document.getElementById("avatar-rig").messageDispatch = messageDispatch;
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -873,11 +873,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
   });
 
-  scene.addEventListener("action_focus_chat", () => {
-    const chatFocusTarget = document.querySelector(".chat-focus-target");
-    chatFocusTarget && chatFocusTarget.focus();
-  });
-
   scene.addEventListener("leave_room_requested", () => {
     entryManager.exitScene();
     remountUI({ roomUnavailableReason: ExitReason.left });

--- a/src/hub.js
+++ b/src/hub.js
@@ -558,19 +558,22 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data,
     });
   });
 
-  scene.addEventListener("adapter-ready", () => {
-    // Append objects once adapter is ready since ownership may be taken.
-    // TODO: We aren't actually connected yet when adapter-ready fires. Should we do this after we finish connecting to NAF?
-    const objectsScene = document.querySelector("#objects-scene");
-    const objectsUrl = getReticulumFetchUrl(`/${hub.hub_id}/objects.gltf`);
-    const objectsEl = document.createElement("a-entity");
+  scene.addEventListener(
+    "didConnectToNetworkedScene",
+    () => {
+      // Append objects once we are in the NAF room since ownership may be taken.
+      const objectsScene = document.querySelector("#objects-scene");
+      const objectsUrl = getReticulumFetchUrl(`/${hub.hub_id}/objects.gltf`);
+      const objectsEl = document.createElement("a-entity");
 
-    objectsEl.setAttribute("gltf-model-plus", { src: objectsUrl, useCache: false, inflate: true });
+      objectsEl.setAttribute("gltf-model-plus", { src: objectsUrl, useCache: false, inflate: true });
 
-    if (!isBotMode) {
-      objectsScene.appendChild(objectsEl);
-    }
-  });
+      if (!isBotMode) {
+        objectsScene.appendChild(objectsEl);
+      }
+    },
+    { once: true }
+  );
 
   scene.setAttribute("networked-scene", {
     room: hub.hub_id,

--- a/src/hub.js
+++ b/src/hub.js
@@ -1116,6 +1116,16 @@ document.addEventListener("DOMContentLoaded", async () => {
   });
 
   events.on(`hub:join`, ({ key, meta }) => {
+    scene.emit("presence_updated", {
+      sessionId: key,
+      profile: meta.profile,
+      roles: meta.roles,
+      permissions: meta.permissions,
+      streaming: meta.streaming,
+      recording: meta.recording
+    });
+  });
+  events.on(`hub:join`, ({ key, meta }) => {
     if (
       APP.suppressPresenceMessages ||
       key === hubChannel.channel.socket.params().session_id ||
@@ -1140,16 +1150,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     });
   });
 
-  events.on(`hub:join`, ({ key, meta }) => {
-    scene.emit("presence_updated", {
-      sessionId: key,
-      profile: meta.profile,
-      roles: meta.roles,
-      permissions: meta.permissions,
-      streaming: meta.streaming,
-      recording: meta.recording
-    });
-  });
   events.on(`hub:change`, ({ key, previous, current }) => {
     if (
       previous.presence === current.presence ||

--- a/src/hub.js
+++ b/src/hub.js
@@ -642,15 +642,6 @@ async function runBotMode(scene, entryManager) {
   entryManager.enterSceneWhenLoaded(false);
 }
 
-function checkForAccountRequired() {
-  // If the app requires an account to join a room, redirect to the sign in page.
-  if (!configs.feature("require_account_for_join")) return;
-  if (store.state.credentials && store.state.credentials.token) return;
-  document.location = `/?sign_in&sign_in_destination=hub&sign_in_destination_url=${encodeURIComponent(
-    document.location.toString()
-  )}`;
-}
-
 document.addEventListener("DOMContentLoaded", async () => {
   if (isOAuthModal) {
     return;
@@ -678,12 +669,18 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
   }
 
-  const defaultRoomId = configs.feature("default_room_id");
   const hubId = getCurrentHubId();
   console.log(`Hub ID: ${hubId}`);
-  if (!defaultRoomId) {
+
+  const shouldRedirectToSignInPage =
     // Default room won't work if account is required to access
-    checkForAccountRequired();
+    !configs.feature("default_room_id") &&
+    configs.feature("require_account_for_join") &&
+    !(store.state.credentials && store.state.credentials.token);
+  if (shouldRedirectToSignInPage) {
+    document.location = `/?sign_in&sign_in_destination=hub&sign_in_destination_url=${encodeURIComponent(
+      document.location.toString()
+    )}`;
   }
 
   const subscriptions = new Subscriptions(hubId);

--- a/src/hub.js
+++ b/src/hub.js
@@ -1101,8 +1101,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
   });
 
-  const hubPhxChannel = socket.channel(`hub:${hubId}`, createHubChannelParams(oauthFlowPermsToken));
-
   const presenceLogEntries = [];
   const addToPresenceLog = entry => {
     entry.key = Date.now().toString();
@@ -1136,6 +1134,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   APP.messageDispatch = messageDispatch;
   document.getElementById("avatar-rig").messageDispatch = messageDispatch;
 
+  const hubPhxChannel = socket.channel(`hub:${hubId}`, createHubChannelParams(oauthFlowPermsToken));
   hubChannel.channel = hubPhxChannel;
   hubChannel.presence = new Presence(hubPhxChannel);
   const { rawOnJoin, rawOnLeave } = denoisePresence(presenceEventsForHub(events));

--- a/src/hub.js
+++ b/src/hub.js
@@ -721,6 +721,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   const authChannel = new AuthChannel(store);
   const hubChannel = new HubChannel(store, hubId);
   window.APP.hubChannel = hubChannel;
+
+  store.addEventListener("profilechanged", hubChannel.sendProfileUpdate.bind(hubChannel));
   const entryManager = new SceneEntryManager(hubChannel, authChannel, history);
   window.APP.entryManager = entryManager;
 
@@ -1185,7 +1187,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     });
   });
 
-  let isInitialJoin = true;
   hubPhxChannel
     .join()
     .receive("ok", async data => {
@@ -1196,11 +1197,6 @@ document.addEventListener("DOMContentLoaded", async () => {
 
       socket.params().session_id = data.session_id;
       socket.params().session_token = data.session_token;
-
-      if (isInitialJoin) {
-        store.addEventListener("profilechanged", hubChannel.sendProfileUpdate.bind(hubChannel));
-      }
-      isInitialJoin = false;
 
       const permsToken = oauthFlowPermsToken || data.perms_token;
       hubChannel.setPermissionsFromToken(permsToken);

--- a/src/hub.js
+++ b/src/hub.js
@@ -943,17 +943,16 @@ document.addEventListener("DOMContentLoaded", async () => {
   });
 
   const environmentScene = document.querySelector("#environment-scene");
-
-  const onFirstEnvironmentLoad = () => {
-    // Replace renderer with a noop renderer to reduce bot resource usage.
-    if (isBotMode) {
-      runBotMode(scene, entryManager);
-    }
-
-    environmentScene.removeEventListener("model-loaded", onFirstEnvironmentLoad);
-  };
-
-  environmentScene.addEventListener("model-loaded", onFirstEnvironmentLoad);
+  environmentScene.addEventListener(
+    "model-loaded",
+    () => {
+      // Replace renderer with a noop renderer to reduce bot resource usage.
+      if (isBotMode) {
+        runBotMode(scene, entryManager);
+      }
+    },
+    { once: true }
+  );
 
   environmentScene.addEventListener("model-loaded", ({ detail: { model } }) => {
     if (!scene.is("entered")) {

--- a/src/hub.js
+++ b/src/hub.js
@@ -1127,7 +1127,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   });
   events.on(`hub:join`, ({ key, meta }) => {
     if (
-      APP.suppressPresenceMessages ||
+      APP.hideHubPresenceEvents ||
       key === hubChannel.channel.socket.params().session_id ||
       hubChannel.presence.list().length > NOISY_OCCUPANT_COUNT
     ) {
@@ -1141,7 +1141,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   });
 
   events.on(`hub:leave`, ({ meta }) => {
-    if (APP.suppressPresenceMessages || hubChannel.presence.list().length > NOISY_OCCUPANT_COUNT) {
+    if (APP.hideHubPresenceEvents || hubChannel.presence.list().length > NOISY_OCCUPANT_COUNT) {
       return;
     }
     messageDispatch.receive({
@@ -1185,7 +1185,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     presenceSync.resolve();
   });
   events.on(`hub:sync`, () => {
-    APP.suppressPresenceMessages = false;
+    APP.hideHubPresenceEvents = false;
   });
   events.on(`hub:sync`, updateVRHudPresenceCount);
   events.on(`hub:sync`, ({ presence }) => {
@@ -1203,7 +1203,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   hubPhxChannel
     .join()
     .receive("ok", async data => {
-      APP.suppressPresenceMessages = true;
+      APP.hideHubPresenceEvents = true;
       presenceSync.promise = new Promise(resolve => {
         presenceSync.resolve = resolve;
       });

--- a/src/hub.js
+++ b/src/hub.js
@@ -558,12 +558,12 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data,
     });
   });
 
-  const objectsScene = document.querySelector("#objects-scene");
-  const objectsUrl = getReticulumFetchUrl(`/${hub.hub_id}/objects.gltf`);
-  const objectsEl = document.createElement("a-entity");
   scene.addEventListener("adapter-ready", () => {
     // Append objects once adapter is ready since ownership may be taken.
     // TODO: We aren't actually connected yet when adapter-ready fires. Should we do this after we finish connecting to NAF?
+    const objectsScene = document.querySelector("#objects-scene");
+    const objectsUrl = getReticulumFetchUrl(`/${hub.hub_id}/objects.gltf`);
+    const objectsEl = document.createElement("a-entity");
 
     objectsEl.setAttribute("gltf-model-plus", { src: objectsUrl, useCache: false, inflate: true });
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -37,11 +37,11 @@ import { detectOS, detect } from "detect-browser";
 import {
   getReticulumFetchUrl,
   getReticulumMeta,
-  invalidateReticulumMeta,
   migrateChannelToSocket,
   connectToReticulum,
   denoisePresence,
-  presenceEventsForHub
+  presenceEventsForHub,
+  tryGetMatchingMeta
 } from "./utils/phoenix-utils";
 import { Presence } from "phoenix";
 import { emitter } from "./emitter";
@@ -1038,37 +1038,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     return params;
   };
   APP.createHubChannelParams = createHubChannelParams;
-
-  const tryGetMatchingMeta = async ({ ret_pool, ret_version }, shouldAbandonMigration) => {
-    const backoffMS = 5000;
-    const randomMS = 15000;
-    const maxAttempts = 10;
-    let didMatchMeta = false;
-    let attempt = 0;
-    while (!didMatchMeta && attempt < maxAttempts && !shouldAbandonMigration()) {
-      try {
-        // Add randomness to the first request avoid flooding reticulum.
-        const delayMS = attempt * backoffMS + (attempt === 0 ? Math.random() * randomMS : 0);
-        console.log(
-          `[reconnect] Getting reticulum meta in ${Math.ceil(delayMS / 1000)} seconds.${
-            attempt ? ` (Attempt ${attempt + 1} of ${maxAttempts})` : ""
-          }`
-        );
-        await sleep(delayMS);
-        invalidateReticulumMeta();
-        console.log(
-          `[reconnect] Getting reticulum meta.${attempt ? ` (Attempt ${attempt + 1} of ${maxAttempts})` : ""}`
-        );
-        const { pool, version } = await getReticulumMeta();
-        didMatchMeta = ret_pool === pool && ret_version === version;
-      } catch {
-        didMatchMeta = false;
-      }
-
-      attempt = attempt + 1;
-    }
-    return didMatchMeta;
-  };
 
   const migrateToNewReticulumServer = async ({ ret_version, ret_pool }, shouldAbandonMigration) => {
     console.log(`[reconnect] Reticulum deploy detected v${ret_version} on ${ret_pool}.`);

--- a/src/hub.js
+++ b/src/hub.js
@@ -688,6 +688,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   subscriptions.register();
 
   const scene = document.querySelector("a-scene");
+  window.APP.scene = scene;
   scene.renderer.debug.checkShaderErrors = false;
 
   // HACK - Trigger initial batch preparation with an invisible object
@@ -700,7 +701,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     physicsSystem.setDebug(isDebug || physicsSystem.debug);
     patchThreeAllocations();
   };
-
   if (scene.hasLoaded) {
     onSceneLoaded();
   } else {
@@ -715,13 +715,12 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   const authChannel = new AuthChannel(store);
   const hubChannel = new HubChannel(store, hubId);
+  window.APP.hubChannel = hubChannel;
   const entryManager = new SceneEntryManager(hubChannel, authChannel, history);
   window.APP.entryManager = entryManager;
 
-  window.APP.scene = scene;
   const audioSystem = scene.systems["hubs-systems"].audioSystem;
   window.APP.mediaDevicesManager = new MediaDevicesManager(scene, store, audioSystem);
-  window.APP.hubChannel = hubChannel;
 
   const performConditionalSignIn = async (predicate, action, signInMessage, onFailure) => {
     if (predicate()) return action();
@@ -791,7 +790,6 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     return false;
   };
-
   remountUI({ availableVREntryTypes: ONLY_SCREEN_AVAILABLE, checkingForDeviceAvailability: true });
   const availableVREntryTypesPromise = getAvailableVREntryTypes();
   scene.addEventListener("enter-vr", () => {
@@ -811,7 +809,6 @@ document.addEventListener("DOMContentLoaded", async () => {
       }
     });
   });
-
   handleEarlyVRMode();
 
   // HACK A-Frame 0.9.0 seems to fail to wire up vrdisplaypresentchange early enough

--- a/src/hub.js
+++ b/src/hub.js
@@ -592,7 +592,7 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data,
       APP.dialog.disconnect();
       APP.dialog.connect({
         serverUrl: `wss://${hub.host}:${hub.port}`,
-        hubId: hub.hub_id,
+        roomId: hub.hub_id,
         joinToken: permsToken,
         serverParams: { host: hub.host, port: hub.port, turn: hub.turn },
         scene,

--- a/src/hub.js
+++ b/src/hub.js
@@ -588,45 +588,17 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data,
     const loadEnvironmentAndConnect = () => {
       updateEnvironmentForHub(hub, entryManager);
 
-      APP.dialog.setClientId(data.session_id);
-      APP.dialog.setTurnConfig(qs.get("force_turn"), qs.get("force_tcp"));
-
-      let connectionErrorTimeout;
-      APP.dialog.setReconnectionListeners(
-        async () => {
-          const serverParams = await hubChannel.getHost();
-          const { host, port } = serverParams;
-          const newServerURL = `wss://${host}:${port}`;
-          // If the Dialog server url has changed, the server has rolled over and we need to reconnect using an updated server URL.
-          if (APP.dialog.serverUrl !== newServerURL) {
-            console.error(`The Dialog server has changed to ${newServerURL}, reconnecting with the new server...`);
-            scene.setAttribute("networked-scene", { serverURL: newServerURL });
-            APP.dialog.setServerUrl(newServerURL);
-            APP.dialog.setServerParams(serverParams);
-            APP.dialog.reconnect();
-          }
-          // Safety guard to show the connection error screen in case we can't reconnect after 30 seconds
-          if (!connectionErrorTimeout) {
-            connectionErrorTimeout = setTimeout(() => {
-              APP.dialog.disconnect();
-              onConnectionError(entryManager, "Timeout trying to reconnect to the room");
-            }, 30000);
-          }
-        },
-        () => {
-          clearTimeout(connectionErrorTimeout);
-          connectionErrorTimeout = null;
-        }
-      );
-
       APP.dialog.connect({
         serverUrl: `wss://${hub.host}:${hub.port}`,
         hubId: hub.hub_id,
         joinToken: permsToken,
         serverParams: { host: hub.host, port: hub.port, turn: hub.turn },
-        scene
+        scene,
+        clientId: data.session_id,
+        forceTcp: qs.get("force_tcp"),
+        forceTurn: qs.get("force_turn"),
+        iceTransportPolicy: qs.get("force_tcp") || qs.get("force_turn") ? "relay" : "all"
       });
-
       scene.addEventListener(
         "adapter-ready",
         ({ detail: adapter }) => {

--- a/src/hub.js
+++ b/src/hub.js
@@ -588,6 +588,8 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data,
     const loadEnvironmentAndConnect = () => {
       updateEnvironmentForHub(hub, entryManager);
 
+      // Disconnect in case this is a re-entry
+      APP.dialog.disconnect();
       APP.dialog.connect({
         serverUrl: `wss://${hub.host}:${hub.port}`,
         hubId: hub.hub_id,

--- a/src/hub.js
+++ b/src/hub.js
@@ -728,7 +728,6 @@ document.addEventListener("DOMContentLoaded", async () => {
   const hubChannel = new HubChannel(store, hubId);
   window.APP.hubChannel = hubChannel;
 
-  store.addEventListener("profilechanged", hubChannel.sendProfileUpdate.bind(hubChannel));
   const entryManager = new SceneEntryManager(hubChannel, authChannel, history);
   window.APP.entryManager = entryManager;
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -55,7 +55,7 @@ import "./phoenix-adapter";
 import nextTick from "./utils/next-tick";
 import { addAnimationComponents } from "./utils/animation";
 import Cookies from "js-cookie";
-import DialogAdapter from "./naf-dialog-adapter";
+import { DialogAdapter, DIALOG_CONNECTION_ERROR_FATAL } from "./naf-dialog-adapter";
 import "./change-hub";
 
 import "./components/scene-components";
@@ -731,6 +731,13 @@ document.addEventListener("DOMContentLoaded", async () => {
   store.addEventListener("profilechanged", hubChannel.sendProfileUpdate.bind(hubChannel));
   const entryManager = new SceneEntryManager(hubChannel, authChannel, history);
   window.APP.entryManager = entryManager;
+
+  APP.dialog.on(DIALOG_CONNECTION_ERROR_FATAL, () => {
+    // TODO: Change the wording of the connect error to match dialog connection error
+    // TODO: Tell the user that dialog is broken, but don't completely end the experience
+    remountUI({ roomUnavailableReason: ExitReason.connectError });
+    APP.entryManager.exitScene();
+  });
 
   const audioSystem = scene.systems["hubs-systems"].audioSystem;
   window.APP.mediaDevicesManager = new MediaDevicesManager(scene, store, audioSystem);

--- a/src/hub.js
+++ b/src/hub.js
@@ -178,7 +178,6 @@ import "./systems/hubs-systems";
 import "./systems/capture-system";
 import "./systems/listed-media";
 import "./systems/linked-media";
-import { SOUND_CHAT_MESSAGE } from "./systems/sound-effects-system";
 import "./systems/audio-debug-system";
 import "./systems/audio-gain-system";
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -577,7 +577,7 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data,
 
   scene.setAttribute("networked-scene", {
     room: hub.hub_id,
-    serverURL: `wss://${hub.host}:${hub.port}`,
+    serverURL: `wss://${hub.host}:${hub.port}`, // TODO: This is confusing because this is the dialog host and port.
     debug: !!isDebug,
     adapter: "phoenix"
   });

--- a/src/naf-dialog-adapter.js
+++ b/src/naf-dialog-adapter.js
@@ -572,12 +572,6 @@ export default class DialogAdapter extends EventEmitter {
       this.emitRTCEvent("info", "RTC", () => `Send transport [connect]`);
       this._sendTransport.observer.on("close", () => {
         this.emitRTCEvent("info", "RTC", () => `Send transport [close]`);
-        // TODO don't call close() twice
-        try {
-          !this._sendTransport?._closed && this._sendTransport.close();
-        } catch (e) {
-          console.error(e);
-        }
       });
       this._sendTransport.observer.on("newproducer", producer => {
         this.emitRTCEvent("info", "RTC", () => `Send transport [newproducer]: ${producer.id}`);
@@ -679,12 +673,6 @@ export default class DialogAdapter extends EventEmitter {
       this.emitRTCEvent("info", "RTC", () => `Receive transport [connect]`);
       this._recvTransport.observer.on("close", () => {
         this.emitRTCEvent("info", "RTC", () => `Receive transport [close]`);
-        // TODO uncomment without calling close() twice
-        try {
-          !this._recvTransport?._closed && this._recvTransport.close();
-        } catch (e) {
-          console.error(e);
-        }
       });
       this._recvTransport.observer.on("newproducer", producer => {
         this.emitRTCEvent("info", "RTC", () => `Receive transport [newproducer]: ${producer.id}`);

--- a/src/naf-dialog-adapter.js
+++ b/src/naf-dialog-adapter.js
@@ -587,7 +587,8 @@ export default class DialogAdapter extends EventEmitter {
       this.emitRTCEvent("info", "RTC", () => `Send transport [connect]`);
       this._sendTransport.observer.on("close", () => {
         this.emitRTCEvent("info", "RTC", () => `Send transport [close]`);
-        !this._sendTransport?._closed && this._sendTransport.close();
+        // TODO uncomment without calling close() twice
+        // !this._sendTransport?._closed && this._sendTransport.close();
       });
       this._sendTransport.observer.on("newproducer", producer => {
         this.emitRTCEvent("info", "RTC", () => `Send transport [newproducer]: ${producer.id}`);
@@ -633,9 +634,10 @@ export default class DialogAdapter extends EventEmitter {
       }
     });
 
-    if (this._localMediaStream) {
-      await this.setLocalMediaStream(this._localMediaStream);
-    }
+    // TODO: Can we remove this?
+    // if (this._localMediaStream) {
+    //   await this.setLocalMediaStream(this._localMediaStream);
+    // }
   }
 
   async closeSendTransport() {
@@ -651,13 +653,16 @@ export default class DialogAdapter extends EventEmitter {
       this._videoProducer = null;
     }
 
+    // TODO: If _sendTransport is falsey then return
+    const transportId = this._sendTransport?.id;
     if (this._sendTransport && !this._sendTransport._closed) {
       this._sendTransport.close();
+      this._sendTransport = null;
     }
 
     if (this._protoo?.connected) {
       try {
-        await this._protoo.request("closeWebRtcTransport", { transportId: this._sendTransport?.id });
+        await this._protoo.request("closeWebRtcTransport", { transportId });
       } catch (err) {
         error(err);
       }
@@ -690,7 +695,8 @@ export default class DialogAdapter extends EventEmitter {
       this.emitRTCEvent("info", "RTC", () => `Receive transport [connect]`);
       this._recvTransport.observer.on("close", () => {
         this.emitRTCEvent("info", "RTC", () => `Receive transport [close]`);
-        !this._recvTransport?._closed && this._recvTransport.close();
+        // TODO uncomment without calling close() twice
+        // !this._recvTransport?._closed && this._recvTransport.close();
       });
       this._recvTransport.observer.on("newproducer", producer => {
         this.emitRTCEvent("info", "RTC", () => `Receive transport [newproducer]: ${producer.id}`);
@@ -720,12 +726,14 @@ export default class DialogAdapter extends EventEmitter {
   }
 
   async closeRecvTransport() {
+    const transportId = this._recvTransport?.id;
     if (this._recvTransport && !this._recvTransport._closed) {
       this._recvTransport.close();
+      this._recvTransport = null;
     }
     if (this._protoo?.connected) {
       try {
-        await this._protoo.request("closeWebRtcTransport", { transportId: this._recvTransport?.id });
+        await this._protoo.request("closeWebRtcTransport", { transportId });
       } catch (err) {
         error(err);
       }
@@ -965,6 +973,7 @@ export default class DialogAdapter extends EventEmitter {
       this._protoo.close();
     }
     setTimeout(() => {
+      // TODO: Give connect the params it needs to be successful
       this.connect();
     }, timeout);
   }

--- a/src/naf-dialog-adapter.js
+++ b/src/naf-dialog-adapter.js
@@ -633,11 +633,6 @@ export default class DialogAdapter extends EventEmitter {
         errback(error);
       }
     });
-
-    // TODO: Can we remove this?
-    // if (this._localMediaStream) {
-    //   await this.setLocalMediaStream(this._localMediaStream);
-    // }
   }
 
   async closeSendTransport() {
@@ -762,6 +757,11 @@ export default class DialogAdapter extends EventEmitter {
       sctpCapabilities: this._useDataChannel ? this._mediasoupDevice.sctpCapabilities : undefined,
       token: this._joinToken
     });
+
+    if (this._localMediaStream) {
+      // TODO: Refactor to be "Create producers"
+      await this.setLocalMediaStream(this._localMediaStream);
+    }
 
     const audioConsumerPromises = [];
 

--- a/src/naf-dialog-adapter.js
+++ b/src/naf-dialog-adapter.js
@@ -476,7 +476,7 @@ export class DialogAdapter extends EventEmitter {
     await this.connect({
       serverUrl: newServerUrl,
       roomId: this._roomId,
-      joinToken: this._joinToken,
+      joinToken: APP.hubChannel.token,
       serverParams,
       scene: this.scene,
       clientId: this._clientId,

--- a/src/naf-dialog-adapter.js
+++ b/src/naf-dialog-adapter.js
@@ -738,7 +738,7 @@ export class DialogAdapter extends EventEmitter {
     await this.createSendTransport(iceServers);
     await this.createRecvTransport(iceServers);
 
-    const { peers } = await this._protoo.request("join", {
+    await this._protoo.request("join", {
       displayName: this._clientId,
       device: this._device,
       rtpCapabilities: this._mediasoupDevice.rtpCapabilities,

--- a/src/naf-dialog-adapter.js
+++ b/src/naf-dialog-adapter.js
@@ -939,6 +939,7 @@ export default class DialogAdapter extends EventEmitter {
     this._shareProducer = null;
     this._cameraProducer = null;
     // Close protoo Peer, though may already be closed if this is happening due to websocket breakdown
+    // Check if connected because we don't want to remove event listeners and close the peer on the "disconnected" event
     if (this._protoo && this._protoo.connected) {
       this._protoo.removeAllListeners();
       this._protoo.close();

--- a/src/naf-dialog-adapter.js
+++ b/src/naf-dialog-adapter.js
@@ -240,7 +240,7 @@ export default class DialogAdapter extends EventEmitter {
 
   async connect({
     serverUrl,
-    hubId,
+    roomId,
     joinToken,
     serverParams,
     scene,
@@ -250,7 +250,7 @@ export default class DialogAdapter extends EventEmitter {
     iceTransportPolicy
   }) {
     this._serverUrl = serverUrl;
-    this._roomId = hubId;
+    this._roomId = roomId;
     this._joinToken = joinToken;
     this._serverParams = serverParams;
     this._clientId = clientId;
@@ -278,21 +278,6 @@ export default class DialogAdapter extends EventEmitter {
     this._protoo.on("close", () => {
       this.emitRTCEvent("error", "Signaling", () => `Closed`);
       this.disconnect();
-    });
-
-    await new Promise((resolve, reject) => {
-      this._protoo.on("open", async () => {
-        this.emitRTCEvent("info", "Signaling", () => `Open`);
-        this._closed = false;
-
-        try {
-          await this._joinRoom();
-          resolve();
-        } catch (err) {
-          this.emitRTCEvent("warn", "Adapter", () => `Error during connect: ${error}`);
-          reject(err);
-        }
-      });
     });
 
     // eslint-disable-next-line no-unused-vars
@@ -451,6 +436,21 @@ export default class DialogAdapter extends EventEmitter {
           this._consumerStats[consumerId]["score"] = score;
         }
       }
+    });
+
+    await new Promise((resolve, reject) => {
+      this._protoo.on("open", async () => {
+        this.emitRTCEvent("info", "Signaling", () => `Open`);
+        this._closed = false;
+
+        try {
+          await this._joinRoom();
+          resolve();
+        } catch (err) {
+          this.emitRTCEvent("warn", "Adapter", () => `Error during connect: ${error}`);
+          reject(err);
+        }
+      });
     });
 
     await Promise.all([this._initialAudioConsumerPromise]);

--- a/src/phoenix-adapter.js
+++ b/src/phoenix-adapter.js
@@ -1,0 +1,258 @@
+import { transportForChannel } from "./transport-for-channel";
+import { authorizeOrSanitizeMessage } from "./utils/permissions-utils";
+
+// TODO: Use the websocket connection, not HEAD requests
+const getTimeOffsetToServer = async () => {
+  const precision = 1000;
+  const clientSentTime = Date.now();
+  const serverReceivedTime =
+    new Date(
+      (await fetch(document.location.href, {
+        method: "HEAD",
+        cache: "no-cache"
+      })).headers.get("Date")
+    ).getTime() +
+    precision / 2;
+  const clientReceivedTime = Date.now();
+  const serverTime = serverReceivedTime + (clientReceivedTime - clientSentTime) / 2;
+  const offset = serverTime - clientReceivedTime;
+  return offset;
+};
+
+const getAverageTimeOffset = (() => {
+  let average = 0;
+  const numOffsetsToGather = 10;
+  const offsets = [];
+  let n = 0;
+
+  const update = async () => {
+    offsets[n % numOffsetsToGather] = await getTimeOffsetToServer();
+    n = n + 1;
+    average = offsets.reduce((acc, offset) => (acc += offset), 0) / offsets.length;
+    if (offsets.length == numOffsetsToGather) {
+      setTimeout(update, 5 * 60 * 1000);
+    } else {
+      update();
+    }
+  };
+
+  update();
+
+  return () => {
+    return average;
+  };
+})();
+
+export default class PhoenixAdapter {
+  constructor() {
+    this.refs = new Map();
+    // TODO: Frozen messages can be handled outside this class.
+    this.frozenUpdates = new Map();
+    this._blockedClients = new Map();
+  }
+  setServerUrl() {}
+  setApp() {}
+  setRoom() {}
+  setWebRtcOptions() {}
+  setServerConnectListeners(nafConnectSuccess, nafConnectFailed) {
+    this.nafConnectSuccess = nafConnectSuccess;
+    this.nafConnectFailed = nafConnectFailed;
+  }
+  setRoomOccupantListener() {}
+  setDataChannelListeners(nafOccupantJoined, nafOccupantLeave, nafMessageReceived) {
+    this.nafOccupantJoined = nafOccupantJoined;
+    this.nafOccupantLeave = nafOccupantLeave;
+    this.nafMessageReceived = nafMessageReceived;
+  }
+  async connect() {
+    this.refs.set("naf", this.hubChannel.channel.on("naf", this.handleIncomingNAF));
+    this.refs.set("nafr", this.hubChannel.channel.on("nafr", this.handleIncomingNAFR));
+
+    this.nafConnectSuccess(this.session_id);
+    this.reliableTransport = transportForChannel(this.hubChannel.channel, true);
+    this.unreliableTransport = transportForChannel(this.hubChannel.channel, false);
+
+    this.hubChannel.presence.list(key => key).forEach(this.nafOccupantJoined);
+    this.refs.set("hub:join", this.events.on(`hub:join`, ({ key }) => this.nafOccupantJoined(key)));
+    this.refs.set("hub:leave", this.events.on(`hub:leave`, ({ key }) => this.nafOccupantLeave(key)));
+  }
+  shouldStartConnectionTo() {}
+  startStreamConnection() {}
+  closeStreamConnection() {}
+  getConnectStatus() {}
+
+  getMediaStream() {
+    return Promise.reject("getMediaStream not implemented in phoenix-adapter");
+  }
+
+  getServerTime() {
+    return Date.now() + getAverageTimeOffset();
+  }
+
+  sendData(clientId, dataType, data) {
+    this.unreliableTransport(clientId, dataType, data);
+  }
+  sendDataGuaranteed(clientId, dataType, data) {
+    this.reliableTransport(clientId, dataType, data);
+  }
+  broadcastData(dataType, data) {
+    this.unreliableTransport(undefined, dataType, data);
+  }
+  broadcastDataGuaranteed(dataType, data) {
+    this.reliableTransport(undefined, dataType, data);
+  }
+
+  disconnect() {
+    this.hubChannel.presence.list(key => key).forEach(this.nafOccupantLeave);
+
+    this.events.off("naf", this.refs.get("naf"));
+    this.events.off("nafr", this.refs.get("nafr"));
+    this.events.off("hub:join", this.refs.get("hub:join"));
+    this.events.off("hub:leave", this.refs.get("hub:leave"));
+    this.refs.delete("naf");
+    this.refs.delete("nafr");
+    this.refs.delete("hub:join");
+    this.refs.delete("hub:leave");
+  }
+
+  toggleFreeze() {
+    if (this.frozen) {
+      this.unfreeze();
+    } else {
+      this.freeze();
+    }
+  }
+
+  freeze() {
+    this.frozen = true;
+  }
+
+  unfreeze() {
+    this.frozen = false;
+    this.flushPendingUpdates();
+  }
+
+  flushPendingUpdates() {
+    for (const [networkId, message] of this.frozenUpdates) {
+      const data = this.getPendingData(networkId, message);
+      if (!data) continue;
+
+      // Override the data type on "um" messages types, since we extract entity updates from "um" messages into
+      // individual frozenUpdates in storeSingleMessage.
+      const dataType = message.dataType === "um" ? "u" : message.dataType;
+
+      this.nafMessageReceived(null, dataType, data, message.source);
+    }
+    this.frozenUpdates.clear();
+  }
+
+  getPendingData(networkId, message) {
+    if (!message) return null;
+
+    const data = message.dataType === "um" ? this.dataForUpdateMultiMessage(networkId, message) : message.data;
+
+    // Ignore messages from users that we may have blocked while frozen.
+    if (data.owner && this._blockedClients.has(data.owner)) return null;
+
+    return data;
+  }
+
+  // Used externally
+  getPendingDataForNetworkId(networkId) {
+    return this.getPendingData(networkId, this.frozenUpdates.get(networkId));
+  }
+
+  handleIncomingNAF = data => {
+    const message = authorizeOrSanitizeMessage(data);
+    const source = "phx-reliable";
+    if (!message.dataType) return;
+
+    message.source = source;
+
+    //TODO: Handle frozen
+    if (this.frozen) {
+      this.storeMessage(message);
+    } else {
+      this.nafMessageReceived(null, message.dataType, message.data, message.source);
+    }
+  };
+  handleIncomingNAFR = ({ from_session_id, naf: unparsedData }) => {
+    // Server optimization: server passes through unparsed NAF message, we must now parse it.
+    const data = JSON.parse(unparsedData);
+    data.from_session_id = from_session_id;
+    this.handleIncomingNAF(data);
+  };
+
+  storeMessage(message) {
+    if (message.dataType === "um") {
+      // UpdateMulti
+      for (let i = 0, l = message.data.d.length; i < l; i++) {
+        this.storeSingleMessage(message, i);
+      }
+    } else {
+      this.storeSingleMessage(message);
+    }
+  }
+
+  storeSingleMessage(message, index) {
+    const data = index !== undefined ? message.data.d[index] : message.data;
+    const dataType = message.dataType;
+
+    const networkId = data.networkId;
+
+    if (!this.frozenUpdates.has(networkId)) {
+      this.frozenUpdates.set(networkId, message);
+    } else {
+      const storedMessage = this.frozenUpdates.get(networkId);
+      const storedData =
+        storedMessage.dataType === "um" ? this.dataForUpdateMultiMessage(networkId, storedMessage) : storedMessage.data;
+
+      // Avoid updating components if the entity data received did not come from the current owner.
+      const isOutdatedMessage = data.lastOwnerTime < storedData.lastOwnerTime;
+      const isContemporaneousMessage = data.lastOwnerTime === storedData.lastOwnerTime;
+      if (isOutdatedMessage || (isContemporaneousMessage && storedData.owner > data.owner)) {
+        return;
+      }
+
+      if (dataType === "r") {
+        const createdWhileFrozen = storedData && storedData.isFirstSync;
+        if (createdWhileFrozen) {
+          // If the entity was created and deleted while frozen, don't bother conveying anything to the consumer.
+          this.frozenUpdates.delete(networkId);
+        } else {
+          // Delete messages override any other messages for this entity
+          this.frozenUpdates.set(networkId, message);
+        }
+      } else {
+        // merge in component updates
+        if (storedData.components && data.components) {
+          Object.assign(storedData.components, data.components);
+        }
+      }
+    }
+  }
+  dataForUpdateMultiMessage(networkId, message) {
+    // "d" is an array of entity datas, where each item in the array represents a unique entity and contains
+    // metadata for the entity, and an array of components that have been updated on the entity.
+    // This method finds the data corresponding to the given networkId.
+    for (let i = 0, l = message.data.d.length; i < l; i++) {
+      const data = message.data.d[i];
+
+      if (data.networkId === networkId) {
+        return data;
+      }
+    }
+
+    return null;
+  }
+
+  block(clientId) {
+    this._blockedClients.set(clientId, true);
+  }
+
+  unblock(clientId) {
+    this._blockedClients.delete(clientId);
+  }
+}
+
+NAF.adapters.register("phoenix", PhoenixAdapter);

--- a/src/phoenix-adapter.js
+++ b/src/phoenix-adapter.js
@@ -104,9 +104,8 @@ export default class PhoenixAdapter {
 
   disconnect() {
     this.hubChannel.presence.list(key => key).forEach(this.nafOccupantLeave);
-
-    this.events.off("naf", this.refs.get("naf"));
-    this.events.off("nafr", this.refs.get("nafr"));
+    this.hubChannel.channel.off("naf", this.refs.get("naf"));
+    this.hubChannel.channel.off("nafr", this.refs.get("nafr"));
     this.events.off("hub:join", this.refs.get("hub:join"));
     this.events.off("hub:leave", this.refs.get("hub:leave"));
     this.refs.delete("naf");

--- a/src/react-components/debug-panel/RtcDebugPanel.js
+++ b/src/react-components/debug-panel/RtcDebugPanel.js
@@ -262,7 +262,7 @@ export default class RtcDebugPanel extends Component {
 
   getDeviceData() {
     let result = {};
-    const device = NAF.connection.adapter._mediasoupDevice;
+    const device = APP.dialog._mediasoupDevice;
     if (device) {
       result["loaded"] = !device._closed ? true : false;
       result["codecs"] = device._recvRtpCapabilities?.codecs.map(
@@ -270,7 +270,7 @@ export default class RtcDebugPanel extends Component {
       );
       result = {
         ...result,
-        ...NAF.connection.adapter.downlinkBwe
+        ...APP.dialog.downlinkBwe
       };
     }
     return result;
@@ -314,9 +314,9 @@ export default class RtcDebugPanel extends Component {
     const result = {};
     let transport;
     if (type === TransportType.SEND) {
-      transport = NAF.connection.adapter._sendTransport;
+      transport = APP.dialog._sendTransport;
     } else if (type === TransportType.RECEIVE) {
-      transport = NAF.connection.adapter._recvTransport;
+      transport = APP.dialog._recvTransport;
     }
     const opened = (transport && !transport._closed && true) || false;
     result["opened"] = opened;
@@ -364,7 +364,7 @@ export default class RtcDebugPanel extends Component {
       result["name"] = profile ? profile.displayName : "N/A";
       result["peerId"] = peer._appData.peerId;
 
-      const stats = NAF.connection.adapter.consumerStats[peer._id];
+      const stats = APP.dialog.consumerStats[peer._id];
       if (result["kind"] === "video" && stats) {
         result["spatialLayer"] = stats["spatialLayer"];
         result["temporalLayer"] = stats["temporalLayer"];
@@ -385,11 +385,11 @@ export default class RtcDebugPanel extends Component {
   }
 
   getSignalingData() {
-    return { connected: !NAF.connection.adapter._closed };
+    return { connected: !APP.dialog._closed };
   }
 
   async getServerData() {
-    return await NAF.connection.adapter.getServerStats();
+    return await APP.dialog.getServerStats();
   }
 
   async getRtpStatsData(peer, type) {
@@ -486,9 +486,9 @@ export default class RtcDebugPanel extends Component {
 
             // Populate graph, speed and stats data
             const statsData = {};
-            if (NAF.connection.adapter._micProducer) {
-              const id = NAF.connection.adapter._micProducer.id;
-              const peer = NAF.connection.adapter._micProducer;
+            if (APP.dialog._micProducer) {
+              const id = APP.dialog._micProducer.id;
+              const peer = APP.dialog._micProducer;
               const speedData = this.getPeerSpeed(id, "bytesSent");
               const rtpStatsData = await this.getRtpStatsData(peer, StatsType.OUTBOUND_RTP);
               const { lastStats, graphData } = this.getGraphData(id, rtpStatsData);
@@ -498,9 +498,9 @@ export default class RtcDebugPanel extends Component {
               statsData[id]["last"] = lastStats;
               statsData[id]["rtpStats"] = rtpStatsData;
             }
-            if (NAF.connection.adapter._cameraProducer) {
-              const id = NAF.connection.adapter._cameraProducer.id;
-              const peer = NAF.connection.adapter._cameraProducer;
+            if (APP.dialog._cameraProducer) {
+              const id = APP.dialog._cameraProducer.id;
+              const peer = APP.dialog._cameraProducer;
               const speedData = this.getPeerSpeed(id, "bytesSent");
               const rtpStatsData = await this.getRtpStatsData(peer, StatsType.OUTBOUND_RTP);
               const { lastStats, graphData } = this.getGraphData(id, rtpStatsData);
@@ -510,9 +510,9 @@ export default class RtcDebugPanel extends Component {
               statsData[id]["last"] = lastStats;
               statsData[id]["rtpStats"] = rtpStatsData;
             }
-            if (NAF.connection.adapter._shareProducer) {
-              const id = NAF.connection.adapter._shareProducer.id;
-              const peer = NAF.connection.adapter._shareProducer;
+            if (APP.dialog._shareProducer) {
+              const id = APP.dialog._shareProducer.id;
+              const peer = APP.dialog._shareProducer;
               const speedData = this.getPeerSpeed(id, "bytesSent");
               const rtpStatsData = await this.getRtpStatsData(peer, StatsType.OUTBOUND_RTP);
               const { lastStats, graphData } = this.getGraphData(id, rtpStatsData);
@@ -522,7 +522,7 @@ export default class RtcDebugPanel extends Component {
               statsData[id]["last"] = lastStats;
               statsData[id]["rtpStats"] = rtpStatsData;
             }
-            for (const consumer of NAF.connection.adapter._consumers) {
+            for (const consumer of APP.dialog._consumers) {
               const id = consumer[0];
               const peer = consumer[1];
               const speedData = this.getPeerSpeed(id, "bytesReceived");
@@ -555,19 +555,19 @@ export default class RtcDebugPanel extends Component {
   }
 
   restartSendICE = () => {
-    NAF.connection.adapter.restartSendICE();
+    APP.dialog.restartSendICE();
   };
 
   restartRecvICE = () => {
-    NAF.connection.adapter.restartRecvICE();
+    APP.dialog.restartRecvICE();
   };
 
   connectSignaling = () => {
-    NAF.connection.adapter.connect();
+    APP.dialog.connect();
   };
 
   disconnectSignaling = () => {
-    NAF.connection.adapter.disconnect();
+    APP.dialog.disconnect();
   };
 
   colorForLevel = level => {

--- a/src/react-components/debug-panel/RtcDebugPanel.js
+++ b/src/react-components/debug-panel/RtcDebugPanel.js
@@ -566,7 +566,7 @@ export default class RtcDebugPanel extends Component {
     APP.dialog.connect({
       serverUrl: APP.dialog._serverUrl,
       roomId: APP.dialog._roomId,
-      joinToken: APP.dialog._joinToken,
+      joinToken: APP.hubChannel.token,
       serverParams: APP.dialog._serverParams,
       scene: APP.dialog.scene,
       clientId: APP.dialog._clientId,

--- a/src/react-components/debug-panel/RtcDebugPanel.js
+++ b/src/react-components/debug-panel/RtcDebugPanel.js
@@ -385,7 +385,7 @@ export default class RtcDebugPanel extends Component {
   }
 
   getSignalingData() {
-    return { connected: !APP.dialog._closed };
+    return { connected: APP.dialog._protoo && APP.dialog._protoo.connected };
   }
 
   async getServerData() {

--- a/src/react-components/debug-panel/RtcDebugPanel.js
+++ b/src/react-components/debug-panel/RtcDebugPanel.js
@@ -563,7 +563,17 @@ export default class RtcDebugPanel extends Component {
   };
 
   connectSignaling = () => {
-    APP.dialog.connect();
+    APP.dialog.connect({
+      serverUrl: APP.dialog._serverUrl,
+      roomId: APP.dialog._roomId,
+      joinToken: APP.dialog._joinToken,
+      serverParams: APP.dialog._serverParams,
+      scene: APP.dialog.scene,
+      clientId: APP.dialog._clientId,
+      forceTcp: APP.dialog._forceTcp,
+      forceTurn: APP.dialog._forceTurn,
+      iceTransportPolicy: APP.dialog._iceTransportPolicy
+    });
   };
 
   disconnectSignaling = () => {

--- a/src/react-components/input/SelectInputField.js
+++ b/src/react-components/input/SelectInputField.js
@@ -110,7 +110,7 @@ SelectInputField.propTypes = {
       PropTypes.string,
       PropTypes.number,
       PropTypes.shape({
-        id: PropTypes.string.isRequired,
+        // id: PropTypes.string.isRequired,
         label: PropTypes.string,
         value: PropTypes.any.isRequired
       })

--- a/src/react-components/room/ContentMenu.js
+++ b/src/react-components/room/ContentMenu.js
@@ -36,13 +36,13 @@ export function PeopleMenuButton(props) {
     <ContentMenuButton {...props}>
       <PeopleIcon />
       <span>
-        <FormattedMessage id="content-menu.people-menu-button" defaultMessage="People" />({props.presenceCount})
+        <FormattedMessage id="content-menu.people-menu-button" defaultMessage="People" />({`${props.presencecount}`})
       </span>
     </ContentMenuButton>
   );
 }
 PeopleMenuButton.propTypes = {
-  presenceCount: PropTypes.number
+  presencecount: PropTypes.number
 };
 
 export function ContentMenu({ children }) {

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -454,7 +454,7 @@ class UIRoot extends Component {
   };
 
   toggleMute = () => {
-    this.props.scene.emit("action_mute");
+    APP.dialog.toggleMicrophone();
   };
 
   shareVideo = mediaSource => {
@@ -571,7 +571,6 @@ class UIRoot extends Component {
   };
 
   beginOrSkipAudioSetup = () => {
-    console.log(this.props.forcedVREntryType);
     const skipAudioSetup = this.props.forcedVREntryType && this.props.forcedVREntryType.endsWith("_now");
 
     if (skipAudioSetup) {
@@ -600,9 +599,6 @@ class UIRoot extends Component {
     clearHistoryState(this.props.history);
 
     const muteOnEntry = this.props.store.state.preferences["muteMicOnEntry"] || false;
-    this.props.store.update({
-      settings: { micMuted: false }
-    });
     await this.props.enterScene(this.state.enterInVR, muteOnEntry);
 
     this.setState({ entered: true, entering: false, showShareDialog: false });
@@ -1356,7 +1352,7 @@ class UIRoot extends Component {
                         <PeopleMenuButton
                           active={this.state.sidebarId === "people"}
                           onClick={() => this.toggleSidebar("people")}
-                          presenceCount={this.state.presenceCount}
+                          presencecount={this.state.presenceCount}
                         />
                       </ContentMenu>
                     )}

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -96,10 +96,6 @@ export default class SceneEntryManager {
       return;
     }
 
-    if (this.mediaDevicesManager.mediaStream) {
-      await NAF.connection.adapter.setLocalMediaStream(this.mediaDevicesManager.mediaStream);
-    }
-
     this.scene.classList.remove("hand-cursor");
     this.scene.classList.add("no-cursor");
 
@@ -123,9 +119,7 @@ export default class SceneEntryManager {
 
     this.scene.addState("entered");
 
-    if (muteOnEntry) {
-      this.scene.emit("action_mute");
-    }
+    APP.dialog.enableMicrophone(!muteOnEntry);
   };
 
   whenSceneLoaded = callback => {
@@ -142,8 +136,8 @@ export default class SceneEntryManager {
 
   exitScene = () => {
     this.scene.exitVR();
-    if (NAF.connection.adapter && NAF.connection.adapter.localMediaStream) {
-      NAF.connection.adapter.localMediaStream.getTracks().forEach(t => t.stop());
+    if (APP.dialog && NAF.connection.adapter.localMediaStream) {
+      APP.dialog.localMediaStream.getTracks().forEach(t => t.stop());
     }
     if (this.hubChannel) {
       this.hubChannel.disconnect();
@@ -497,7 +491,6 @@ export default class SceneEntryManager {
 
     this.scene.addEventListener("action_end_mic_sharing", async () => {
       await this.mediaDevicesManager.stopMicShare();
-      this.scene.emit("action_mute");
     });
 
     this.scene.addEventListener("action_selected_media_result_entry", async e => {
@@ -630,7 +623,7 @@ export default class SceneEntryManager {
       this.mediaDevicesManager.mediaStream.addTrack(audioDestination.stream.getAudioTracks()[0]);
     }
 
-    await NAF.connection.adapter.setLocalMediaStream(this.mediaDevicesManager.mediaStream);
+    await APP.dialog.setLocalMediaStream(this.mediaDevicesManager.mediaStream);
     audioEl.play();
   };
 }

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -136,7 +136,7 @@ export default class SceneEntryManager {
 
   exitScene = () => {
     this.scene.exitVR();
-    if (APP.dialog && NAF.connection.adapter.localMediaStream) {
+    if (APP.dialog && APP.dialog.localMediaStream) {
       APP.dialog.localMediaStream.getTracks().forEach(t => t.stop());
     }
     if (this.hubChannel) {

--- a/src/subscriptions.js
+++ b/src/subscriptions.js
@@ -21,6 +21,25 @@ export default class Subscriptions {
     this.hubId = hubId;
   }
 
+  register() {
+    if (navigator.serviceWorker) {
+      try {
+        navigator.serviceWorker
+          .register("/hub.service.js")
+          .then(() => {
+            navigator.serviceWorker.ready
+              .then(registration => this.setRegistration(registration))
+              .catch(() => this.setRegistrationFailed());
+          })
+          .catch(() => this.setRegistrationFailed());
+      } catch (e) {
+        this.setRegistrationFailed();
+      }
+    } else {
+      this.setRegistrationFailed();
+    }
+  }
+
   setHubChannel = hubChannel => {
     this.hubChannel = hubChannel;
   };

--- a/src/transport-for-channel.js
+++ b/src/transport-for-channel.js
@@ -1,0 +1,40 @@
+export function transportForChannel(channel, reliable = true) {
+  return (clientId, dataType, data) => {
+    const payload = { dataType, data };
+
+    if (clientId) {
+      payload.clientId = clientId;
+    }
+
+    const isOpen = channel.socket.connectionState() === "open";
+
+    if (isOpen || reliable) {
+      const hasFirstSync =
+        payload.dataType === "um" ? payload.data.d.find(r => r.isFirstSync) : payload.data.isFirstSync;
+
+      if (hasFirstSync) {
+        if (isOpen) {
+          channel.push("naf", payload);
+        } else {
+          // Memory is re-used, so make a copy
+          channel.push("naf", AFRAME.utils.clone(payload));
+        }
+      } else {
+        // Optimization: Strip isFirstSync and send payload as a string to reduce server parsing.
+        // The server will not parse messages without isFirstSync keys when sent to the nafr event.
+        //
+        // The client must assume any payload that does not have a isFirstSync key is not a first sync.
+        const nafrPayload = AFRAME.utils.clone(payload);
+        if (nafrPayload.dataType === "um") {
+          for (let i = 0; i < nafrPayload.data.d.length; i++) {
+            delete nafrPayload.data.d[i].isFirstSync;
+          }
+        } else {
+          delete nafrPayload.data.isFirstSync;
+        }
+
+        channel.push("nafr", { naf: JSON.stringify(nafrPayload) });
+      }
+    }
+  };
+}

--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -107,7 +107,7 @@ export default class HubChannel extends EventTarget {
   async migrateToHub(hubId) {
     let presenceBindings;
 
-    const newChannel = this.channel.socket.channel(`hub:${hubId}`, APP.createHubChannelParams());
+    const newChannel = this.channel.socket.channel(`hub:${hubId}`, APP.hubChannelParamsForPermsToken());
     const data = await migrateToChannel(this.channel, newChannel);
 
     if (this.presence) {

--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -147,7 +147,10 @@ export default class HubChannel extends EventTarget {
 
     // Refresh the token 1 minute before it expires.
     const nextRefresh = new Date(this._permissions.exp * 1000 - 60 * 1000) - new Date();
-    setTimeout(async () => {
+    if (this.fetchPermissionsTimeout) {
+      clearTimeout(this.fetchPermissionsTimeout);
+    }
+    this.fetchPermissionsTimeout = setTimeout(async () => {
       const result = await this.fetchPermissions();
       this.dispatchEvent(new CustomEvent("permissions-refreshed", { detail: result }));
     }, nextRefresh);

--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -43,6 +43,8 @@ export default class HubChannel extends EventTarget {
     this._signedIn = !!this.store.state.credentials.token;
     this._permissions = {};
     this._blockedSessionIds = new Set();
+
+    store.addEventListener("profilechanged", this.sendProfileUpdate.bind(this));
   }
 
   get signedIn() {

--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -140,6 +140,7 @@ export default class HubChannel extends EventTarget {
 
   setPermissionsFromToken = token => {
     // Note: token is not verified.
+    this.token = token;
     this._permissions = jwtDecode(token);
     configs.setIsAdmin(this._permissions.postgrest_role === "ret_admin");
     this.dispatchEvent(new CustomEvent("permissions_updated"));

--- a/src/utils/hub-utils.js
+++ b/src/utils/hub-utils.js
@@ -1,0 +1,12 @@
+import configs from "./configs";
+export function getCurrentHubId() {
+  const qs = new URLSearchParams(location.search);
+  const defaultRoomId = configs.feature("default_room_id");
+
+  return (
+    qs.get("hub_id") ||
+    (document.location.pathname === "/" && defaultRoomId
+      ? defaultRoomId
+      : document.location.pathname.substring(1).split("/")[0])
+  );
+}

--- a/src/utils/hub-utils.js
+++ b/src/utils/hub-utils.js
@@ -10,3 +10,17 @@ export function getCurrentHubId() {
       : document.location.pathname.substring(1).split("/")[0])
   );
 }
+
+export function updateVRHudPresenceCount({ presence }) {
+  const occupantCount = Object.getOwnPropertyNames(presence.state).length;
+  const vrHudPresenceCount = document.querySelector("#hud-presence-count");
+  vrHudPresenceCount.setAttribute("text", "value", occupantCount.toString());
+}
+export function updateSceneCopresentState(presence, scene) {
+  const occupantCount = Object.getOwnPropertyNames(presence.state).length;
+  if (occupantCount > 1) {
+    scene.addState("copresent");
+  } else {
+    scene.removeState("copresent");
+  }
+}

--- a/src/utils/hub-utils.js
+++ b/src/utils/hub-utils.js
@@ -24,3 +24,27 @@ export function updateSceneCopresentState(presence, scene) {
     scene.removeState("copresent");
   }
 }
+
+export function createHubChannelParams({
+  permsToken,
+  profile,
+  pushSubscriptionEndpoint,
+  isMobile,
+  isMobileVR,
+  isEmbed,
+  hubInviteId,
+  authToken
+}) {
+  return {
+    profile,
+    push_subscription_endpoint: pushSubscriptionEndpoint,
+    auth_token: authToken || null,
+    perms_token: permsToken || null,
+    context: {
+      mobile: isMobile || isMobileVR,
+      embed: isEmbed,
+      hmd: isMobileVR
+    },
+    hub_invite_id: hubInviteId
+  };
+}

--- a/src/utils/media-devices-manager.js
+++ b/src/utils/media-devices-manager.js
@@ -129,8 +129,7 @@ export default class MediaDevicesManager {
       console.log("No available audio tracks");
     }
 
-    await NAF.connection.adapter.setLocalMediaStream(this._mediaStream);
-    NAF.connection.adapter.enableMicrophone(this._scene.is("muted"));
+    await APP.dialog.setLocalMediaStream(this._mediaStream);
 
     return result;
   }
@@ -209,8 +208,8 @@ export default class MediaDevicesManager {
     this.audioTrack?.stop();
     this.audioTrack = null;
 
-    await NAF.connection.adapter.setLocalMediaStream(this._mediaStream);
-    NAF.connection.adapter.enableMicrophone(false);
+    await APP.dialog.setLocalMediaStream(this._mediaStream);
+    APP.dialog.enableMicrophone(false);
   }
 
   async startVideoShare(constraints, isDisplayMedia, target, success, error) {
@@ -241,7 +240,7 @@ export default class MediaDevicesManager {
           this.audioSystem.addStreamToOutboundAudio("screenshare", newStream);
         }
 
-        await NAF.connection.adapter.setLocalMediaStream(this._mediaStream);
+        await APP.dialog.setLocalMediaStream(this._mediaStream);
       }
     } catch (e) {
       error(e);
@@ -262,7 +261,7 @@ export default class MediaDevicesManager {
 
     this.audioSystem.removeStreamFromOutboundAudio("screenshare");
 
-    await NAF.connection.adapter.setLocalMediaStream(this._mediaStream);
+    await APP.dialog.setLocalMediaStream(this._mediaStream);
   }
 
   async shouldShowHmdMicWarning() {

--- a/src/utils/permissions-utils.js
+++ b/src/utils/permissions-utils.js
@@ -232,9 +232,8 @@ export function authorizeOrSanitizeMessage(message) {
   }
 }
 
-const PHOENIX_RELIABLE_NAF = "phx-reliable";
 export function applyPersistentSync(networkId) {
   if (!persistentSyncs[networkId]) return;
-  NAF.connection.adapter.onData(authorizeOrSanitizeMessage(persistentSyncs[networkId]), PHOENIX_RELIABLE_NAF);
+  NAF.connection.adapter.handleIncomingNAF(persistentSyncs[networkId]);
   delete persistentSyncs[networkId];
 }

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -336,3 +336,37 @@ export function hasEmbedPresences(presences) {
 
   return false;
 }
+
+export function denoisePresence({ onJoin, onLeave, onChange }) {
+  return {
+    rawOnJoin: (key, beforeJoin, afterJoin) => {
+      if (beforeJoin === undefined) {
+        onJoin(key, afterJoin.metas[0]);
+      }
+    },
+    rawOnLeave: (key, remaining, removed) => {
+      if (remaining.metas.length === 0) {
+        onLeave(key, removed.metas[0]);
+      } else {
+        onChange(key, removed.metas[removed.metas.length - 1], remaining.metas[remaining.metas.length - 1]);
+      }
+    }
+  };
+}
+
+export function presenceEventsForHub(events) {
+  const onJoin = (key, meta) => {
+    events.trigger(`hub:join`, { key, meta });
+  };
+  const onLeave = (key, meta) => {
+    events.trigger(`hub:leave`, { key, meta });
+  };
+  const onChange = (key, previous, current) => {
+    events.trigger(`hub:change`, { key, previous, current });
+  };
+  return {
+    onJoin,
+    onLeave,
+    onChange
+  };
+}

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -261,7 +261,7 @@ export function getPresenceProfileForSession(presences, sessionId) {
 function migrateBindings(oldChannel, newChannel) {
   const doNotDuplicate = ["phx_close", "phx_error", "phx_reply", "presence_state", "presence_diff"];
   const shouldDuplicate = event => {
-    !event.startsWith("chan_reply_") && !doNotDuplicate.includes(event);
+    return !event.startsWith("chan_reply_") && !doNotDuplicate.includes(event);
   };
   for (let i = 0, l = oldChannel.bindings.length; i < l; i++) {
     const item = oldChannel.bindings[i];


### PR DESCRIPTION
This PR changes a few things.

- There is a new `NAF` adapter called `PhoenixAdapter`. The `PhoenixAdapter` handles `naf` and `nafr` events on the `hub:${hubId}` phoenix channel, and tells `NAF` when participants join and leave the hub room. (It uses `Presence` to know about the other participants.)
- The `DialogAdapter` does not have to care about `NAF` anymore, so it doesn't. We give dialog only the information it needs (`serverParams`, `hubId`, `turn` info etc) to join the `protoo` room and establish `WebRTC` connections with the help of `mediasoup`.
- Mic state is simpler:
  - The source of truth is [`APP.dialog.isMicEnabled`](https://github.com/mozilla/hubs/blob/feature/phoenix-adapter/src/naf-dialog-adapter.js#L937-L939). 
  - The mic state is not stored in `localStorage` or in a `muted` css class on the `scene`. 
  - We do not toggle the microphone when selecting a new input device from the preference menu.
- Hub channel presence events are handled by various event handlers, rather than having a small number of event handlers do a bunch of work.
    
    
Built on top of https://github.com/mozilla/hubs/pull/4364 