### PR TITLE
fix: object menu pin/unpin state

### DIFF
--- a/src/react-components/room/object-hooks.js
+++ b/src/react-components/room/object-hooks.js
@@ -73,10 +73,9 @@ export function usePinObject(hubChannel, scene, object) {
       function onPinStateChanged() {
         setIsPinned(getPinnedState(el));
       }
-
       el.addEventListener("pinned", onPinStateChanged);
       el.addEventListener("unpinned", onPinStateChanged);
-
+      setIsPinned(getPinnedState(el));
       return () => {
         el.removeEventListener("pinned", onPinStateChanged);
         el.removeEventListener("unpinned", onPinStateChanged);


### PR DESCRIPTION
This fix resolves #4414

added a check to the `usePinObject` hook effect that sets the pinned state based on the value of `getPinnedState()`

https://user-images.githubusercontent.com/4493657/129995247-1302d8c2-a2f5-4cc2-abc6-b536dc0f0f93.mp4

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/HUBS-747)
