### PR TITLE
Audio fixes

### DIFF
--- a/src/change-hub.js
+++ b/src/change-hub.js
@@ -99,7 +99,7 @@ export async function changeHub(hubId, addToHistory = true) {
 window.changeHub = changeHub;
 
 // TODO see if there is a better way to do this with react router
-window.addEventListener("popstate", function(e) {
+window.addEventListener("popstate", function() {
   if (!APP.store.state.preferences.fastRoomSwitching) return;
   const qs = new URLSearchParams(location.search);
   const newHubId = qs.get("hub_id") || document.location.pathname.substring(1).split("/")[0];

--- a/src/components/audio-params.js
+++ b/src/components/audio-params.js
@@ -197,13 +197,6 @@ AFRAME.registerComponent("audio-params", {
         audio.panner.orientationY.value,
         audio.panner.orientationZ.value
       );
-      this.data.distanceModel = audio.panner.distanceModel;
-      this.data.rolloffFactor = audio.panner.rolloffFactor;
-      this.data.refDistance = audio.panner.refDistance;
-      this.data.maxDistance = audio.panner.maxDistance;
-      this.data.coneInnerAngle = audio.panner.coneInnerAngle;
-      this.data.coneOuterAngle = audio.panner.coneOuterAngle;
-      this.data.coneOuterGain = audio.panner.coneOuterGain;
       this.updateDistances();
       this.updateAttenuation();
     }

--- a/src/components/audio-params.js
+++ b/src/components/audio-params.js
@@ -200,25 +200,21 @@ AFRAME.registerComponent("audio-params", {
     const audio = this.getAudio();
     if (audio) {
       if (audio.panner) {
-        this.el.setAttribute("audio-params", {
-          position: new THREE.Vector3(
-            audio.panner.positionX.value,
-            audio.panner.positionY.value,
-            audio.panner.positionZ.value
-          ),
-          orientation: new THREE.Vector3(
-            audio.panner.orientationX.value,
-            audio.panner.orientationY.value,
-            audio.panner.orientationZ.value
-          )
-        });
+        this.data.position = new THREE.Vector3(
+          audio.panner.positionX.value,
+          audio.panner.positionY.value,
+          audio.panner.positionZ.value
+        );
+        this.data.orientation = new THREE.Vector3(
+          audio.panner.orientationX.value,
+          audio.panner.orientationY.value,
+          audio.panner.orientationZ.value
+        );
         this.updateAttenuation();
       } else {
         this.el.object3D.getWorldDirection(this.data.orientation);
         this.el.object3D.getWorldPosition(this.data.position);
-        this.el.setAttribute("audio-params", {
-          rolloffFactor: 0
-        });
+        this.data.rolloffFactor = 0;
       }
       this.updateDistances();
     }
@@ -313,21 +309,17 @@ AFRAME.registerComponent("audio-params", {
 
   updateDistances() {
     this.el.sceneEl.audioListener.getWorldPosition(this.listenerPos);
-    this.el.setAttribute("audio-params", {
-      distance: this.data.position.distanceTo(this.listenerPos),
-      squaredDistance: this.data.position.distanceToSquared(this.listenerPos)
-    });
+    this.data.distance = this.data.position.distanceTo(this.listenerPos);
+    this.data.squaredDistance = this.data.position.distanceToSquared(this.listenerPos);
   },
 
   updateAttenuation() {
-    this.el.setAttribute("audio-params", {
-      attenuation: distanceModels[this.data.distanceModel](
-        this.data.distance,
-        this.data.rolloffFactor,
-        this.data.refDistance,
-        this.data.maxDistance
-      )
-    });
+    this.data.attenuation = distanceModels[this.data.distanceModel](
+      this.data.distance,
+      this.data.rolloffFactor,
+      this.data.refDistance,
+      this.data.maxDistance
+    );
   },
 
   clipGain(gain) {

--- a/src/components/audio-params.js
+++ b/src/components/audio-params.js
@@ -194,21 +194,25 @@ AFRAME.registerComponent("audio-params", {
     const audio = this.getAudio();
     if (audio) {
       if (audio.panner) {
-        this.data.position = new THREE.Vector3(
-          audio.panner.positionX.value,
-          audio.panner.positionY.value,
-          audio.panner.positionZ.value
-        );
-        this.data.orientation = new THREE.Vector3(
-          audio.panner.orientationX.value,
-          audio.panner.orientationY.value,
-          audio.panner.orientationZ.value
-        );
+        this.el.setAttribute("audio-params", {
+          position: new THREE.Vector3(
+            audio.panner.positionX.value,
+            audio.panner.positionY.value,
+            audio.panner.positionZ.value
+          ),
+          orientation: new THREE.Vector3(
+            audio.panner.orientationX.value,
+            audio.panner.orientationY.value,
+            audio.panner.orientationZ.value
+          )
+        });
         this.updateAttenuation();
       } else {
         this.el.object3D.getWorldDirection(this.data.orientation);
         this.el.object3D.getWorldPosition(this.data.position);
-        this.data.rolloffFactor = 0;
+        this.el.setAttribute("audio-params", {
+          rolloffFactor: 0
+        });
       }
       this.updateDistances();
     }
@@ -303,26 +307,31 @@ AFRAME.registerComponent("audio-params", {
 
   updateDistances() {
     this.el.sceneEl.audioListener.getWorldPosition(this.listenerPos);
-    this.data.distance = this.data.position.distanceTo(this.listenerPos);
-    this.data.squaredDistance = this.data.position.distanceToSquared(this.listenerPos);
+    this.el.setAttribute("audio-params", {
+      distance: this.data.position.distanceTo(this.listenerPos),
+      squaredDistance: this.data.position.distanceToSquared(this.listenerPos)
+    });
   },
 
   updateAttenuation() {
-    this.data.attenuation = distanceModels[this.data.distanceModel](
-      this.data.distance,
-      this.data.rolloffFactor,
-      this.data.refDistance,
-      this.data.maxDistance
-    );
+    this.el.setAttribute("audio-params", {
+      attenuation: distanceModels[this.data.distanceModel](
+        this.data.distance,
+        this.data.rolloffFactor,
+        this.data.refDistance,
+        this.data.maxDistance
+      )
+    });
   },
 
   clipGain(gain) {
     if (!this.data.isClipped) {
       const audio = this.getAudio();
-      this.data.isClipped = true;
-      this.data.preClipGain = this.data.gain;
-      this.data.gain = gain;
-      this.data.gain = Math.max(0.001, this.data.gain);
+      this.el.setAttribute("audio-params", {
+        isClipped: true,
+        preClipGain: this.data.gain,
+        gain: Math.max(0.001, gain)
+      });
       audio.gain.gain.exponentialRampToValueAtTime(this.data.gain, audio.context.currentTime + MUTE_DELAY_SECS);
     }
   },
@@ -330,9 +339,10 @@ AFRAME.registerComponent("audio-params", {
   unclipGain() {
     if (this.data.isClipped) {
       const audio = this.getAudio();
-      this.data.isClipped = false;
-      this.data.gain = this.data.preClipGain;
-      this.data.gain = Math.max(0.001, this.data.gain);
+      this.el.setAttribute("audio-params", {
+        isClipped: false,
+        gain: Math.max(0.001, this.data.preClipGain)
+      });
       audio?.gain?.gain.exponentialRampToValueAtTime(this.data.gain, audio.context.currentTime + MUTE_DELAY_SECS);
     }
   },
@@ -366,7 +376,9 @@ AFRAME.registerComponent("audio-params", {
 
   updateClipping() {
     const { clippingEnabled, clippingThreshold } = window.APP.store.state.preferences;
-    this.data.clippingEnabled = clippingEnabled !== undefined ? clippingEnabled : CLIPPING_THRESHOLD_ENABLED;
-    this.data.clippingThreshold = clippingThreshold !== undefined ? clippingThreshold : CLIPPING_THRESHOLD_DEFAULT;
+    this.el.setAttribute("audio-params", {
+      clippingEnabled: clippingEnabled !== undefined ? clippingEnabled : CLIPPING_THRESHOLD_ENABLED,
+      clippingThreshold: clippingThreshold !== undefined ? clippingThreshold : CLIPPING_THRESHOLD_DEFAULT
+    });
   }
 });

--- a/src/components/audio-params.js
+++ b/src/components/audio-params.js
@@ -59,7 +59,7 @@ export const TargetAudioDefaults = Object.freeze({
   VOLUME: 1.0
 });
 
-const MUTE_DELAY_SECS = 1;
+export const GAIN_TIME_CONST = 0.2;
 
 const distanceModels = {
   linear: function(distance, rolloffFactor, refDistance, maxDistance) {
@@ -371,7 +371,7 @@ AFRAME.registerComponent("audio-params", {
     if (audioOutputMode === "audio") {
       this.data.gain = this.data.gain * Math.min(1, 10 / Math.max(1, this.data.squaredDistance));
     }
-    gainFilter?.gain.exponentialRampToValueAtTime(this.data.gain, audio.context.currentTime + MUTE_DELAY_SECS);
+    gainFilter?.gain.setTargetAtTime(this.data.gain, audio.context.currentTime, GAIN_TIME_CONST);
   },
 
   updateClipping() {

--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -52,18 +52,6 @@ AFRAME.registerComponent("avatar-audio-source", {
 
     const audioListener = this.el.sceneEl.audioListener;
     const audio = new THREE.PositionalAudio(audioListener);
-    this.el.setAttribute("audio-params", {
-      audioType: AvatarAudioDefaults.AUDIO_TYPE,
-      sourceType: SourceType.AVATAR_AUDIO_SOURCE,
-      distanceModel: AvatarAudioDefaults.DISTANCE_MODEL,
-      rolloffFactor: AvatarAudioDefaults.ROLLOFF_FACTORROLLOFF_FACTOR,
-      refDistance: AvatarAudioDefaults.REF_DISTANCE,
-      maxDistance: AvatarAudioDefaults.MAX_DISTANCE,
-      coneInnerAngle: AvatarAudioDefaults.INNER_ANGLE,
-      coneOuterAngle: AvatarAudioDefaults.OUTER_ANGLE,
-      coneOuterGain: AvatarAudioDefaults.OUTER_GAIN,
-      gain: AvatarAudioDefaults.VOLUME
-    });
     this.el.components["audio-params"].setAudio(audio);
 
     this.audioSystem.removeAudio(audio);

--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -1,4 +1,4 @@
-import { SourceType, AvatarAudioDefaults, TargetAudioDefaults, AudioType } from "./audio-params";
+import { SourceType, TargetAudioDefaults, AudioType } from "./audio-params";
 import { MixerType } from "../systems/audio-system";
 const INFO_INIT_FAILED = "Failed to initialize avatar-audio-source.";
 const INFO_NO_NETWORKED_EL = "Could not find networked el.";

--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -1,4 +1,4 @@
-import { SourceType, AvatarAudioDefaults, TargetAudioDefaults } from "./audio-params";
+import { SourceType, AvatarAudioDefaults, TargetAudioDefaults, AudioType } from "./audio-params";
 import { MixerType } from "../systems/audio-system";
 const INFO_INIT_FAILED = "Failed to initialize avatar-audio-source.";
 const INFO_NO_NETWORKED_EL = "Could not find networked el.";
@@ -53,6 +53,7 @@ AFRAME.registerComponent("avatar-audio-source", {
     const audioListener = this.el.sceneEl.audioListener;
     const audio = new THREE.PositionalAudio(audioListener);
     this.el.setAttribute("audio-params", {
+      audioType: AvatarAudioDefaults.AUDIO_TYPE,
       sourceType: SourceType.AVATAR_AUDIO_SOURCE,
       distanceModel: AvatarAudioDefaults.DISTANCE_MODEL,
       rolloffFactor: AvatarAudioDefaults.ROLLOFF_FACTORROLLOFF_FACTOR,
@@ -286,7 +287,13 @@ AFRAME.registerComponent("audio-target", {
 
   createAudio: function() {
     const audioListener = this.el.sceneEl.audioListener;
-    const audio = new THREE.PositionalAudio(audioListener);
+
+    let audio = null;
+    if (this.el.components["audio-params"].data.audioType === AudioType.PannerNode) {
+      audio = new THREE.PositionalAudio(audioListener);
+    } else {
+      audio = new THREE.Audio(audioListener);
+    }
 
     if (this.data.maxDelay > 0) {
       const delayNode = audio.context.createDelay(this.data.maxDelay);

--- a/src/components/avatar-volume-controls.js
+++ b/src/components/avatar-volume-controls.js
@@ -25,7 +25,6 @@ AFRAME.registerComponent("avatar-volume-controls", {
 
   changeVolumeBy(v) {
     const vol = THREE.Math.clamp(this.audioParamsComp.data.gain + v, 0, MAX_VOLUME);
-    this.el.setAttribute("avatar-volume-controls", "volume", vol);
     this.audioParamsComp.el.setAttribute("audio-params", "gain", vol);
     this.updateVolumeLabel();
   },

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -53,6 +53,7 @@ for (let i = 0; i <= 20; i++) {
 
 import { KTX2Loader } from "three/examples/jsm/loaders/KTX2Loader";
 import { rewriteBasisTranscoderUrls } from "../utils/media-url-utils";
+import { AudioType } from "./audio-params";
 const loadingManager = new THREE.LoadingManager();
 loadingManager.setURLModifier(rewriteBasisTranscoderUrls);
 
@@ -257,7 +258,6 @@ AFRAME.registerComponent("media-video", {
     audioSrc: { type: "string" },
     contentType: { type: "string" },
     loop: { type: "boolean", default: true },
-    audioType: { type: "string", default: "pannernode" },
     hidePlaybackControls: { type: "boolean", default: false },
     videoPaused: { type: "boolean" },
     projection: { type: "string", default: "flat" },
@@ -516,8 +516,9 @@ AFRAME.registerComponent("media-video", {
       this.updateSrc(oldData);
       return;
     }
+
     const shouldRecreateAudio =
-      !shouldUpdateSrc && this.mediaElementAudioSource && oldData.audioType !== this.data.audioType;
+      !shouldUpdateSrc && this.mediaElementAudioSource && this.audio?.panner?.audioType !== this.data.audioType;
     if (shouldRecreateAudio) {
       this.setupAudio();
       return;
@@ -530,7 +531,12 @@ AFRAME.registerComponent("media-video", {
       this.el.removeObject3D("sound");
     }
 
-    this.audio = new THREE.PositionalAudio(this.el.sceneEl.audioListener);
+    const audioListener = this.el.sceneEl.audioListener;
+    if (this.el.components["audio-params"].data.audioType === AudioType.PannerNode) {
+      this.audio = new THREE.PositionalAudio(audioListener);
+    } else {
+      this.audio = new THREE.Audio(audioListener);
+    }
 
     this.audioSystem.removeAudio(this.audio);
     this.audioSystem.addAudio(MixerType.MEDIA, this.audio);

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -241,11 +241,11 @@ async function mediaInflator(el, componentName, componentData, components) {
   if (componentName === "video" || componentName === "audio") {
     mediaOptions.videoPaused = !componentData.autoPlay;
     mediaOptions.loop = componentData.loop;
-    mediaOptions.audioType = componentData.audioType;
     mediaOptions.hidePlaybackControls = !isControlled;
 
-    if (componentData.audioType && componentData.audioType === "pannernode") {
+    if (componentData.audioType) {
       el.setAttribute("audio-params", {
+        audioType: componentData.audioType,
         sourceType: SourceType.MEDIA_VIDEO,
         distanceModel: componentData.distanceModel,
         rolloffFactor: componentData.rolloffFactor,

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -3,7 +3,7 @@ import "./components/gltf-model-plus";
 import { getSanitizedComponentMapping } from "./utils/component-mappings";
 import { TYPE, SHAPE, FIT } from "three-ammo/constants";
 const COLLISION_LAYERS = require("./constants").COLLISION_LAYERS;
-import { SourceType } from "./components/audio-params";
+import { AudioType, SourceType } from "./components/audio-params";
 
 function registerRootSceneComponent(componentName) {
   AFRAME.GLTFModelPlus.registerComponent(componentName, componentName, (el, componentName, componentData) => {
@@ -470,7 +470,28 @@ AFRAME.GLTFModelPlus.registerComponent(
       }
     }
 
-    el.setAttribute(componentName, { ...componentData, srcEl });
+    // Migrate audio-target component that has built-in audio params
+    if (componentData.positional) {
+      el.setAttribute("audio-params", {
+        audioType: componentData.positional ? AudioType.PannerNode : AudioType.Stereo,
+        sourceType: SourceType.MEDIA_VIDEO,
+        distanceModel: componentData.distanceModel,
+        rolloffFactor: componentData.rolloffFactor,
+        refDistance: componentData.refDistance,
+        maxDistance: componentData.maxDistance,
+        coneInnerAngle: componentData.coneInnerAngle,
+        coneOuterAngle: componentData.coneOuterAngle,
+        coneOuterGain: componentData.coneOuterGain,
+        gain: componentData.volume
+      });
+    }
+
+    el.setAttribute(componentName, {
+      minDelay: componentData.minDelay,
+      maxDelay: componentData.maxDelay,
+      debug: componentData.debug,
+      srcEl
+    });
   }
 );
 AFRAME.GLTFModelPlus.registerComponent("zone-audio-source", "zone-audio-source");

--- a/src/systems/audio-settings-system.js
+++ b/src/systems/audio-settings-system.js
@@ -37,13 +37,13 @@ export class AudioSettingsSystem {
       avatarConeOuterAngle: AvatarAudioDefaults.OUTER_ANGLE,
       avatarConeOuterGain: AvatarAudioDefaults.OUTER_GAIN,
       mediaVolume: MediaAudioDefaults.VOLUME,
-      mediaDistanceModel: AvatarAudioDefaults.DISTANCE_MODEL,
-      mediaRolloffFactor: AvatarAudioDefaults.ROLLOFF_FACTOR,
-      mediaRefDistance: AvatarAudioDefaults.REF_DISTANCE,
-      mediaMaxDistance: AvatarAudioDefaults.MAX_DISTANCE,
-      mediaConeInnerAngle: AvatarAudioDefaults.INNER_ANGLE,
-      mediaConeOuterAngle: AvatarAudioDefaults.OUTER_ANGLE,
-      mediaConeOuterGain: AvatarAudioDefaults.OUTER_GAIN
+      mediaDistanceModel: MediaAudioDefaults.DISTANCE_MODEL,
+      mediaRolloffFactor: MediaAudioDefaults.ROLLOFF_FACTOR,
+      mediaRefDistance: MediaAudioDefaults.REF_DISTANCE,
+      mediaMaxDistance: MediaAudioDefaults.MAX_DISTANCE,
+      mediaConeInnerAngle: MediaAudioDefaults.INNER_ANGLE,
+      mediaConeOuterAngle: MediaAudioDefaults.OUTER_ANGLE,
+      mediaConeOuterGain: MediaAudioDefaults.OUTER_GAIN
     };
     this.audioSettings = this.defaultSettings;
     this.mediaVideos = [];

--- a/src/systems/audio-system.js
+++ b/src/systems/audio-system.js
@@ -194,11 +194,9 @@ export class AudioSystem {
   updatePrefs() {
     const { globalVoiceVolume, globalMediaVolume } = window.APP.store.state.preferences;
     let newGain = (globalMediaVolume !== undefined ? globalMediaVolume : 100) / 100;
-    newGain = Math.max(0.001, newGain);
     this.mixer[MixerType.MEDIA].gain.setTargetAtTime(newGain, this.audioContext.currentTime, GAIN_TIME_CONST);
 
     newGain = (globalVoiceVolume !== undefined ? globalVoiceVolume : 100) / 100;
-    newGain = Math.max(0.001, newGain);
     this.mixer[MixerType.AVATAR].gain.setTargetAtTime(newGain, this.audioContext.currentTime, GAIN_TIME_CONST);
   }
 

--- a/src/systems/audio-system.js
+++ b/src/systems/audio-system.js
@@ -1,4 +1,5 @@
 import { LogMessageType } from "../react-components/room/ChatSidebar";
+import { GAIN_TIME_CONST } from "../components/audio-params";
 
 export const MixerType = Object.freeze({
   AVATAR: 0,
@@ -194,11 +195,11 @@ export class AudioSystem {
     const { globalVoiceVolume, globalMediaVolume } = window.APP.store.state.preferences;
     let newGain = (globalMediaVolume !== undefined ? globalMediaVolume : 100) / 100;
     newGain = Math.max(0.001, newGain);
-    this.mixer[MixerType.MEDIA].gain.exponentialRampToValueAtTime(newGain, this.audioContext.currentTime + 1);
+    this.mixer[MixerType.MEDIA].gain.setTargetAtTime(newGain, this.audioContext.currentTime, GAIN_TIME_CONST);
 
     newGain = (globalVoiceVolume !== undefined ? globalVoiceVolume : 100) / 100;
     newGain = Math.max(0.001, newGain);
-    this.mixer[MixerType.AVATAR].gain.exponentialRampToValueAtTime(newGain, this.audioContext.currentTime + 1);
+    this.mixer[MixerType.AVATAR].gain.setTargetAtTime(newGain, this.audioContext.currentTime, GAIN_TIME_CONST);
   }
 
   /**


### PR DESCRIPTION
This PR fixes several audio related issues:

- We were restoring the component data with the panner values every tick so the component always got reset to default value. The first commit fixes that. Fixes #4434
- Restores the support for stereo audio elements that was accidentally removed during the audio parameters refactor.
- We weren't creating the `audio-params`  component for old audio-targets with builtin audio parameters. Related #4438
- We were still setting volume  on `avatar-audio-source` but we are now setting that on the `audio-params` component and that was logging an error. Fixes #4454