### PR TITLE
Audio Zones

### DIFF
--- a/src/components/audio-params.js
+++ b/src/components/audio-params.js
@@ -1,7 +1,8 @@
 import { Vector3 } from "three";
 import { AudioNormalizer } from "../utils/audio-normalizer";
 import { CLIPPING_THRESHOLD_ENABLED, CLIPPING_THRESHOLD_DEFAULT } from "../react-components/preferences-screen";
-import { AvatarAudioDefaults, DISTANCE_MODEL_OPTIONS } from "../systems/audio-settings-system";
+
+export const DISTANCE_MODEL_OPTIONS = ["linear", "inverse", "exponential"];
 
 export const SourceType = Object.freeze({
   MEDIA_VIDEO: 0,
@@ -9,6 +10,50 @@ export const SourceType = Object.freeze({
   AVATAR_RIG: 2,
   AUDIO_TARGET: 3,
   AUDIO_ZONE: 4
+});
+
+export const AudioType = {
+  Stereo: "stereo",
+  PannerNode: "pannernode"
+};
+
+export const DistanceModelType = {
+  Linear: "linear",
+  Inverse: "inverse",
+  Exponential: "exponential"
+};
+
+export const AvatarAudioDefaults = Object.freeze({
+  DISTANCE_MODEL: DistanceModelType.Inverse,
+  ROLLOFF_FACTOR: 2,
+  REF_DISTANCE: 1,
+  MAX_DISTANCE: 10000,
+  INNER_ANGLE: 180,
+  OUTER_ANGLE: 360,
+  OUTER_GAIN: 0,
+  VOLUME: 1.0
+});
+
+export const MediaAudioDefaults = Object.freeze({
+  DISTANCE_MODEL: DistanceModelType.Inverse,
+  ROLLOFF_FACTOR: 1,
+  REF_DISTANCE: 1,
+  MAX_DISTANCE: 10000,
+  INNER_ANGLE: 360,
+  OUTER_ANGLE: 0,
+  OUTER_GAIN: 0,
+  VOLUME: 0.5
+});
+
+export const TargetAudioDefaults = Object.freeze({
+  DISTANCE_MODEL: DistanceModelType.Inverse,
+  ROLLOFF_FACTOR: 5,
+  REF_DISTANCE: 8,
+  MAX_DISTANCE: 10000,
+  INNER_ANGLE: 170,
+  OUTER_ANGLE: 300,
+  OUTER_GAIN: 0.3,
+  VOLUME: 1.0
 });
 
 const MUTE_DELAY_SECS = 1;
@@ -26,6 +71,7 @@ const distanceModels = {
 };
 
 AFRAME.registerComponent("audio-params", {
+  multiple: true,
   schema: {
     enabled: { default: true },
     debuggable: { default: true },
@@ -308,7 +354,6 @@ AFRAME.registerComponent("audio-params", {
       this.data.gain = this.data.gain * Math.min(1, 10 / Math.max(1, this.data.squaredDistance));
     }
     gainFilter?.gain.exponentialRampToValueAtTime(this.data.gain, audio.context.currentTime + MUTE_DELAY_SECS);
-    console.log(`gain updated: ${newGain}`);
   },
 
   updateClipping() {

--- a/src/components/audio-params.js
+++ b/src/components/audio-params.js
@@ -3,7 +3,13 @@ import { AudioNormalizer } from "../utils/audio-normalizer";
 import { CLIPPING_THRESHOLD_ENABLED, CLIPPING_THRESHOLD_DEFAULT } from "../react-components/preferences-screen";
 import { AvatarAudioDefaults, DISTANCE_MODEL_OPTIONS } from "../systems/audio-settings-system";
 
-export const SourceType = Object.freeze({ MEDIA_VIDEO: 0, AVATAR_AUDIO_SOURCE: 1, AVATAR_RIG: 2, AUDIO_TARGET: 3 });
+export const SourceType = Object.freeze({
+  MEDIA_VIDEO: 0,
+  AVATAR_AUDIO_SOURCE: 1,
+  AVATAR_RIG: 2,
+  AUDIO_TARGET: 3,
+  AUDIO_ZONE: 4
+});
 
 const MUTE_DELAY_SECS = 1;
 
@@ -22,6 +28,7 @@ const distanceModels = {
 AFRAME.registerComponent("audio-params", {
   schema: {
     enabled: { default: true },
+    debuggable: { default: true },
     isLocal: { default: false },
     position: { type: "vec3", default: { x: 0, y: 0, z: 0 } },
     orientation: { type: "vec3", default: { x: 0, y: 0, z: 0 } },
@@ -29,9 +36,12 @@ AFRAME.registerComponent("audio-params", {
     rolloffFactor: { default: AvatarAudioDefaults.ROLLOFF_FACTOR },
     refDistance: { default: AvatarAudioDefaults.REF_DISTANCE },
     maxDistance: { default: AvatarAudioDefaults.MAX_DISTANCE },
+    coneInnerAngle: { default: AvatarAudioDefaults.INNER_ANGLE },
+    coneOuterAngle: { default: AvatarAudioDefaults.OUTER_ANGLE },
+    coneOuterGain: { default: AvatarAudioDefaults.OUTER_GAIN },
     clippingEnabled: { default: CLIPPING_THRESHOLD_ENABLED },
     clippingThreshold: { default: CLIPPING_THRESHOLD_DEFAULT },
-    prevGain: { default: 1.0 },
+    preClipGain: { default: 1.0 },
     isClipped: { default: false },
     gain: { default: 1.0 },
     sourceType: { default: -1 },
@@ -41,6 +51,7 @@ AFRAME.registerComponent("audio-params", {
   },
 
   init() {
+    this.audioRef = null;
     this.avatarRigPosition = new THREE.Vector3();
     this.avatarAudio = {
       panner: {
@@ -86,23 +97,20 @@ AFRAME.registerComponent("audio-params", {
     this.data.clippingThreshold =
       audioClippingThreshold !== undefined ? audioClippingThreshold : CLIPPING_THRESHOLD_DEFAULT;
 
-    this.onVolumeUpdated = this.volumeUpdated.bind(this);
     this.onSourceSetAdded = this.sourceSetAdded.bind(this);
     if (this.data.isLocal) {
       this.data.sourceType = SourceType.AVATAR_RIG;
     } else if (this.el.components["media-video"]) {
       this.data.sourceType = SourceType.MEDIA_VIDEO;
-      this.data.gain = this.el.components["media-video"].data.volume;
-      this.el.addEventListener("media-volume-changed", this.onVolumeUpdated);
     } else if (this.el.components["avatar-audio-source"]) {
       this.data.sourceType = SourceType.AVATAR_AUDIO_SOURCE;
-      this.data.gain =
-        this.el.parentEl?.parentEl?.querySelector("[avatar-volume-controls]").components["avatar-volume-controls"]?.data
-          .volume || 1.0;
-      this.el.parentEl?.parentEl?.addEventListener("avatar-volume-changed", this.onVolumeUpdated);
     } else if (this.el.components["audio-target"]) {
       this.data.sourceType = SourceType.AUDIO_TARGET;
+    } else if (this.el.components["audio-zone"]) {
+      this.data.sourceType = SourceType.AUDIO_ZONE;
     }
+    this.audioSettings = this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem.audioSettings;
+    this.avatarRigObj = document.getElementById("avatar-rig").querySelector(".camera").object3D;
   },
 
   remove() {
@@ -112,20 +120,27 @@ AFRAME.registerComponent("audio-params", {
       this.el.sceneEl?.systems["hubs-systems"].gainSystem.unregisterSource(this);
     }
 
-    this.el.removeEventListener("media-volume-changed", this.onVolumeUpdated);
-    this.el.parentEl?.parentEl?.removeEventListener("avatar-volume-changed", this.onVolumeUpdated);
-
     if (this.data.sourceType === SourceType.AVATAR_AUDIO_SOURCE) {
       this.el.components["avatar-audio-source"].el.removeEventListener("sound-source-set", this.onSourceSetAdded);
     }
   },
 
+  update(oldData) {
+    if (this.data !== oldData && this.audioRef) {
+      this.audioRef.setDistanceModel(this.data.distanceModel);
+      this.audioRef.setRolloffFactor(this.data.rolloffFactor);
+      this.audioRef.setRefDistance(this.data.refDistance);
+      this.audioRef.setMaxDistance(this.data.maxDistance);
+      this.audioRef.panner.coneInnerAngle = this.data.coneInnerAngle;
+      this.audioRef.panner.coneOuterAngle = this.data.coneOuterAngle;
+      this.audioRef.panner.coneOuterGain = this.data.coneOuterGain;
+      this.data.gain && this.updateGain(this.data.gain);
+    }
+  },
+
   tick() {
-    const audio = this.audio();
+    const audio = this.getAudio();
     if (audio) {
-      if (audio.updateMatrixWorld) {
-        audio.updateMatrixWorld(true);
-      }
       this.data.position = new THREE.Vector3(
         audio.panner.positionX.value,
         audio.panner.positionY.value,
@@ -157,45 +172,63 @@ AFRAME.registerComponent("audio-params", {
     }
   },
 
-  audio() {
-    if (this.data.sourceType === SourceType.AVATAR_RIG) {
-      // Create fake parametes for the avatar rig as it doens't have an audio source.
-      const audioParams = this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem.audioSettings;
-      const avatarRigObj = document.getElementById("avatar-rig").querySelector(".camera").object3D;
-      avatarRigObj.updateMatrixWorld(true);
-      avatarRigObj.getWorldPosition(this.avatarRigPosition);
-      this.avatarRigOrientation.set(0, 0, -1);
-      const worldQuat = new THREE.Quaternion();
-      avatarRigObj.getWorldQuaternion(worldQuat);
-      this.avatarRigOrientation.applyQuaternion(worldQuat);
-      this.avatarAudio.panner.orientationX.value = this.avatarRigOrientation.x;
-      this.avatarAudio.panner.orientationY.value = this.avatarRigOrientation.y;
-      this.avatarAudio.panner.orientationZ.value = this.avatarRigOrientation.z;
-      this.avatarAudio.panner.positionX.value = this.avatarRigPosition.x;
-      this.avatarAudio.panner.positionY.value = this.avatarRigPosition.y;
-      this.avatarAudio.panner.positionZ.value = this.avatarRigPosition.z;
-      this.avatarAudio.panner.distanceModel = audioParams.avatarDistanceModel;
-      this.avatarAudio.panner.maxDistance = audioParams.avatarMaxDistance;
-      this.avatarAudio.panner.refDistance = audioParams.avatarRefDistance;
-      this.avatarAudio.panner.rolloffFactor = audioParams.avatarRolloffFactor;
-      this.avatarAudio.panner.coneInnerAngle = audioParams.avatarConeInnerAngle;
-      this.avatarAudio.panner.coneOuterAngle = audioParams.avatarConeOuterAngle;
-      this.avatarAudio.panner.coneOuterGain = audioParams.avatarConeOuterGainain;
-      return this.avatarAudio;
-    } else if (this.data.sourceType === SourceType.MEDIA_VIDEO) {
-      const audio = this.el.getObject3D("sound");
-      return audio?.panner ? audio : null;
-    } else if (this.data.sourceType === SourceType.AVATAR_AUDIO_SOURCE) {
-      const audio = this.el.getObject3D("avatar-audio-source");
-      return audio?.panner ? audio : null;
-    } else if (this.data.sourceType === SourceType.AUDIO_TARGET) {
-      const audio = this.el.getObject3D("audio-target");
-      return audio?.panner ? audio : null;
+  getAudio() {
+    switch (this.data.sourceType) {
+      case SourceType.AVATAR_RIG: {
+        // Create fake parametes for the avatar rig as it doens't have an audio source.
+        const audioParams = this.audioSettings;
+        this.avatarRigObj.updateMatrixWorld(true);
+        this.avatarRigObj.getWorldPosition(this.avatarRigPosition);
+        this.avatarRigOrientation.set(0, 0, -1);
+        const worldQuat = new THREE.Quaternion();
+        this.avatarRigObj.getWorldQuaternion(worldQuat);
+        this.avatarRigOrientation.applyQuaternion(worldQuat);
+        return {
+          panner: {
+            orientationX: {
+              value: this.avatarRigOrientation.x
+            },
+            orientationY: {
+              value: this.avatarRigOrientation.y
+            },
+            orientationZ: {
+              value: this.avatarRigOrientation.z
+            },
+            positionX: {
+              value: this.avatarRigPosition.x
+            },
+            positionY: {
+              value: this.avatarRigPosition.y
+            },
+            positionZ: {
+              value: this.avatarRigPosition.z
+            },
+            distanceModel: audioParams.avatarDistanceModel,
+            maxDistance: audioParams.avatarMaxDistance,
+            refDistance: audioParams.avatarRefDistance,
+            rolloffFactor: audioParams.avatarRolloffFactor,
+            coneInnerAngle: audioParams.avatarConeInnerAngle,
+            coneOuterAngle: audioParams.avatarConeOuterAngle,
+            coneOuterGain: audioParams.avatarConeOuterGain
+          }
+        };
+      }
+      case SourceType.MEDIA_VIDEO:
+      case SourceType.AVATAR_AUDIO_SOURCE:
+      case SourceType.AUDIO_TARGET: {
+        return this.audioRef?.panner ? this.audioRef : null;
+      }
     }
+
+    return null;
+  },
+
+  setAudio(audio) {
+    this.audioRef = audio;
   },
 
   enableNormalizer() {
-    const audio = this.audio();
+    const audio = this.getAudio();
     if (audio) {
       const avatarAudioSource = this.el.components["avatar-audio-source"];
       if (avatarAudioSource) {
@@ -231,54 +264,55 @@ AFRAME.registerComponent("audio-params", {
 
   clipGain(gain) {
     if (!this.data.isClipped) {
-      const audio = this.audio();
+      const audio = this.getAudio();
       this.data.isClipped = true;
-      this.data.prevGain = this.data.gain;
+      this.data.preClipGain = this.data.gain;
       this.data.gain = gain;
-      this.data.gain = this.data.gain === 0 ? 0.001 : this.data.gain;
+      this.data.gain = Math.max(0.001, this.data.gain);
       audio.gain.gain.exponentialRampToValueAtTime(this.data.gain, audio.context.currentTime + MUTE_DELAY_SECS);
     }
   },
 
   unclipGain() {
     if (this.data.isClipped) {
-      const audio = this.audio();
+      const audio = this.getAudio();
       this.data.isClipped = false;
-      this.data.gain = this.data.prevGain;
-      this.data.gain = this.data.gain === 0 ? 0.001 : this.data.gain;
+      this.data.gain = this.data.preClipGain;
+      this.data.gain = Math.max(0.001, this.data.gain);
       audio?.gain?.gain.exponentialRampToValueAtTime(this.data.gain, audio.context.currentTime + MUTE_DELAY_SECS);
     }
   },
 
   updateGain(newGain) {
-    const audio = this.audio();
-    if (this.data.isClipped) {
-      this.data.prevGain = newGain;
-    } else {
-      this.data.prevGain = this.data.gain;
-      this.data.gain = newGain;
-    }
-    this.data.gain = this.data.gain === 0 ? 0.001 : this.data.gain;
-    audio?.gain?.gain.exponentialRampToValueAtTime(this.data.gain, audio.context.currentTime + MUTE_DELAY_SECS);
-  },
+    const audio = this.getAudio();
+    if (!audio) return;
 
-  volumeUpdated({ detail: volume }) {
-    let globalVolume = 100;
-    const { audioOutputMode, globalVoiceVolume, globalMediaVolume } = window.APP.store.state.preferences;
-    if (this.data.sourceType === SourceType.MEDIA_VIDEO) {
-      globalVolume = globalMediaVolume;
-    } else if (this.data.sourceType === SourceType.AVATAR_AUDIO_SOURCE) {
-      globalVolume = globalVoiceVolume;
+    this.data.gain = Math.max(0.001, newGain);
+    let gainFilter;
+    switch (this.data.sourceType) {
+      case SourceType.MEDIA_VIDEO: {
+        gainFilter = this.el.components["media-video"].getGainFilter();
+        break;
+      }
+      case SourceType.AVATAR_AUDIO_SOURCE: {
+        gainFilter = this.el.components["avatar-audio-source"].getGainFilter();
+        break;
+      }
+      case SourceType.AUDIO_TARGET: {
+        gainFilter = this.el.components["audio-target"].getGainFilter();
+        break;
+      }
     }
-    const volumeModifier = (globalVolume !== undefined ? globalVolume : 100) / 100;
-    let newGain = volumeModifier * volume;
+    const { audioOutputMode } = window.APP.store.state.preferences;
     if (audioOutputMode === "audio") {
-      newGain = this.data.gain * Math.min(1, 10 / Math.max(1, this.data.squaredDistance));
+      this.data.gain = this.data.gain * Math.min(1, 10 / Math.max(1, this.data.squaredDistance));
     }
-    this.updateGain(newGain);
+    gainFilter?.gain.exponentialRampToValueAtTime(this.data.gain, audio.context.currentTime + MUTE_DELAY_SECS);
+    console.log(`gain updated: ${newGain}`);
   },
 
-  clippingUpdated({ clippingEnabled, clippingThreshold }) {
+  updateClipping() {
+    const { clippingEnabled, clippingThreshold } = window.APP.store.state.preferences;
     this.data.clippingEnabled = clippingEnabled !== undefined ? clippingEnabled : CLIPPING_THRESHOLD_ENABLED;
     this.data.clippingThreshold = clippingThreshold !== undefined ? clippingThreshold : CLIPPING_THRESHOLD_DEFAULT;
   }

--- a/src/components/audio-params.js
+++ b/src/components/audio-params.js
@@ -180,7 +180,7 @@ AFRAME.registerComponent("audio-params", {
       this.audioRef.panner.coneInnerAngle = this.data.coneInnerAngle;
       this.audioRef.panner.coneOuterAngle = this.data.coneOuterAngle;
       this.audioRef.panner.coneOuterGain = this.data.coneOuterGain;
-      this.data.gain && this.updateGain(this.data.gain);
+      this.data.gain !== undefined && this.updateGain(this.data.gain);
     }
   },
 

--- a/src/components/audio-params.js
+++ b/src/components/audio-params.js
@@ -171,8 +171,8 @@ AFRAME.registerComponent("audio-params", {
     }
   },
 
-  update(oldData) {
-    if (this.data !== oldData && this.audioRef) {
+  update() {
+    if (this.audioRef) {
       this.audioRef.setDistanceModel(this.data.distanceModel);
       this.audioRef.setRolloffFactor(this.data.rolloffFactor);
       this.audioRef.setRefDistance(this.data.refDistance);
@@ -218,56 +218,59 @@ AFRAME.registerComponent("audio-params", {
     }
   },
 
-  getAudio() {
-    switch (this.data.sourceType) {
-      case SourceType.AVATAR_RIG: {
-        // Create fake parametes for the avatar rig as it doens't have an audio source.
-        const audioParams = this.audioSettings;
-        this.avatarRigObj.updateMatrixWorld(true);
-        this.avatarRigObj.getWorldPosition(this.avatarRigPosition);
-        this.avatarRigOrientation.set(0, 0, -1);
-        const worldQuat = new THREE.Quaternion();
-        this.avatarRigObj.getWorldQuaternion(worldQuat);
-        this.avatarRigOrientation.applyQuaternion(worldQuat);
-        return {
-          panner: {
-            orientationX: {
-              value: this.avatarRigOrientation.x
-            },
-            orientationY: {
-              value: this.avatarRigOrientation.y
-            },
-            orientationZ: {
-              value: this.avatarRigOrientation.z
-            },
-            positionX: {
-              value: this.avatarRigPosition.x
-            },
-            positionY: {
-              value: this.avatarRigPosition.y
-            },
-            positionZ: {
-              value: this.avatarRigPosition.z
-            },
-            distanceModel: audioParams.avatarDistanceModel,
-            maxDistance: audioParams.avatarMaxDistance,
-            refDistance: audioParams.avatarRefDistance,
-            rolloffFactor: audioParams.avatarRolloffFactor,
-            coneInnerAngle: audioParams.avatarConeInnerAngle,
-            coneOuterAngle: audioParams.avatarConeOuterAngle,
-            coneOuterGain: audioParams.avatarConeOuterGain
-          }
-        };
-      }
-      case SourceType.MEDIA_VIDEO:
-      case SourceType.AVATAR_AUDIO_SOURCE:
-      case SourceType.AUDIO_TARGET: {
-        return this.audioRef?.panner ? this.audioRef : null;
-      }
-    }
+  getAudio: (function() {
+    const worldQuat = new THREE.Quaternion();
 
-    return null;
-  },
+    return function() {
+      switch (this.data.sourceType) {
+        case SourceType.AVATAR_RIG: {
+          // Create fake parametes for the avatar rig as it doens't have an audio source.
+          const audioParams = this.audioSettings;
+          this.avatarRigObj.updateMatrixWorld(true);
+          this.avatarRigObj.getWorldPosition(this.avatarRigPosition);
+          this.avatarRigOrientation.set(0, 0, -1);
+          this.avatarRigObj.getWorldQuaternion(worldQuat);
+          this.avatarRigOrientation.applyQuaternion(worldQuat);
+          return {
+            panner: {
+              orientationX: {
+                value: this.avatarRigOrientation.x
+              },
+              orientationY: {
+                value: this.avatarRigOrientation.y
+              },
+              orientationZ: {
+                value: this.avatarRigOrientation.z
+              },
+              positionX: {
+                value: this.avatarRigPosition.x
+              },
+              positionY: {
+                value: this.avatarRigPosition.y
+              },
+              positionZ: {
+                value: this.avatarRigPosition.z
+              },
+              distanceModel: audioParams.avatarDistanceModel,
+              maxDistance: audioParams.avatarMaxDistance,
+              refDistance: audioParams.avatarRefDistance,
+              rolloffFactor: audioParams.avatarRolloffFactor,
+              coneInnerAngle: audioParams.avatarConeInnerAngle,
+              coneOuterAngle: audioParams.avatarConeOuterAngle,
+              coneOuterGain: audioParams.avatarConeOuterGain
+            }
+          };
+        }
+        case SourceType.MEDIA_VIDEO:
+        case SourceType.AVATAR_AUDIO_SOURCE:
+        case SourceType.AUDIO_TARGET: {
+          return this.audioRef?.panner ? this.audioRef : null;
+        }
+      }
+
+      return null;
+    };
+  })(),
 
   setAudio(audio) {
     this.audioRef = audio;

--- a/src/components/audio-zone-entity.js
+++ b/src/components/audio-zone-entity.js
@@ -1,0 +1,56 @@
+// Component to track the zones state of an entity.
+// Records the audio zones where the entity is and returns current/past states.
+AFRAME.registerComponent("audio-zone-entity", {
+  init() {
+    this.zones = [];
+    this.prevZones = [];
+  },
+
+  remove() {
+    this.zones.length = 0;
+    this.prevZones.length = 0;
+  },
+
+  // Update the previous zones array.
+  tock() {
+    this.prevZones = [...this.zones];
+  },
+
+  // Adds a zone to the current zones array.
+  addZone(zone) {
+    const index = this.zones.indexOf(zone);
+    if (index < 0) {
+      this.zones.push(zone);
+    }
+  },
+
+  // Removes a zone from the current zones array.
+  removeZone(zone) {
+    const index = this.zones.indexOf(zone);
+    if (index !== -1) {
+      this.zones.splice(index, 1);
+    }
+  },
+
+  // Returns true if this entity is inside a zone.
+  isInZone(zone) {
+    return this.zones.includes(zone);
+  },
+
+  // Returns true if this entity was inside the zone in the previous tick.
+  wasInZone(zone) {
+    return this.prevZones.includes(zone);
+  },
+
+  // Returns true if the entity has change zones (a zone has been added or removes in the last tick).
+  isUpdated() {
+    return !(
+      this.zones.length === this.prevZones.length && this.zones.every((value, index) => value === this.prevZones[index])
+    );
+  },
+
+  // Return the array of zones the entity is currently inside of.
+  getZones() {
+    return this.zones;
+  }
+});

--- a/src/components/audio-zone-entity.js
+++ b/src/components/audio-zone-entity.js
@@ -1,5 +1,8 @@
-// Component to track the zones state of an entity.
-// Records the audio zones where the entity is and returns current/past states.
+/**
+ * Represents an entity in the audio-zones-system.
+ * Records the audio zones where the entity is and returns current/past states.
+ * This entity is used together with the audio-zone-listeneror audio-zone-sourcecomponents to composite actual entities.
+ **/
 AFRAME.registerComponent("audio-zone-entity", {
   init() {
     this.zones = [];

--- a/src/components/audio-zone-entity.js
+++ b/src/components/audio-zone-entity.js
@@ -1,7 +1,7 @@
 /**
  * Represents an entity in the audio-zones-system.
  * Records the audio zones where the entity is and returns current/past states.
- * This entity is used together with the audio-zone-listeneror audio-zone-sourcecomponents to composite actual entities.
+ * This entity is used together with the audio-zone-listeneror audio-zone-source components to composite actual entities.
  **/
 AFRAME.registerComponent("audio-zone-entity", {
   init() {
@@ -16,7 +16,10 @@ AFRAME.registerComponent("audio-zone-entity", {
 
   // Update the previous zones array.
   tock() {
-    this.prevZones = [...this.zones];
+    this.prevZones.length = this.zones.length;
+    for (let i = 0; i < this.zones.length; i++) {
+      this.prevZones[i] = this.zones[i];
+    }
   },
 
   // Adds a zone to the current zones array.

--- a/src/components/audio-zone-listener.js
+++ b/src/components/audio-zone-listener.js
@@ -1,0 +1,24 @@
+// Represents the scene audio listener in the audio zones system.
+AFRAME.registerComponent("audio-zone-listener", {
+  dependencies: ["audio-zone-entity"],
+
+  init() {
+    this.position = new THREE.Vector3();
+    this.listener = this.el.sceneEl?.audioListener;
+    this.entity = this.el.components["audio-zone-entity"];
+    this.el.sceneEl?.systems["hubs-systems"].audioZonesSystem.setListener(this);
+  },
+
+  remove() {
+    this.el.sceneEl?.systems["hubs-systems"].audioZonesSystem.unsetListener();
+  },
+
+  tick() {
+    this.listener.getWorldPosition(this.position);
+  },
+
+  // Returns the audio listener world position.
+  getPosition() {
+    return this.position;
+  }
+});

--- a/src/components/audio-zone-listener.js
+++ b/src/components/audio-zone-listener.js
@@ -1,4 +1,6 @@
-// Represents the scene audio listener in the audio zones system.
+/**
+ * Represents the scene audio listener in the audio-zones-system.
+ */
 AFRAME.registerComponent("audio-zone-listener", {
   dependencies: ["audio-zone-entity"],
 

--- a/src/components/audio-zone-source.js
+++ b/src/components/audio-zone-source.js
@@ -1,0 +1,53 @@
+import { THREE } from "aframe";
+
+const zero = new THREE.Vector3(0, 0, 0);
+
+// Represents an audio-zone-entity that emits audio in the audio-zones-system.
+// Expects an audio-params component.
+AFRAME.registerComponent("audio-zone-source", {
+  dependencies: ["audio-zone-entity"],
+
+  init() {
+    this.prevAudioParamsData = null;
+    this.audioParamsComp = this.el.components["audio-params"];
+    this.entity = this.el.components["audio-zone-entity"];
+    this.el.sceneEl?.systems["hubs-systems"].audioZonesSystem.registerSource(this);
+  },
+
+  remove() {
+    this.el.sceneEl?.systems["hubs-systems"].audioZonesSystem.unregisterSource(this);
+  },
+
+  // Returns the audio source world position.
+  getPosition() {
+    return this.audioParamsComp?.data.position || zero;
+  },
+
+  // Updates the audio-params component with new audio parameters.
+  apply(params) {
+    if (!params) return;
+    if (this.audioParamsComp) {
+      if (this.prevAudioParamsData === null) {
+        this.prevAudioParamsData = {
+          distanceModel: this.audioParamsComp.data.distanceModel,
+          maxDistance: this.audioParamsComp.data.maxDistance,
+          refDistance: this.audioParamsComp.data.refDistance,
+          rolloffFactor: this.audioParamsComp.data.rolloffFactor,
+          coneInnerAngle: this.audioParamsComp.data.coneInnerAngle,
+          coneOuterAngle: this.audioParamsComp.data.coneOuterAngle,
+          coneOuterGain: this.audioParamsComp.data.coneOuterGain,
+          gain: this.audioParamsComp.data.gain
+        };
+      }
+      this.el.setAttribute("audio-params", params);
+    }
+  },
+
+  // Restores the original audio parameters.
+  restore() {
+    if (this.prevAudioParamsData) {
+      this.el.setAttribute("audio-params", this.prevAudioParamsData);
+    }
+    this.prevAudioParamsData = null;
+  }
+});

--- a/src/components/audio-zone-source.js
+++ b/src/components/audio-zone-source.js
@@ -2,8 +2,10 @@ import { THREE } from "aframe";
 
 const zero = new THREE.Vector3(0, 0, 0);
 
-// Represents an audio-zone-entity that emits audio in the audio-zones-system.
-// Expects an audio-params component.
+/**
+ * Represents an audio-zone-entity that has an audio component in the audio-zones-system.
+ * Expects an audio-params component. It can be an audio, video, avatar or an audio target.
+ */
 AFRAME.registerComponent("audio-zone-source", {
   dependencies: ["audio-zone-entity"],
 

--- a/src/components/audio-zone.js
+++ b/src/components/audio-zone.js
@@ -1,0 +1,94 @@
+const DEBUG_BBAA_COLOR = 0x49ef4;
+
+const debugMaterial = new THREE.MeshBasicMaterial({
+  color: DEBUG_BBAA_COLOR,
+  transparent: true,
+  opacity: 0.25,
+  side: THREE.DoubleSide
+});
+
+// Represents an 3D box area in the audio zones system that can contain audio-zone-entities.
+// It can be of inOut or/and outIn type.
+// - inOut: applies this zone's audio parameters to an audio-zone-source when the source is inside and listener is outside.
+//  i.e. You want to prevent audio to come out from a room containing audio sources.
+// - outIn: applies this zone's audio parameters to the an audio-zone-source when the listener is inside and the source is outside.
+//  i.e. You want to prevent audio to come into a room from audio sources outside.
+AFRAME.registerComponent("audio-zone", {
+  schema: {
+    enabled: { default: true },
+    inOut: { default: true },
+    outIn: { default: true },
+    debuggable: { default: true }
+  },
+
+  init() {
+    this.currentPos = new THREE.Vector3();
+    this.lastPosition = new THREE.Vector3();
+    this.worldBoundingBox = new THREE.Box3();
+    this.object3D = this.el.object3D;
+
+    for (let i = this.object3D.children.length - 1; i >= 0; i--) {
+      this.object3D.children[i].visible = false;
+    }
+
+    const debugGeometry = new THREE.BoxBufferGeometry();
+    this.debugMesh = new THREE.Mesh(debugGeometry, debugMaterial);
+    this.debugMesh.el = this.object3D.el;
+    const debugBBAA = new THREE.BoxHelper(this.debugMesh, DEBUG_BBAA_COLOR);
+    this.object3D.add(debugBBAA);
+
+    this.el.sceneEl?.systems["audio-debug"].registerZone(this);
+    this.el.sceneEl?.systems["hubs-systems"].audioZonesSystem.registerZone(this);
+
+    this.enableDebug(window.APP.store.state.preferences.showAudioDebugPanel);
+    this.el.setAttribute("audio-params", "debuggable", false);
+    this.audioParamsComp = this.el.components["audio-params"];
+  },
+
+  remove() {
+    this.el.sceneEl?.systems["audio-debug"].unregisterZone(this);
+    this.el.sceneEl?.systems["hubs-systems"].audioZonesSystem.unregisterZone(this);
+  },
+
+  tick() {
+    this.lastPosition = this.currentPos.clone();
+    this.object3D.getWorldPosition(this.currentPos);
+    if (this.data.enabled) {
+      this.worldBoundingBox.copy(this.debugMesh.geometry.boundingBox).applyMatrix4(this.object3D.matrixWorld);
+    }
+  },
+
+  update() {
+    this.enableDebug(this.data.debuggable && window.APP.store.state.preferences.showAudioDebugPanel);
+  },
+
+  isEnabled() {
+    return this.data.enabled;
+  },
+
+  getBoundingBox() {
+    return this.worldBoundingBox;
+  },
+
+  enableDebug(debuggable) {
+    this.data.debuggable = debuggable;
+    this.object3D.visible = debuggable;
+  },
+
+  getAudioParams() {
+    return {
+      distanceModel: this.audioParamsComp.data.distanceModel,
+      maxDistance: this.audioParamsComp.data.maxDistance,
+      refDistance: this.audioParamsComp.data.refDistance,
+      rolloffFactor: this.audioParamsComp.data.rolloffFactor,
+      coneInnerAngle: this.audioParamsComp.data.coneInnerAngle,
+      coneOuterAngle: this.audioParamsComp.data.coneOuterAngle,
+      coneOuterGain: this.audioParamsComp.data.coneOuterGain,
+      gain: this.audioParamsComp.data.gain
+    };
+  },
+
+  contains(position) {
+    return this.worldBoundingBox.containsPoint(position);
+  }
+});

--- a/src/components/audio-zone.js
+++ b/src/components/audio-zone.js
@@ -25,19 +25,6 @@ AFRAME.registerComponent("audio-zone", {
   },
 
   init() {
-    const bbox = new THREE.Box3();
-    bbox.setFromObject(this.el.object3D);
-    const size = new THREE.Vector3();
-    bbox.getSize(size);
-    // Adjust the box scale to the bounding box size
-    if (size.length() > 0) {
-      this.el.object3D.scale.set(size.x, size.y, size.z);
-    }
-
-    for (let i = this.el.object3D.children.length - 1; i >= 0; i--) {
-      this.el.object3D.children[i].visible = false;
-    }
-
     const debugGeometry = new THREE.BoxGeometry();
     this.debugMesh = new THREE.Mesh(debugGeometry, debugMaterial);
     this.debugMesh.el = this.el.object3D.el;

--- a/src/components/audio-zone.js
+++ b/src/components/audio-zone.js
@@ -7,12 +7,15 @@ const debugMaterial = new THREE.MeshBasicMaterial({
   side: THREE.DoubleSide
 });
 
-// Represents an 3D box area in the audio zones system that can contain audio-zone-entities.
-// It can be of inOut or/and outIn type.
-// - inOut: applies this zone's audio parameters to an audio-zone-source when the source is inside and listener is outside.
-//  i.e. You want to prevent audio to come out from a room containing audio sources.
-// - outIn: applies this zone's audio parameters to the an audio-zone-source when the listener is inside and the source is outside.
-//  i.e. You want to prevent audio to come into a room from audio sources outside.
+/**
+ * Represents an 3D box area in the audio-zones-system that can contain audio-zone-entities.
+ * I has an audio-params components which values are used to override the audio sources audio properties 
+ * based on the source's and listener's position. It can be of inOut or/and outIn types.
+    inOut: applies this zone's audio-params to an audio-zone-source when the source is inside and listener is outside.
+    i.e. You want to mute audio sources inside the audio zone when the listener is outside.
+    outIn: applies this zone's audio-params to the an audio-zone-source when the listener is inside and the source is outside.
+    i.e. You want to mute audio sources from outside the audio zone when the listener is inside.
+ */
 AFRAME.registerComponent("audio-zone", {
   schema: {
     enabled: { default: true },

--- a/src/components/audio-zone.js
+++ b/src/components/audio-zone.js
@@ -27,11 +27,20 @@ AFRAME.registerComponent("audio-zone", {
     this.worldBoundingBox = new THREE.Box3();
     this.object3D = this.el.object3D;
 
+    const bbox = new THREE.Box3();
+    bbox.setFromObject(this.object3D);
+    const size = new THREE.Vector3();
+    bbox.getSize(size);
+    // Adjust the box scale to the bounding box size
+    if (size.length() > 0) {
+      this.object3D.scale.set(size.x, size.y, size.z);
+    }
+
     for (let i = this.object3D.children.length - 1; i >= 0; i--) {
       this.object3D.children[i].visible = false;
     }
 
-    const debugGeometry = new THREE.BoxBufferGeometry();
+    const debugGeometry = new THREE.BoxGeometry();
     this.debugMesh = new THREE.Mesh(debugGeometry, debugMaterial);
     this.debugMesh.el = this.object3D.el;
     const debugBBAA = new THREE.BoxHelper(this.debugMesh, DEBUG_BBAA_COLOR);

--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -1,5 +1,4 @@
-import { AvatarAudioDefaults, TargetAudioDefaults } from "../systems/audio-settings-system";
-import { SourceType } from "./audio-params";
+import { SourceType, AvatarAudioDefaults, TargetAudioDefaults } from "./audio-params";
 
 const INFO_INIT_FAILED = "Failed to initialize avatar-audio-source.";
 const INFO_NO_NETWORKED_EL = "Could not find networked el.";

--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -1,5 +1,5 @@
 import { SourceType, AvatarAudioDefaults, TargetAudioDefaults } from "./audio-params";
-
+import { MixerType } from "../systems/audio-system";
 const INFO_INIT_FAILED = "Failed to initialize avatar-audio-source.";
 const INFO_NO_NETWORKED_EL = "Could not find networked el.";
 const INFO_NO_OWNER = "Networked component has no owner.";
@@ -65,8 +65,8 @@ AFRAME.registerComponent("avatar-audio-source", {
     });
     this.el.components["audio-params"].setAudio(audio);
 
-    this.audioSystem.removeAudioFromVoice(audio);
-    this.audioSystem.addAudioToVoice(audio);
+    this.audioSystem.removeAudio(audio);
+    this.audioSystem.addAudio(MixerType.AVATAR, audio);
 
     if (SHOULD_CREATE_SILENT_AUDIO_ELS) {
       createSilentAudioEl(stream); // TODO: Do the audio els need to get cleaned up?
@@ -87,7 +87,7 @@ AFRAME.registerComponent("avatar-audio-source", {
     const audio = this.el.getObject3D(this.attrName);
     if (!audio) return;
 
-    this.audioSystem.removeAudioFromVoice(audio);
+    this.audioSystem.removeAudio(audio);
     this.el.removeObject3D(this.attrName);
   },
 
@@ -281,6 +281,7 @@ AFRAME.registerComponent("audio-target", {
     this.destroyAudio();
     this.el.removeAttribute("audio-params");
     this.el.removeAttribute("audio-zone-source");
+    this.el.removeAttribute("audio-zone-entity");
   },
 
   createAudio: function() {
@@ -300,8 +301,8 @@ AFRAME.registerComponent("audio-target", {
     audio.updateMatrixWorld();
     this.audio = audio;
 
-    this.audioSystem.removeAudioFromMedia(this.audio);
-    this.audioSystem.addAudioToMedia(this.audio);
+    this.audioSystem.removeAudio(this.audio);
+    this.audioSystem.addAudio(MixerType.MEDIA, this.audio);
 
     const filters = this.audio.getFilters();
     filters.push(this.gainFilter);
@@ -327,7 +328,7 @@ AFRAME.registerComponent("audio-target", {
     const audio = this.el.getObject3D(this.attrName);
     if (!audio) return;
 
-    this.audioSystem.removeAudioFromMedia(this.audio);
+    this.audioSystem.removeAudio(this.audio);
     this.el.removeObject3D(this.attrName);
   },
 

--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -1,4 +1,4 @@
-import { AvatarAudioDefaults, TargetAudioDefaults, DISTANCE_MODEL_OPTIONS } from "../systems/audio-settings-system";
+import { AvatarAudioDefaults, TargetAudioDefaults } from "../systems/audio-settings-system";
 import { SourceType } from "./audio-params";
 
 const INFO_INIT_FAILED = "Failed to initialize avatar-audio-source.";

--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -1,4 +1,5 @@
 import { AvatarAudioDefaults, TargetAudioDefaults, DISTANCE_MODEL_OPTIONS } from "../systems/audio-settings-system";
+import { SourceType } from "./audio-params";
 
 const INFO_INIT_FAILED = "Failed to initialize avatar-audio-source.";
 const INFO_NO_NETWORKED_EL = "Could not find networked el.";
@@ -42,32 +43,7 @@ async function getMediaStream(el) {
   return stream;
 }
 
-function setPositionalAudioProperties(audio, settings) {
-  audio.setDistanceModel(settings.distanceModel);
-  audio.setMaxDistance(settings.maxDistance);
-  audio.setRefDistance(settings.refDistance);
-  audio.setRolloffFactor(settings.rolloffFactor);
-  audio.panner.coneInnerAngle = settings.innerAngle;
-  audio.panner.coneOuterAngle = settings.outerAngle;
-  audio.panner.coneOuterGain = settings.outerGain;
-}
-
 AFRAME.registerComponent("avatar-audio-source", {
-  schema: {
-    positional: { default: true },
-    distanceModel: {
-      default: AvatarAudioDefaults.DISTANCE_MODEL,
-      oneOf: [DISTANCE_MODEL_OPTIONS]
-    },
-    maxDistance: { default: AvatarAudioDefaults.MAX_DISTANCE },
-    refDistance: { default: AvatarAudioDefaults.REF_DISTANCE },
-    rolloffFactor: { default: AvatarAudioDefaults.ROLLOFF_FACTOR },
-
-    innerAngle: { default: AvatarAudioDefaults.INNER_ANGLE },
-    outerAngle: { default: AvatarAudioDefaults.OUTER_ANGLE },
-    outerGain: { default: AvatarAudioDefaults.OUTER_GAIN }
-  },
-
   createAudio: async function() {
     this.isCreatingAudio = true;
     const stream = await getMediaStream(this.el);
@@ -76,10 +52,22 @@ AFRAME.registerComponent("avatar-audio-source", {
     if (!stream || isRemoved) return;
 
     const audioListener = this.el.sceneEl.audioListener;
-    const audio = this.data.positional ? new THREE.PositionalAudio(audioListener) : new THREE.Audio(audioListener);
-    if (this.data.positional) {
-      setPositionalAudioProperties(audio, this.data);
-    }
+    const audio = new THREE.PositionalAudio(audioListener);
+    this.el.setAttribute("audio-params", {
+      sourceType: SourceType.AVATAR_AUDIO_SOURCE,
+      distanceModel: AvatarAudioDefaults.DISTANCE_MODEL,
+      rolloffFactor: AvatarAudioDefaults.ROLLOFF_FACTORROLLOFF_FACTOR,
+      refDistance: AvatarAudioDefaults.REF_DISTANCE,
+      maxDistance: AvatarAudioDefaults.MAX_DISTANCE,
+      coneInnerAngle: AvatarAudioDefaults.INNER_ANGLE,
+      coneOuterAngle: AvatarAudioDefaults.OUTER_ANGLE,
+      coneOuterGain: AvatarAudioDefaults.OUTER_GAIN,
+      gain: AvatarAudioDefaults.VOLUME
+    });
+    this.el.components["audio-params"].setAudio(audio);
+
+    this.audioSystem.removeAudioFromVoice(audio);
+    this.audioSystem.addAudioToVoice(audio);
 
     if (SHOULD_CREATE_SILENT_AUDIO_ELS) {
       createSilentAudioEl(stream); // TODO: Do the audio els need to get cleaned up?
@@ -87,8 +75,10 @@ AFRAME.registerComponent("avatar-audio-source", {
 
     this.destination = audio.context.createMediaStreamDestination();
     this.mediaStreamSource = audio.context.createMediaStreamSource(stream);
+    this.gainFilter = audio.context.createGain();
     const destinationSource = audio.context.createMediaStreamSource(this.destination.stream);
-    this.mediaStreamSource.connect(this.destination);
+    this.mediaStreamSource.connect(this.gainFilter);
+    this.gainFilter.connect(this.destination);
     audio.setNodeSource(destinationSource);
     this.el.setObject3D(this.attrName, audio);
     this.el.emit("sound-source-set", { soundSource: destinationSource });
@@ -98,11 +88,12 @@ AFRAME.registerComponent("avatar-audio-source", {
     const audio = this.el.getObject3D(this.attrName);
     if (!audio) return;
 
-    audio.disconnect();
+    this.audioSystem.removeAudioFromVoice(audio);
     this.el.removeObject3D(this.attrName);
   },
 
   init() {
+    this.audioSystem = this.el.sceneEl.systems["hubs-systems"].audioSystem;
     this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem.registerAvatarAudioSource(this);
     // We subscribe to audio stream notifications for this peer to update the audio source
     // This could happen in case there is an ICE failure that requires a transport recreation.
@@ -132,34 +123,23 @@ AFRAME.registerComponent("avatar-audio-source", {
     });
   },
 
-  update(oldData) {
-    if (this.isCreatingAudio) return;
-
-    const audio = this.el.getObject3D(this.attrName);
-    if (!audio) return;
-
-    const shouldRecreateAudio = oldData.positional !== this.data.positional;
-    if (shouldRecreateAudio) {
-      this.destroyAudio();
-      this.createAudio();
-    } else if (this.data.positional) {
-      setPositionalAudioProperties(audio, this.data);
-    }
-  },
-
   remove: function() {
     this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem.unregisterAvatarAudioSource(this);
     NAF.connection.adapter.off("stream_updated", this._onStreamUpdated);
     this.destroyAudio();
+  },
+
+  getGainFilter() {
+    return this.gainFilter;
   }
 });
 
 function createWhiteNoise(audioContext, gain) {
   const bufferSize = 2 * audioContext.sampleRate,
     noiseBuffer = audioContext.createBuffer(1, bufferSize, audioContext.sampleRate),
-    output = noiseBuffer.getChannelData(0);
+    gainFilter = noiseBuffer.getChannelData(0);
   for (let i = 0; i < bufferSize; i++) {
-    output[i] = (Math.random() * 2 - 1) * gain;
+    gainFilter[i] = (Math.random() * 2 - 1) * gain;
   }
 
   const whiteNoise = audioContext.createBufferSource();
@@ -189,7 +169,7 @@ AFRAME.registerComponent("zone-audio-source", {
   init() {
     const audioListener = this.el.sceneEl.audioListener;
     const ctx = audioListener.context;
-    this.output = ctx.createGain();
+    this.gainFilter = ctx.createGain();
     if (this.data.debug) {
       this.whiteNoise = createWhiteNoise(ctx, 0.01);
       this.setInput(this.whiteNoise);
@@ -211,18 +191,18 @@ AFRAME.registerComponent("zone-audio-source", {
 
   setInput(newInput) {
     if (this.input) {
-      this.input.disconnect(this.output);
+      this.input.disconnect(this.gainFilter);
       this.input = null;
     }
 
     if (newInput) {
-      newInput.connect(this.output);
+      newInput.connect(this.gainFilter);
       this.input = newInput;
     }
   },
 
-  getAudioOutput() {
-    return this.output;
+  getGainFilter() {
+    return this.gainFilter;
   },
 
   tick() {
@@ -270,53 +250,43 @@ AFRAME.registerComponent("zone-audio-source", {
  */
 AFRAME.registerComponent("audio-target", {
   schema: {
-    positional: { default: true },
-
-    distanceModel: {
-      default: TargetAudioDefaults.DISTANCE_MODEL,
-      oneOf: [DISTANCE_MODEL_OPTIONS]
-    },
-    maxDistance: { default: TargetAudioDefaults.MAX_DISTANCE },
-    refDistance: { default: TargetAudioDefaults.REF_DISTANCE },
-    rolloffFactor: { default: TargetAudioDefaults.ROLLOFF_FACTOR },
-
-    innerAngle: { default: TargetAudioDefaults.INNER_ANGLE },
-    outerAngle: { default: TargetAudioDefaults.OUTER_ANGLE },
-    outerGain: { default: TargetAudioDefaults.OUTER_GAIN },
-
     minDelay: { default: 0.01 },
     maxDelay: { default: 0.13 },
-    gain: { default: TargetAudioDefaults.VOLUME },
-
     srcEl: { type: "selector" },
-
     debug: { default: false }
   },
 
   init() {
+    this.audioSystem = this.el.sceneEl.systems["hubs-systems"].audioSystem;
+    this.el.setAttribute("audio-params", {
+      sourceType: SourceType.AUDIO_TARGET,
+      distanceModel: TargetAudioDefaults.DISTANCE_MODEL,
+      rolloffFactor: TargetAudioDefaults.ROLLOFF_FACTOR,
+      refDistance: TargetAudioDefaults.REF_DISTANCE,
+      maxDistance: TargetAudioDefaults.MAX_DISTANCE,
+      coneInnerAngle: TargetAudioDefaults.INNER_ANGLE,
+      coneOuterAngle: TargetAudioDefaults.OUTER_ANGLE,
+      coneOuterGain: TargetAudioDefaults.OUTER_GAIN,
+      gain: TargetAudioDefaults.VOLUME
+    });
     this.createAudio();
     // TODO this is to ensure targets and sources loaded at the same time don't have
     // an order depndancy but this should be done in a more robust way
     setTimeout(() => {
       this.connectAudio();
     }, 0);
-    this.el.setAttribute("audio-params", this.data);
+    this.el.setAttribute("audio-zone-source");
   },
 
   remove: function() {
     this.destroyAudio();
     this.el.removeAttribute("audio-params");
+    this.el.removeAttribute("audio-zone-source");
   },
 
   createAudio: function() {
     const audioListener = this.el.sceneEl.audioListener;
-    const audio = this.data.positional ? new THREE.PositionalAudio(audioListener) : new THREE.Audio(audioListener);
-
-    if (this.data.positional) {
-      setPositionalAudioProperties(audio, this.data);
-    }
-
-    audio.setVolume(this.data.gain);
+    const audio = new THREE.PositionalAudio(audioListener);
 
     if (this.data.maxDelay > 0) {
       const delayNode = audio.context.createDelay(this.data.maxDelay);
@@ -324,16 +294,29 @@ AFRAME.registerComponent("audio-target", {
       audio.setFilters([delayNode]);
     }
 
+    this.gainFilter = THREE.AudioContext.getContext().createGain();
+
     this.el.setObject3D(this.attrName, audio);
     audio.matrixNeedsUpdate = true;
     audio.updateMatrixWorld();
     this.audio = audio;
+
+    this.audioSystem.removeAudioFromMedia(this.audio);
+    this.audioSystem.addAudioToMedia(this.audio);
+
+    const filters = this.audio.getFilters();
+    filters.push(this.gainFilter);
+    this.audio.setFilters(filters);
+
+    this.el.components["audio-params"].setAudio(audio);
+
+    this.audio.updateMatrixWorld();
   },
 
   connectAudio() {
     const srcEl = this.data.srcEl;
     const srcZone = srcEl && srcEl.components["zone-audio-source"];
-    const node = srcZone && srcZone.getAudioOutput();
+    const node = srcZone && srcZone.getGainFilter();
     if (node) {
       this.audio.setNodeSource(node);
     } else {
@@ -345,13 +328,11 @@ AFRAME.registerComponent("audio-target", {
     const audio = this.el.getObject3D(this.attrName);
     if (!audio) return;
 
-    audio.disconnect();
+    this.audioSystem.removeAudioFromMedia(this.audio);
     this.el.removeObject3D(this.attrName);
   },
 
-  update() {
-    if (this.data.positional) {
-      setPositionalAudioProperties(this.audio, this.data);
-    }
+  getGainFilter() {
+    return this.gainFilter;
   }
 });

--- a/src/components/avatar-volume-controls.js
+++ b/src/components/avatar-volume-controls.js
@@ -4,10 +4,6 @@ const SMALL_STEP = 1 / (VOLUME_LABELS.length / 2);
 const BIG_STEP = (MAX_VOLUME - 1) / (VOLUME_LABELS.length / 2);
 
 AFRAME.registerComponent("avatar-volume-controls", {
-  schema: {
-    volume: { type: "number", default: 1.0 }
-  },
-
   init() {
     this.volumeUp = this.volumeUp.bind(this);
     this.volumeDown = this.volumeDown.bind(this);
@@ -20,7 +16,7 @@ AFRAME.registerComponent("avatar-volume-controls", {
     this.update = this.update.bind(this);
     this.normalizer = null;
     window.APP.store.addEventListener("statechanged", this.update);
-
+    this.audioParamsComp = this.el.parentEl.parentEl.querySelector("[audio-params]").components["audio-params"];
     this.updateVolumeLabel();
   },
   remove() {
@@ -28,29 +24,33 @@ AFRAME.registerComponent("avatar-volume-controls", {
   },
 
   changeVolumeBy(v) {
-    const vol = THREE.Math.clamp(this.data.volume + v, 0, MAX_VOLUME);
+    const vol = THREE.Math.clamp(this.audioParamsComp.data.gain + v, 0, MAX_VOLUME);
     this.el.setAttribute("avatar-volume-controls", "volume", vol);
-    this.el.emit("avatar-volume-changed", vol);
+    this.audioParamsComp.el.setAttribute("audio-params", "gain", vol);
     this.updateVolumeLabel();
   },
 
   volumeUp() {
-    const step = this.data.volume > 1 - SMALL_STEP ? BIG_STEP : SMALL_STEP;
+    const step = this.audioParamsComp.data.gain > 1 - SMALL_STEP ? BIG_STEP : SMALL_STEP;
     this.changeVolumeBy(step);
   },
 
   volumeDown() {
-    const step = this.data.volume > 1 + SMALL_STEP ? BIG_STEP : SMALL_STEP;
+    const step = this.audioParamsComp.data.gain > 1 + SMALL_STEP ? BIG_STEP : SMALL_STEP;
     this.changeVolumeBy(-1 * step);
   },
 
   updateVolumeLabel() {
     const numBars = Math.min(
       VOLUME_LABELS.length - 1,
-      this.data.volume <= 1.001
-        ? Math.floor(this.data.volume / SMALL_STEP)
-        : Math.floor(VOLUME_LABELS.length / 2 + (this.data.volume - 1) / BIG_STEP)
+      this.audioParamsComp.data.gain <= 1.001
+        ? Math.floor(this.audioParamsComp.data.gain / SMALL_STEP)
+        : Math.floor(VOLUME_LABELS.length / 2 + (this.audioParamsComp.data.gain - 1) / BIG_STEP)
     );
-    this.volumeLabel.setAttribute("text", "value", this.data.volume === 0 ? "Muted" : VOLUME_LABELS[numBars]);
+    this.volumeLabel.setAttribute(
+      "text",
+      "value",
+      this.audioParamsComp.data.gain === 0 ? "Muted" : VOLUME_LABELS[numBars]
+    );
   }
 });

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -172,6 +172,7 @@ AFRAME.registerComponent("media-loader", {
     this.el.removeAttribute("media-pager");
     this.el.removeAttribute("media-video");
     this.el.removeAttribute("audio-params");
+    this.el.removeAttribute("audio-zone-source");
     this.el.removeAttribute("media-pdf");
     this.el.setAttribute("media-image", { src: "error" });
     this.clearLoadingTimeout();
@@ -350,6 +351,7 @@ AFRAME.registerComponent("media-loader", {
       this.el.removeAttribute("media-pager");
       this.el.removeAttribute("media-video");
       this.el.removeAttribute("audio-params");
+      this.el.removeAttribute("audio-zone-source");
       this.el.removeAttribute("media-pdf");
       this.el.removeAttribute("media-image");
     }
@@ -463,6 +465,7 @@ AFRAME.registerComponent("media-loader", {
           })
         );
         this.el.setAttribute("audio-params", {});
+        this.el.setAttribute("audio-zone-source", {});
         if (this.el.components["position-at-border__freeze"]) {
           this.el.setAttribute("position-at-border__freeze", { isFlat: true });
         }
@@ -473,6 +476,7 @@ AFRAME.registerComponent("media-loader", {
         this.el.removeAttribute("gltf-model-plus");
         this.el.removeAttribute("media-video");
         this.el.removeAttribute("audio-params");
+        this.el.removeAttribute("audio-zone-source");
         this.el.removeAttribute("media-pdf");
         this.el.removeAttribute("media-pager");
         this.el.addEventListener(
@@ -516,6 +520,7 @@ AFRAME.registerComponent("media-loader", {
         this.el.removeAttribute("gltf-model-plus");
         this.el.removeAttribute("media-video");
         this.el.removeAttribute("audio-params");
+        this.el.removeAttribute("audio-zone-source");
         this.el.removeAttribute("media-image");
         this.el.setAttribute(
           "media-pdf",
@@ -550,6 +555,7 @@ AFRAME.registerComponent("media-loader", {
         this.el.removeAttribute("media-image");
         this.el.removeAttribute("media-video");
         this.el.removeAttribute("audio-params");
+        this.el.removeAttribute("audio-zone-source");
         this.el.removeAttribute("media-pdf");
         this.el.removeAttribute("media-pager");
         this.el.addEventListener(
@@ -584,6 +590,7 @@ AFRAME.registerComponent("media-loader", {
         this.el.removeAttribute("gltf-model-plus");
         this.el.removeAttribute("media-video");
         this.el.removeAttribute("audio-params");
+        this.el.removeAttribute("audio-zone-source");
         this.el.removeAttribute("media-pdf");
         this.el.removeAttribute("media-pager");
         this.el.addEventListener(

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -173,6 +173,7 @@ AFRAME.registerComponent("media-loader", {
     this.el.removeAttribute("media-video");
     this.el.removeAttribute("audio-params");
     this.el.removeAttribute("audio-zone-source");
+    this.el.removeAttribute("audio-zone-entity");
     this.el.removeAttribute("media-pdf");
     this.el.setAttribute("media-image", { src: "error" });
     this.clearLoadingTimeout();
@@ -352,6 +353,7 @@ AFRAME.registerComponent("media-loader", {
       this.el.removeAttribute("media-video");
       this.el.removeAttribute("audio-params");
       this.el.removeAttribute("audio-zone-source");
+      this.el.removeAttribute("audio-zone-entity");
       this.el.removeAttribute("media-pdf");
       this.el.removeAttribute("media-image");
     }
@@ -477,6 +479,7 @@ AFRAME.registerComponent("media-loader", {
         this.el.removeAttribute("media-video");
         this.el.removeAttribute("audio-params");
         this.el.removeAttribute("audio-zone-source");
+        this.el.removeAttribute("audio-zone-entity");
         this.el.removeAttribute("media-pdf");
         this.el.removeAttribute("media-pager");
         this.el.addEventListener(
@@ -521,6 +524,7 @@ AFRAME.registerComponent("media-loader", {
         this.el.removeAttribute("media-video");
         this.el.removeAttribute("audio-params");
         this.el.removeAttribute("audio-zone-source");
+        this.el.removeAttribute("audio-zone-entity");
         this.el.removeAttribute("media-image");
         this.el.setAttribute(
           "media-pdf",
@@ -556,6 +560,7 @@ AFRAME.registerComponent("media-loader", {
         this.el.removeAttribute("media-video");
         this.el.removeAttribute("audio-params");
         this.el.removeAttribute("audio-zone-source");
+        this.el.removeAttribute("audio-zone-entity");
         this.el.removeAttribute("media-pdf");
         this.el.removeAttribute("media-pager");
         this.el.addEventListener(
@@ -591,6 +596,7 @@ AFRAME.registerComponent("media-loader", {
         this.el.removeAttribute("media-video");
         this.el.removeAttribute("audio-params");
         this.el.removeAttribute("audio-zone-source");
+        this.el.removeAttribute("audio-zone-entity");
         this.el.removeAttribute("media-pdf");
         this.el.removeAttribute("media-pager");
         this.el.addEventListener(

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -17,7 +17,6 @@ import { applyPersistentSync } from "../utils/permissions-utils";
 import { refreshMediaMirror, getCurrentMirroredMedia } from "../utils/mirror-utils";
 import { detect } from "detect-browser";
 import semver from "semver";
-import { MediaAudioDefaults } from "../systems/audio-settings-system";
 
 import qsTruthy from "../utils/qs_truthy";
 
@@ -256,17 +255,9 @@ AFRAME.registerComponent("media-video", {
     src: { type: "string" },
     audioSrc: { type: "string" },
     contentType: { type: "string" },
-    volume: { type: "number", default: MediaAudioDefaults.VOLUME },
     loop: { type: "boolean", default: true },
     audioType: { type: "string", default: "pannernode" },
     hidePlaybackControls: { type: "boolean", default: false },
-    distanceModel: { type: "string", default: MediaAudioDefaults.DISTANCE_MODEL },
-    rolloffFactor: { type: "number", default: MediaAudioDefaults.ROLLOFF_FACTOR },
-    refDistance: { type: "number", default: MediaAudioDefaults.REF_DISTANCE },
-    maxDistance: { type: "number", default: MediaAudioDefaults.MAX_DISTANCE },
-    coneInnerAngle: { type: "number", default: MediaAudioDefaults.INNER_ANGLE },
-    coneOuterAngle: { type: "number", default: MediaAudioDefaults.OUTER_ANGLE },
-    coneOuterGain: { type: "number", default: MediaAudioDefaults.OUTER_GAIN },
     videoPaused: { type: "boolean" },
     projection: { type: "string", default: "flat" },
     time: { type: "number" },
@@ -289,6 +280,9 @@ AFRAME.registerComponent("media-video", {
     this.snap = this.snap.bind(this);
     this.changeVolumeBy = this.changeVolumeBy.bind(this);
     this.togglePlaying = this.togglePlaying.bind(this);
+
+    this.audioSystem = this.el.sceneEl.systems["hubs-systems"].audioSystem;
+    this.gainFilter = THREE.AudioContext.getContext().createGain();
 
     this.lastUpdate = 0;
     this.videoMutedAt = 0;
@@ -403,9 +397,9 @@ AFRAME.registerComponent("media-video", {
   },
 
   changeVolumeBy(v) {
-    const vol = THREE.Math.clamp(this.data.volume + v, 0, 1);
-    this.el.setAttribute("media-video", "volume", vol);
-    this.el.emit("media-volume-changed", vol);
+    const gain = this.el.components["audio-params"].data.gain;
+    const vol = THREE.Math.clamp(gain + v, 0, 1);
+    this.el.setAttribute("audio-params", "gain", vol);
     this.updateVolumeLabel();
   },
 
@@ -466,7 +460,7 @@ AFRAME.registerComponent("media-video", {
     if (this._ignorePauseStateChanges) return;
 
     this.el.setAttribute("media-video", "videoPaused", this.video.paused);
-    this.el.setAttribute("audio-params", { enabled: !this.video.paused });
+    this.el.setAttribute("audio-params", "enabled", !this.video.paused);
 
     if (this.networkedEl && NAF.utils.isMine(this.networkedEl)) {
       this.el.emit("owned-video-state-changed");
@@ -527,14 +521,6 @@ AFRAME.registerComponent("media-video", {
       this.setupAudio();
       return;
     }
-
-    const disablePositionalAudio = window.APP.store.state.preferences.audioOutputMode === "audio";
-    const shouldSetPositionalAudioProperties =
-      this.audio && this.data.audioType === "pannernode" && !disablePositionalAudio;
-    if (shouldSetPositionalAudioProperties) {
-      this.setPositionalAudioProperties();
-      return;
-    }
   },
 
   setupAudio() {
@@ -543,16 +529,18 @@ AFRAME.registerComponent("media-video", {
       this.el.removeObject3D("sound");
     }
 
-    const disablePositionalAudio = window.APP.store.state.preferences.audioOutputMode === "audio";
-    if (!disablePositionalAudio && this.data.audioType === "pannernode") {
-      this.audio = new THREE.PositionalAudio(this.el.sceneEl.audioListener);
-      this.setPositionalAudioProperties();
-    } else {
-      this.audio = new THREE.Audio(this.el.sceneEl.audioListener);
-    }
+    this.audio = new THREE.PositionalAudio(this.el.sceneEl.audioListener);
+
+    this.audioSystem.removeAudioFromMedia(this.audio);
+    this.audioSystem.addAudioToMedia(this.audio);
+
+    const filters = this.audio.getFilters();
+    filters.push(this.gainFilter);
+    this.audio.setFilters(filters);
 
     this.audio.setNodeSource(this.mediaElementAudioSource);
     this.el.setObject3D("sound", this.audio);
+    this.el.components["audio-params"].setAudio(this.audio);
 
     // Make sure that the audio is initialized to the right place.
     // Its matrix may not update if this element is not visible.
@@ -560,14 +548,8 @@ AFRAME.registerComponent("media-video", {
     this.audio.updateMatrixWorld();
   },
 
-  setPositionalAudioProperties() {
-    this.audio.setDistanceModel(this.data.distanceModel);
-    this.audio.setRolloffFactor(this.data.rolloffFactor);
-    this.audio.setRefDistance(this.data.refDistance);
-    this.audio.setMaxDistance(this.data.maxDistance);
-    this.audio.panner.coneInnerAngle = this.data.coneInnerAngle;
-    this.audio.panner.coneOuterAngle = this.data.coneOuterAngle;
-    this.audio.panner.coneOuterGain = this.data.coneOuterGain;
+  getGainFilter() {
+    return this.gainFilter;
   },
 
   async updateSrc(oldData) {
@@ -918,11 +900,8 @@ AFRAME.registerComponent("media-video", {
   },
 
   updateVolumeLabel() {
-    this.volumeLabel.setAttribute(
-      "text",
-      "value",
-      this.data.volume === 0 ? "MUTE" : VOLUME_LABELS[Math.floor(this.data.volume / 0.05)]
-    );
+    const volume = this.el.components["audio-params"].data.gain;
+    this.volumeLabel.setAttribute("text", "value", volume === 0 ? "MUTE" : VOLUME_LABELS[Math.floor(volume / 0.05)]);
   },
 
   tick: (() => {
@@ -992,7 +971,7 @@ AFRAME.registerComponent("media-video", {
 
     if (this.audio) {
       this.el.removeObject3D("sound");
-      this.audio.disconnect();
+      this.audioSystem.removeAudioFromMedia(this.audio);
       delete this.audio;
     }
 

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -17,6 +17,7 @@ import { applyPersistentSync } from "../utils/permissions-utils";
 import { refreshMediaMirror, getCurrentMirroredMedia } from "../utils/mirror-utils";
 import { detect } from "detect-browser";
 import semver from "semver";
+import { MixerType } from "../systems/audio-system";
 
 import qsTruthy from "../utils/qs_truthy";
 
@@ -531,8 +532,8 @@ AFRAME.registerComponent("media-video", {
 
     this.audio = new THREE.PositionalAudio(this.el.sceneEl.audioListener);
 
-    this.audioSystem.removeAudioFromMedia(this.audio);
-    this.audioSystem.addAudioToMedia(this.audio);
+    this.audioSystem.removeAudio(this.audio);
+    this.audioSystem.addAudio(MixerType.MEDIA, this.audio);
 
     const filters = this.audio.getFilters();
     filters.push(this.gainFilter);
@@ -971,7 +972,7 @@ AFRAME.registerComponent("media-video", {
 
     if (this.audio) {
       this.el.removeObject3D("sound");
-      this.audioSystem.removeAudioFromMedia(this.audio);
+      this.audioSystem.removeAudio(this.audio);
       delete this.audio;
     }
 

--- a/src/components/open-media-button.js
+++ b/src/components/open-media-button.js
@@ -28,7 +28,7 @@ AFRAME.registerComponent("open-media-button", {
             label = "use scene";
           } else if ((hubId = await isHubsRoomUrl(src))) {
             const url = new URL(src);
-            if (url.hash && APP.hub.hub_id === hubId) {
+            if (url.hash && window.APP.hub.hub_id === hubId) {
               label = "go to";
             } else {
               label = "visit room";
@@ -56,7 +56,7 @@ AFRAME.registerComponent("open-media-button", {
         this.el.sceneEl.emit("scene_media_selected", this.src);
       } else if ((hubId = await isHubsRoomUrl(this.src))) {
         const url = new URL(this.src);
-        if (url.hash && APP.hub.hub_id === hubId) {
+        if (url.hash && window.APP.hub.hub_id === hubId) {
           // move to waypoint w/o writing to history
           window.history.replaceState(null, null, window.location.href.split("#")[0] + url.hash);
         } else {

--- a/src/components/player-info.js
+++ b/src/components/player-info.js
@@ -187,7 +187,6 @@ AFRAME.registerComponent("player-info", {
         el.setAttribute("emit-scene-event-on-remove", "event:action_end_video_sharing");
       }
     }
-
     this.el.querySelector("[audio-params]")?.setAttribute("audio-params", { enabled: !this.data.muted });
   },
   handleModelError() {

--- a/src/components/scene-components.js
+++ b/src/components/scene-components.js
@@ -28,3 +28,7 @@ import "./environment-map";
 import "./trigger-volume";
 import "./video-pause-state";
 import "./particle-emitter";
+import "./audio-zone";
+import "./audio-zone-entity";
+import "./audio-zone-source";
+import "./audio-zone-listener";

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -3,6 +3,7 @@ import "./components/gltf-model-plus";
 import { getSanitizedComponentMapping } from "./utils/component-mappings";
 import { TYPE, SHAPE, FIT } from "three-ammo/constants";
 const COLLISION_LAYERS = require("./constants").COLLISION_LAYERS;
+import { SourceType } from "./components/audio-params";
 
 function registerRootSceneComponent(componentName) {
   AFRAME.GLTFModelPlus.registerComponent(componentName, componentName, (el, componentName, componentData) => {
@@ -240,19 +241,22 @@ async function mediaInflator(el, componentName, componentData, components) {
 
   if (componentName === "video" || componentName === "audio") {
     mediaOptions.videoPaused = !componentData.autoPlay;
-    mediaOptions.volume = componentData.volume;
     mediaOptions.loop = componentData.loop;
     mediaOptions.audioType = componentData.audioType;
     mediaOptions.hidePlaybackControls = !isControlled;
 
-    if (componentData.audioType === "pannernode") {
-      mediaOptions.distanceModel = componentData.distanceModel;
-      mediaOptions.rolloffFactor = componentData.rolloffFactor;
-      mediaOptions.refDistance = componentData.refDistance;
-      mediaOptions.maxDistance = componentData.maxDistance;
-      mediaOptions.coneInnerAngle = componentData.coneInnerAngle;
-      mediaOptions.coneOuterAngle = componentData.coneOuterAngle;
-      mediaOptions.coneOuterGain = componentData.coneOuterGain;
+    if (componentData.audioType && componentData.audioType === "pannernode") {
+      el.setAttribute("audio-params", {
+        sourceType: SourceType.MEDIA_VIDEO,
+        distanceModel: componentData.distanceModel,
+        rolloffFactor: componentData.rolloffFactor,
+        refDistance: componentData.refDistance,
+        maxDistance: componentData.maxDistance,
+        coneInnerAngle: componentData.coneInnerAngle,
+        coneOuterAngle: componentData.coneOuterAngle,
+        coneOuterGain: componentData.coneOuterGain,
+        gain: componentData.volume
+      });
     }
 
     el.setAttribute("video-pause-state", { paused: mediaOptions.videoPaused });
@@ -471,3 +475,22 @@ AFRAME.GLTFModelPlus.registerComponent(
   }
 );
 AFRAME.GLTFModelPlus.registerComponent("zone-audio-source", "zone-audio-source");
+
+AFRAME.GLTFModelPlus.registerComponent(
+  "audio-params",
+  "audio-params",
+  (el, componentName, componentData, components) => {
+    if (components["audio"] || components["video"]) {
+      componentData["sourceType"] = SourceType.MEDIA_VIDEO;
+    } else if (components["audio-target"]) {
+      componentData["sourceType"] = SourceType.AUDIO_TARGET;
+    } else if (components["audio-zone"]) {
+      componentData["sourceType"] = SourceType.AUDIO_ZONE;
+    }
+    el.setAttribute(componentName, { ...componentData });
+  }
+);
+
+AFRAME.GLTFModelPlus.registerComponent("audio-zone", "audio-zone", (el, componentName, componentData) => {
+  el.setAttribute(componentName, { ...componentData });
+});

--- a/src/hub.html
+++ b/src/hub.html
@@ -220,8 +220,9 @@
 
                         <template data-name="Head">
                             <a-entity
-                                avatar-audio-source="rolloffFactor: 2.0;"
-                                audio-params
+                                avatar-audio-source
+                                audio-params="rolloffFactor: 2.0;"
+                                audio-zone-source
                                 personal-space-invader="radius: 0.15; useMaterial: true;"
                                 bone-visibility
                                 body-helper="type: kinematic; collisionFilterGroup: 4; collisionFilterMask: 1;"
@@ -1198,6 +1199,7 @@
                 class="camera"
                 personal-space-bubble="radius: 0.4;"
                 audio-params="isLocal: true"
+                audio-zone-listener
                 rotation
                 pitch-yaw-rotator
                 set-yxz-order

--- a/src/hub.html
+++ b/src/hub.html
@@ -221,7 +221,7 @@
                         <template data-name="Head">
                             <a-entity
                                 avatar-audio-source
-                                audio-params="rolloffFactor: 2.0;"
+                                audio-params
                                 audio-zone-source
                                 personal-space-invader="radius: 0.15; useMaterial: true;"
                                 bone-visibility

--- a/src/react-components/auth/AuthContext.js
+++ b/src/react-components/auth/AuthContext.js
@@ -49,7 +49,7 @@ async function checkIsAdmin(socket, store) {
 const noop = () => {};
 
 export function StorybookAuthContextProvider({ children }) {
-  const [context, setContext] = useState({
+  const [context] = useState({
     initialized: true,
     isSignedIn: true,
     isAdmin: true,
@@ -62,6 +62,11 @@ export function StorybookAuthContextProvider({ children }) {
   });
   return <AuthContext.Provider value={context}>{children}</AuthContext.Provider>;
 }
+
+StorybookAuthContextProvider.propTypes = {
+  children: PropTypes.node,
+  store: PropTypes.object.isRequired
+};
 
 export function AuthContextProvider({ children, store }) {
   const signIn = useCallback(

--- a/src/react-components/debug-panel/AudioDebugPanel.js
+++ b/src/react-components/debug-panel/AudioDebugPanel.js
@@ -16,7 +16,7 @@ import {
   GLOBAL_VOLUME_DEFAULT
 } from "../../react-components/preferences-screen";
 import { SelectInputField } from "../input/SelectInputField";
-import { DISTANCE_MODEL_OPTIONS } from "../../systems/audio-settings-system";
+import { DISTANCE_MODEL_OPTIONS, DistanceModelType } from "../../components/audio-params";
 
 const ROLLOFF_MIN = 0.0;
 const ROLLOFF_MAX = 20.0;
@@ -311,7 +311,7 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
                     distanceModel: value
                   });
                 });
-                if (value === "linear" && avatarRolloffFactor > 1.0) {
+                if (value === DistanceModelType.Linear && avatarRolloffFactor > 1.0) {
                   setAvatarRolloffFactor(1.0);
                 }
                 updateAudioSettings({
@@ -325,9 +325,9 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
             </SelectProperty>
             <SliderProperty
               defaultValue={avatarRolloffFactor}
-              step={avatarDistanceModel === "linear" ? ROLLOFF_LIN_STEP : ROLLOFF_STEP}
-              min={avatarDistanceModel === "linear" ? ROLLOFF_LIN_MIN : ROLLOFF_MIN}
-              max={avatarDistanceModel === "linear" ? ROLLOFF_LIN_MAX : ROLLOFF_MAX}
+              step={avatarDistanceModel === DistanceModelType.Linear ? ROLLOFF_LIN_STEP : ROLLOFF_STEP}
+              min={avatarDistanceModel === DistanceModelType.Linear ? ROLLOFF_LIN_MIN : ROLLOFF_MIN}
+              max={avatarDistanceModel === DistanceModelType.Linear ? ROLLOFF_LIN_MAX : ROLLOFF_MAX}
               onChange={value => {
                 setAvatarRolloffFactor(value);
                 const avatarAudioSources = scene.current.querySelectorAll("[avatar-audio-source]");
@@ -472,7 +472,7 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
                     distanceModel: value
                   });
                 });
-                if (value === "linear" && mediaRolloffFactor > 1.0) {
+                if (value === DistanceModelType.Linear && mediaRolloffFactor > 1.0) {
                   setMediaRolloffFactor(1.0);
                 }
                 updateAudioSettings({
@@ -486,9 +486,9 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
             </SelectProperty>
             <SliderProperty
               defaultValue={mediaRolloffFactor}
-              step={mediaDistanceModel === "linear" ? ROLLOFF_LIN_STEP : ROLLOFF_STEP}
-              min={mediaDistanceModel === "linear" ? ROLLOFF_LIN_MIN : ROLLOFF_MIN}
-              max={mediaDistanceModel === "linear" ? ROLLOFF_LIN_MAX : ROLLOFF_MAX}
+              step={mediaDistanceModel === DistanceModelType.Linear ? ROLLOFF_LIN_STEP : ROLLOFF_STEP}
+              min={mediaDistanceModel === DistanceModelType.Linear ? ROLLOFF_LIN_MIN : ROLLOFF_MIN}
+              max={mediaDistanceModel === DistanceModelType.Linear ? ROLLOFF_LIN_MAX : ROLLOFF_MAX}
               onChange={value => {
                 setMediaRolloffFactor(value);
                 const elements = scene.current.querySelectorAll("[media-video], [audio-target]");

--- a/src/react-components/debug-panel/AudioDebugPanel.js
+++ b/src/react-components/debug-panel/AudioDebugPanel.js
@@ -89,7 +89,7 @@ SliderProperty.propTypes = {
   children: PropTypes.node
 };
 
-export function AudioDebugPanel({ isNarrow, isCollapsed, onCollapsed }) {
+export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
   const scene = useRef(document.querySelector("a-scene"));
   const audioSettings = useRef(scene.current.systems["hubs-systems"].audioSettingsSystem);
   const store = useRef(window.APP.store);
@@ -211,15 +211,15 @@ export function AudioDebugPanel({ isNarrow, isCollapsed, onCollapsed }) {
     <div
       className={classNames(styles.audioDebugContainer)}
       style={{
-        height: isNarrow && !isCollapsed && "80%",
-        maxHeight: isNarrow && !isCollapsed && "80%"
+        height: isNarrow && !collapsed && "80%",
+        maxHeight: isNarrow && !collapsed && "80%"
       }}
     >
       <CollapsiblePanel
         title={<FormattedMessage id="audio-debug-panel.audio-debug-title" defaultMessage="Audio Debug" />}
         isRoot
         border
-        collapsed={isCollapsed}
+        collapsed={collapsed}
         onCollapse={onCollapsed}
       >
         <CollapsiblePanel
@@ -307,7 +307,7 @@ export function AudioDebugPanel({ isNarrow, isCollapsed, onCollapsed }) {
                 setAvatarDistanceModel(value);
                 const avatarAudioSources = scene.current.querySelectorAll("[avatar-audio-source]");
                 avatarAudioSources.forEach(source => {
-                  source.setAttribute("avatar-audio-source", {
+                  source.setAttribute("audio-params", {
                     distanceModel: value
                   });
                 });
@@ -332,7 +332,7 @@ export function AudioDebugPanel({ isNarrow, isCollapsed, onCollapsed }) {
                 setAvatarRolloffFactor(value);
                 const avatarAudioSources = scene.current.querySelectorAll("[avatar-audio-source]");
                 avatarAudioSources.forEach(source => {
-                  source.setAttribute("avatar-audio-source", {
+                  source.setAttribute("audio-params", {
                     rolloffFactor: value
                   });
                 });
@@ -354,7 +354,7 @@ export function AudioDebugPanel({ isNarrow, isCollapsed, onCollapsed }) {
                 setAvatarRefDistance(value);
                 const avatarAudioSources = scene.current.querySelectorAll("[avatar-audio-source]");
                 avatarAudioSources.forEach(source => {
-                  source.setAttribute("avatar-audio-source", {
+                  source.setAttribute("audio-params", {
                     refDistance: value
                   });
                 });
@@ -376,7 +376,7 @@ export function AudioDebugPanel({ isNarrow, isCollapsed, onCollapsed }) {
                 setAvatarMaxDistance(value);
                 const avatarAudioSources = scene.current.querySelectorAll("[avatar-audio-source]");
                 avatarAudioSources.forEach(source => {
-                  source.setAttribute("avatar-audio-source", {
+                  source.setAttribute("audio-params", {
                     maxDistance: value
                   });
                 });
@@ -398,8 +398,8 @@ export function AudioDebugPanel({ isNarrow, isCollapsed, onCollapsed }) {
                 setAvatarConeInnerAngle(value);
                 const avatarAudioSources = scene.current.querySelectorAll("[avatar-audio-source]");
                 avatarAudioSources.forEach(source => {
-                  source.setAttribute("avatar-audio-source", {
-                    innerAngle: value
+                  source.setAttribute("audio-params", {
+                    coneInnerAngle: value
                   });
                 });
                 updateAudioSettings({
@@ -420,8 +420,8 @@ export function AudioDebugPanel({ isNarrow, isCollapsed, onCollapsed }) {
                 setAvatarConeOuterAngle(value);
                 const avatarAudioSources = scene.current.querySelectorAll("[avatar-audio-source]");
                 avatarAudioSources.forEach(source => {
-                  source.setAttribute("avatar-audio-source", {
-                    outerAngle: value
+                  source.setAttribute("audio-params", {
+                    coneOuterAngle: value
                   });
                 });
                 updateAudioSettings({
@@ -442,8 +442,8 @@ export function AudioDebugPanel({ isNarrow, isCollapsed, onCollapsed }) {
                 setAvatarConeOuterGain(value);
                 const avatarAudioSources = scene.current.querySelectorAll("[avatar-audio-source]");
                 avatarAudioSources.forEach(source => {
-                  source.setAttribute("avatar-audio-source", {
-                    outerGain: value
+                  source.setAttribute("audio-params", {
+                    coneOuterGain: value
                   });
                 });
                 updateAudioSettings({
@@ -466,15 +466,9 @@ export function AudioDebugPanel({ isNarrow, isCollapsed, onCollapsed }) {
               options={DISTANCE_MODEL_OPTIONS}
               onChange={value => {
                 setMediaDistanceModel(value);
-                const mediaAudioSources = scene.current.querySelectorAll("[media-video]");
-                mediaAudioSources.forEach(source => {
-                  source.setAttribute("media-video", {
-                    distanceModel: value
-                  });
-                });
-                const targetAudioSources = scene.current.querySelectorAll("[audio-target]");
-                targetAudioSources.forEach(source => {
-                  source.setAttribute("audio-target", {
+                const elements = scene.current.querySelectorAll("[media-video], [audio-target]");
+                elements.forEach(source => {
+                  source.setAttribute("audio-params", {
                     distanceModel: value
                   });
                 });
@@ -497,15 +491,9 @@ export function AudioDebugPanel({ isNarrow, isCollapsed, onCollapsed }) {
               max={mediaDistanceModel === "linear" ? ROLLOFF_LIN_MAX : ROLLOFF_MAX}
               onChange={value => {
                 setMediaRolloffFactor(value);
-                const mediaAudioSources = scene.current.querySelectorAll("[media-video]");
-                mediaAudioSources.forEach(source => {
-                  source.setAttribute("media-video", {
-                    rolloffFactor: value
-                  });
-                });
-                const targetAudioSources = scene.current.querySelectorAll("[audio-target]");
-                targetAudioSources.forEach(source => {
-                  source.setAttribute("audio-target", {
+                const elements = scene.current.querySelectorAll("[media-video], [audio-target]");
+                elements.forEach(source => {
+                  source.setAttribute("audio-params", {
                     rolloffFactor: value
                   });
                 });
@@ -525,15 +513,9 @@ export function AudioDebugPanel({ isNarrow, isCollapsed, onCollapsed }) {
               max={DISTANCE_MAX}
               onChange={value => {
                 setMediaRefDistance(value);
-                const mediaAudioSources = scene.current.querySelectorAll("[media-video]");
-                mediaAudioSources.forEach(source => {
-                  source.setAttribute("media-video", {
-                    refDistance: value
-                  });
-                });
-                const targetAudioSources = scene.current.querySelectorAll("[audio-target]");
-                targetAudioSources.forEach(source => {
-                  source.setAttribute("audio-target", {
+                const elements = scene.current.querySelectorAll("[media-video], [audio-target]");
+                elements.forEach(source => {
+                  source.setAttribute("audio-params", {
                     refDistance: value
                   });
                 });
@@ -553,15 +535,9 @@ export function AudioDebugPanel({ isNarrow, isCollapsed, onCollapsed }) {
               max={DISTANCE_MAX}
               onChange={value => {
                 setMediaMaxDistance(value);
-                const mediaAudioSources = scene.current.querySelectorAll("[media-video]");
-                mediaAudioSources.forEach(source => {
-                  source.setAttribute("media-video", {
-                    maxDistance: value
-                  });
-                });
-                const targetAudioSources = scene.current.querySelectorAll("[audio-target]");
-                targetAudioSources.forEach(source => {
-                  source.setAttribute("audio-target", {
+                const elements = scene.current.querySelectorAll("[media-video], [audio-target]");
+                elements.forEach(source => {
+                  source.setAttribute("audio-params", {
                     maxDistance: value
                   });
                 });
@@ -581,16 +557,10 @@ export function AudioDebugPanel({ isNarrow, isCollapsed, onCollapsed }) {
               max={ANGLE_MAX}
               onChange={value => {
                 setMediaConeInnerAngle(value);
-                const mediaAudioSources = scene.current.querySelectorAll("[media-video]");
-                mediaAudioSources.forEach(source => {
-                  source.setAttribute("media-video", {
+                const elements = scene.current.querySelectorAll("[media-video], [audio-target]");
+                elements.forEach(source => {
+                  source.setAttribute("audio-params", {
                     coneInnerAngle: value
-                  });
-                });
-                const targetAudioSources = scene.current.querySelectorAll("[audio-target]");
-                targetAudioSources.forEach(source => {
-                  source.setAttribute("audio-target", {
-                    innerAngle: value
                   });
                 });
                 updateAudioSettings({
@@ -609,16 +579,10 @@ export function AudioDebugPanel({ isNarrow, isCollapsed, onCollapsed }) {
               max={ANGLE_MAX}
               onChange={value => {
                 setMediaConeOuterAngle(value);
-                const mediaAudioSources = scene.current.querySelectorAll("[media-video]");
-                mediaAudioSources.forEach(source => {
-                  source.setAttribute("media-video", {
+                const elements = scene.current.querySelectorAll("[media-video], [audio-target]");
+                elements.forEach(source => {
+                  source.setAttribute("audio-params", {
                     coneOuterAngle: value
-                  });
-                });
-                const targetAudioSources = scene.current.querySelectorAll("[audio-target]");
-                targetAudioSources.forEach(source => {
-                  source.setAttribute("audio-target", {
-                    outerAngle: value
                   });
                 });
                 updateAudioSettings({
@@ -637,16 +601,10 @@ export function AudioDebugPanel({ isNarrow, isCollapsed, onCollapsed }) {
               max={GAIN_MAX}
               onChange={value => {
                 setMediaConeOuterGain(value);
-                const mediaAudioSources = scene.current.querySelectorAll("[media-video]");
-                mediaAudioSources.forEach(source => {
-                  source.setAttribute("media-video", {
+                const elements = scene.current.querySelectorAll("[media-video], [audio-target]");
+                elements.forEach(source => {
+                  source.setAttribute("audio-params", {
                     coneOuterGain: value
-                  });
-                });
-                const targetAudioSources = scene.current.querySelectorAll("[audio-target]");
-                targetAudioSources.forEach(source => {
-                  source.setAttribute("audio-target", {
-                    outerGain: value
                   });
                 });
                 updateAudioSettings({
@@ -667,7 +625,7 @@ export function AudioDebugPanel({ isNarrow, isCollapsed, onCollapsed }) {
 
 AudioDebugPanel.propTypes = {
   isNarrow: PropTypes.bool,
-  isCollapsed: PropTypes.bool,
+  collapsed: PropTypes.bool,
   onCollapsed: PropTypes.func,
   children: PropTypes.node
 };

--- a/src/react-components/debug-panel/RtcDebugPanel.js
+++ b/src/react-components/debug-panel/RtcDebugPanel.js
@@ -231,7 +231,7 @@ export default class RtcDebugPanel extends Component {
 
     this.state = {
       log: [],
-      collapsed: { Local: false, Log: isMobile, Remote: true, Audio: false }
+      collapsed: { Local: false, Log: isMobile, Remote: true, Audio: true }
     };
   }
 

--- a/src/react-components/room/RoomSidebar.js
+++ b/src/react-components/room/RoomSidebar.js
@@ -18,9 +18,7 @@ function SceneAttribution({ attribution }) {
   const author = attribution.author || unknown;
 
   if (attribution.url) {
-    const source = attribution.url.includes("sketchfab.com")
-      ? "Sketchfab"
-      : null;
+    const source = attribution.url.includes("sketchfab.com") ? "Sketchfab" : null;
 
     return (
       <li className={styles.attribution}>
@@ -82,7 +80,7 @@ export function SceneInfo({ accountId, scene, showAttributions, canChangeScene, 
     <Button preset="primary" onClick={onChangeScene}>
       <FormattedMessage id="room-sidebar.scene-info.change-scene-button" defaultMessage="Change Scene" />
     </Button>
-  )
+  );
   if (!scene) return changeSceneButton;
   const showSceneLink = allowDisplayOfSceneLink(accountId, scene);
   const attributions = (scene.attributions && scene.attributions.content) || [];

--- a/src/react-components/room/useObjectList.js
+++ b/src/react-components/room/useObjectList.js
@@ -26,11 +26,7 @@ function getDisplayString(el) {
   }
 
   const firstPart =
-      url.indexOf("sketchfab.com") !== -1
-        ? "Sketchfab"
-        : url.indexOf("youtube.com") !== -1
-          ? "YouTube"
-          : lessHost;
+    url.indexOf("sketchfab.com") !== -1 ? "Sketchfab" : url.indexOf("youtube.com") !== -1 ? "YouTube" : lessHost;
 
   return `${firstPart} ... ${resourceName.substr(0, 4)}`;
 }

--- a/src/react-components/scene-ui.js
+++ b/src/react-components/scene-ui.js
@@ -111,7 +111,9 @@ class SceneUI extends Component {
               author: _author,
               a: chunks =>
                 url ? (
-                  <a href={url} target="_blank" rel="noopener noreferrer"> {chunks}
+                  <a href={url} target="_blank" rel="noopener noreferrer">
+                    {" "}
+                    {chunks}
                   </a>
                 ) : (
                   <>{chunks}</>

--- a/src/react-components/tokens/CreateToken.js
+++ b/src/react-components/tokens/CreateToken.js
@@ -27,13 +27,13 @@ export const CreateToken = ({ scopes, scopeInfo, selectedScopes }) => (
             className={classNames(styleUtils.flexBasis50, styleUtils.margin0)}
             labelClassName={styles.radioLabel}
             value={1}
-            label="Account"
+            label={<FormattedMessage id="new-token.account" defaultMessage="Account" />}
           />
           <RadioInputOption
             labelClassName={styles.radioLabel}
             className={classNames(styleUtils.flexBasis50, styleUtils.margin0)}
             value={2}
-            label="App"
+            label={<FormattedMessage id="new-token.app" defaultMessage="App" />}
           />
         </RadioInputField>
       </Row>

--- a/src/react-components/tokens/RevealTokenModal.js
+++ b/src/react-components/tokens/RevealTokenModal.js
@@ -47,7 +47,11 @@ export const RevealTokenModal = ({ token, selectedScopes, onClose }) => {
           inputClassName={classNames(styles.backgroundDarkGrey, styles.textWhite)}
           label={<FormattedMessage id="save-api-token.copy-label" defaultMessage="API Token" />}
           value={token.token}
-          description={<p><FormattedMessage id="save-api-token.copied" defaultMessage="Copied" /></p>}
+          description={
+            <p>
+              <FormattedMessage id="save-api-token.copied" defaultMessage="Copied" />
+            </p>
+          }
           afterInput={
             <Button preset="accent6" onClick={noop}>
               <FormattedMessage id="save-api-token.copy" defaultMessage="Copy" />:

--- a/src/react-components/tokens/Token.js
+++ b/src/react-components/tokens/Token.js
@@ -6,7 +6,7 @@ import { Row } from "../layout/Row";
 import styles from "./Token.scss";
 
 export function Token({ tokenInfo, onRevokeToken }) {
-  const { account_id, id, inserted_at, is_revoked, scopes, subject_type, token, updated_at } = tokenInfo;
+  const { account_id, inserted_at, scopes, subject_type } = tokenInfo;
 
   return (
     <div className={styles.borderGrey}>
@@ -14,7 +14,10 @@ export function Token({ tokenInfo, onRevokeToken }) {
         <Row breakpointColumn="md" topMargin="md" childrenMarginR="xl">
           <div>
             <span>
-              <b>{subject_type.charAt(0).toUpperCase() + subject_type.slice(1)} Token</b>
+              <b>
+                {subject_type.charAt(0).toUpperCase() + subject_type.slice(1)}
+                <FormattedMessage id="tokens.token" defaultMessage="Token" />
+              </b>
             </span>
           </div>
           <div>
@@ -50,7 +53,7 @@ export function Token({ tokenInfo, onRevokeToken }) {
 }
 
 Token.propTypes = {
-  token: PropTypes.shape({
+  tokenInfo: PropTypes.shape({
     account_id: PropTypes.string,
     id: PropTypes.string,
     inserted_at: PropTypes.string,

--- a/src/systems/audio-debug-system.js
+++ b/src/systems/audio-debug-system.js
@@ -1,6 +1,7 @@
 import { THREE } from "aframe";
 import audioDebugVert from "./audio-debug.vert";
 import audioDebugFrag from "./audio-debug.frag";
+import { DistanceModelType } from "../components/audio-params";
 
 const MAX_DEBUG_SOURCES = 64;
 
@@ -103,11 +104,11 @@ AFRAME.registerSystem("audio-debug", {
           this.sourcePositions[sourceNum] = source.data.position;
           this.sourceOrientations[sourceNum] = source.data.orientation;
           this.distanceModels[sourceNum] = 0;
-          if (source.data.distanceModel === "linear") {
+          if (source.data.distanceModel === DistanceModelType.Linear) {
             this.distanceModels[sourceNum] = 0;
-          } else if (source.data.distanceModel === "inverse") {
+          } else if (source.data.distanceModel === DistanceModelType.Inverse) {
             this.distanceModels[sourceNum] = 1;
-          } else if (source.data.distanceModel === "exponential") {
+          } else if (source.data.distanceModel === DistanceModelType.Exponential) {
             this.distanceModels[sourceNum] = 2;
           }
           this.maxDistances[sourceNum] = source.data.maxDistance;

--- a/src/systems/audio-debug-system.js
+++ b/src/systems/audio-debug-system.js
@@ -13,6 +13,7 @@ AFRAME.registerSystem("audio-debug", {
     window.APP.store.addEventListener("statechanged", this.updateState.bind(this));
 
     this.sources = [];
+    this.zones = [];
 
     this.material = new THREE.ShaderMaterial({
       uniforms: {
@@ -78,6 +79,18 @@ AFRAME.registerSystem("audio-debug", {
     }
   },
 
+  registerZone(zone) {
+    this.zones.push(zone);
+  },
+
+  unregisterZone(zone) {
+    const index = this.zones.indexOf(zone);
+
+    if (index !== -1) {
+      this.zones.splice(index, 1);
+    }
+  },
+
   tick(time) {
     if (!this.data.enabled) {
       return;
@@ -85,7 +98,7 @@ AFRAME.registerSystem("audio-debug", {
 
     let sourceNum = 0;
     this.sources.forEach(source => {
-      if (source.data.enabled) {
+      if (source.data.enabled && source.data.debuggable) {
         if (sourceNum < MAX_DEBUG_SOURCES) {
           this.sourcePositions[sourceNum] = source.data.position;
           this.sourceOrientations[sourceNum] = source.data.orientation;
@@ -126,6 +139,9 @@ AFRAME.registerSystem("audio-debug", {
 
   enableDebugMode(enabled) {
     if (enabled === undefined || enabled === this.data.enabled) return;
+    this.zones.forEach(zone => {
+      zone.el.setAttribute("audio-zone", "debuggable", enabled);
+    });
     const envRoot = document.getElementById("environment-root");
     const meshEl = envRoot.querySelector(".trimesh") || envRoot.querySelector(".navMesh");
     if (meshEl) {

--- a/src/systems/audio-gain-system.js
+++ b/src/systems/audio-gain-system.js
@@ -1,16 +1,15 @@
-import { SourceType } from "../components/audio-params";
-
 const CLIPPING_GAIN = 0.0001;
 
 export class GainSystem {
   constructor() {
     this.sources = [];
-    window.APP.store.addEventListener("statechanged", this.updatePrefs.bind(this));
+    this.onPrefsUpdated = this.updatePrefs.bind(this);
+    window.APP.store.addEventListener("statechanged", this.onPrefsUpdated);
   }
 
   remove() {
     this.sources = [];
-    window.APP.store.removeEventListener("statechanged", this.updatePrefs);
+    window.APP.store.removeEventListener("statechanged", this.onPrefsUpdated);
   }
 
   registerSource(source) {
@@ -28,42 +27,23 @@ export class GainSystem {
   tick() {
     this.sources.forEach(source => {
       if (source.data.clippingEnabled) {
-        const audio = source.audio();
+        const audio = source.getAudio();
         if (source.data.attenuation < source.data.clippingThreshold) {
           if (audio.gain.gain.value > 0 && !source.data.isClipped) {
             source.clipGain(CLIPPING_GAIN);
           }
         } else if (source.data.isClipped) {
           source.unclipGain();
-        } else {
-          // Update the non positional audio attenuation
-          if (this.audioOutputMode === "audio") {
-            this.updateSourceGain(source);
-          }
         }
-      } else {
+      } else if (source.data.isClipped) {
         source.unclipGain();
       }
     });
   }
 
   updatePrefs() {
-    const { enableAudioClipping, audioClippingThreshold } = window.APP.store.state.preferences;
     this.sources.forEach(source => {
-      this.updateSourceGain(source);
-      source.clippingUpdated({ clippingEnabled: enableAudioClipping, clippingThreshold: audioClippingThreshold });
+      source.updateClipping();
     });
-  }
-
-  updateSourceGain(source) {
-    let volume = 1.0;
-    if (source.data.sourceType === SourceType.MEDIA_VIDEO) {
-      volume = source.el.components["media-video"]?.data.volume;
-    } else if (source.data.sourceType === SourceType.AVATAR_AUDIO_SOURCE) {
-      volume = source.el.parentEl.parentEl.querySelector("[avatar-volume-controls]").components[
-        "avatar-volume-controls"
-      ]?.data.volume;
-    }
-    source.volumeUpdated({ detail: volume });
   }
 }

--- a/src/systems/audio-settings-system.js
+++ b/src/systems/audio-settings-system.js
@@ -6,7 +6,7 @@ export const AvatarAudioDefaults = Object.freeze({
   INNER_ANGLE: 180,
   OUTER_ANGLE: 360,
   OUTER_GAIN: 0,
-  VOLUME: 0.5
+  VOLUME: 1.0
 });
 
 export const MediaAudioDefaults = Object.freeze({
@@ -34,27 +34,27 @@ export const TargetAudioDefaults = Object.freeze({
 export const DISTANCE_MODEL_OPTIONS = ["linear", "inverse", "exponential"];
 
 function updateMediaAudioSettings(mediaVideo, settings) {
-  mediaVideo.el.setAttribute("media-video", {
+  mediaVideo.el.setAttribute("audio-params", {
     distanceModel: settings.mediaDistanceModel,
     rolloffFactor: settings.mediaRolloffFactor,
     refDistance: settings.mediaRefDistance,
     maxDistance: settings.mediaMaxDistance,
     coneInnerAngle: settings.mediaConeInnerAngle,
     coneOuterAngle: settings.mediaConeOuterAngle,
-    coneOuterGain: settings.mediaConeOuterGain
+    coneOuterGain: settings.mediaConeOuterGain,
+    gain: settings.mediaVolume
   });
 }
 
-function updateAvatarAudioSettings(avatarAudioSource, settings, positional) {
-  avatarAudioSource.el.setAttribute("avatar-audio-source", {
-    positional,
+function updateAvatarAudioSettings(avatarAudioSource, settings) {
+  avatarAudioSource.el.setAttribute("audio-params", {
     distanceModel: settings.avatarDistanceModel,
     maxDistance: settings.avatarMaxDistance,
     refDistance: settings.avatarRefDistance,
     rolloffFactor: settings.avatarRolloffFactor,
-    innerAngle: settings.avatarConeInnerAngle,
-    outerAngle: settings.avatarConeOuterAngle,
-    outerGain: settings.avatarConeOuterGain
+    coneInnerAngle: settings.avatarConeInnerAngle,
+    coneOuterAngle: settings.avatarConeOuterAngle,
+    coneOuterGain: settings.avatarConeOuterGain
   });
 }
 
@@ -129,8 +129,7 @@ export class AudioSettingsSystem {
     if (index === -1) {
       this.avatarAudioSources.push(avatarAudioSource);
     }
-    const positional = window.APP.store.state.preferences.audioOutputMode !== "audio";
-    updateAvatarAudioSettings(avatarAudioSource, this.audioSettings, positional);
+    updateAvatarAudioSettings(avatarAudioSource, this.audioSettings);
   }
 
   unregisterAvatarAudioSource(avatarAudioSource) {
@@ -147,9 +146,8 @@ export class AudioSettingsSystem {
       updateMediaAudioSettings(mediaVideo, settings);
     }
 
-    const positional = window.APP.store.state.preferences.audioOutputMode !== "audio";
     for (const avatarAudioSource of this.avatarAudioSources) {
-      updateAvatarAudioSettings(avatarAudioSource, settings, positional);
+      updateAvatarAudioSettings(avatarAudioSource, settings);
     }
   }
 

--- a/src/systems/audio-settings-system.js
+++ b/src/systems/audio-settings-system.js
@@ -1,37 +1,4 @@
-export const AvatarAudioDefaults = Object.freeze({
-  DISTANCE_MODEL: "inverse",
-  ROLLOFF_FACTOR: 2,
-  REF_DISTANCE: 1,
-  MAX_DISTANCE: 10000,
-  INNER_ANGLE: 180,
-  OUTER_ANGLE: 360,
-  OUTER_GAIN: 0,
-  VOLUME: 1.0
-});
-
-export const MediaAudioDefaults = Object.freeze({
-  DISTANCE_MODEL: "inverse",
-  ROLLOFF_FACTOR: 1,
-  REF_DISTANCE: 1,
-  MAX_DISTANCE: 10000,
-  INNER_ANGLE: 360,
-  OUTER_ANGLE: 0,
-  OUTER_GAIN: 0,
-  VOLUME: 0.5
-});
-
-export const TargetAudioDefaults = Object.freeze({
-  DISTANCE_MODEL: "inverse",
-  ROLLOFF_FACTOR: 5,
-  REF_DISTANCE: 8,
-  MAX_DISTANCE: 10000,
-  INNER_ANGLE: 170,
-  OUTER_ANGLE: 300,
-  OUTER_GAIN: 0.3,
-  VOLUME: 1.0
-});
-
-export const DISTANCE_MODEL_OPTIONS = ["linear", "inverse", "exponential"];
+import { AvatarAudioDefaults, MediaAudioDefaults } from "../components/audio-params";
 
 function updateMediaAudioSettings(mediaVideo, settings) {
   mediaVideo.el.setAttribute("audio-params", {

--- a/src/systems/audio-zones-system.js
+++ b/src/systems/audio-zones-system.js
@@ -1,0 +1,155 @@
+// We apply the parameters that dim the audio the most
+function paramsReducer(acc, curr) {
+  if (acc === null) acc = curr;
+  acc.gain = Math.min(acc.gain, curr.gain);
+  acc.maxDistance = Math.min(acc.maxDistance, curr.maxDistance);
+  acc.refDistance = Math.min(acc.refDistance, curr.refDistance);
+  acc.rolloffFactor = Math.max(acc.rolloffFactor, curr.rolloffFactor);
+  acc.coneInnerAngle = Math.min(acc.coneInnerAngle, curr.coneInnerAngle);
+  acc.coneOuterAngle = Math.min(acc.coneOuterAngle, curr.coneOuterAngle);
+  acc.coneOuterGain = Math.min(acc.coneOuterGain, curr.coneOuterGain);
+  return acc;
+}
+
+// This system updates the audio-zone-sources audio parameters based on the listener's position.
+// If several audio-zones are in between the audio-zone-listener and the audio-zone-source, the applied audio parameters is a reduction
+// of the auzio-zones most restrictive audio parameters.
+// i.e. If there are two audio-zones in between the listener and the source and the first one has gain == 0.1
+// and the other has gain == 1.0, gain == 0.1 is applied to the source.
+export class AudioZonesSystem {
+  constructor(scene) {
+    this.scene = scene;
+    this.listener = null;
+    this.sources = [];
+    this.zones = [];
+    this.initialized = false;
+    this.ray = new THREE.Ray();
+    this.rayDir = new THREE.Vector3();
+    this.normalizedRayDir = new THREE.Vector3();
+    this.intersectTarget = new THREE.Vector3();
+  }
+
+  remove() {
+    this.sources = [];
+    this.zones = [];
+  }
+
+  setListener(listener) {
+    this.listener = listener;
+  }
+
+  unsetListener() {
+    this.listener = null;
+  }
+
+  registerSource(source) {
+    this.sources.push(source);
+  }
+
+  unregisterSource(source) {
+    const index = this.sources.indexOf(source);
+
+    if (index !== -1) {
+      this.sources.splice(index, 1);
+    }
+  }
+
+  registerZone(zone) {
+    this.zones.push(zone);
+  }
+
+  unregisterZone(zone) {
+    const index = this.zones.indexOf(zone);
+
+    if (index !== -1) {
+      this.zones.splice(index, 1);
+    }
+  }
+
+  tick() {
+    if (!this.scene.is("entered") || this.zones.length === 0) return;
+
+    // Update zones
+    this._updateZones();
+
+    this.sources.forEach(source => {
+      // Only check whenever either the source or the listener have updated zones (moved)
+      if (source.entity.isUpdated() || this.listener.entity.isUpdated()) {
+        // Cast a ray from the listener to the source
+        this.rayDir = source
+          .getPosition()
+          .clone()
+          .sub(this.listener.getPosition());
+        this.normalizedRayDir = this.rayDir.clone().normalize();
+        this.ray.set(this.listener.getPosition(), this.normalizedRayDir);
+
+        // First we check the zones the source is contained in and we check the inOut property
+        // to modify the sources audio params when the listener is outside the source's zones
+        // We always apply the outmost active zone audio params, the zone that's closest to the listener
+        const inOutParams = source.entity
+          .getZones()
+          .filter(zone => {
+            const zoneBBAA = zone.getBoundingBox();
+            this.intersectTarget = new THREE.Vector3();
+            this.ray.intersectBox(zoneBBAA, this.intersectTarget);
+            return this.intersectTarget !== null && zone.data.inOut && !this.listener.entity.getZones().includes(zone);
+          })
+          .map(zone => zone.getAudioParams())
+          .reduce(paramsReducer, null);
+
+        // Then we check the zones the listener is contained in and we check the outIn property
+        // to modify the sources audio params when the source is outside the listener's zones
+        // We always apply the inmost active zone audio params, the zone that's closest to the listener
+        const outInParams = this.listener.entity
+          .getZones()
+          .filter(zone => {
+            const zoneBBAA = zone.getBoundingBox();
+            this.intersectTarget = new THREE.Vector3();
+            this.ray.intersectBox(zoneBBAA, this.intersectTarget);
+            return this.intersectTarget !== null && zone.data.outIn && !source.entity.getZones().includes(zone);
+          })
+          .map(zone => zone.getAudioParams())
+          .reduce(paramsReducer, null);
+
+        // Resolve the zones
+        if (outInParams || inOutParams) {
+          const params = outInParams ? outInParams : inOutParams;
+          params.gain = outInParams && inOutParams ? Math.min(outInParams.gain, inOutParams.gain) : params.gain;
+          params.coneOuterGain =
+            outInParams && inOutParams
+              ? Math.min(outInParams.coneOuterGain, inOutParams.coneOuterGain)
+              : params.coneOuterGain;
+          source.apply(params);
+        } else {
+          source.restore();
+        }
+      }
+    });
+  }
+
+  _updateZones() {
+    this.zones.forEach(zone => {
+      if (!zone.isEnabled()) return;
+
+      const isListenerInZone = zone.contains(this.listener.getPosition());
+      const wasListenerInZone = this.listener.entity.isInZone(zone);
+      // Update audio zone listener status
+      if (isListenerInZone && !wasListenerInZone) {
+        this.listener.entity.addZone(zone);
+      } else if (!isListenerInZone && wasListenerInZone) {
+        this.listener.entity.removeZone(zone);
+      }
+      // Update audio zone source status
+      this.sources.forEach(source => {
+        const isSourceInZone = zone.contains(source.getPosition());
+        const wasSourceInZone = source.entity.isInZone(zone);
+        // Check if the audio source is in the audio zone
+        if (isSourceInZone && !wasSourceInZone) {
+          source.entity.addZone(zone);
+        } else if (!isSourceInZone && wasSourceInZone) {
+          source.entity.removeZone(zone);
+        }
+      });
+    });
+  }
+}

--- a/src/systems/audio-zones-system.js
+++ b/src/systems/audio-zones-system.js
@@ -1,4 +1,4 @@
-// We apply the parameters that dim the audio the most
+// We apply the most restrictive audio parameters
 function paramsReducer(acc, curr) {
   if (acc === null) acc = curr;
   acc.gain = Math.min(acc.gain, curr.gain);
@@ -11,11 +11,16 @@ function paramsReducer(acc, curr) {
   return acc;
 }
 
-// This system updates the audio-zone-sources audio parameters based on the listener's position.
-// If several audio-zones are in between the audio-zone-listener and the audio-zone-source, the applied audio parameters is a reduction
-// of the auzio-zones most restrictive audio parameters.
-// i.e. If there are two audio-zones in between the listener and the source and the first one has gain == 0.1
-// and the other has gain == 1.0, gain == 0.1 is applied to the source.
+/**
+ * This system updates the audio-zone-sources audio-params based on the audio-zone-listener position.
+ * On every tick it computes the audio-zone-source and audio-zone-listener positions to check
+ * if the listener is inside/outside an audio-zone and applies the zone's audio parameters based.
+ * It only updates in case there has been any changes in the sources or listener's positions.
+ * If several audio-zones are in between the audio-zone-listener and the audio-zone-source, the applied
+ * audio parameters is a reduction of the audio-zones most restrictive audio parameters.
+ * i.e. If there are two audio-zones in between the listener and the source and the first one has gain == 0.1
+ * and the other has gain == 1.0, gain == 0.1 is applied to the source.
+ */
 export class AudioZonesSystem {
   constructor(scene) {
     this.scene = scene;
@@ -127,6 +132,7 @@ export class AudioZonesSystem {
     });
   }
 
+  // Updates zones states in case they have changed.
   _updateZones() {
     this.zones.forEach(zone => {
       if (!zone.isEnabled()) return;

--- a/src/systems/audio-zones-system.js
+++ b/src/systems/audio-zones-system.js
@@ -27,12 +27,18 @@ export class AudioZonesSystem {
     this.listener = null;
     this.sources = [];
     this.zones = [];
+    this.forceUpdate = false;
     this.initialized = false;
+  }
+
+  init() {
+    this.el.sceneEl.addEventListener("environment-scene-loaded", this.onSceneLoaded);
   }
 
   remove() {
     this.sources = [];
     this.zones = [];
+    this.el.sceneEl.removeEventListener("environment-scene-loaded", this.onSceneLoaded);
   }
 
   setListener(listener) {
@@ -81,7 +87,8 @@ export class AudioZonesSystem {
       for (let i = 0; i < this.sources.length; i++) {
         const source = this.sources[i];
         // Only check whenever either the source or the listener have updated zones (moved)
-        if (source.entity.isUpdated() || this.listener.entity.isUpdated()) {
+        if (source.entity.isUpdated() || this.listener.entity.isUpdated() || this.forceUpdate) {
+          this.forceUpdate = false;
           // Cast a ray from the listener to the source
           rayDir.copy(
             source
@@ -162,4 +169,8 @@ export class AudioZonesSystem {
       });
     }
   }
+
+  onSceneLoaded = () => {
+    this.forceUpdate = true;
+  };
 }

--- a/src/systems/hubs-systems.js
+++ b/src/systems/hubs-systems.js
@@ -30,6 +30,7 @@ import { ShadowSystem } from "./shadow-system";
 import { MediaFramesSystem } from "./media-frames";
 import { InspectYourselfSystem } from "./inspect-yourself-system";
 import { EmojiSystem } from "./emoji-system";
+import { AudioZonesSystem } from "./audio-zones-system";
 import { GainSystem } from "./audio-gain-system";
 
 AFRAME.registerSystem("hubs-systems", {
@@ -70,6 +71,7 @@ AFRAME.registerSystem("hubs-systems", {
     this.mediaFramesSystem = new MediaFramesSystem(this.physicsSystem, this.el.systems.interaction);
     this.inspectYourselfSystem = new InspectYourselfSystem();
     this.emojiSystem = new EmojiSystem(this.el);
+    this.audioZonesSystem = new AudioZonesSystem(this.el);
     this.gainSystem = new GainSystem();
   },
 
@@ -115,6 +117,7 @@ AFRAME.registerSystem("hubs-systems", {
     this.uvScrollSystem.tick(dt);
     this.shadowSystem.tick();
     this.mediaFramesSystem.tick();
+    this.audioZonesSystem.tick();
     this.gainSystem.tick();
 
     // We run this late in the frame so that its the last thing to have an opinion about the scale of an object

--- a/src/systems/linked-media.js
+++ b/src/systems/linked-media.js
@@ -49,7 +49,7 @@ AFRAME.registerSystem("linked-media", {
 
     // As a convenience, if elA is a video, we turn its volume off so we don't hear it twice
     if (elA.components["media-video"]) {
-      elA.setAttribute("media-video", "volume", 0);
+      elA.setAttribute("audio-params", "gain", 0);
     }
 
     this.handlers.push([elA, elB, handlerA, handlerB]);
@@ -64,8 +64,8 @@ AFRAME.registerSystem("linked-media", {
       }
 
       // As a convenience, if elA is a video, we restore its volume to 50% since we muted it upon link.
-      if (elA.components["media-video"]) {
-        elA.setAttribute("media-video", "volume", 0.5);
+      if (elA.components["audio-params"]) {
+        elA.setAttribute("audio-params", "gain", 0.5);
       }
     }
 


### PR DESCRIPTION
This PR adds support for **Audio Zones**, a 3D box volume that modifies the audio properties of audio sources (avatars, videos and audios) based on the source's and listener's positions with respect to the audio zone. One obvious application would be to dim audio sources' volumes based on 3D areas like rooms to mimic the real world behavior.

### Components
- `audio-zone-entity`
Represents an entity in the `audio-zones-system`. Records the audio zones where the entity is and returns current/past states. This entity is used together with the `audio-zone-listener`or `audio-zone-source`components to composite actual entities.
- `audio-zone-source`
Represents an `audio-zone-entity` that has an audio component in the `audio-zones-system`. Expects an `audio-params` component. It can be an audio, video, avatar or an audio target.
- `audio-zone-listener`
Represents an `audio-zone-entity` that is the scene's audio listener in the `audio-zones-system`.
- `audio-zone`
Represents an 3D box area in the `audio-zones-system` that can contain `audio-zone-entities`. I has an `audio-params` components which values are used to override the audio sources audio properties based on the source's and listener's position.
It can be of `inOut` or/and `outIn` types.
    + **inOut**: applies this zone's `audio-params` to an `audio-zone-source` when the source is inside and listener is outside. i.e. _Mute or dim audio sources inside the audio zone when the listener is outside_.
    + **outIn**: applies this zone's `audio-params` to the an `audio-zone-source` when the listener is inside and the source is outside. i.e. _Mute or dim audio sources from outside the audio zone when the listener is inside_.

### Systems
- `audio-zones-system`
This system updates the `audio-zone-sources` `audio-params` based on the `audio-zone-listener` position. On every tick it computes the `audio-zone-source` and `audio-zone-listener` positions to check if the listener is inside/outside an `audio-zone` and applies the zone's audio parameters. It only updates in case there has been any changes in the sources or  listener's positions.
If several audio-zones are in between the `audio-zone-listener` and the `audio-zone-source`, the applied audio parameters is a reduction of the `audio-zones` most restrictive audio parameters. i.e. _If there are two audio-zones in between the listener and the source and the first one has gain == 0.1 and the other has gain == 1.0, gain == 0.1 is applied to the source._

This PR also refactors the current global media/avatar volume handling to use a global gain node instead of updating individual audio's gain values

Related https://github.com/mozilla/Spoke/pull/1156 
Related https://github.com/MozillaReality/hubs-blender-exporter/pull/36
Fixes #4167