### PR TITLE
Copy mesh geometry to prevent the transform matrix being applied twice

### DIFF
--- a/src/systems/nav.js
+++ b/src/systems/nav.js
@@ -14,7 +14,7 @@ AFRAME.registerSystem("nav", {
       console.error("tried to load multiple nav meshes");
       this.removeNavMeshData();
     }
-    const geometry = mesh.geometry;
+    const geometry = mesh.geometry.clone();
     mesh.updateMatrices();
     geometry.applyMatrix4(mesh.matrixWorld);
     this.pathfinder.setZoneData(zone, Pathfinding.createZone(geometry));


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/4510

[This recent update to three.js ](https://github.com/mozilla/hubs/commit/4ea709ede09bce3cb1ff580916ed55261d502aaf#diff-e71a77a47ab916709aaf35571578358c7cb73db0d1970c008236a9ced02c6955L127) means that the transform matrix is applied directly to the underlying geometry rather than to a copy. This leads to the transform being applied twice to the three.js view of the nav-mesh and causing teleport problems and display problems in the rare cases where the nav-mesh is visible.