### PR TITLE
fix: white space break spaces for room description

### DIFF
--- a/src/react-components/input/InputField.scss
+++ b/src/react-components/input/InputField.scss
@@ -11,6 +11,7 @@
   flex-direction: column;
   width: 100%;
   max-width: 300px;
+  white-space: break-spaces;
 }
 
 :local(.fullWidth) {


### PR DESCRIPTION
Resolves #4284

Currently room descriptions do not respect breaks:
<img width="1195" alt="Screen Shot 2021-07-14 at 8 42 29 AM" src="https://user-images.githubusercontent.com/4493657/125652706-679eebbb-508c-465d-9c40-2c9ac94225c8.png">

with fix:
<img width="1209" alt="Screen Shot 2021-07-14 at 8 43 16 AM" src="https://user-images.githubusercontent.com/4493657/125652873-81990863-b63e-4cc0-bb8d-ed12af18f2a8.png">
