### PR TITLE
Add crossOrigin for reaction images to avoid CORS error on Chrome

### DIFF
--- a/src/react-components/popover/ImageGridPopover.js
+++ b/src/react-components/popover/ImageGridPopover.js
@@ -19,6 +19,8 @@ export function ImageGridPopover({ fullscreen, items, closePopover }) {
 
               closePopover();
             }}
+            // crossOrigin: "anonymous" is a workaround for CORS error on Chrome. See #4400
+            crossOrigin="anonymous"
           />
         );
       })}


### PR DESCRIPTION
This PR fixes https://github.com/mozilla/hubs/issues/3357#issuecomment-859182129

**The problem this PR fixes**

The small emojis are not rendered for "Reaction" in Chrome on hubs.mozilla.com (and other Hubs instance) due to the CORS error.

![image](https://user-images.githubusercontent.com/7637832/125120768-cab5bb80-e0a7-11eb-8bf5-1041d59042fe.png)

I can't reproduce this problem on Firefox, so it seems Chrome specific problem.
And I can't reproduce it on local dev server.

**How to reproduce**

1. I click the "React" button, the reaction popover shows up as the following screenshot. 

![image](https://user-images.githubusercontent.com/7637832/125121639-1026b880-e0a9-11eb-8dcb-28a80623fbf2.png)

2. Click one of emojis. Big emoji model is placed in a room but small emojis aren't rendered.

3. Open browser console and see the CORS error.

**The root issue**

It seems Chrome (wrongly?) returns the network cache even for different request headers.

In 1. in "how to reproduce" the Hubs client loads emoji image files with &lt;img&gt; without sending origin in react component. The CloudFront returns the response without "access-control-allow-\*" properties in the response header. (This "returning without access-control-allow-\* for the request which doesn't include Origin" behavior seems to be expected as CORS specification).

In 2. the Hubs client loads the selected emoji image file again with `fetch()` with sending origin (this seems a default behavior of `fetch()`) in Three.js `ImageBitmapLoader`. But the Chrome seems to see the response locally cached in 1., doesn't see "access-control-allow-\*" properties in the cached response header, and throws 'No "Access-Control-Allow-Origin" in the response header' error.

**Solution**

Adding `crossOrigin` attribute in the &lt;img&gt; tag for emoji is an easy solution.

**Additional context**

* I checked Origin request and Cache policies in the CloudFront and they look correct. And I experimented with some other policies but the problem wasn't resolved.
* I tried `curl` command to send requests with Origin and without Origin in the request headers. For the request with Origin the CloudFront returns the response with "access-control-allow-\*" in the response header while for the request without Origin the CloudFront returns the response without "access-control-allow-\*" in the response header.
* This results that CloudFront distincts the requests between with Origin and without Origin looks correct. So I concluded this is a Chrome side problem and we should add a workaround in our code.
* One thing which makes me feel unconfident for my speculation is the network tab in Chrome dev tool doesn't indicate that the response for the request caused the CORS error is from disk cache. But I couldn't come up with other scenarios.

![image](https://user-images.githubusercontent.com/7637832/125128754-5254f780-e0b3-11eb-9773-69cf4497caf3.png)
