### PR TITLE
fix permission token update, use dialog adapter token for kick

### DIFF
--- a/src/naf-dialog-adapter.js
+++ b/src/naf-dialog-adapter.js
@@ -944,12 +944,12 @@ export class DialogAdapter extends EventEmitter {
     }
   }
 
-  kick(clientId, permsToken) {
+  kick(clientId) {
     return this._protoo
       .request("kick", {
         room_id: this.room,
         user_id: clientId,
-        token: permsToken
+        token: this._joinToken
       })
       .then(() => {
         document.body.dispatchEvent(new CustomEvent("kicked", { detail: { clientId: clientId } }));

--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -150,10 +150,7 @@ export default class HubChannel extends EventTarget {
     if (this.fetchPermissionsTimeout) {
       clearTimeout(this.fetchPermissionsTimeout);
     }
-    this.fetchPermissionsTimeout = setTimeout(async () => {
-      const result = await this.fetchPermissions();
-      this.dispatchEvent(new CustomEvent("permissions-refreshed", { detail: result }));
-    }, nextRefresh);
+    this.fetchPermissionsTimeout = setTimeout(this.fetchPermissions, nextRefresh);
   };
 
   sendEnteringEvent = async () => {
@@ -430,8 +427,7 @@ export default class HubChannel extends EventTarget {
   isHidden = sessionId => this._blockedSessionIds.has(sessionId);
 
   kick = async sessionId => {
-    const permsToken = await this.fetchPermissions();
-    APP.dialog.kick(sessionId, permsToken);
+    APP.dialog.kick(sessionId);
     this.channel.push("kick", { session_id: sessionId });
   };
 


### PR DESCRIPTION
Remove event `permissions-refreshed` that was redundant with `permissions_updated`.
Simplify permission refresh timer, clear existing timer if permissions are refreshed early.
In `hubChannel.kick`, do not refetch permissions so as to pass perms token to NAF dialog adapter's `kick`; instead, use NAF dialog adapter's `_joinToken` internally.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/HUBS-783)
