### PR TITLE
Hubs Cloud: Fix broken media positional audio

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -862,6 +862,8 @@ AFRAME.registerComponent("media-video", {
         videoEl.onerror = failLoad;
 
         if (this.data.audioSrc) {
+          videoEl.muted = true;
+
           // If there's an audio src, create an audio element to play it that we keep in sync
           // with the video while this component is active.
           audioEl = createVideoOrAudioEl("audio");


### PR DESCRIPTION
In Hubs Cloud, somehow Media positional audio has been broken. This PR fixes it.

The root issue seems that the same two audio sounds come out for a media, one is a video element and another one is Three.js PositionalAudio (WebAudio panner). The former volume should be louder in general because no attenuation. So we feel that positional audio doesn't work although we just don't hear the positional audio because of the louder video element non-positional audio. This PR fixes this problem by muting the video element.

This change is a part of https://github.com/mozilla/hubs/commit/a53a59b1c19992a0758c48f3e4686018d8bd2b30 which is a commit already merged to master. So media positional audio works in hubs.mozilla.com.

@keianhzo Did you notice that the media positional audio was broken and fix it in the commit?