### PR TITLE
Add missing properties in media-video component schema

### DIFF
--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -265,7 +265,10 @@ AFRAME.registerComponent("media-video", {
     projection: { type: "string", default: "flat" },
     time: { type: "number" },
     tickRate: { default: 1000 }, // ms interval to send time interval updates
-    syncTolerance: { default: 2 }
+    syncTolerance: { default: 2 },
+    linkedVideoTexture: { default: null },
+    linkedAudioSource: { default: null },
+    linkedMediaElementAudioSource: { default: null }
   },
 
   init() {


### PR DESCRIPTION
From: https://github.com/mozilla/hubs/pull/4487#issuecomment-895118581

**The problem this PR fixes**

If I magnify a video of GIF, the following console warnings show up.

![image](https://user-images.githubusercontent.com/7637832/128919927-d365105f-3c4a-4b21-b0df-307fe420768a.png)

Note: I opened another issue for the error https://github.com/mozilla/hubs/issues/4499

**Root issue**

`media-video` schema doesn't have the properties.

**Solution**

Add them to the schema.

If there is any historical reasons why we didn't add them, let me know @netpro2k @brianpeiris 
