### PR TITLE
Disable positional audio for Safari as a workaround for its positional audio bug

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -42,7 +42,7 @@ import "./utils/threejs-positional-audio-updatematrixworld";
 import "./utils/threejs-world-update";
 import "./utils/threejs-raycast-patches";
 import patchThreeAllocations from "./utils/threejs-allocation-patches";
-import { detectOS, detect } from "detect-browser";
+import { isSafari } from "./utils/detect-safari";
 import {
   getReticulumFetchUrl,
   getReticulumMeta,
@@ -670,11 +670,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     return;
   }
 
-  const detectedOS = detectOS(navigator.userAgent);
-  const browser = detect();
   // HACK - it seems if we don't initialize the mic track up-front, voices can drop out on iOS
   // safari when initializing it later.
-  if (["iOS", "Mac OS"].includes(detectedOS) && ["safari", "ios"].includes(browser.name)) {
+  if (isSafari()) {
     try {
       await navigator.mediaDevices.getUserMedia({ audio: true });
     } catch (e) {

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -3,6 +3,7 @@ import merge from "deepmerge";
 import Cookies from "js-cookie";
 import jwtDecode from "jwt-decode";
 import { qsGet } from "../utils/qs_truthy.js";
+import { isSafari } from "../utils/detect-safari";
 
 const LOCAL_STORE_KEY = "___hubs_store";
 const STORE_STATE_CACHE_KEY = Symbol();
@@ -242,6 +243,12 @@ export default class Store extends EventTarget {
       onLoadActions: [],
       preferences: {}
     });
+
+    // Temporary fix for distorted audio in Safari.
+    // See https://github.com/mozilla/hubs/issues/4411
+    if (isSafari()) {
+      this.update({ preferences: { audioOutputMode: "audio" } });
+    }
 
     this._shouldResetAvatarOnInit = false;
 

--- a/src/systems/audio-settings-system.js
+++ b/src/systems/audio-settings-system.js
@@ -1,4 +1,5 @@
 import { AvatarAudioDefaults, MediaAudioDefaults } from "../components/audio-params";
+import { isSafari } from "../utils/detect-safari";
 
 function updateMediaAudioSettings(mediaVideo, settings) {
   mediaVideo.el.setAttribute("audio-params", {
@@ -51,9 +52,12 @@ export class AudioSettingsSystem {
 
     this.sceneEl.addEventListener("reset_scene", this.onSceneReset);
 
+    // Do not force panner audio in Safari as a temporary fix for distorted audio.
+    // See https://github.com/mozilla/hubs/issues/4411
     if (
-      !window.APP.store.state.preferences.audioOutputMode ||
-      window.APP.store.state.preferences.audioOutputMode === "audio"
+      !isSafari() &&
+      (!window.APP.store.state.preferences.audioOutputMode ||
+        window.APP.store.state.preferences.audioOutputMode === "audio")
     ) {
       //hack to always reset to "panner"
       window.APP.store.update({

--- a/src/utils/detect-safari.js
+++ b/src/utils/detect-safari.js
@@ -1,0 +1,6 @@
+import { detect } from "detect-browser";
+
+export function isSafari() {
+  const browser = detect();
+  return ["iOS", "Mac OS"].includes(browser.os) && ["safari", "ios"].includes(browser.name);
+}


### PR DESCRIPTION
Currently audio in Hubs is choppy and distorted on Safari. It seems being caused by Safari Positional Audio bug. And the bug seems to have a bad impact to performance. (Refer to #4411).

We have reported the bug to Safari. And we have applied the temporal fix in #4442 by disabling positional audio for Hubs Cloud. Positional audio is one of the important features for us but non-positional audio should be much better than broken audio.

I would like to suggest to apply the same change to `master` (hubs.mozilla.com) because Safari users who tries hubs.mozilla.com may think Hubs is useless due to this problem and this problem blocks a lot of tests of the upstream on Safari.

@keianhzo Can you review to check if this temporal fix can affect new audio features you recently added?
