### PR TITLE
Force initial matrix update to compute correct initial bbaa

### DIFF
--- a/src/components/audio-zone.js
+++ b/src/components/audio-zone.js
@@ -30,6 +30,7 @@ AFRAME.registerComponent("audio-zone", {
     this.debugMesh.el = this.el.object3D.el;
     const debugBBAA = new THREE.BoxHelper(this.debugMesh, DEBUG_BBAA_COLOR);
     this.el.object3D.add(debugBBAA);
+    this.el.object3D.updateMatrixWorld(true);
 
     this.el.sceneEl?.systems["audio-debug"].registerZone(this);
     this.el.sceneEl?.systems["hubs-systems"].audioZonesSystem.registerZone(this);


### PR DESCRIPTION
We need to force a world matrix update on creation so  the BBAA can be correctly computed even if the object is initially not visible ( audio-debugging disabled)

This was causing audio zones not to work if the audio debug mode was disabled initially.