### PR TITLE
Make sure audio-params is available when media-video is created

### DIFF
--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -171,7 +171,6 @@ AFRAME.registerComponent("media-loader", {
     this.el.removeAttribute("gltf-model-plus");
     this.el.removeAttribute("media-pager");
     this.el.removeAttribute("media-video");
-    this.el.removeAttribute("audio-params");
     this.el.removeAttribute("audio-zone-source");
     this.el.removeAttribute("media-pdf");
     this.el.setAttribute("media-image", { src: "error" });
@@ -350,7 +349,6 @@ AFRAME.registerComponent("media-loader", {
       this.el.removeAttribute("gltf-model-plus");
       this.el.removeAttribute("media-pager");
       this.el.removeAttribute("media-video");
-      this.el.removeAttribute("audio-params");
       this.el.removeAttribute("audio-zone-source");
       this.el.removeAttribute("media-pdf");
       this.el.removeAttribute("media-image");
@@ -464,7 +462,6 @@ AFRAME.registerComponent("media-loader", {
             linkedMediaElementAudioSource
           })
         );
-        this.el.setAttribute("audio-params", {});
         this.el.setAttribute("audio-zone-source", {});
         if (this.el.components["position-at-border__freeze"]) {
           this.el.setAttribute("position-at-border__freeze", { isFlat: true });
@@ -475,7 +472,6 @@ AFRAME.registerComponent("media-loader", {
       } else if (contentType.startsWith("image/")) {
         this.el.removeAttribute("gltf-model-plus");
         this.el.removeAttribute("media-video");
-        this.el.removeAttribute("audio-params");
         this.el.removeAttribute("audio-zone-source");
         this.el.removeAttribute("media-pdf");
         this.el.removeAttribute("media-pager");
@@ -519,7 +515,6 @@ AFRAME.registerComponent("media-loader", {
       } else if (contentType.startsWith("application/pdf")) {
         this.el.removeAttribute("gltf-model-plus");
         this.el.removeAttribute("media-video");
-        this.el.removeAttribute("audio-params");
         this.el.removeAttribute("audio-zone-source");
         this.el.removeAttribute("media-image");
         this.el.setAttribute(
@@ -554,7 +549,6 @@ AFRAME.registerComponent("media-loader", {
       ) {
         this.el.removeAttribute("media-image");
         this.el.removeAttribute("media-video");
-        this.el.removeAttribute("audio-params");
         this.el.removeAttribute("audio-zone-source");
         this.el.removeAttribute("media-pdf");
         this.el.removeAttribute("media-pager");
@@ -589,7 +583,6 @@ AFRAME.registerComponent("media-loader", {
       } else if (contentType.startsWith("text/html")) {
         this.el.removeAttribute("gltf-model-plus");
         this.el.removeAttribute("media-video");
-        this.el.removeAttribute("audio-params");
         this.el.removeAttribute("audio-zone-source");
         this.el.removeAttribute("media-pdf");
         this.el.removeAttribute("media-pager");

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -55,7 +55,7 @@ for (let i = 0; i <= 20; i++) {
 
 import { KTX2Loader } from "three/examples/jsm/loaders/KTX2Loader";
 import { rewriteBasisTranscoderUrls } from "../utils/media-url-utils";
-import { AudioType } from "./audio-params";
+import { AudioType, MediaAudioDefaults } from "./audio-params";
 const loadingManager = new THREE.LoadingManager();
 loadingManager.setURLModifier(rewriteBasisTranscoderUrls);
 
@@ -293,6 +293,18 @@ AFRAME.registerComponent("media-video", {
     this.isSnapping = false;
     this.videoIsLive = null; // value null until we've determined if the video is live or not.
     this.onSnapImageLoaded = () => (this.isSnapping = false);
+
+    this.el.setAttribute("audio-params", {
+      audioType: MediaAudioDefaults.AUDIO_TYPE,
+      distanceModel: MediaAudioDefaults.DISTANCE_MODEL,
+      rolloffFactor: MediaAudioDefaults.ROLLOFF_FACTOR,
+      refDistance: MediaAudioDefaults.REF_DISTANCE,
+      maxDistance: MediaAudioDefaults.MAX_DISTANCE,
+      coneInnerAngle: MediaAudioDefaults.INNER_ANGLE,
+      coneOuterAngle: MediaAudioDefaults.OUTER_ANGLE,
+      coneOuterGain: MediaAudioDefaults.OUTER_GAIN,
+      gain: MediaAudioDefaults.VOLUME
+    });
 
     this.el.setAttribute("hover-menu__video", { template: "#video-hover-menu", isFlat: true });
     this.el.components["hover-menu__video"].getHoverMenu().then(menu => {
@@ -969,6 +981,8 @@ AFRAME.registerComponent("media-video", {
 
   remove() {
     this.cleanUp();
+
+    this.el.removeAttribute("audio-params");
 
     if (this.mesh) {
       this.el.removeObject3D("mesh");


### PR DESCRIPTION
After creating the `media-video` component from `media-loader`A-Frame calls `update` then we are calling `updateSrc` asynchronously which calls `setupAudio` and that's where the exceptions is thrown. 

My understanding is that there is some race condition happening that prevents the `audio-params` component to be created before the `setupAudio`call happens but it only happens in two scenarios that I know of, one is this one during a `linked-media` entity creation (#4472) and the other one is during the creation of a remote `media-video` (#4456). 

It's is unclear to me why is this happening only in those scenarios and not when creating a local `media-video` entity.

This PR moves the `audio-params` component creation from `media-loader` to `media-video` init/remove (as that's the only media view where we really need it) and that seems to guarantee that the component is available when `setupAudio` is called.
- Fixes #4472
- Fixes #4456
- Fixes #4477 We were not initializing the `audio-params` component with the default parameters for drag&drop media which doesn't have an `audio-params`.  Also I was tempted to add a to see  check if we already have and `audio-params` component to make sure we don't override the audio parameters for components were the `audio-params` component but as far as I know that could only happen in case the GLTF file has a `media-video` component declared before the `audio-params` component by manual manipulation so it should be a case.