### PR TITLE
Fix mute reversed in VR

### DIFF
--- a/src/components/audio-feedback.js
+++ b/src/components/audio-feedback.js
@@ -315,7 +315,7 @@ AFRAME.registerComponent("mic-button", {
     const active = this.data.active;
     const hovering = this.hovering;
     const spriteNames =
-      SPRITE_NAMES[!active ? (hovering ? "MIC_HOVER" : "MIC") : hovering ? "MIC_OFF_HOVER" : "MIC_OFF"];
+      SPRITE_NAMES[active ? (hovering ? "MIC_HOVER" : "MIC") : hovering ? "MIC_OFF_HOVER" : "MIC_OFF"];
     const level = micLevelForVolume(audioAnalyser.volume);
     const spriteName = spriteNames[level];
     if (spriteName !== this.prevSpriteName) {


### PR DESCRIPTION
Fixes #4504

We set the active state of the `mic-button` component in just two places:
https://github.com/mozilla/hubs/blob/1cd1d619f90224b0e7145304c0db86515f90b52d/src/components/in-world-hud.js#L17
https://github.com/mozilla/hubs/blob/1cd1d619f90224b0e7145304c0db86515f90b52d/src/components/in-world-hud.js#L22

And we are in both using the mic enabled state while in the `mic-button` component we were expecting a disabled state:
https://github.com/mozilla/hubs/blob/1cd1d619f90224b0e7145304c0db86515f90b52d/src/components/audio-feedback.js#L317-L318

This fix seems to be the logical state of this code but I must be missing something becasue this wasn't broken on Desktop and I can't understand why...