### PR TITLE
Teleport fix

### DIFF
--- a/src/systems/audio-debug-system.js
+++ b/src/systems/audio-debug-system.js
@@ -162,7 +162,6 @@ AFRAME.registerSystem("audio-debug", {
       navMesh.visible = enabled;
       navMesh.traverse(obj => {
         if (obj.isMesh) {
-          obj.visible = enabled;
           if (obj.material) {
             if (enabled) {
               obj._hubs_audio_debug_material = obj.material;


### PR DESCRIPTION
We were making the navMesh invisible when disabling the Audio Debug view and the Raycaster doesn't intersect with invisible objects. Changing the parent's visibility allows us to show/hide while keeping the actual navMesh intersectable