### PR TITLE
MediaQueryList.addEventListener doesn't work in Safari and IE

### DIFF
--- a/src/react-components/styles/theme.js
+++ b/src/react-components/styles/theme.js
@@ -33,9 +33,15 @@ function useDarkMode() {
 
     setDarkMode(darkmodeQuery.matches);
 
-    darkmodeQuery.addEventListener("change", event => {
-      setDarkMode(event.matches);
-    });
+    if (darkmodeQuery.addEventListener) {
+      darkmodeQuery.addEventListener("change", event => {
+        setDarkMode(event.matches);
+      });
+    } else {
+      darkmodeQuery.addListener(event => {
+        setDarkMode(event.matches);
+      });
+    }
   }, []);
 
   return darkMode;


### PR DESCRIPTION
however you can use MediaQueryList.addListener

refer:
https://stackoverflow.com/questions/62028516/window-matchmedia-does-not-work-in-safari

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/HUBS-785)
