### PR TITLE
Fixed the missing remove snap interact event listener in media-views.js

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -1004,6 +1004,7 @@ AFRAME.registerComponent("media-video", {
       this.volumeDownButton.object3D.removeEventListener("interact", this.volumeDown);
       this.seekForwardButton.object3D.removeEventListener("interact", this.seekForward);
       this.seekBackButton.object3D.removeEventListener("interact", this.seekBack);
+      this.snapButton.object3D.removeEventListener("interact", this.snap);
     }
 
     window.APP.store.removeEventListener("statechanged", this.onPreferenceChanged);


### PR DESCRIPTION
This PR fixes #4485 by adding missing `this.snapButton.object3D.removeEventListener("interact", this.snap);` in `remove()` in `media-views.js`.