### PR TITLE
Disable audio debugger for WebGL < 2.0

### DIFF
--- a/src/change-hub.js
+++ b/src/change-hub.js
@@ -99,7 +99,7 @@ export async function changeHub(hubId, addToHistory = true) {
 window.changeHub = changeHub;
 
 // TODO see if there is a better way to do this with react router
-window.addEventListener("popstate", function(e) {
+window.addEventListener("popstate", function() {
   if (!APP.store.state.preferences.fastRoomSwitching) return;
   const qs = new URLSearchParams(location.search);
   const newHubId = qs.get("hub_id") || document.location.pathname.substring(1).split("/")[0];

--- a/src/systems/audio-debug-system.js
+++ b/src/systems/audio-debug-system.js
@@ -2,6 +2,7 @@ import { THREE } from "aframe";
 import audioDebugVert from "./audio-debug.vert";
 import audioDebugFrag from "./audio-debug.frag";
 import { DistanceModelType } from "../components/audio-params";
+import { getWebGLVersion } from "../utils/webgl";
 
 const MAX_DEBUG_SOURCES = 64;
 
@@ -11,6 +12,12 @@ AFRAME.registerSystem("audio-debug", {
   },
 
   init() {
+    this.unsupported = false;
+    const webGLVersion = getWebGLVersion(this.el.sceneEl.renderer);
+    if (webGLVersion < "2.0") {
+      this.unsupported = true;
+    }
+
     window.APP.store.addEventListener("statechanged", this.updateState.bind(this));
 
     this.onSceneLoaded = this.onSceneLoaded.bind(this);
@@ -143,7 +150,7 @@ AFRAME.registerSystem("audio-debug", {
   },
 
   enableDebugMode(enabled, force = false) {
-    if ((enabled === undefined || enabled === this.data.enabled) && !force) return;
+    if (((enabled === undefined || enabled === this.data.enabled) && !force) ||   this.unsupported) return;
     this.zones.forEach(zone => {
       zone.el.setAttribute("audio-zone", "debuggable", enabled);
     });

--- a/src/systems/audio-debug-system.js
+++ b/src/systems/audio-debug-system.js
@@ -150,7 +150,7 @@ AFRAME.registerSystem("audio-debug", {
   },
 
   enableDebugMode(enabled, force = false) {
-    if (((enabled === undefined || enabled === this.data.enabled) && !force) ||   this.unsupported) return;
+    if (((enabled === undefined || enabled === this.data.enabled) && !force) || this.unsupported) return;
     this.zones.forEach(zone => {
       zone.el.setAttribute("audio-zone", "debuggable", enabled);
     });

--- a/src/utils/webgl.js
+++ b/src/utils/webgl.js
@@ -34,3 +34,8 @@ export function patchWebGLRenderingContext() {
     };
   }
 }
+
+export function getWebGLVersion(renderer) {
+  const gl = renderer.getContext("webgl") || renderer.getContext("experimental-webgl");
+  return gl.getParameter(gl.VERSION).split(" ")[1];
+}

--- a/src/utils/webgl.js
+++ b/src/utils/webgl.js
@@ -36,6 +36,6 @@ export function patchWebGLRenderingContext() {
 }
 
 export function getWebGLVersion(renderer) {
-  const gl = renderer.getContext("webgl") || renderer.getContext("experimental-webgl");
+  const gl = renderer.getContext();
   return gl.getParameter(gl.VERSION).split(" ")[1];
 }


### PR DESCRIPTION
The audio debugging shader uses GLSL 3.00.0 ES features. This PR disables the shader for any device using WebGL < 2.0