### PR TITLE
Fix wrong transparent object menu buttons and texts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15821,9 +15821,8 @@
       "integrity": "sha512-OQlwyK/U5ISEoEaZCOxCzkfqq6F1coUKXQuwkWMAmRmvKyAfrEyX63G8c87aPvZO35z+PItObcpYNtBmjk4SBQ=="
     },
     "aframe-slice9-component": {
-      "version": "1.0.0",
-      "resolved": "https://registry.yarnpkg.com/aframe-slice9-component/-/aframe-slice9-component-1.0.0.tgz",
-      "integrity": "sha1-+w+EQdrdHosRzCRRK6eqaS1iK+E="
+      "version": "github:takahirox/aframe-slice9-component#2ec0810cbf23f487a10c767d24dee6d5b7ede77f",
+      "from": "github:takahirox/aframe-slice9-component#AlphaTest"
     },
     "aggregate-error": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@popperjs/core": "^2.4.4",
     "aframe": "github:mozillareality/aframe#hubs/master",
     "aframe-rounded": "^1.0.3",
-    "aframe-slice9-component": "^1.0.0",
+    "aframe-slice9-component": "github:takahirox/aframe-slice9-component#AlphaTest",
     "ammo-debug-drawer": "github:infinitelee/ammo-debug-drawer",
     "ammo.js": "github:mozillareality/ammo.js#hubs/master",
     "animejs": "github:mozillareality/anime#hubs/master",

--- a/src/hub.html
+++ b/src/hub.html
@@ -973,6 +973,7 @@
                     right: 66;
                     bottom: 66;
                     opacity: 1.0;
+                    alphaTest: 0.1;
                     src: #button"
             ></a-mixin>
 
@@ -985,6 +986,7 @@
                     right: 66;
                     bottom: 66;
                     opacity: 1.0;
+                    alphaTest: 0.1;
                     src: #button"
             ></a-mixin>
 
@@ -997,6 +999,7 @@
                     right: 66;
                     bottom: 66;
                     opacity: 1.0;
+                    alphaTest: 0.1;
                     src: #action-button"
             ></a-mixin>
 
@@ -1009,6 +1012,7 @@
                     right: 66;
                     bottom: 66;
                     opacity: 1.0;
+                    alphaTest: 0.1;
                     src: #action-button"
             ></a-mixin>
 
@@ -1027,6 +1031,7 @@
                     right: 66;
                     bottom: 66;
                     opacity: 1.0;
+                    alphaTest: 0.1;
                     src: #button"
             ></a-mixin>
         </a-assets>

--- a/src/hub.html
+++ b/src/hub.html
@@ -972,7 +972,7 @@
                     top: 64;
                     right: 66;
                     bottom: 66;
-                    opacity: 1.0;
+                    transparent: false;
                     alphaTest: 0.1;
                     src: #button"
             ></a-mixin>
@@ -985,7 +985,7 @@
                     top: 64;
                     right: 66;
                     bottom: 66;
-                    opacity: 1.0;
+                    transparent: false;
                     alphaTest: 0.1;
                     src: #button"
             ></a-mixin>
@@ -998,7 +998,7 @@
                     top: 64;
                     right: 66;
                     bottom: 66;
-                    opacity: 1.0;
+                    transparent: false;
                     alphaTest: 0.1;
                     src: #action-button"
             ></a-mixin>
@@ -1011,7 +1011,7 @@
                     top: 64;
                     right: 66;
                     bottom: 66;
-                    opacity: 1.0;
+                    transparent: false;
                     alphaTest: 0.1;
                     src: #action-button"
             ></a-mixin>
@@ -1030,7 +1030,7 @@
                     top: 64;
                     right: 66;
                     bottom: 66;
-                    opacity: 1.0;
+                    transparent: false;
                     alphaTest: 0.1;
                     src: #button"
             ></a-mixin>


### PR DESCRIPTION
This PR fixes #4416 and #4417 by applying `alphaTest` to `slice9` component and making `slice9` opaque for object menu buttons.

The screenshot of this PR. Please compare with the ones in #4416 and #4417.

![image](https://user-images.githubusercontent.com/7637832/128225839-9a6384bc-36c9-43a0-801d-3651f4648cbe.png)

Currently `slice9` component doesn't have `alphaTest` attribute so I made my fork.

If this change looks good and we merge, I will make a PR to `slice9` component. When it will be merged, I will update package.json and package-lock.json.

**The mechanism of the problems**

* The text is placed in front of the slice9 component and the slice9 component is placed in front of an object
* Currently all of them are somehow transparent and farther objects should be render first
* Three.js determines the render order by checking the distance of objects from the camera to generally the center of the objects
* If object group in which the text, the slice9 component, and the object are involved, is rotated and/or it is far from the camera, Three.js can wrongly determine the render order and render the texts or slice9 earlier than others (This is the limitation of the current efficient but non-perfect render order decision algorithm of Three.js)
* If it the wrong render order happens overlapped areas of slice9 and object are not rendered because of depth test. This is the reason why currently texts and the around of slice9 can be transparent to background

**How to solve**

* The `slice9` component seems to be expected to be transparent because the component renders to the plane geometry mesh and uses alpha blend to cut off the four corners
* But for that purpose, using alphaTest should be smarter and more efficient than alpha blend (=transparent). So I introduced `alphaTest` attribute to the `slice9` component and it resolves #4417 because the four corner will be discorded in the shader and (my understanding is) the depth will not be written neither.
* With alphaTest, we can make the `slice9` components for the object menu opaque. In Three.js opaque objects are rendered earlier than transparent object. So the render order between texts (transparent) and `slice9` (opaque) will be always correct and #4416 will be fixed.

**Note**

* The font we currently use seems to require `transparent`. So opaque texts can't be a solution unless we change the font.