### PR TITLE
Handle audio debug preference state change correctly

### DIFF
--- a/src/systems/audio-debug-system.js
+++ b/src/systems/audio-debug-system.js
@@ -193,15 +193,15 @@ AFRAME.registerSystem("audio-debug", {
     }
   },
 
-  updateState(force = false) {
-    const isEnabled = window.APP.store.state.preferences.showAudioDebugPanel;
-    if (force || (isEnabled !== undefined && isEnabled !== this.data.enabled)) {
+  updateState({ force }) {
+    const isEnabled = window.APP.store.state.preferences.showAudioDebugPanel || false;
+    if (force || isEnabled !== this.data.enabled) {
       this.enableDebugMode(isEnabled, force);
     }
   },
 
   onSceneLoaded() {
     this.navMeshObject = null;
-    this.updateState(true);
+    this.updateState({ force: true });
   }
 });


### PR DESCRIPTION
Fixes #4475

Store `updateState` event send an object with an `isTrusted` property but we were assuming that we weren't getting any parameters. We also need to check if the `showAudioDebugPanel` preference is undefined in case it's been reset.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/HUBS-752)
