### PR TITLE
Load builtin audio-params for audio-targets

### DIFF
--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -257,17 +257,6 @@ AFRAME.registerComponent("audio-target", {
 
   init() {
     this.audioSystem = this.el.sceneEl.systems["hubs-systems"].audioSystem;
-    this.el.setAttribute("audio-params", {
-      sourceType: SourceType.AUDIO_TARGET,
-      distanceModel: TargetAudioDefaults.DISTANCE_MODEL,
-      rolloffFactor: TargetAudioDefaults.ROLLOFF_FACTOR,
-      refDistance: TargetAudioDefaults.REF_DISTANCE,
-      maxDistance: TargetAudioDefaults.MAX_DISTANCE,
-      coneInnerAngle: TargetAudioDefaults.INNER_ANGLE,
-      coneOuterAngle: TargetAudioDefaults.OUTER_ANGLE,
-      coneOuterGain: TargetAudioDefaults.OUTER_GAIN,
-      gain: TargetAudioDefaults.VOLUME
-    });
     this.createAudio();
     // TODO this is to ensure targets and sources loaded at the same time don't have
     // an order depndancy but this should be done in a more robust way

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -470,7 +470,26 @@ AFRAME.GLTFModelPlus.registerComponent(
       }
     }
 
-    el.setAttribute(componentName, { ...componentData, srcEl });
+    // Migrate audio-target component that still has builting audio params
+    if (componentData.positional !== undefined) {
+      el.setAttribute("audio-params", {
+        sourceType: SourceType.AUDIO_TARGET,
+        distanceModel: componentData.distanceModel,
+        rolloffFactor: componentData.rolloffFactor,
+        refDistance: componentData.refDistance,
+        maxDistance: componentData.maxDistance,
+        coneInnerAngle: componentData.coneInnerAngle,
+        coneOuterAngle: componentData.coneOuterAngle,
+        coneOuterGain: componentData.coneOuterGain,
+        gain: componentData.gain
+      });
+    }
+    el.setAttribute(componentName, {
+      minDelay: componentData.minDelay,
+      maxDelay: componentData.maxDelay,
+      debug: componentData.debug,
+      srcEl
+    });
   }
 );
 AFRAME.GLTFModelPlus.registerComponent("zone-audio-source", "zone-audio-source");


### PR DESCRIPTION
We were no loading audio params for audio-targets with builtin audio params (instead of having a separate audio-params component)