### PR TITLE
HDR Lightmaps & Environment Settings System

### DIFF
--- a/src/assets/stylesheets/hub.scss
+++ b/src/assets/stylesheets/hub.scss
@@ -52,3 +52,11 @@ a-entity {
   vertical-align: -0.125em;
   height: 1em;
 }
+
+// Dat GUI
+.dg select {
+  color: black;
+}
+.dg input {
+  line-height: normal;
+}

--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -184,11 +184,6 @@ AFRAME.registerComponent("camera-tool", {
       const width = 0.28;
       const geometry = new THREE.PlaneBufferGeometry(width, width / this.camera.aspect);
 
-      const environmentMapComponent = this.el.sceneEl.components["environment-map"];
-      if (environmentMapComponent) {
-        environmentMapComponent.applyEnvironmentMap(this.el.object3D);
-      }
-
       this.screen = new THREE.Mesh(geometry, material);
       this.screen.rotation.set(0, Math.PI, 0);
       this.screen.position.set(0, 0, -0.042);

--- a/src/components/environment-map.js
+++ b/src/components/environment-map.js
@@ -1,4 +1,3 @@
-import { forEachMaterial } from "../utils/material-utils";
 import cubeMapPosX from "../assets/images/cubemap/posx.jpg";
 import cubeMapNegX from "../assets/images/cubemap/negx.jpg";
 import cubeMapPosY from "../assets/images/cubemap/posy.jpg";
@@ -14,27 +13,3 @@ export async function createDefaultEnvironmentMap() {
   texture.format = THREE.RGBFormat;
   return texture;
 }
-
-AFRAME.registerComponent("environment-map", {
-  init() {
-    this.environmentMap = null;
-
-    this.updateEnvironmentMap = this.updateEnvironmentMap.bind(this);
-  },
-
-  updateEnvironmentMap(environmentMap) {
-    this.environmentMap = environmentMap;
-    this.applyEnvironmentMap(this.el.object3D);
-  },
-
-  applyEnvironmentMap(object3D) {
-    object3D.traverse(object => {
-      forEachMaterial(object, material => {
-        if (material.isMeshStandardMaterial) {
-          material.envMap = this.environmentMap;
-          material.needsUpdate = true;
-        }
-      });
-    });
-  }
-});

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -770,12 +770,6 @@ AFRAME.registerComponent("gltf-model-plus", {
         if (el) rewires.push(() => (o.el = el));
       });
 
-      const environmentMapComponent = this.el.sceneEl.components["environment-map"];
-
-      if (environmentMapComponent) {
-        environmentMapComponent.applyEnvironmentMap(object3DToSet);
-      }
-
       if (lastSrc) {
         gltfCache.release(lastSrc);
       }

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -460,7 +460,6 @@ class GLTFHubsComponentsExtension {
 
   extendScene(sceneIdx) {
     const ext = this.parser.json.scenes[sceneIdx]?.extensions?.MOZ_hubs_components;
-    console.log("extendceneParams", ext, sceneIdx, this.parser.json.scenes[sceneIdx]);
     if (ext) return this.resolveComponentLinks(ext);
   }
 
@@ -470,8 +469,6 @@ class GLTFHubsComponentsExtension {
   }
 
   resolveComponentLinks(ext) {
-    console.log("resolveComponentLinks", ext);
-
     const deps = [];
 
     for (const componentName in ext) {
@@ -480,16 +477,9 @@ class GLTFHubsComponentsExtension {
         const value = props[propName];
         const type = value?.__mhc_link_type;
         if (type && value.index !== undefined) {
-          console.log("Loading link", value);
           deps.push(
             this.parser.getDependency(type, value.index).then(loadedDep => {
-              console.log(`${type} loaded`, loadedDep);
               props[propName] = loadedDep;
-              // TODO figure out if this is sane
-              if (type === "texture") {
-                loadedDep.flipY = true;
-              }
-              console.log(props);
             })
           );
         }

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -25,7 +25,6 @@ import { waitForDOMContentLoaded } from "../utils/async-utils";
 
 import { SHAPE } from "three-ammo/constants";
 
-let loadingObjectEnvMap;
 let loadingObject;
 
 waitForDOMContentLoaded().then(() => {
@@ -192,15 +191,6 @@ AFRAME.registerComponent("media-loader", {
     this.updateScale(true, false);
 
     if (useFancyLoader) {
-      const environmentMapComponent = this.el.sceneEl.components["environment-map"];
-      if (environmentMapComponent) {
-        const currentEnivronmentMap = environmentMapComponent.environmentMap;
-        if (loadingObjectEnvMap !== currentEnivronmentMap) {
-          environmentMapComponent.applyEnvironmentMap(mesh);
-          loadingObjectEnvMap = currentEnivronmentMap;
-        }
-      }
-
       this.loaderMixer = new THREE.AnimationMixer(mesh);
 
       this.loadingClip = this.loaderMixer.clipAction(mesh.animations[0]);

--- a/src/components/scene-components.js
+++ b/src/components/scene-components.js
@@ -24,7 +24,6 @@ import "./floaty-object";
 import "./super-spawner";
 import "./water";
 import "./simple-water";
-import "./environment-map";
 import "./trigger-volume";
 import "./video-pause-state";
 import "./particle-emitter";

--- a/src/components/skybox.js
+++ b/src/components/skybox.js
@@ -3,9 +3,6 @@
 // in webpack production mode.
 require("three/examples/js/lights/LightProbeGenerator");
 
-import qsTruthy from "../utils/qs_truthy";
-const isBotMode = qsTruthy("bot");
-
 const {
   AmbientLight,
   BackSide,
@@ -479,7 +476,7 @@ AFRAME.registerComponent("skybox", {
       // It's kept to a low value to not wash out objects in very dark environments.
       // This is a hack, but the results are much better than they are without it.
       this.el.setObject3D("ambient-light", new AmbientLight(0xffffff, 0.3));
-      this.el.setObject3D("light-probe", this.sky.generateLightProbe(renderer));
+      this.el.setObject3D("light-probe", this.sky.generateLightProbe(this.el.sceneEl.renderer));
     }
 
     // TODO if we care about dynamic skybox changes we should also update the enviornment map here

--- a/src/components/skybox.js
+++ b/src/components/skybox.js
@@ -472,21 +472,8 @@ AFRAME.registerComponent("skybox", {
       this.sky.matrixNeedsUpdate = true;
     }
 
-    // TODO do we care about updating enviornment map after scene load?
-    // this.updateEnvironmentMap();
-  },
-
-  updateEnvironmentMap() {
-    const environmentMapComponent = this.el.sceneEl.components["environment-map"];
-    const renderer = this.el.sceneEl.renderer;
-
-    const quality = window.APP.store.materialQualitySetting;
-
-    if (environmentMapComponent && !isBotMode && quality === "high") {
-      const envMap = this.sky.generateEnvironmentMap(renderer);
-      environmentMapComponent.updateEnvironmentMap(envMap);
-    } else if (quality === "medium") {
-      // TODO this still needs to be accounted for
+    // TODO Remove or rework medium quality mode
+    if (window.APP.store.materialQualitySetting === "medium") {
       // This extra ambient light is here to normalize lighting with the MeshStandardMaterial.
       // Without it, objects are significantly darker in brighter environments.
       // It's kept to a low value to not wash out objects in very dark environments.
@@ -494,6 +481,9 @@ AFRAME.registerComponent("skybox", {
       this.el.setObject3D("ambient-light", new AmbientLight(0xffffff, 0.3));
       this.el.setObject3D("light-probe", this.sky.generateLightProbe(renderer));
     }
+
+    // TODO if we care about dynamic skybox changes we should also update the enviornment map here
+    //
   },
 
   remove() {

--- a/src/components/skybox.js
+++ b/src/components/skybox.js
@@ -430,12 +430,6 @@ AFRAME.registerComponent("skybox", {
   init() {
     this.sky = new Sky();
     this.el.setObject3D("mesh", this.sky);
-
-    this.updateEnvironmentMap = this.updateEnvironmentMap.bind(this);
-    // HACK: Render environment map on next frame to avoid bug where the render target texture is black.
-    // This is likely due to the custom elements attached callback being synchronous on Chrome but not Firefox.
-    // Added timeout due to additional case where texture is black in Firefox.
-    requestAnimationFrame(() => setTimeout(this.updateEnvironmentMap));
   },
 
   update(oldData) {
@@ -478,7 +472,8 @@ AFRAME.registerComponent("skybox", {
       this.sky.matrixNeedsUpdate = true;
     }
 
-    this.updateEnvironmentMap();
+    // TODO do we care about updating enviornment map after scene load?
+    // this.updateEnvironmentMap();
   },
 
   updateEnvironmentMap() {
@@ -491,6 +486,7 @@ AFRAME.registerComponent("skybox", {
       const envMap = this.sky.generateEnvironmentMap(renderer);
       environmentMapComponent.updateEnvironmentMap(envMap);
     } else if (quality === "medium") {
+      // TODO this still needs to be accounted for
       // This extra ambient light is here to normalize lighting with the MeshStandardMaterial.
       // Without it, objects are significantly darker in brighter environments.
       // It's kept to a low value to not wash out objects in very dark environments.

--- a/src/components/tools/networked-drawing.js
+++ b/src/components/tools/networked-drawing.js
@@ -90,11 +90,6 @@ AFRAME.registerComponent("networked-drawing", {
 
     this.el.setObject3D("mesh", this.drawing);
 
-    const environmentMapComponent = this.el.sceneEl.components["environment-map"];
-    if (environmentMapComponent) {
-      environmentMapComponent.applyEnvironmentMap(this.drawing);
-    }
-
     this.prevIdx = Object.assign({}, this.sharedBuffer.idx);
     this.idx = Object.assign({}, this.sharedBuffer.idx);
     this.vertexCount = 0; //number of vertices added for current line (used for line deletion).

--- a/src/components/tools/pen-laser.js
+++ b/src/components/tools/pen-laser.js
@@ -30,12 +30,6 @@ AFRAME.registerComponent("pen-laser", {
     this.laserTip.scale.setScalar(0.01);
     this.laserTip.matrixNeedsUpdate = true;
 
-    const environmentMapComponent = this.el.sceneEl.components["environment-map"];
-    if (environmentMapComponent) {
-      environmentMapComponent.applyEnvironmentMap(this.laser);
-      environmentMapComponent.applyEnvironmentMap(this.laserTip);
-    }
-
     //prevents the line from being a raycast target for the cursor
     this.laser.raycast = function() {};
 

--- a/src/components/tools/pen.js
+++ b/src/components/tools/pen.js
@@ -140,11 +140,6 @@ AFRAME.registerComponent("pen", {
 
     this.el.setObject3D("mesh", this.penTip);
 
-    const environmentMapComponent = this.el.sceneEl.components["environment-map"];
-    if (environmentMapComponent) {
-      environmentMapComponent.applyEnvironmentMap(this.el.parentEl.object3D);
-    }
-
     this.penLaserAttributesUpdated = false;
     this.penLaserAttributes = {
       color: "#FF0033",

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -373,7 +373,12 @@ AFRAME.GLTFModelPlus.registerComponent(
       enterComponentMapping = getSanitizedComponentMapping(enterComponent, enterProperty, publicComponents);
       leaveComponentMapping = getSanitizedComponentMapping(leaveComponent, leaveProperty, publicComponents);
 
-      targetEntity = indexToEntityMap[target];
+      // indexToEntityMap should be considered depredcated. These references are now resovled by the GLTFHubsComponentExtension
+      if (typeof target === "number") {
+        targetEntity = indexToEntityMap[target];
+      } else {
+        targetEntity = target?.el;
+      }
 
       if (!targetEntity) {
         throw new Error(`Couldn't find target entity with index: ${target}.`);
@@ -434,7 +439,12 @@ AFRAME.GLTFModelPlus.registerComponent(
 
     let srcEl;
     if (srcNode !== undefined) {
-      srcEl = indexToEntityMap[srcNode];
+      // indexToEntityMap should be considered depredcated. These references are now resovled by the GLTFHubsComponentExtension
+      if (typeof srcNode === "number") {
+        srcEl = indexToEntityMap[srcNode];
+      } else {
+        srcEl = srcNode?.el;
+      }
       if (!srcEl) {
         console.warn(
           `Error inflating gltf component "video-texture-srcEl": Couldn't find srcEl entity with index ${srcNode}`
@@ -462,7 +472,12 @@ AFRAME.GLTFModelPlus.registerComponent(
 
     let srcEl;
     if (srcNode !== undefined) {
-      srcEl = indexToEntityMap[srcNode];
+      // indexToEntityMap should be considered depredcated. These references are now resovled by the GLTFHubsComponentExtension
+      if (typeof srcNode === "number") {
+        srcEl = indexToEntityMap[srcNode];
+      } else {
+        srcEl = srcNode?.el;
+      }
       if (!srcEl) {
         console.warn(
           `Error inflating gltf component ${componentName}: Couldn't find srcEl entity with index ${srcNode}`

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -529,3 +529,15 @@ AFRAME.GLTFModelPlus.registerComponent(
 AFRAME.GLTFModelPlus.registerComponent("audio-zone", "audio-zone", (el, componentName, componentData) => {
   el.setAttribute(componentName, { ...componentData });
 });
+
+AFRAME.GLTFModelPlus.registerComponent(
+  "environment-settings",
+  "environment-settings",
+  (el, componentName, componentData) => {
+    // TODO a bit silly to be storing this as an aframe component. Use a glboal store of some sort
+    el.setAttribute(componentName, {
+      ...componentData,
+      backgroundColor: new THREE.Color(componentData.backgroundColor)
+    });
+  }
+);

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -534,6 +534,13 @@ AFRAME.GLTFModelPlus.registerComponent(
   "environment-settings",
   "environment-settings",
   (el, componentName, componentData) => {
+    if (componentData.envMapTexture) {
+      // assume equirect for now
+      componentData.envMapTexture.mapping = THREE.EquirectangularReflectionMapping;
+      // TODO do we always want to flip for enviornmetn map?
+      componentData.envMapTexture.flipY = true;
+    }
+
     // TODO a bit silly to be storing this as an aframe component. Use a glboal store of some sort
     el.setAttribute(componentName, {
       ...componentData,

--- a/src/hub.html
+++ b/src/hub.html
@@ -79,7 +79,6 @@
         freeze-controller
         personal-space-bubble="debug: false;"
         rotate-selected-object
-        environment-map
         light="defaultLightsEnabled: false"
     >
         <a-assets>

--- a/src/hub.js
+++ b/src/hub.js
@@ -398,6 +398,8 @@ export async function updateEnvironmentForHub(hub, entryManager) {
   const environmentScene = document.querySelector("#environment-scene");
   const sceneEl = document.querySelector("a-scene");
 
+  const envSystem = sceneEl.systems["hubs-systems"].environmentSystem;
+
   console.log(`Scene URL: ${sceneUrl}`);
 
   let environmentEl = null;
@@ -414,6 +416,8 @@ export async function updateEnvironmentForHub(hub, entryManager) {
         document.querySelector(".a-canvas").classList.remove("a-hidden");
 
         sceneEl.addState("visible");
+
+        envSystem.updateEnvironment(environmentEl);
 
         //TODO: check if the environment was made with spoke to determine if a shape should be added
         traverseMeshesAndAddShapes(environmentEl);
@@ -441,6 +445,8 @@ export async function updateEnvironmentForHub(hub, entryManager) {
           "model-loaded",
           () => {
             environmentEl.removeEventListener("model-error", sceneErrorHandler);
+
+            envSystem.updateEnvironment(environmentEl);
             traverseMeshesAndAddShapes(environmentEl);
 
             // We've already entered, so move to new spawn point once new environment is loaded

--- a/src/scene.html
+++ b/src/scene.html
@@ -37,7 +37,6 @@
             alpha: false;"
         shadow="type: pcfsoft;autoUpdate: false"
         light="defaultLightsEnabled: false"
-        environment-map
     >
         <a-entity
             id="scene-root"

--- a/src/systems/environment-system.js
+++ b/src/systems/environment-system.js
@@ -1,0 +1,145 @@
+import { GUI } from "three/examples/jsm/libs/dat.gui.module.js";
+import qsTruthy from "../utils/qs_truthy";
+
+const toneMappingOptions = {
+  None: "NoToneMapping",
+  Linear: "LinearToneMapping",
+  Reinhard: "ReinhardToneMapping",
+  Cineon: "CineonToneMapping",
+  ACESFilmic: "ACESFilmicToneMapping"
+};
+
+const defaultEnvSettings = {
+  toneMapping: toneMappingOptions.Linear,
+  toneMappingExposure: 1,
+  physicallyCorrectLights: true,
+  envMapTexture: null,
+  backgroundTexture: null,
+  backgroundColor: new THREE.Color("#000000")
+};
+
+export class EnvironmentSystem {
+  constructor(sceneEl) {
+    this.scene = sceneEl.object3D;
+    this.renderer = sceneEl.renderer;
+
+    this.pmremGenerator = new THREE.PMREMGenerator(this.renderer);
+
+    this.applyEnvSettings(defaultEnvSettings);
+
+    if (qsTruthy("envSettingsDebug")) {
+      this.setupDebugView();
+    }
+  }
+
+  setupDebugView() {
+    const debugSettings = { ...defaultEnvSettings };
+
+    const updateDebug = () => {
+      this.applyEnvSettings(debugSettings);
+    };
+
+    const gui = new GUI();
+    gui
+      .add(debugSettings, "toneMapping", Object.values(toneMappingOptions))
+      .onChange(updateDebug)
+      .listen();
+    gui
+      .add(debugSettings, "toneMappingExposure", 0, 4, 0.01)
+      .onChange(updateDebug)
+      .listen();
+    gui
+      .add(debugSettings, "physicallyCorrectLights", true)
+      .onChange(updateDebug)
+      .listen();
+    gui.open();
+
+    this.debugGui = gui;
+    this.debugSettings = debugSettings;
+
+    window.$E = this;
+  }
+
+  updateEnvironment(envEl) {
+    const envSettingsEl = envEl.querySelector("[environment-settings]");
+    const skyboxEl = envEl.querySelector("[skybox]");
+    console.log(skyboxEl);
+    const envSettings = {
+      ...defaultEnvSettings,
+      skybox: skyboxEl?.components["skybox"]
+    };
+
+    if (envSettingsEl) {
+      Object.assign(envSettings, envSettingsEl.components["environment-settings"].data);
+    }
+
+    this.applyEnvSettings(envSettings);
+  }
+
+  applyEnvSettings(settings) {
+    if (this.debugSettings) {
+      Object.assign(this.debugSettings, settings);
+    }
+
+    let materialsNeedUpdate = false;
+
+    console.log("Applying environment settings", settings);
+
+    if (this.renderer.physicallyCorrectLights !== settings.physicallyCorrectLights) {
+      this.renderer.physicallyCorrectLights = settings.physicallyCorrectLights;
+      materialsNeedUpdate = true;
+    }
+
+    const newToneMapping = THREE[settings.toneMapping];
+    if (this.renderer.toneMapping !== newToneMapping) {
+      this.renderer.toneMapping = newToneMapping;
+      materialsNeedUpdate = true;
+    }
+
+    this.renderer.toneMappingExposure = settings.toneMappingExposure;
+
+    this.scene.remove(window.lp);
+
+    if (settings.backgroundTexture) {
+      settings.backgroundTexture.mapping = THREE.EquirectangularReflectionMapping;
+      this.scene.background = settings.backgroundTexture;
+    } else {
+      this.scene.background = settings.backgroundColor;
+    }
+
+    if (settings.envMapTexture) {
+      settings.envMapTexture.mapping = THREE.EquirectangularReflectionMapping;
+      // TODO don't regenerate this every time
+      const pmrem = this.pmremGenerator.fromEquirectangular(settings.envMapTexture);
+      this.scene.environment = pmrem.texture;
+      // this.scene.environment = null;
+
+      // var cube = new THREE.WebGLCubeRenderTarget(512);
+      // cube.fromEquirectangularTexture(this.renderer, settings.envMapTexture);
+      // console.log("cube", cube);
+      // window.lp = LightProbeGenerator.fromCubeRenderTarget(this.renderer, cube);
+      // this.scene.add(window.lp);
+      // this.scene.background = cube.texture;
+    } else if (settings.skybox) {
+      const envMap = settings.skybox.sky.generateEnvironmentMap(this.renderer);
+      this.scene.environment = envMap;
+    } else {
+      this.scene.environment = null;
+    }
+
+    if (materialsNeedUpdate) {
+      console.log("materials need updating");
+      this.scene.traverse(o => {
+        if (o.material) o.material.needsUpdate = true;
+      });
+    }
+  }
+}
+
+AFRAME.registerComponent("environment-settings", {
+  schema: {
+    toneMapping: { default: defaultEnvSettings.toneMapping, oneOf: Object.values(toneMappingOptions) },
+    toneMappingExposure: { default: defaultEnvSettings.toneMappingExposure },
+    backgroundColor: { type: "color", default: defaultEnvSettings.background }
+  }
+});

--- a/src/systems/environment-system.js
+++ b/src/systems/environment-system.js
@@ -1,6 +1,15 @@
 import { GUI } from "three/examples/jsm/libs/dat.gui.module.js";
 import qsTruthy from "../utils/qs_truthy";
 
+// This disabled lighting contribution from the environment map for things that have a lightmap
+// TODO do this in a less hacky way, maybe make it configurable
+THREE.ShaderChunk.lights_fragment_maps = THREE.ShaderChunk.lights_fragment_maps.replace(
+  "iblIrradiance += getLightProbeIndirectIrradiance( geometry, maxMipLevel );",
+  `#ifndef USE_LIGHTMAP
+     iblIrradiance += getLightProbeIndirectIrradiance( geometry, maxMipLevel );
+   #endif`
+);
+
 const toneMappingOptions = {
   None: "NoToneMapping",
   Linear: "LinearToneMapping",

--- a/src/systems/hubs-systems.js
+++ b/src/systems/hubs-systems.js
@@ -32,6 +32,7 @@ import { InspectYourselfSystem } from "./inspect-yourself-system";
 import { EmojiSystem } from "./emoji-system";
 import { AudioZonesSystem } from "./audio-zones-system";
 import { GainSystem } from "./audio-gain-system";
+import { EnvironmentSystem } from "./environment-system";
 
 AFRAME.registerSystem("hubs-systems", {
   init() {
@@ -73,6 +74,7 @@ AFRAME.registerSystem("hubs-systems", {
     this.emojiSystem = new EmojiSystem(this.el);
     this.audioZonesSystem = new AudioZonesSystem();
     this.gainSystem = new GainSystem();
+    this.environmentSystem = new EnvironmentSystem(this.el);
   },
 
   tick(t, dt) {


### PR DESCRIPTION
This PR adds support for RGBE (.hdr) lightmaps and add a system to deal with environment settings. It also introduces the `environment-settings` component, which for now allows setting tone mapping, exposure, and custom equirectangular environment maps and backgrounds (also optionally HDR).

Currently only a single environment map is supporter per scene, but the plan would be to eventually allow multiple environment maps either by object or area (TBD)

This PR also reworks how references to GLTF types work on `MOZ_hubs_components`. Now instead of just listing the index, a special marker object is used so that the application loading the GLTF does not need to be aware of the component schema to be able to resolve the reference. This is important as we begin to add more tooling to our pipeline as there will be more things that need to "pass through" component data without breaking it. For now this applies to Spoke and the WIP "Hubs GLB tools". 

The marker object looks like:
```json
{ "__mhc_link_type": "texture", "index": 1}
```
This also begins to transition MOZ_hubs_components implementation to an actual GLTFLoader plugin, though right now does not change any of the existing "inflation" code.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/HUBS-776)
