### PR TITLE
Remove audio-params component

### DIFF
--- a/src/components/audio-params.js
+++ b/src/components/audio-params.js
@@ -23,7 +23,7 @@ export const DistanceModelType = {
 };
 
 export const AvatarAudioDefaults = Object.freeze({
-  AUDIO_TYPE: AudioType.PannerNode,
+  audioType: AudioType.PannerNode,
   distanceModel: DistanceModelType.Inverse,
   rolloffFactor: 2,
   refDistance: 1,
@@ -35,7 +35,7 @@ export const AvatarAudioDefaults = Object.freeze({
 });
 
 export const MediaAudioDefaults = Object.freeze({
-  AUDIO_TYPE: AudioType.PannerNode,
+  audioType: AudioType.PannerNode,
   distanceModel: DistanceModelType.Inverse,
   rolloffFactor: 1,
   refDistance: 1,
@@ -47,7 +47,7 @@ export const MediaAudioDefaults = Object.freeze({
 });
 
 export const TargetAudioDefaults = Object.freeze({
-  AUDIO_TYPE: AudioType.PannerNode,
+  audioType: AudioType.PannerNode,
   distanceModel: DistanceModelType.Inverse,
   rolloffFactor: 5,
   refDistance: 8,

--- a/src/components/audio-params.js
+++ b/src/components/audio-params.js
@@ -60,12 +60,4 @@ export const TargetAudioDefaults = Object.freeze({
 export const GAIN_TIME_CONST = 0.2;
 
 // TODO: Reintroduce audio normalization
-AFRAME.registerComponent("audio-params", {
-  init() {
-    this.el.sceneEl?.systems["hubs-systems"].gainSystem.registerSource(this);
-  },
-
-  remove() {
-    this.el.sceneEl?.systems["hubs-systems"].gainSystem.unregisterSource(this);
-  }
-});
+AFRAME.registerComponent("audio-params", {});

--- a/src/components/audio-params.js
+++ b/src/components/audio-params.js
@@ -63,12 +63,10 @@ export const GAIN_TIME_CONST = 0.2;
 AFRAME.registerComponent("audio-params", {
   init() {
     this.audioRef = null;
-    this.el.sceneEl?.systems["audio-debug"].registerSource(this);
     this.el.sceneEl?.systems["hubs-systems"].gainSystem.registerSource(this);
   },
 
   remove() {
-    this.el.sceneEl?.systems["audio-debug"].unregisterSource(this);
     this.el.sceneEl?.systems["hubs-systems"].gainSystem.unregisterSource(this);
   },
 

--- a/src/components/audio-params.js
+++ b/src/components/audio-params.js
@@ -64,7 +64,6 @@ AFRAME.registerComponent("audio-params", {
   schema: {
     enabled: { default: true },
     debuggable: { default: true },
-    audioType: { default: AvatarAudioDefaults.AUDIO_TYPE },
     sourceType: { default: -1 }
   },
 

--- a/src/components/audio-params.js
+++ b/src/components/audio-params.js
@@ -60,4 +60,3 @@ export const TargetAudioDefaults = Object.freeze({
 export const GAIN_TIME_CONST = 0.2;
 
 // TODO: Reintroduce audio normalization
-AFRAME.registerComponent("audio-params", {});

--- a/src/components/audio-params.js
+++ b/src/components/audio-params.js
@@ -62,8 +62,7 @@ export const GAIN_TIME_CONST = 0.2;
 // TODO: Reintroduce audio normalization
 AFRAME.registerComponent("audio-params", {
   schema: {
-    enabled: { default: true },
-    debuggable: { default: true }
+    enabled: { default: true }
   },
 
   init() {

--- a/src/components/audio-params.js
+++ b/src/components/audio-params.js
@@ -61,7 +61,6 @@ export const GAIN_TIME_CONST = 0.2;
 
 // TODO: Reintroduce audio normalization
 AFRAME.registerComponent("audio-params", {
-  multiple: true,
   schema: {
     enabled: { default: true },
     debuggable: { default: true }

--- a/src/components/audio-params.js
+++ b/src/components/audio-params.js
@@ -61,10 +61,6 @@ export const GAIN_TIME_CONST = 0.2;
 
 // TODO: Reintroduce audio normalization
 AFRAME.registerComponent("audio-params", {
-  schema: {
-    enabled: { default: true }
-  },
-
   init() {
     this.audioRef = null;
     this.el.sceneEl?.systems["audio-debug"].registerSource(this);

--- a/src/components/audio-params.js
+++ b/src/components/audio-params.js
@@ -6,7 +6,7 @@ export const DISTANCE_MODEL_OPTIONS = ["linear", "inverse", "exponential"];
 export const SourceType = Object.freeze({
   MEDIA_VIDEO: 0,
   AVATAR_AUDIO_SOURCE: 1,
-  AVATAR_RIG: 2,
+  // TODO: Fill in missing value (2)
   AUDIO_TARGET: 3,
   AUDIO_ZONE: 4
 });
@@ -24,37 +24,37 @@ export const DistanceModelType = {
 
 export const AvatarAudioDefaults = Object.freeze({
   AUDIO_TYPE: AudioType.PannerNode,
-  DISTANCE_MODEL: DistanceModelType.Inverse,
-  ROLLOFF_FACTOR: 2,
-  REF_DISTANCE: 1,
-  MAX_DISTANCE: 10000,
-  INNER_ANGLE: 180,
-  OUTER_ANGLE: 360,
-  OUTER_GAIN: 0,
+  distanceModel: DistanceModelType.Inverse,
+  rolloffFactor: 2,
+  refDistance: 1,
+  maxDistance: 10000,
+  coneInnerAngle: 180,
+  coneOuterAngle: 360,
+  coneOuterGain: 0,
   VOLUME: 1.0
 });
 
 export const MediaAudioDefaults = Object.freeze({
   AUDIO_TYPE: AudioType.PannerNode,
-  DISTANCE_MODEL: DistanceModelType.Inverse,
-  ROLLOFF_FACTOR: 1,
-  REF_DISTANCE: 1,
-  MAX_DISTANCE: 10000,
-  INNER_ANGLE: 360,
-  OUTER_ANGLE: 0,
-  OUTER_GAIN: 0,
+  distanceModel: DistanceModelType.Inverse,
+  rolloffFactor: 1,
+  refDistance: 1,
+  maxDistance: 10000,
+  coneInnerAngle: 360,
+  coneOuterAngle: 0,
+  coneOuterGain: 0,
   VOLUME: 0.5
 });
 
 export const TargetAudioDefaults = Object.freeze({
   AUDIO_TYPE: AudioType.PannerNode,
-  DISTANCE_MODEL: DistanceModelType.Inverse,
-  ROLLOFF_FACTOR: 5,
-  REF_DISTANCE: 8,
-  MAX_DISTANCE: 10000,
-  INNER_ANGLE: 170,
-  OUTER_ANGLE: 300,
-  OUTER_GAIN: 0.3,
+  distanceModel: DistanceModelType.Inverse,
+  rolloffFactor: 5,
+  refDistance: 8,
+  maxDistance: 10000,
+  coneInnerAngle: 170,
+  coneOuterAngle: 300,
+  coneOuterGain: 0.3,
   VOLUME: 1.0
 });
 
@@ -66,13 +66,6 @@ AFRAME.registerComponent("audio-params", {
     enabled: { default: true },
     debuggable: { default: true },
     audioType: { default: AvatarAudioDefaults.AUDIO_TYPE },
-    distanceModel: { default: AvatarAudioDefaults.DISTANCE_MODEL, oneOf: [DISTANCE_MODEL_OPTIONS] },
-    rolloffFactor: { default: AvatarAudioDefaults.ROLLOFF_FACTOR },
-    refDistance: { default: AvatarAudioDefaults.REF_DISTANCE },
-    maxDistance: { default: AvatarAudioDefaults.MAX_DISTANCE },
-    coneInnerAngle: { default: AvatarAudioDefaults.INNER_ANGLE },
-    coneOuterAngle: { default: AvatarAudioDefaults.OUTER_ANGLE },
-    coneOuterGain: { default: AvatarAudioDefaults.OUTER_GAIN },
     clippingEnabled: { default: CLIPPING_THRESHOLD_ENABLED },
     clippingThreshold: { default: CLIPPING_THRESHOLD_DEFAULT },
     preClipGain: { default: 1.0 },
@@ -106,7 +99,6 @@ AFRAME.registerComponent("audio-params", {
     } else if (this.el.components["audio-zone"]) {
       sourceType = SourceType.AUDIO_ZONE;
     }
-    this.audioSettings = this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem.audioSettings;
 
     this.el.setAttribute("audio-params", {
       sourceType,
@@ -129,26 +121,12 @@ AFRAME.registerComponent("audio-params", {
 
   update() {
     if (this.audioRef) {
-      if (this.data.audioType === AudioType.PannerNode) {
-        this.audioRef.setDistanceModel(this.data.distanceModel);
-        this.audioRef.setRolloffFactor(this.data.rolloffFactor);
-        this.audioRef.setRefDistance(this.data.refDistance);
-        this.audioRef.setMaxDistance(this.data.maxDistance);
-        this.audioRef.panner.coneInnerAngle = this.data.coneInnerAngle;
-        this.audioRef.panner.coneOuterAngle = this.data.coneOuterAngle;
-        this.audioRef.panner.coneOuterGain = this.data.coneOuterGain;
-      }
+      // TODO: Move the gain stuff to update-audio-settings
       this.data.gain !== undefined && this.updateGain(this.data.gain);
     }
   },
 
   tick() {
-    if (this.audioRef) {
-      if (!this.audioRef.panner) {
-        this.data.rolloffFactor = 0;
-      }
-    }
-
     if (this.normalizer !== null) {
       this.normalizer.apply();
     } else {

--- a/src/components/audio-params.js
+++ b/src/components/audio-params.js
@@ -62,15 +62,10 @@ export const GAIN_TIME_CONST = 0.2;
 // TODO: Reintroduce audio normalization
 AFRAME.registerComponent("audio-params", {
   init() {
-    this.audioRef = null;
     this.el.sceneEl?.systems["hubs-systems"].gainSystem.registerSource(this);
   },
 
   remove() {
     this.el.sceneEl?.systems["hubs-systems"].gainSystem.unregisterSource(this);
-  },
-
-  setAudio(audio) {
-    this.audioRef = audio;
   }
 });

--- a/src/components/audio-params.js
+++ b/src/components/audio-params.js
@@ -1,4 +1,5 @@
-import { AudioNormalizer } from "../utils/audio-normalizer";
+// TODO: Reintroduce audio normalization
+// import { AudioNormalizer } from "../utils/audio-normalizer";
 
 export const DISTANCE_MODEL_OPTIONS = ["linear", "inverse", "exponential"];
 
@@ -58,5 +59,3 @@ export const TargetAudioDefaults = Object.freeze({
 });
 
 export const GAIN_TIME_CONST = 0.2;
-
-// TODO: Reintroduce audio normalization

--- a/src/components/audio-params.js
+++ b/src/components/audio-params.js
@@ -1,5 +1,4 @@
 import { AudioNormalizer } from "../utils/audio-normalizer";
-import { CLIPPING_THRESHOLD_ENABLED, CLIPPING_THRESHOLD_DEFAULT } from "../react-components/preferences-screen";
 
 export const DISTANCE_MODEL_OPTIONS = ["linear", "inverse", "exponential"];
 
@@ -66,10 +65,6 @@ AFRAME.registerComponent("audio-params", {
     enabled: { default: true },
     debuggable: { default: true },
     audioType: { default: AvatarAudioDefaults.AUDIO_TYPE },
-    clippingEnabled: { default: CLIPPING_THRESHOLD_ENABLED },
-    clippingThreshold: { default: CLIPPING_THRESHOLD_DEFAULT },
-    preClipGain: { default: 1.0 },
-    isClipped: { default: false },
     gain: { default: 1.0 },
     sourceType: { default: -1 }
   },
@@ -82,11 +77,6 @@ AFRAME.registerComponent("audio-params", {
     if (!this.data.isLocal) {
       this.el.sceneEl?.systems["hubs-systems"].gainSystem.registerSource(this);
     }
-
-    const { enableAudioClipping, audioClippingThreshold } = window.APP.store.state.preferences;
-    const clippingEnabled = enableAudioClipping !== undefined ? enableAudioClipping : CLIPPING_THRESHOLD_ENABLED;
-    const clippingThreshold =
-      audioClippingThreshold !== undefined ? audioClippingThreshold : CLIPPING_THRESHOLD_DEFAULT;
 
     this.onSourceSetAdded = this.sourceSetAdded.bind(this);
     let sourceType;
@@ -101,9 +91,7 @@ AFRAME.registerComponent("audio-params", {
     }
 
     this.el.setAttribute("audio-params", {
-      sourceType,
-      clippingEnabled,
-      clippingThreshold
+      sourceType
     });
   },
 
@@ -160,25 +148,6 @@ AFRAME.registerComponent("audio-params", {
     }
   },
 
-  clipGain(gain) {
-    if (!this.data.isClipped) {
-      this.el.setAttribute("audio-params", {
-        isClipped: true,
-        preClipGain: this.data.gain,
-        gain
-      });
-    }
-  },
-
-  unclipGain() {
-    if (this.data.isClipped) {
-      this.el.setAttribute("audio-params", {
-        isClipped: false,
-        gain: this.data.preClipGain
-      });
-    }
-  },
-
   updateGain(newGain) {
     if (!this.audioRef) return;
 
@@ -207,13 +176,5 @@ AFRAME.registerComponent("audio-params", {
       this.data.gain = newGain * Math.min(1, 10 / Math.max(1, squaredDistance));
     }
     gainFilter?.gain.setTargetAtTime(this.data.gain, this.audioRef.context.currentTime, GAIN_TIME_CONST);
-  },
-
-  updateClipping() {
-    const { clippingEnabled, clippingThreshold } = window.APP.store.state.preferences;
-    this.el.setAttribute("audio-params", {
-      clippingEnabled: clippingEnabled !== undefined ? clippingEnabled : CLIPPING_THRESHOLD_ENABLED,
-      clippingThreshold: clippingThreshold !== undefined ? clippingThreshold : CLIPPING_THRESHOLD_DEFAULT
-    });
   }
 });

--- a/src/components/audio-zone-source.js
+++ b/src/components/audio-zone-source.js
@@ -1,13 +1,14 @@
 import { THREE } from "aframe";
+import { updateAudioSettings } from "../update-audio-settings";
 
 AFRAME.registerComponent("audio-zone-source", {
   init() {
     this.originalAudioParamsData = null;
-    this.isModified = false;
     this.el.sceneEl.systems["hubs-systems"].audioZonesSystem.registerSource(this);
   },
 
   remove() {
+    APP.zoneOverrides.delete(this.el);
     this.el.sceneEl.systems["hubs-systems"].audioZonesSystem.unregisterSource(this);
   },
 
@@ -23,27 +24,24 @@ AFRAME.registerComponent("audio-zone-source", {
   },
 
   apply(params) {
-    if (!this.originalAudioParamsData) {
-      const data = this.el.components["audio-params"].data;
-      this.originalAudioParamsData = {
-        distanceModel: data.distanceModel,
-        maxDistance: data.maxDistance,
-        refDistance: data.refDistance,
-        rolloffFactor: data.rolloffFactor,
-        coneInnerAngle: data.coneInnerAngle,
-        coneOuterAngle: data.coneOuterAngle,
-        coneOuterGain: data.coneOuterGain,
-        gain: data.gain
-      };
+    APP.zoneOverrides.set(this.el, params);
+    const audio = APP.audios.get(this.el);
+    if (audio) {
+      updateAudioSettings(this.el, audio);
     }
+
+    //TODO: remove
     this.el.setAttribute("audio-params", params);
-    this.isModified = true;
   },
 
   restore() {
-    if (this.isModified && this.originalAudioParamsData) {
-      this.el.setAttribute("audio-params", this.originalAudioParamsData);
-      this.isModified = false;
+    APP.zoneOverrides.delete(this.el);
+    const audio = APP.audios.get(this.el);
+    if (audio) {
+      updateAudioSettings(this.el, audio);
     }
+
+    // TODO: remove
+    this.el.setAttribute("audio-params", this.originalAudioParamsData);
   }
 });

--- a/src/components/audio-zone-source.js
+++ b/src/components/audio-zone-source.js
@@ -15,11 +15,13 @@ AFRAME.registerComponent("audio-zone-source", {
   getPosition: () => {
     const sourcePos = new THREE.Vector3();
     return () => {
-      if (this.el.components["audio-params"].audioRef) {
-        this.el.components["audio-params"].audioRef.getWorldPosition(sourcePos);
-        return sourcePos.clone();
+      const audio = APP.audios.get(this.el);
+      if (audio) {
+        audio.getWorldPosition(sourcePos);
+      } else {
+        sourcePos.set(0, 0, 0);
       }
-      return new THREE.Vector3(0, 0, 0);
+      return sourcePos;
     };
   },
 

--- a/src/components/audio-zone-source.js
+++ b/src/components/audio-zone-source.js
@@ -12,9 +12,9 @@ AFRAME.registerComponent("audio-zone-source", {
     this.el.sceneEl.systems["hubs-systems"].audioZonesSystem.unregisterSource(this);
   },
 
-  getPosition: () => {
+  getPosition: (() => {
     const sourcePos = new THREE.Vector3();
-    return () => {
+    return function() {
       const audio = APP.audios.get(this.el);
       if (audio) {
         audio.getWorldPosition(sourcePos);
@@ -23,7 +23,7 @@ AFRAME.registerComponent("audio-zone-source", {
       }
       return sourcePos;
     };
-  },
+  })(),
 
   apply(params) {
     APP.zoneOverrides.set(this.el, params);

--- a/src/components/audio-zone-source.js
+++ b/src/components/audio-zone-source.js
@@ -1,7 +1,5 @@
 import { THREE } from "aframe";
 
-const zero = new THREE.Vector3(0, 0, 0);
-
 AFRAME.registerComponent("audio-zone-source", {
   init() {
     this.originalAudioParamsData = null;
@@ -13,8 +11,15 @@ AFRAME.registerComponent("audio-zone-source", {
     this.el.sceneEl.systems["hubs-systems"].audioZonesSystem.unregisterSource(this);
   },
 
-  getPosition() {
-    return this.el.components["audio-params"].data.position || zero;
+  getPosition: () => {
+    const sourcePos = new THREE.Vector3();
+    return () => {
+      if (this.el.components["audio-params"].audioRef) {
+        this.el.components["audio-params"].audioRef.getWorldPosition(sourcePos);
+        return sourcePos.clone();
+      }
+      return new THREE.Vector3(0, 0, 0);
+    };
   },
 
   apply(params) {

--- a/src/components/audio-zone-source.js
+++ b/src/components/audio-zone-source.js
@@ -31,9 +31,6 @@ AFRAME.registerComponent("audio-zone-source", {
     if (audio) {
       updateAudioSettings(this.el, audio);
     }
-
-    //TODO: remove
-    this.el.setAttribute("audio-params", params);
   },
 
   restore() {
@@ -42,8 +39,5 @@ AFRAME.registerComponent("audio-zone-source", {
     if (audio) {
       updateAudioSettings(this.el, audio);
     }
-
-    // TODO: remove
-    this.el.setAttribute("audio-params", this.originalAudioParamsData);
   }
 });

--- a/src/components/audio-zone.js
+++ b/src/components/audio-zone.js
@@ -37,6 +37,7 @@ AFRAME.registerComponent("audio-zone", {
 
     this.enableDebug(window.APP.store.state.preferences.showAudioDebugPanel);
     this.el.setAttribute("audio-params", "debuggable", false);
+    // TODO Remove this
     this.audioParamsComp = this.el.components["audio-params"];
   },
 

--- a/src/components/audio-zone.js
+++ b/src/components/audio-zone.js
@@ -7,15 +7,6 @@ const debugMaterial = new THREE.MeshBasicMaterial({
   side: THREE.DoubleSide
 });
 
-/**
- * Represents an 3D box area in the audio-zones-system that can contain audio-zone-entities.
- * It has an audio-params component whose values are used to override the audio source's audio properties.
- * based on the source's and listener's position. It can be of inOut or/and outIn types.
-    inOut: applies this zone's audio-params to an audio-zone-source when the source is inside and listener is outside.
-    i.e. You want to mute audio sources inside the audio zone when the listener is outside.
-    outIn: applies this zone's audio-params to the an audio-zone-source when the listener is inside and the source is outside.
-    i.e. You want to mute audio sources from outside the audio zone when the listener is inside.
- */
 AFRAME.registerComponent("audio-zone", {
   schema: {
     enabled: { default: true },

--- a/src/components/audio-zone.js
+++ b/src/components/audio-zone.js
@@ -36,9 +36,6 @@ AFRAME.registerComponent("audio-zone", {
     this.el.sceneEl?.systems["hubs-systems"].audioZonesSystem.registerZone(this);
 
     this.enableDebug(window.APP.store.state.preferences.showAudioDebugPanel);
-    this.el.setAttribute("audio-params", "debuggable", false);
-    // TODO Remove this
-    this.audioParamsComp = this.el.components["audio-params"];
   },
 
   remove() {

--- a/src/components/audio-zone.js
+++ b/src/components/audio-zone.js
@@ -66,16 +66,7 @@ AFRAME.registerComponent("audio-zone", {
   },
 
   getAudioParams() {
-    return {
-      distanceModel: this.audioParamsComp.data.distanceModel,
-      maxDistance: this.audioParamsComp.data.maxDistance,
-      refDistance: this.audioParamsComp.data.refDistance,
-      rolloffFactor: this.audioParamsComp.data.rolloffFactor,
-      coneInnerAngle: this.audioParamsComp.data.coneInnerAngle,
-      coneOuterAngle: this.audioParamsComp.data.coneOuterAngle,
-      coneOuterGain: this.audioParamsComp.data.coneOuterGain,
-      gain: this.audioParamsComp.data.gain
-    };
+    return APP.audioOverrides.get(this.el);
   },
 
   contains(position) {

--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -1,5 +1,6 @@
 import { SourceType, TargetAudioDefaults, AudioType } from "./audio-params";
 import { MixerType } from "../systems/audio-system";
+import { updateAudioSettings } from "../update-audio-settings";
 const INFO_INIT_FAILED = "Failed to initialize avatar-audio-source.";
 const INFO_NO_NETWORKED_EL = "Could not find networked el.";
 const INFO_NO_OWNER = "Networked component has no owner.";
@@ -70,6 +71,10 @@ AFRAME.registerComponent("avatar-audio-source", {
     audio.setNodeSource(destinationSource);
     this.el.setObject3D(this.attrName, audio);
     this.el.emit("sound-source-set", { soundSource: destinationSource });
+
+    APP.audios.set(this.el, audio);
+    APP.sourceType.set(this.el, SourceType.AVATAR_AUDIO_SOURCE);
+    updateAudioSettings(this.el, audio);
   },
 
   destroyAudio() {
@@ -248,13 +253,6 @@ AFRAME.registerComponent("audio-target", {
     this.audioSystem = this.el.sceneEl.systems["hubs-systems"].audioSystem;
     this.el.setAttribute("audio-params", {
       sourceType: SourceType.AUDIO_TARGET,
-      distanceModel: TargetAudioDefaults.DISTANCE_MODEL,
-      rolloffFactor: TargetAudioDefaults.ROLLOFF_FACTOR,
-      refDistance: TargetAudioDefaults.REF_DISTANCE,
-      maxDistance: TargetAudioDefaults.MAX_DISTANCE,
-      coneInnerAngle: TargetAudioDefaults.INNER_ANGLE,
-      coneOuterAngle: TargetAudioDefaults.OUTER_ANGLE,
-      coneOuterGain: TargetAudioDefaults.OUTER_GAIN,
       gain: TargetAudioDefaults.VOLUME
     });
     this.createAudio();
@@ -305,6 +303,9 @@ AFRAME.registerComponent("audio-target", {
     this.el.components["audio-params"].setAudio(audio);
 
     this.audio.updateMatrixWorld();
+    APP.audios.set(this.el, audio);
+    APP.sourceType.set(this.el, SourceType.AUDIO_TARGET);
+    updateAudioSettings(this.el, audio);
   },
 
   connectAudio() {

--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -257,7 +257,6 @@ AFRAME.registerComponent("audio-target", {
 
   remove: function() {
     this.destroyAudio();
-    this.el.removeAttribute("audio-params");
     this.el.removeAttribute("audio-zone-source");
   },
 

--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -64,10 +64,8 @@ AFRAME.registerComponent("avatar-audio-source", {
 
     this.destination = audio.context.createMediaStreamDestination();
     this.mediaStreamSource = audio.context.createMediaStreamSource(stream);
-    this.gainFilter = audio.context.createGain();
     const destinationSource = audio.context.createMediaStreamSource(this.destination.stream);
-    this.mediaStreamSource.connect(this.gainFilter);
-    this.gainFilter.connect(this.destination);
+    this.mediaStreamSource.connect(this.destination);
     audio.setNodeSource(destinationSource);
     this.el.setObject3D(this.attrName, audio);
     this.el.emit("sound-source-set", { soundSource: destinationSource });
@@ -83,6 +81,9 @@ AFRAME.registerComponent("avatar-audio-source", {
 
     this.audioSystem.removeAudio(audio);
     this.el.removeObject3D(this.attrName);
+
+    APP.audios.delete(this.el);
+    APP.sourceType.delete(this.el);
   },
 
   init() {
@@ -120,10 +121,6 @@ AFRAME.registerComponent("avatar-audio-source", {
     this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem.unregisterAvatarAudioSource(this);
     APP.dialog.off("stream_updated", this._onStreamUpdated);
     this.destroyAudio();
-  },
-
-  getGainFilter() {
-    return this.gainFilter;
   }
 });
 
@@ -252,8 +249,7 @@ AFRAME.registerComponent("audio-target", {
   init() {
     this.audioSystem = this.el.sceneEl.systems["hubs-systems"].audioSystem;
     this.el.setAttribute("audio-params", {
-      sourceType: SourceType.AUDIO_TARGET,
-      gain: TargetAudioDefaults.VOLUME
+      sourceType: SourceType.AUDIO_TARGET
     });
     this.createAudio();
     // TODO this is to ensure targets and sources loaded at the same time don't have
@@ -286,8 +282,6 @@ AFRAME.registerComponent("audio-target", {
       audio.setFilters([delayNode]);
     }
 
-    this.gainFilter = THREE.AudioContext.getContext().createGain();
-
     this.el.setObject3D(this.attrName, audio);
     audio.matrixNeedsUpdate = true;
     audio.updateMatrixWorld();
@@ -295,10 +289,6 @@ AFRAME.registerComponent("audio-target", {
 
     this.audioSystem.removeAudio(this.audio);
     this.audioSystem.addAudio(MixerType.MEDIA, this.audio);
-
-    const filters = this.audio.getFilters();
-    filters.push(this.gainFilter);
-    this.audio.setFilters(filters);
 
     this.el.components["audio-params"].setAudio(audio);
 
@@ -325,9 +315,8 @@ AFRAME.registerComponent("audio-target", {
 
     this.audioSystem.removeAudio(this.audio);
     this.el.removeObject3D(this.attrName);
-  },
 
-  getGainFilter() {
-    return this.gainFilter;
+    APP.audios.delete(this.el);
+    APP.sourceType.delete(this.el);
   }
 });

--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -1,5 +1,4 @@
-import { SourceType, TargetAudioDefaults, AudioType } from "./audio-params";
-import { MixerType } from "../systems/audio-system";
+import { SourceType, AudioType } from "./audio-params";
 import { updateAudioSettings } from "../update-audio-settings";
 const INFO_INIT_FAILED = "Failed to initialize avatar-audio-source.";
 const INFO_NO_NETWORKED_EL = "Could not find networked el.";
@@ -56,7 +55,7 @@ AFRAME.registerComponent("avatar-audio-source", {
     this.el.components["audio-params"].setAudio(audio);
 
     this.audioSystem.removeAudio(audio);
-    this.audioSystem.addAudio(MixerType.AVATAR, audio);
+    this.audioSystem.addAudio(SourceType.AVATAR_AUDIO_SOURCE, audio);
 
     if (SHOULD_CREATE_SILENT_AUDIO_ELS) {
       createSilentAudioEl(stream); // TODO: Do the audio els need to get cleaned up?
@@ -288,7 +287,7 @@ AFRAME.registerComponent("audio-target", {
     this.audio = audio;
 
     this.audioSystem.removeAudio(this.audio);
-    this.audioSystem.addAudio(MixerType.MEDIA, this.audio);
+    this.audioSystem.addAudio(SourceType.AVATAR_AUDIO_SOURCE, this.audio);
 
     this.el.components["audio-params"].setAudio(audio);
 

--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -247,9 +247,6 @@ AFRAME.registerComponent("audio-target", {
 
   init() {
     this.audioSystem = this.el.sceneEl.systems["hubs-systems"].audioSystem;
-    this.el.setAttribute("audio-params", {
-      sourceType: SourceType.AUDIO_TARGET
-    });
     this.createAudio();
     // TODO this is to ensure targets and sources loaded at the same time don't have
     // an order depndancy but this should be done in a more robust way

--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -52,7 +52,6 @@ AFRAME.registerComponent("avatar-audio-source", {
 
     const audioListener = this.el.sceneEl.audioListener;
     const audio = new THREE.PositionalAudio(audioListener);
-    this.el.components["audio-params"].setAudio(audio);
 
     this.audioSystem.removeAudio(audio);
     this.audioSystem.addAudio(SourceType.AVATAR_AUDIO_SOURCE, audio);
@@ -286,8 +285,6 @@ AFRAME.registerComponent("audio-target", {
 
     this.audioSystem.removeAudio(this.audio);
     this.audioSystem.addAudio(SourceType.AVATAR_AUDIO_SOURCE, this.audio);
-
-    this.el.components["audio-params"].setAudio(audio);
 
     this.audio.updateMatrixWorld();
     APP.audios.set(this.el, audio);

--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -1,5 +1,5 @@
 import { SourceType, AudioType } from "./audio-params";
-import { updateAudioSettings } from "../update-audio-settings";
+import { getCurrentAudioSettings, updateAudioSettings } from "../update-audio-settings";
 const INFO_INIT_FAILED = "Failed to initialize avatar-audio-source.";
 const INFO_NO_NETWORKED_EL = "Could not find networked el.";
 const INFO_NO_OWNER = "Networked component has no owner.";
@@ -266,10 +266,11 @@ AFRAME.registerComponent("audio-target", {
   },
 
   createAudio: function() {
+    APP.sourceType.set(this.el, SourceType.AUDIO_TARGET);
     const audioListener = this.el.sceneEl.audioListener;
-
     let audio = null;
-    if (this.el.components["audio-params"].data.audioType === AudioType.PannerNode) {
+    const { audioType } = getCurrentAudioSettings(this.el);
+    if (audioType === AudioType.PannerNode) {
       audio = new THREE.PositionalAudio(audioListener);
     } else {
       audio = new THREE.Audio(audioListener);
@@ -293,7 +294,6 @@ AFRAME.registerComponent("audio-target", {
 
     this.audio.updateMatrixWorld();
     APP.audios.set(this.el, audio);
-    APP.sourceType.set(this.el, SourceType.AUDIO_TARGET);
     updateAudioSettings(this.el, audio);
   },
 

--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -86,7 +86,6 @@ AFRAME.registerComponent("avatar-audio-source", {
 
   init() {
     this.audioSystem = this.el.sceneEl.systems["hubs-systems"].audioSystem;
-    this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem.registerAvatarAudioSource(this);
     // We subscribe to audio stream notifications for this peer to update the audio source
     // This could happen in case there is an ICE failure that requires a transport recreation.
     APP.dialog.on("stream_updated", this._onStreamUpdated, this);
@@ -116,7 +115,6 @@ AFRAME.registerComponent("avatar-audio-source", {
   },
 
   remove: function() {
-    this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem.unregisterAvatarAudioSource(this);
     APP.dialog.off("stream_updated", this._onStreamUpdated);
     this.destroyAudio();
   }

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -20,7 +20,7 @@ import semver from "semver";
 import { createPlaneBufferGeometry } from "../utils/three-utils";
 import HubsTextureLoader from "../loaders/HubsTextureLoader";
 import { getCurrentAudioSettings, updateAudioSettings } from "../update-audio-settings";
-import { SourceType } from "./audio-params";
+import { SourceType, AudioType } from "./audio-params";
 
 import qsTruthy from "../utils/qs_truthy";
 
@@ -56,7 +56,6 @@ for (let i = 0; i <= 20; i++) {
 
 import { KTX2Loader } from "three/examples/jsm/loaders/KTX2Loader";
 import { rewriteBasisTranscoderUrls } from "../utils/media-url-utils";
-import { AudioType, MediaAudioDefaults } from "./audio-params";
 const loadingManager = new THREE.LoadingManager();
 loadingManager.setURLModifier(rewriteBasisTranscoderUrls);
 
@@ -299,20 +298,6 @@ AFRAME.registerComponent("media-video", {
     this.isSnapping = false;
     this.videoIsLive = null; // value null until we've determined if the video is live or not.
     this.onSnapImageLoaded = () => (this.isSnapping = false);
-
-    if (!this.el.components["audio-params"]) {
-      this.el.setAttribute("audio-params", {
-        audioType: MediaAudioDefaults.AUDIO_TYPE,
-        distanceModel: MediaAudioDefaults.DISTANCE_MODEL,
-        rolloffFactor: MediaAudioDefaults.ROLLOFF_FACTOR,
-        refDistance: MediaAudioDefaults.REF_DISTANCE,
-        maxDistance: MediaAudioDefaults.MAX_DISTANCE,
-        coneInnerAngle: MediaAudioDefaults.INNER_ANGLE,
-        coneOuterAngle: MediaAudioDefaults.OUTER_ANGLE,
-        coneOuterGain: MediaAudioDefaults.OUTER_GAIN,
-        gain: MediaAudioDefaults.VOLUME
-      });
-    }
 
     this.el.setAttribute("hover-menu__video", { template: "#video-hover-menu", isFlat: true });
     this.el.components["hover-menu__video"].getHoverMenu().then(menu => {
@@ -986,8 +971,6 @@ AFRAME.registerComponent("media-video", {
 
   remove() {
     this.cleanUp();
-
-    this.el.removeAttribute("audio-params");
 
     if (this.mesh) {
       this.el.removeObject3D("mesh");

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -20,6 +20,8 @@ import semver from "semver";
 import { createPlaneBufferGeometry } from "../utils/three-utils";
 import HubsTextureLoader from "../loaders/HubsTextureLoader";
 import { MixerType } from "../systems/audio-system";
+import { updateAudioSettings } from "../update-audio-settings";
+import { SourceType } from "./audio-params";
 
 import qsTruthy from "../utils/qs_truthy";
 
@@ -572,6 +574,10 @@ AFRAME.registerComponent("media-video", {
     // Its matrix may not update if this element is not visible.
     // See https://github.com/mozilla/hubs/issues/2855
     this.audio.updateMatrixWorld();
+
+    APP.audios.set(this.el, this.audio);
+    APP.sourceType.set(this.el, SourceType.MEDIA_VIDEO);
+    updateAudioSettings(this.el, this.audio);
   },
 
   getGainFilter() {

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -256,6 +256,8 @@ function timeFmt(t) {
   return h === "00" ? `${m}:${s}` : `${h}:${m}:${s}`;
 }
 
+const MAX_MULTIPLIER = 2;
+
 AFRAME.registerComponent("media-video", {
   schema: {
     src: { type: "string" },
@@ -274,6 +276,7 @@ AFRAME.registerComponent("media-video", {
   },
 
   init() {
+    APP.gainMultipliers.set(this.el, 1);
     this.onPauseStateChange = this.onPauseStateChange.bind(this);
     this.updateHoverMenu = this.updateHoverMenu.bind(this);
     this.tryUpdateVideoPlaybackState = this.tryUpdateVideoPlaybackState.bind(this);
@@ -290,7 +293,6 @@ AFRAME.registerComponent("media-video", {
     this.togglePlaying = this.togglePlaying.bind(this);
 
     this.audioSystem = this.el.sceneEl.systems["hubs-systems"].audioSystem;
-    this.gainFilter = THREE.AudioContext.getContext().createGain();
 
     this.lastUpdate = 0;
     this.videoMutedAt = 0;
@@ -381,6 +383,7 @@ AFRAME.registerComponent("media-video", {
       evt.detail.cameraEl.getObject3D("camera").add(sceneEl.audioListener);
     });
 
+    // TODO Probably we will get rid of this at some point
     this.audioOutputModePref = window.APP.store.state.preferences.audioOutputMode;
     this.onPreferenceChanged = () => {
       const newPref = window.APP.store.state.preferences.audioOutputMode;
@@ -419,18 +422,22 @@ AFRAME.registerComponent("media-video", {
   },
 
   changeVolumeBy(v) {
-    const gain = this.el.components["audio-params"].data.gain;
-    const vol = THREE.Math.clamp(gain + v, 0, 1);
-    this.el.setAttribute("audio-params", "gain", vol);
+    let gainMultiplier = APP.gainMultipliers.get(this.el);
+    gainMultiplier = THREE.Math.clamp(gainMultiplier + v, 0, MAX_MULTIPLIER);
+    APP.gainMultipliers.set(this.el, gainMultiplier);
     this.updateVolumeLabel();
+    const audio = APP.audios.get(this.el);
+    if (audio) {
+      updateAudioSettings(this.el, audio);
+    }
   },
 
   volumeUp() {
-    this.changeVolumeBy(0.1);
+    this.changeVolumeBy(0.2);
   },
 
   volumeDown() {
-    this.changeVolumeBy(-0.1);
+    this.changeVolumeBy(-0.2);
   },
 
   async snap() {
@@ -537,13 +544,6 @@ AFRAME.registerComponent("media-video", {
       this.updateSrc(oldData);
       return;
     }
-
-    const shouldRecreateAudio =
-      !shouldUpdateSrc && this.mediaElementAudioSource && this.audio?.panner?.audioType !== this.data.audioType;
-    if (shouldRecreateAudio) {
-      this.setupAudio();
-      return;
-    }
   },
 
   setupAudio() {
@@ -562,10 +562,6 @@ AFRAME.registerComponent("media-video", {
     this.audioSystem.removeAudio(this.audio);
     this.audioSystem.addAudio(MixerType.MEDIA, this.audio);
 
-    const filters = this.audio.getFilters();
-    filters.push(this.gainFilter);
-    this.audio.setFilters(filters);
-
     this.audio.setNodeSource(this.mediaElementAudioSource);
     this.el.setObject3D("sound", this.audio);
     this.el.components["audio-params"].setAudio(this.audio);
@@ -578,10 +574,6 @@ AFRAME.registerComponent("media-video", {
     APP.audios.set(this.el, this.audio);
     APP.sourceType.set(this.el, SourceType.MEDIA_VIDEO);
     updateAudioSettings(this.el, this.audio);
-  },
-
-  getGainFilter() {
-    return this.gainFilter;
   },
 
   async updateSrc(oldData) {
@@ -933,8 +925,12 @@ AFRAME.registerComponent("media-video", {
   },
 
   updateVolumeLabel() {
-    const volume = this.el.components["audio-params"].data.gain;
-    this.volumeLabel.setAttribute("text", "value", volume === 0 ? "MUTE" : VOLUME_LABELS[Math.floor(volume / 0.05)]);
+    const gainMultiplier = APP.gainMultipliers.get(this.el);
+    this.volumeLabel.setAttribute(
+      "text",
+      "value",
+      gainMultiplier === 0 ? "MUTE" : VOLUME_LABELS[Math.floor(gainMultiplier / (MAX_MULTIPLIER / 20))]
+    );
   },
 
   tick: (() => {
@@ -1003,6 +999,10 @@ AFRAME.registerComponent("media-video", {
       clearInterval(this._audioSyncInterval);
       this._audioSyncInterval = null;
     }
+
+    APP.gainMultipliers.delete(this.el);
+    APP.audios.delete(this.el);
+    APP.sourceType.delete(this.el);
 
     if (this.audio) {
       this.el.removeObject3D("sound");

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -473,6 +473,11 @@ AFRAME.registerComponent("media-video", {
     if (this._ignorePauseStateChanges) return;
 
     this.el.setAttribute("media-video", "videoPaused", this.video.paused);
+    if (this.video.paused) {
+      APP.isAudioPaused.add(this.el);
+    } else {
+      APP.isAudioPaused.delete(this.el);
+    }
 
     if (this.networkedEl && NAF.utils.isMine(this.networkedEl)) {
       this.el.emit("owned-video-state-changed");
@@ -971,6 +976,8 @@ AFRAME.registerComponent("media-video", {
 
   remove() {
     this.cleanUp();
+
+    APP.isAudioPaused.delete(this.el);
 
     if (this.mesh) {
       this.el.removeObject3D("mesh");

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -19,7 +19,6 @@ import { detect } from "detect-browser";
 import semver from "semver";
 import { createPlaneBufferGeometry } from "../utils/three-utils";
 import HubsTextureLoader from "../loaders/HubsTextureLoader";
-import { MixerType } from "../systems/audio-system";
 import { updateAudioSettings } from "../update-audio-settings";
 import { SourceType } from "./audio-params";
 
@@ -560,7 +559,7 @@ AFRAME.registerComponent("media-video", {
     }
 
     this.audioSystem.removeAudio(this.audio);
-    this.audioSystem.addAudio(MixerType.MEDIA, this.audio);
+    this.audioSystem.addAudio(SourceType.MEDIA_VIDEO, this.audio);
 
     this.audio.setNodeSource(this.mediaElementAudioSource);
     this.el.setObject3D("sound", this.audio);

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -564,7 +564,6 @@ AFRAME.registerComponent("media-video", {
 
     this.audio.setNodeSource(this.mediaElementAudioSource);
     this.el.setObject3D("sound", this.audio);
-    this.el.components["audio-params"].setAudio(this.audio);
 
     // Make sure that the audio is initialized to the right place.
     // Its matrix may not update if this element is not visible.

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -488,7 +488,6 @@ AFRAME.registerComponent("media-video", {
     if (this._ignorePauseStateChanges) return;
 
     this.el.setAttribute("media-video", "videoPaused", this.video.paused);
-    this.el.setAttribute("audio-params", "enabled", !this.video.paused);
 
     if (this.networkedEl && NAF.utils.isMine(this.networkedEl)) {
       this.el.emit("owned-video-state-changed");

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -19,7 +19,7 @@ import { detect } from "detect-browser";
 import semver from "semver";
 import { createPlaneBufferGeometry } from "../utils/three-utils";
 import HubsTextureLoader from "../loaders/HubsTextureLoader";
-import { updateAudioSettings } from "../update-audio-settings";
+import { getCurrentAudioSettings, updateAudioSettings } from "../update-audio-settings";
 import { SourceType } from "./audio-params";
 
 import qsTruthy from "../utils/qs_truthy";
@@ -550,9 +550,11 @@ AFRAME.registerComponent("media-video", {
       this.audio.disconnect();
       this.el.removeObject3D("sound");
     }
+    APP.sourceType.set(this.el, SourceType.MEDIA_VIDEO);
 
+    const { audioType } = getCurrentAudioSettings(this.el);
     const audioListener = this.el.sceneEl.audioListener;
-    if (this.el.components["audio-params"].data.audioType === AudioType.PannerNode) {
+    if (audioType === AudioType.PannerNode) {
       this.audio = new THREE.PositionalAudio(audioListener);
     } else {
       this.audio = new THREE.Audio(audioListener);
@@ -571,7 +573,6 @@ AFRAME.registerComponent("media-video", {
     this.audio.updateMatrixWorld();
 
     APP.audios.set(this.el, this.audio);
-    APP.sourceType.set(this.el, SourceType.MEDIA_VIDEO);
     updateAudioSettings(this.el, this.audio);
   },
 

--- a/src/components/player-info.js
+++ b/src/components/player-info.js
@@ -68,6 +68,7 @@ AFRAME.registerComponent("player-info", {
     registerComponentInstance(this, "player-info");
   },
   remove() {
+    APP.isAudioPaused.delete(this.el);
     deregisterComponentInstance(this, "player-info");
   },
   play() {
@@ -183,6 +184,12 @@ AFRAME.registerComponent("player-info", {
       if (this.isLocalPlayerInfo) {
         el.setAttribute("emit-scene-event-on-remove", "event:action_end_video_sharing");
       }
+    }
+
+    if (this.data.muted) {
+      APP.isAudioPaused.add(this.el);
+    } else {
+      APP.isAudioPaused.delete(this.el);
     }
   },
   handleModelError() {

--- a/src/components/player-info.js
+++ b/src/components/player-info.js
@@ -184,7 +184,6 @@ AFRAME.registerComponent("player-info", {
         el.setAttribute("emit-scene-event-on-remove", "event:action_end_video_sharing");
       }
     }
-    this.el.querySelector("[audio-params]")?.setAttribute("audio-params", { enabled: !this.data.muted });
   },
   handleModelError() {
     window.APP.store.resetToRandomDefaultAvatar();

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -267,8 +267,7 @@ async function mediaInflator(el, componentName, componentData, components) {
       // TODO: Remove the line below
       el.setAttribute("audio-params", {
         audioType: componentData.audioType,
-        sourceType: SourceType.MEDIA_VIDEO,
-        gain: componentData.volume
+        sourceType: SourceType.MEDIA_VIDEO
       });
     }
 
@@ -507,8 +506,7 @@ AFRAME.GLTFModelPlus.registerComponent(
 
       // TODO: Remove
       el.setAttribute("audio-params", {
-        audioType: componentData.positional ? AudioType.PannerNode : AudioType.Stereo,
-        gain: componentData.volume
+        audioType: componentData.positional ? AudioType.PannerNode : AudioType.Stereo
       });
     }
 

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -245,6 +245,17 @@ async function mediaInflator(el, componentName, componentData, components) {
     mediaOptions.hidePlaybackControls = !isControlled;
 
     if (componentData.audioType) {
+      // This is an old version of this component, which had built-in audio parameters.
+      // The way we are handling it is wrong. If a user created a scene with this old version
+      // of the component, all of these parameters will be present whether the user explicitly set
+      // the values for them or not. But really, they should only count as "overrides" if the user
+      // meant for them to take precendence over the app and scene defaults.
+      // TODO: Fix this issue. One option is to just ignore this component data, which might break old scenes
+      //       but simplifying the handling. Another option is to compare the component data here with
+      //       the "defaults" and only save the values that are different from the defaults. However,
+      //       this loses information if the user changed the scene settings but wanted this specific
+      //       node to use the "defaults".
+      //       I don't see a perfect solution here and would prefer not to handle the "legacy" components.
       APP.audioOverrides.set(el, {
         audioType: componentData.audioType,
         distanceModel: componentData.distanceModel,
@@ -515,8 +526,18 @@ AFRAME.GLTFModelPlus.registerComponent(
       }
     }
 
-    // Migrate audio-target component that has built-in audio params
     if (componentData.positional !== undefined) {
+      // This is an old version of the audio-target component, which had built-in audio parameters.
+      // The way we are handling it is wrong. If a user created a scene in spoke with this old version
+      // of this component, all of these parameters will be present whether the user explicitly set
+      // the values for them or not. But really, they should only count as "overrides" if the user
+      // meant for them to take precendence over the app and scene defaults.
+      // TODO: Fix this issue. One option is to just ignore this component data, which might break old scenes
+      //       but simplifying the handling. Another option is to compare the component data here with
+      //       the "defaults" and only save the values that are different from the defaults. However,
+      //       this loses information if the user changed the scene settings but wanted this specific
+      //       node to use the "defaults".
+      //       I don't see a perfect solution here and would prefer not to handle the "legacy" components.
       APP.audioOverrides.set(el, {
         audioType: componentData.positional ? AudioType.PannerNode : AudioType.Stereo,
         distanceModel: componentData.distanceModel,

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -3,7 +3,7 @@ import "./components/gltf-model-plus";
 import { getSanitizedComponentMapping } from "./utils/component-mappings";
 import { TYPE, SHAPE, FIT } from "three-ammo/constants";
 const COLLISION_LAYERS = require("./constants").COLLISION_LAYERS;
-import { AudioType, SourceType } from "./components/audio-params";
+import { AudioType, AvatarAudioDefaults, MediaAudioDefaults, SourceType } from "./components/audio-params";
 import { updateAudioSettings } from "./update-audio-settings";
 
 function registerRootSceneComponent(componentName) {
@@ -429,7 +429,46 @@ AFRAME.GLTFModelPlus.registerComponent("particle-emitter", "particle-emitter");
 AFRAME.GLTFModelPlus.registerComponent("networked-drawing-buffer", "networked-drawing-buffer");
 
 AFRAME.GLTFModelPlus.registerComponent("audio-settings", "audio-settings", (el, _componentName, componentData) => {
-  el.sceneEl.systems["hubs-systems"].audioSettingsSystem.updateAudioSettings(componentData);
+  const removeUndefined = obj => {
+    return Object.entries(obj).reduce((result, [key, value]) => {
+      if (value !== undefined) {
+        result[key] = value;
+      }
+      return result;
+    }, {});
+  };
+  // TODO: This component should only overwrite the scene audio defaults if this
+  //       component is on the scene node. If this component is on some other node
+  //       we don't care about it and should ignore it.
+  APP.sceneAudioDefaults.set(
+    SourceType.MEDIA_VIDEO,
+    removeUndefined({
+      distanceModel: componentData.mediaDistanceModel,
+      rolloffFactor: componentData.mediaRolloffFactor,
+      refDistance: componentData.mediaRefDistance,
+      maxDistance: componentData.mediaMaxDistance,
+      coneInnerAngle: componentData.mediaConeInnerAngle,
+      coneOuterAngle: componentData.mediaConeOuterAngle,
+      coneOuterGain: componentData.mediaConeOuterGain,
+      gain: componentData.mediaVolume
+    })
+  );
+  APP.sceneAudioDefaults.set(
+    SourceType.AVATAR_AUDIO_SOURCE,
+    removeUndefined({
+      distanceModel: componentData.avatarDistanceModel,
+      rolloffFactor: componentData.avatarRolloffFactor,
+      refDistance: componentData.avatarRefDistance,
+      maxDistance: componentData.avatarMaxDistance,
+      coneInnerAngle: componentData.avatarConeInnerAngle,
+      coneOuterAngle: componentData.avatarConeOuterAngle,
+      coneOuterGain: componentData.avatarConeOuterGain,
+      gain: componentData.avatarVolume
+    })
+  );
+  for (const [el, audio] of APP.audios.entries()) {
+    updateAudioSettings(el, audio);
+  }
 });
 
 AFRAME.GLTFModelPlus.registerComponent(

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -507,27 +507,13 @@ AFRAME.GLTFModelPlus.registerComponent(
 );
 AFRAME.GLTFModelPlus.registerComponent("zone-audio-source", "zone-audio-source");
 
-AFRAME.GLTFModelPlus.registerComponent(
-  "audio-params",
-  "audio-params",
-  (el, componentName, componentData, components) => {
-    APP.audioOverrides.set(el, componentData);
-    const audio = APP.audios.get(el);
-    if (audio) {
-      updateAudioSettings(el, audio);
-    }
-
-    // TODO: Remove
-    if (components["audio"] || components["video"]) {
-      componentData["sourceType"] = SourceType.MEDIA_VIDEO;
-    } else if (components["audio-target"]) {
-      componentData["sourceType"] = SourceType.AUDIO_TARGET;
-    } else if (components["audio-zone"]) {
-      componentData["sourceType"] = SourceType.AUDIO_ZONE;
-    }
-    el.setAttribute(componentName, { ...componentData });
+AFRAME.GLTFModelPlus.registerComponent("audio-params", "audio-params", (el, componentName, componentData) => {
+  APP.audioOverrides.set(el, componentData);
+  const audio = APP.audios.get(el);
+  if (audio) {
+    updateAudioSettings(el, audio);
   }
-);
+});
 
 AFRAME.GLTFModelPlus.registerComponent("audio-zone", "audio-zone", (el, componentName, componentData) => {
   el.setAttribute(componentName, { ...componentData });

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -3,7 +3,7 @@ import "./components/gltf-model-plus";
 import { getSanitizedComponentMapping } from "./utils/component-mappings";
 import { TYPE, SHAPE, FIT } from "three-ammo/constants";
 const COLLISION_LAYERS = require("./constants").COLLISION_LAYERS;
-import { AudioType, AvatarAudioDefaults, MediaAudioDefaults, SourceType } from "./components/audio-params";
+import { AudioType, SourceType } from "./components/audio-params";
 import { updateAudioSettings } from "./update-audio-settings";
 
 function registerRootSceneComponent(componentName) {

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -256,19 +256,12 @@ async function mediaInflator(el, componentName, componentData, components) {
         coneOuterGain: componentData.coneOuterGain,
         gain: componentData.volume
       });
+      APP.sourceType.set(el, SourceType.MEDIA_VIDEO);
 
-      // TODO: This feels very weird.
-      // Is it likely or possible that we have an audio by now?
       const audio = APP.audios.get(el);
       if (audio) {
         updateAudioSettings(el, audio);
       }
-
-      // TODO: Remove the line below
-      el.setAttribute("audio-params", {
-        audioType: componentData.audioType,
-        sourceType: SourceType.MEDIA_VIDEO
-      });
     }
 
     el.setAttribute("video-pause-state", { paused: mediaOptions.videoPaused });
@@ -496,18 +489,12 @@ AFRAME.GLTFModelPlus.registerComponent(
         coneOuterGain: componentData.coneOuterGain,
         gain: componentData.volume
       });
+      APP.sourceType.set(el, SourceType.AUDIO_TARGET);
 
-      // TODO: This feels very weird.
-      // Is it likely or possible that we have an audio by now?
       const audio = APP.audios.get(el);
       if (audio) {
-        updateAudioSettings(this.el, audio);
+        updateAudioSettings(el, audio);
       }
-
-      // TODO: Remove
-      el.setAttribute("audio-params", {
-        audioType: componentData.positional ? AudioType.PannerNode : AudioType.Stereo
-      });
     }
 
     el.setAttribute(componentName, {

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -547,7 +547,7 @@ AFRAME.GLTFModelPlus.registerComponent(
         coneInnerAngle: componentData.coneInnerAngle,
         coneOuterAngle: componentData.coneOuterAngle,
         coneOuterGain: componentData.coneOuterGain,
-        gain: componentData.volume
+        gain: componentData.gain
       });
       APP.sourceType.set(el, SourceType.AUDIO_TARGET);
 

--- a/src/hub.html
+++ b/src/hub.html
@@ -1203,7 +1203,6 @@
                 id="avatar-pov-node"
                 class="camera"
                 personal-space-bubble="radius: 0.4;"
-                audio-params="isLocal: true"
                 rotation
                 pitch-yaw-rotator
                 set-yxz-order

--- a/src/hub.html
+++ b/src/hub.html
@@ -221,7 +221,6 @@
                         <template data-name="Head">
                             <a-entity
                                 avatar-audio-source
-                                audio-params
                                 audio-zone-source
                                 personal-space-invader="radius: 0.15; useMaterial: true;"
                                 bone-visibility

--- a/src/hub.html
+++ b/src/hub.html
@@ -319,7 +319,6 @@
                     position-at-border__freeze="target:.freeze-menu"
                     position-at-border__freeze-unprivileged="target:.freeze-unprivileged-menu"
                     listed-media
-                    use-audio-system-settings
                 >
                     <a-entity class="ui interactable-ui">
                         <a-entity class="freeze-menu" visibility-while-frozen="withinDistance: 100; withPermission: spawn_and_move_media">

--- a/src/hub.js
+++ b/src/hub.js
@@ -141,7 +141,6 @@ import "./components/optional-alternative-to-not-hide";
 import "./components/avatar-audio-source";
 import "./components/avatar-inspect-collider";
 import "./components/video-texture-target";
-import "./components/audio-params";
 
 import ReactDOM from "react-dom";
 import React from "react";

--- a/src/hub.js
+++ b/src/hub.js
@@ -199,6 +199,15 @@ window.APP.RENDER_ORDER = {
   HUD_ICONS: 2,
   CURSOR: 3
 };
+
+// TODO: Remove comments
+// TODO: Rename or reconfigure these as needed
+APP.audios = new Map(); //                     el -> (THREE.Audio || THREE.PositionalAudio)
+APP.sourceType = new Map(); //                 el -> SourceType
+APP.audioOverrides = new Map(); //             el -> AudioSettings
+APP.zoneOverrides = new Map(); //              el -> AudioSettings
+APP.sceneAudioDefaults = new Map(); // SourceType -> AudioSettings
+
 const store = window.APP.store;
 store.update({ preferences: { shouldPromptForRefresh: undefined } }); // Clear flag that prompts for refresh from preference screen
 const mediaSearchStore = window.APP.mediaSearchStore;

--- a/src/hub.js
+++ b/src/hub.js
@@ -201,13 +201,14 @@ window.APP.RENDER_ORDER = {
 
 // TODO: Remove comments
 // TODO: Rename or reconfigure these as needed
-APP.audios = new Map(); //                     el -> (THREE.Audio || THREE.PositionalAudio)
-APP.sourceType = new Map(); //                 el -> SourceType
-APP.audioOverrides = new Map(); //             el -> AudioSettings
-APP.zoneOverrides = new Map(); //              el -> AudioSettings
-APP.sceneAudioDefaults = new Map(); // SourceType -> AudioSettings
+APP.audios = new Map(); //                           el -> (THREE.Audio || THREE.PositionalAudio)
+APP.sourceType = new Map(); //                       el -> SourceType
+APP.audioOverrides = new Map(); //                   el -> AudioSettings
+APP.zoneOverrides = new Map(); //                    el -> AudioSettings
+APP.audioDebugPanelOverrides = new Map(); // SourceType -> AudioSettings
+APP.sceneAudioDefaults = new Map(); //       SourceType -> AudioSettings
+APP.gainMultipliers = new Map(); //                  el -> Number
 APP.clippingState = new Set();
-APP.gainMultipliers = new Map();
 APP.linkedMutedState = new Set();
 
 const store = window.APP.store;

--- a/src/hub.js
+++ b/src/hub.js
@@ -208,6 +208,8 @@ APP.audioOverrides = new Map(); //             el -> AudioSettings
 APP.zoneOverrides = new Map(); //              el -> AudioSettings
 APP.sceneAudioDefaults = new Map(); // SourceType -> AudioSettings
 APP.clippingState = new Set();
+APP.gainMultipliers = new Map();
+APP.linkedMutedState = new Set();
 
 const store = window.APP.store;
 store.update({ preferences: { shouldPromptForRefresh: undefined } }); // Clear flag that prompts for refresh from preference screen

--- a/src/hub.js
+++ b/src/hub.js
@@ -210,6 +210,7 @@ APP.sceneAudioDefaults = new Map(); //       SourceType -> AudioSettings
 APP.gainMultipliers = new Map(); //                  el -> Number
 APP.clippingState = new Set();
 APP.linkedMutedState = new Set();
+APP.isAudioPaused = new Set();
 
 const store = window.APP.store;
 store.update({ preferences: { shouldPromptForRefresh: undefined } }); // Clear flag that prompts for refresh from preference screen

--- a/src/hub.js
+++ b/src/hub.js
@@ -207,6 +207,7 @@ APP.sourceType = new Map(); //                 el -> SourceType
 APP.audioOverrides = new Map(); //             el -> AudioSettings
 APP.zoneOverrides = new Map(); //              el -> AudioSettings
 APP.sceneAudioDefaults = new Map(); // SourceType -> AudioSettings
+APP.clippingState = new Set();
 
 const store = window.APP.store;
 store.update({ preferences: { shouldPromptForRefresh: undefined } }); // Clear flag that prompts for refresh from preference screen

--- a/src/react-components/debug-panel/AudioDebugPanel.js
+++ b/src/react-components/debug-panel/AudioDebugPanel.js
@@ -16,7 +16,8 @@ import {
   GLOBAL_VOLUME_DEFAULT
 } from "../../react-components/preferences-screen";
 import { SelectInputField } from "../input/SelectInputField";
-import { DISTANCE_MODEL_OPTIONS, DistanceModelType } from "../../components/audio-params";
+import { DISTANCE_MODEL_OPTIONS, DistanceModelType, SourceType } from "../../components/audio-params";
+import { getCurrentAudioSettingsForSourceType, updateAudioSettings } from "../../update-audio-settings";
 
 const ROLLOFF_MIN = 0.0;
 const ROLLOFF_MAX = 20.0;
@@ -59,7 +60,6 @@ SelectProperty.propTypes = {
 };
 
 function SliderProperty({ defaultValue, step, min, max, onChange, children }) {
-  const [value, setValue] = useState(defaultValue);
   return (
     <div className={classNames(styles.audioDebugRow)}>
       <span style={{ flex: "none", padEnd: "10px" }}>{children}</span>
@@ -68,14 +68,13 @@ function SliderProperty({ defaultValue, step, min, max, onChange, children }) {
         step={step}
         min={min}
         max={max}
-        value={value}
+        value={defaultValue}
         onChange={e => {
           const parsedValue = parseFloat(e.target.value);
-          setValue(parsedValue);
           onChange(parsedValue);
         }}
       />
-      <span className={classNames(styles.valueText)}>{value}</span>
+      <span className={classNames(styles.valueText)}>{defaultValue}</span>
     </div>
   );
 }
@@ -89,113 +88,63 @@ SliderProperty.propTypes = {
   children: PropTypes.node
 };
 
+function getPrefs() {
+  const prefs = {
+    enableAudioClipping: APP.store.state.preferences.enableAudioClipping,
+    audioClippingThreshold: APP.store.state.preferences.audioClippingThreshold,
+    globalVoiceVolume: APP.store.state.preferences.globalVoiceVolume,
+    globalMediaVolume: APP.store.state.preferences.globalMediaVolume
+  };
+  if (prefs.enableAudioClipping === undefined) prefs.enableAudioClipping = CLIPPING_THRESHOLD_ENABLED;
+  if (prefs.audioClippingThreshold === undefined) prefs.audioClippingThreshol = CLIPPING_THRESHOLD_DEFAULT;
+  if (prefs.globalVoiceVolume === undefined) prefs.globalVoiceVolume = GLOBAL_VOLUME_DEFAULT;
+  if (prefs.globalMediaVolume === undefined) prefs.globalMediaVolume = GLOBAL_VOLUME_DEFAULT;
+  return prefs;
+}
+
 export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
-  const scene = useRef(document.querySelector("a-scene"));
-  const audioSettings = useRef(scene.current.systems["hubs-systems"].audioSettingsSystem);
-  const store = useRef(window.APP.store);
-
-  const {
-    enableAudioClipping,
-    audioClippingThreshold,
-    globalVoiceVolume,
-    globalMediaVolume
-  } = store.current.state.preferences;
-  const [clippingEnabled, setClippingEnabled] = useState(
-    enableAudioClipping !== undefined ? enableAudioClipping : CLIPPING_THRESHOLD_ENABLED
-  );
-  const [clippingThreshold, setClippingThreshold] = useState(
-    audioClippingThreshold !== undefined ? audioClippingThreshold : CLIPPING_THRESHOLD_DEFAULT
-  );
-  const [voiceVolume, setVoiceVolume] = useState(
-    globalVoiceVolume !== undefined ? globalVoiceVolume : GLOBAL_VOLUME_DEFAULT
-  );
-  const [mediaVolume, setMediaVolume] = useState(
-    globalMediaVolume !== undefined ? globalMediaVolume : GLOBAL_VOLUME_DEFAULT
-  );
-  const [avatarDistanceModel, setAvatarDistanceModel] = useState(
-    audioSettings.current.defaultSettings.avatarDistanceModel
-  );
-  const [avatarRolloffFactor, setAvatarRolloffFactor] = useState(
-    audioSettings.current.defaultSettings.avatarRolloffFactor
-  );
-  const [avatarRefDistance, setAvatarRefDistance] = useState(audioSettings.current.defaultSettings.avatarRefDistance);
-  const [avatarMaxDistance, setAvatarMaxDistance] = useState(audioSettings.current.defaultSettings.avatarMaxDistance);
-  const [avatarConeInnerAngle, setAvatarConeInnerAngle] = useState(
-    audioSettings.current.defaultSettings.avatarConeInnerAngle
-  );
-  const [avatarConeOuterAngle, setAvatarConeOuterAngle] = useState(
-    audioSettings.current.defaultSettings.avatarConeOuterAngle
-  );
-  const [avatarConeOuterGain, setAvatarConeOuterGain] = useState(
-    audioSettings.current.defaultSettings.avatarConeOuterGain
-  );
-  const [mediaDistanceModel, setMediaDistanceModel] = useState(
-    audioSettings.current.defaultSettings.mediaDistanceModel
-  );
-  const [mediaRolloffFactor, setMediaRolloffFactor] = useState(
-    audioSettings.current.defaultSettings.mediaRolloffFactor
-  );
-  const [mediaRefDistance, setMediaRefDistance] = useState(audioSettings.current.defaultSettings.mediaRefDistance);
-  const [mediaMaxDistance, setMediaMaxDistance] = useState(audioSettings.current.defaultSettings.mediaMaxDistance);
-  const [mediaConeInnerAngle, setMediaConeInnerAngle] = useState(
-    audioSettings.current.defaultSettings.mediaConeInnerAngle
-  );
-  const [mediaConeOuterAngle, setMediaConeOuterAngle] = useState(
-    audioSettings.current.defaultSettings.mediaConeOuterAngle
-  );
-  const [mediaConeOuterGain, setMediaConeOuterGain] = useState(
-    audioSettings.current.defaultSettings.mediaConeOuterGain
+  const [mediaSettings, setMediaSettings] = useState(getCurrentAudioSettingsForSourceType(SourceType.MEDIA_VIDEO));
+  const [avatarSettings, setAvatarSettings] = useState(
+    getCurrentAudioSettingsForSourceType(SourceType.AVATAR_AUDIO_SOURCE)
   );
 
+  const onSettingChange = (sourceType, newSetting) => {
+    const settings = Object.assign({}, APP.audioDebugPanelOverrides.get(sourceType), newSetting);
+    APP.audioDebugPanelOverrides.set(sourceType, settings);
+    if (sourceType === SourceType.MEDIA_VIDEO) {
+      // We use the spread operator here because React comparisons are shallow, which means
+      // we must create a new object whenever we want mediaSettings or avatarSettings to update.
+      setMediaSettings({ ...getCurrentAudioSettingsForSourceType(SourceType.MEDIA_VIDEO) });
+    } else {
+      setAvatarSettings({ ...getCurrentAudioSettingsForSourceType(SourceType.AVATAR_AUDIO_SOURCE) });
+    }
+    for (const [el, audio] of APP.audios.entries()) {
+      updateAudioSettings(el, audio);
+    }
+  };
+
+  const [preferences, setPreferences] = useState(getPrefs());
   const onPreferencesUpdated = useCallback(
     () => {
-      const {
-        enableAudioClipping,
-        audioClippingThreshold,
-        globalVoiceVolume,
-        globalMediaVolume
-      } = store.current.state.preferences;
-      setClippingEnabled(enableAudioClipping);
-      setClippingThreshold(audioClippingThreshold);
-      setVoiceVolume(globalVoiceVolume);
-      setMediaVolume(globalMediaVolume);
+      setPreferences(getPrefs());
     },
-    [setClippingEnabled, setClippingThreshold, setVoiceVolume, setMediaVolume]
+    [setPreferences]
   );
-
   useEffect(
     () => {
       onPreferencesUpdated();
-      store.current.addEventListener("statechanged", onPreferencesUpdated);
-
-      const currentStore = store.current;
+      APP.store.addEventListener("statechanged", onPreferencesUpdated);
       return () => {
-        currentStore.removeEventListener("statechanged", onPreferencesUpdated);
+        APP.store.removeEventListener("statechanged", onPreferencesUpdated);
+        APP.audioDebugPanelOverrides.delete(SourceType.MEDIA_VIDEO);
+        APP.audioDebugPanelOverrides.delete(SourceType.AVATAR_AUDIO_SOURCE);
+        for (const [el, audio] of APP.audios.entries()) {
+          updateAudioSettings(el, audio);
+        }
       };
     },
-    [store, onPreferencesUpdated]
+    [onPreferencesUpdated]
   );
-
-  const updateAudioSettings = newSettings => {
-    const prevSettings = {
-      avatarDistanceModel,
-      avatarRefDistance,
-      avatarMaxDistance,
-      avatarRolloffFactor,
-      avatarConeInnerAngle,
-      avatarConeOuterAngle,
-      avatarConeOuterGain,
-      mediaDistanceModel,
-      mediaRefDistance,
-      mediaMaxDistance,
-      mediaRolloffFactor,
-      mediaConeInnerAngle,
-      mediaConeOuterAngle,
-      mediaConeOuterGain
-    };
-    const settings = Object.assign({}, prevSettings, newSettings);
-    audioSettings.current.updateAudioSettings(settings);
-  };
 
   return (
     <div
@@ -221,23 +170,23 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
             <input
               tabIndex="0"
               type="checkbox"
-              checked={clippingEnabled}
+              checked={preferences.enableAudioClipping}
               onChange={() => {
-                store.current.update({
+                APP.store.update({
                   preferences: {
-                    enableAudioClipping: !clippingEnabled
+                    enableAudioClipping: !preferences.enableAudioClipping
                   }
                 });
               }}
               style={{ marginLeft: "10px" }}
             />
             <SliderProperty
-              defaultValue={clippingThreshold}
+              defaultValue={preferences.audioClippingThreshold}
               step={CLIPPING_THRESHOLD_STEP}
               min={CLIPPING_THRESHOLD_MIN}
               max={CLIPPING_THRESHOLD_MAX}
               onChange={value => {
-                store.current.update({
+                APP.store.update({
                   preferences: {
                     audioClippingThreshold: value
                   }
@@ -250,12 +199,12 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
             </SliderProperty>
           </div>
           <SliderProperty
-            defaultValue={voiceVolume}
+            defaultValue={preferences.globalVoiceVolume}
             step={GLOBAL_VOLUME_STEP}
             min={GLOBAL_VOLUME_MIN}
             max={GLOBAL_VOLUME_MAX}
             onChange={value => {
-              store.current.update({
+              APP.store.update({
                 preferences: {
                   globalVoiceVolume: value
                 }
@@ -267,12 +216,12 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
             </p>
           </SliderProperty>
           <SliderProperty
-            defaultValue={mediaVolume}
+            defaultValue={preferences.globalMediaVolume}
             step={GLOBAL_VOLUME_STEP}
             min={GLOBAL_VOLUME_MIN}
             max={GLOBAL_VOLUME_MAX}
             onChange={value => {
-              store.current.update({
+              APP.store.update({
                 preferences: {
                   globalMediaVolume: value
                 }
@@ -291,23 +240,14 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
             grow
           >
             <SelectProperty
-              defaultValue={audioSettings.current.defaultSettings.avatarDistanceModel}
+              defaultValue={avatarSettings.distanceModel}
               options={DISTANCE_MODEL_OPTIONS}
               onChange={value => {
-                setAvatarDistanceModel(value);
-                const avatarAudioSources = scene.current.querySelectorAll("[avatar-audio-source]");
-                avatarAudioSources.forEach(source => {
-                  // TODO: Add a layer to the audio settings that partially applies these values while the debug panel is open
-                  source.setAttribute("audio-params", {
-                    distanceModel: value
-                  });
-                });
-                if (value === DistanceModelType.Linear && avatarRolloffFactor > 1.0) {
-                  setAvatarRolloffFactor(1.0);
+                const newSetting = { distanceModel: value };
+                if (value === DistanceModelType.Linear && avatarSettings.rolloffFactor > 1.0) {
+                  newSetting.rolloffFactor = 1.0;
                 }
-                updateAudioSettings({
-                  avatarDistanceModel: value
-                });
+                onSettingChange(SourceType.AVATAR_AUDIO_SOURCE, newSetting);
               }}
             >
               <p className={classNames(styles.propText)}>
@@ -315,21 +255,12 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
               </p>
             </SelectProperty>
             <SliderProperty
-              defaultValue={avatarRolloffFactor}
-              step={avatarDistanceModel === DistanceModelType.Linear ? ROLLOFF_LIN_STEP : ROLLOFF_STEP}
-              min={avatarDistanceModel === DistanceModelType.Linear ? ROLLOFF_LIN_MIN : ROLLOFF_MIN}
-              max={avatarDistanceModel === DistanceModelType.Linear ? ROLLOFF_LIN_MAX : ROLLOFF_MAX}
+              defaultValue={avatarSettings.rolloffFactor}
+              step={avatarSettings.distanceModel === DistanceModelType.Linear ? ROLLOFF_LIN_STEP : ROLLOFF_STEP}
+              min={avatarSettings.distanceModel === DistanceModelType.Linear ? ROLLOFF_LIN_MIN : ROLLOFF_MIN}
+              max={avatarSettings.distanceModel === DistanceModelType.Linear ? ROLLOFF_LIN_MAX : ROLLOFF_MAX}
               onChange={value => {
-                setAvatarRolloffFactor(value);
-                const avatarAudioSources = scene.current.querySelectorAll("[avatar-audio-source]");
-                avatarAudioSources.forEach(source => {
-                  source.setAttribute("audio-params", {
-                    rolloffFactor: value
-                  });
-                });
-                updateAudioSettings({
-                  avatarRolloffFactor: value
-                });
+                onSettingChange(SourceType.AVATAR_AUDIO_SOURCE, { rolloffFactor: value });
               }}
             >
               <p className={classNames(styles.propText)}>
@@ -337,21 +268,12 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
               </p>
             </SliderProperty>
             <SliderProperty
-              defaultValue={avatarRefDistance}
+              defaultValue={avatarSettings.refDistance}
               step={DISTANCE_STEP}
               min={DISTANCE_MIN}
               max={DISTANCE_MAX}
               onChange={value => {
-                setAvatarRefDistance(value);
-                const avatarAudioSources = scene.current.querySelectorAll("[avatar-audio-source]");
-                avatarAudioSources.forEach(source => {
-                  source.setAttribute("audio-params", {
-                    refDistance: value
-                  });
-                });
-                updateAudioSettings({
-                  avatarRefDistance: value
-                });
+                onSettingChange(SourceType.AVATAR_AUDIO_SOURCE, { refDistance: value });
               }}
             >
               <p className={classNames(styles.propText)}>
@@ -359,21 +281,12 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
               </p>
             </SliderProperty>
             <SliderProperty
-              defaultValue={avatarMaxDistance}
+              defaultValue={avatarSettings.maxDistance}
               step={DISTANCE_STEP}
               min={DISTANCE_MIN}
               max={DISTANCE_MAX}
               onChange={value => {
-                setAvatarMaxDistance(value);
-                const avatarAudioSources = scene.current.querySelectorAll("[avatar-audio-source]");
-                avatarAudioSources.forEach(source => {
-                  source.setAttribute("audio-params", {
-                    maxDistance: value
-                  });
-                });
-                updateAudioSettings({
-                  avatarMaxDistance: value
-                });
+                onSettingChange(SourceType.AVATAR_AUDIO_SOURCE, { maxDistance: value });
               }}
             >
               <p className={classNames(styles.propText)}>
@@ -381,21 +294,12 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
               </p>
             </SliderProperty>
             <SliderProperty
-              defaultValue={avatarConeInnerAngle}
+              defaultValue={avatarSettings.coneInnerAngle}
               step={ANGLE_STEP}
               min={ANGLE_MIN}
               max={ANGLE_MAX}
               onChange={value => {
-                setAvatarConeInnerAngle(value);
-                const avatarAudioSources = scene.current.querySelectorAll("[avatar-audio-source]");
-                avatarAudioSources.forEach(source => {
-                  source.setAttribute("audio-params", {
-                    coneInnerAngle: value
-                  });
-                });
-                updateAudioSettings({
-                  avatarConeInnerAngle: value
-                });
+                onSettingChange(SourceType.AVATAR_AUDIO_SOURCE, { coneInnerAngle: value });
               }}
             >
               <p className={classNames(styles.propText)}>
@@ -403,21 +307,12 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
               </p>
             </SliderProperty>
             <SliderProperty
-              defaultValue={avatarConeOuterAngle}
+              defaultValue={avatarSettings.coneOuterAngle}
               step={ANGLE_STEP}
               min={ANGLE_MIN}
               max={ANGLE_MAX}
               onChange={value => {
-                setAvatarConeOuterAngle(value);
-                const avatarAudioSources = scene.current.querySelectorAll("[avatar-audio-source]");
-                avatarAudioSources.forEach(source => {
-                  source.setAttribute("audio-params", {
-                    coneOuterAngle: value
-                  });
-                });
-                updateAudioSettings({
-                  avatarConeOuterAngle: value
-                });
+                onSettingChange(SourceType.AVATAR_AUDIO_SOURCE, { coneOuterAngle: value });
               }}
             >
               <p className={classNames(styles.propText)}>
@@ -425,21 +320,12 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
               </p>
             </SliderProperty>
             <SliderProperty
-              defaultValue={avatarConeOuterGain}
+              defaultValue={avatarSettings.coneOuterGain}
               step={GAIN_STEP}
               min={GAIN_MIN}
               max={GAIN_MAX}
               onChange={value => {
-                setAvatarConeOuterGain(value);
-                const avatarAudioSources = scene.current.querySelectorAll("[avatar-audio-source]");
-                avatarAudioSources.forEach(source => {
-                  source.setAttribute("audio-params", {
-                    coneOuterGain: value
-                  });
-                });
-                updateAudioSettings({
-                  avatarConeOuterGain: value
-                });
+                onSettingChange(SourceType.AVATAR_AUDIO_SOURCE, { coneOuterGain: value });
               }}
             >
               <p className={classNames(styles.propText)}>
@@ -453,22 +339,14 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
             grow
           >
             <SelectProperty
-              defaultValue={audioSettings.current.defaultSettings.mediaDistanceModel}
+              defaultValue={mediaSettings.distanceModel}
               options={DISTANCE_MODEL_OPTIONS}
               onChange={value => {
-                setMediaDistanceModel(value);
-                const elements = scene.current.querySelectorAll("[media-video], [audio-target]");
-                elements.forEach(source => {
-                  source.setAttribute("audio-params", {
-                    distanceModel: value
-                  });
-                });
-                if (value === DistanceModelType.Linear && mediaRolloffFactor > 1.0) {
-                  setMediaRolloffFactor(1.0);
+                const newSetting = { distanceModel: value };
+                if (value === DistanceModelType.Linear && mediaSettings.rolloffFactor > 1.0) {
+                  newSetting.rolloffFactor = 1.0;
                 }
-                updateAudioSettings({
-                  mediaDistanceModel: value
-                });
+                onSettingChange(SourceType.MEDIA_VIDEO, newSetting);
               }}
             >
               <p className={classNames(styles.propText)}>
@@ -476,21 +354,12 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
               </p>
             </SelectProperty>
             <SliderProperty
-              defaultValue={mediaRolloffFactor}
-              step={mediaDistanceModel === DistanceModelType.Linear ? ROLLOFF_LIN_STEP : ROLLOFF_STEP}
-              min={mediaDistanceModel === DistanceModelType.Linear ? ROLLOFF_LIN_MIN : ROLLOFF_MIN}
-              max={mediaDistanceModel === DistanceModelType.Linear ? ROLLOFF_LIN_MAX : ROLLOFF_MAX}
+              defaultValue={mediaSettings.rolloffFactor}
+              step={mediaSettings.distanceModel === DistanceModelType.Linear ? ROLLOFF_LIN_STEP : ROLLOFF_STEP}
+              min={mediaSettings.distanceModel === DistanceModelType.Linear ? ROLLOFF_LIN_MIN : ROLLOFF_MIN}
+              max={mediaSettings.distanceModel === DistanceModelType.Linear ? ROLLOFF_LIN_MAX : ROLLOFF_MAX}
               onChange={value => {
-                setMediaRolloffFactor(value);
-                const elements = scene.current.querySelectorAll("[media-video], [audio-target]");
-                elements.forEach(source => {
-                  source.setAttribute("audio-params", {
-                    rolloffFactor: value
-                  });
-                });
-                updateAudioSettings({
-                  mediaRolloffFactor: value
-                });
+                onSettingChange(SourceType.MEDIA_VIDEO, { rolloffFactor: value });
               }}
             >
               <p className={classNames(styles.propText)}>
@@ -498,21 +367,12 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
               </p>
             </SliderProperty>
             <SliderProperty
-              defaultValue={mediaRefDistance}
+              defaultValue={mediaSettings.refDistance}
               step={DISTANCE_STEP}
               min={DISTANCE_MIN}
               max={DISTANCE_MAX}
               onChange={value => {
-                setMediaRefDistance(value);
-                const elements = scene.current.querySelectorAll("[media-video], [audio-target]");
-                elements.forEach(source => {
-                  source.setAttribute("audio-params", {
-                    refDistance: value
-                  });
-                });
-                updateAudioSettings({
-                  mediaRefDistance: value
-                });
+                onSettingChange(SourceType.MEDIA_VIDEO, { refDistance: value });
               }}
             >
               <p className={classNames(styles.propText)}>
@@ -520,21 +380,12 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
               </p>
             </SliderProperty>
             <SliderProperty
-              defaultValue={mediaMaxDistance}
+              defaultValue={mediaSettings.maxDistance}
               step={DISTANCE_STEP}
               min={DISTANCE_MIN}
               max={DISTANCE_MAX}
               onChange={value => {
-                setMediaMaxDistance(value);
-                const elements = scene.current.querySelectorAll("[media-video], [audio-target]");
-                elements.forEach(source => {
-                  source.setAttribute("audio-params", {
-                    maxDistance: value
-                  });
-                });
-                updateAudioSettings({
-                  mediaMaxDistance: value
-                });
+                onSettingChange(SourceType.MEDIA_VIDEO, { maxDistance: value });
               }}
             >
               <p className={classNames(styles.propText)}>
@@ -542,21 +393,12 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
               </p>
             </SliderProperty>
             <SliderProperty
-              defaultValue={mediaConeInnerAngle}
+              defaultValue={mediaSettings.coneInnerAngle}
               step={ANGLE_STEP}
               min={ANGLE_MIN}
               max={ANGLE_MAX}
               onChange={value => {
-                setMediaConeInnerAngle(value);
-                const elements = scene.current.querySelectorAll("[media-video], [audio-target]");
-                elements.forEach(source => {
-                  source.setAttribute("audio-params", {
-                    coneInnerAngle: value
-                  });
-                });
-                updateAudioSettings({
-                  mediaConeInnerAngle: value
-                });
+                onSettingChange(SourceType.MEDIA_VIDEO, { coneInnerAngle: value });
               }}
             >
               <p className={classNames(styles.propText)}>
@@ -564,21 +406,12 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
               </p>
             </SliderProperty>
             <SliderProperty
-              defaultValue={mediaConeOuterAngle}
+              defaultValue={mediaSettings.coneOuterAngle}
               step={ANGLE_STEP}
               min={ANGLE_MIN}
               max={ANGLE_MAX}
               onChange={value => {
-                setMediaConeOuterAngle(value);
-                const elements = scene.current.querySelectorAll("[media-video], [audio-target]");
-                elements.forEach(source => {
-                  source.setAttribute("audio-params", {
-                    coneOuterAngle: value
-                  });
-                });
-                updateAudioSettings({
-                  mediaConeOuterAngle: value
-                });
+                onSettingChange(SourceType.MEDIA_VIDEO, { coneOuterAngle: value });
               }}
             >
               <p className={classNames(styles.propText)}>
@@ -586,21 +419,12 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
               </p>
             </SliderProperty>
             <SliderProperty
-              defaultValue={mediaConeOuterGain}
+              defaultValue={mediaSettings.coneOuterGain}
               step={GAIN_STEP}
               min={GAIN_MIN}
               max={GAIN_MAX}
               onChange={value => {
-                setMediaConeOuterGain(value);
-                const elements = scene.current.querySelectorAll("[media-video], [audio-target]");
-                elements.forEach(source => {
-                  source.setAttribute("audio-params", {
-                    coneOuterGain: value
-                  });
-                });
-                updateAudioSettings({
-                  mediaConeOuterGain: value
-                });
+                onSettingChange(SourceType.MEDIA_VIDEO, { coneOuterGain: value });
               }}
             >
               <p className={classNames(styles.propText)}>

--- a/src/react-components/debug-panel/AudioDebugPanel.js
+++ b/src/react-components/debug-panel/AudioDebugPanel.js
@@ -155,20 +155,10 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
         globalVoiceVolume,
         globalMediaVolume
       } = store.current.state.preferences;
-      const clippingEnabled = enableAudioClipping !== undefined ? enableAudioClipping : CLIPPING_THRESHOLD_DEFAULT;
-      const clippingThreshold =
-        audioClippingThreshold !== undefined ? audioClippingThreshold : CLIPPING_THRESHOLD_DEFAULT;
       setClippingEnabled(enableAudioClipping);
-      setClippingThreshold(clippingThreshold);
+      setClippingThreshold(audioClippingThreshold);
       setVoiceVolume(globalVoiceVolume);
       setMediaVolume(globalMediaVolume);
-      const audioParams = scene.current.querySelectorAll("[audio-params]");
-      audioParams.forEach(source => {
-        source.setAttribute("audio-params", {
-          clippingThreshold,
-          clippingEnabled
-        });
-      });
     },
     [setClippingEnabled, setClippingThreshold, setVoiceVolume, setMediaVolume]
   );

--- a/src/react-components/debug-panel/AudioDebugPanel.js
+++ b/src/react-components/debug-panel/AudioDebugPanel.js
@@ -307,6 +307,7 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
                 setAvatarDistanceModel(value);
                 const avatarAudioSources = scene.current.querySelectorAll("[avatar-audio-source]");
                 avatarAudioSources.forEach(source => {
+                  // TODO: Add a layer to the audio settings that partially applies these values while the debug panel is open
                   source.setAttribute("audio-params", {
                     distanceModel: value
                   });

--- a/src/react-components/debug-panel/AudioDebugPanel.js
+++ b/src/react-components/debug-panel/AudioDebugPanel.js
@@ -112,11 +112,9 @@ export function AudioDebugPanel({ isNarrow, collapsed, onCollapsed }) {
     const settings = Object.assign({}, APP.audioDebugPanelOverrides.get(sourceType), newSetting);
     APP.audioDebugPanelOverrides.set(sourceType, settings);
     if (sourceType === SourceType.MEDIA_VIDEO) {
-      // We use the spread operator here because React comparisons are shallow, which means
-      // we must create a new object whenever we want mediaSettings or avatarSettings to update.
-      setMediaSettings({ ...getCurrentAudioSettingsForSourceType(SourceType.MEDIA_VIDEO) });
+      setMediaSettings(getCurrentAudioSettingsForSourceType(SourceType.MEDIA_VIDEO));
     } else {
-      setAvatarSettings({ ...getCurrentAudioSettingsForSourceType(SourceType.AVATAR_AUDIO_SOURCE) });
+      setAvatarSettings(getCurrentAudioSettingsForSourceType(SourceType.AVATAR_AUDIO_SOURCE));
     }
     for (const [el, audio] of APP.audios.entries()) {
       updateAudioSettings(el, audio);

--- a/src/react-components/debug-panel/AudioDebugPanel.js
+++ b/src/react-components/debug-panel/AudioDebugPanel.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useRef, useEffect } from "react";
+import React, { useCallback, useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { FormattedMessage } from "react-intl";
 import styles from "./AudioDebugPanel.scss";

--- a/src/systems/audio-debug-system.js
+++ b/src/systems/audio-debug-system.js
@@ -115,7 +115,7 @@ AFRAME.registerSystem("audio-debug", {
 
       let sourceNum = 0;
       this.sources.forEach(source => {
-        if (source.data.enabled && source.data.debuggable && source.audioRef) {
+        if (source.data.enabled && source.audioRef) {
           if (sourceNum < MAX_DEBUG_SOURCES) {
             const audio = APP.audios.get(source.el);
             if (!audio) {

--- a/src/systems/audio-debug-system.js
+++ b/src/systems/audio-debug-system.js
@@ -117,23 +117,39 @@ AFRAME.registerSystem("audio-debug", {
       this.sources.forEach(source => {
         if (source.data.enabled && source.data.debuggable && source.audioRef) {
           if (sourceNum < MAX_DEBUG_SOURCES) {
-            source.audioRef.getWorldPosition(sourcePos);
-            source.audioRef.getWorldDirection(sourceDir);
+            const audio = APP.audios.get(source.el);
+            if (!audio) {
+              return;
+            }
+            audio.getWorldPosition(sourcePos);
+            audio.getWorldDirection(sourceDir);
             this.sourcePositions[sourceNum] = sourcePos.clone();
             this.sourceOrientations[sourceNum] = sourceDir.clone();
+
+            const panner = audio.panner || {
+              distanceModel: DistanceModelType.Inverse,
+              maxDistance: 0,
+              refDistance: 0,
+              rolloffFactor: 0,
+              coneInnerAngle: 0,
+              coneOuterAngle: 0
+            };
+
             this.distanceModels[sourceNum] = 0;
-            if (source.data.distanceModel === DistanceModelType.Linear) {
+            if (panner.distanceModel === DistanceModelType.Linear) {
               this.distanceModels[sourceNum] = 0;
-            } else if (source.data.distanceModel === DistanceModelType.Inverse) {
+            } else if (panner.distanceModel === DistanceModelType.Inverse) {
               this.distanceModels[sourceNum] = 1;
-            } else if (source.data.distanceModel === DistanceModelType.Exponential) {
+            } else if (panner.distanceModel === DistanceModelType.Exponential) {
               this.distanceModels[sourceNum] = 2;
             }
-            this.maxDistances[sourceNum] = source.data.maxDistance;
-            this.refDistances[sourceNum] = source.data.refDistance;
-            this.rolloffFactors[sourceNum] = source.data.rolloffFactor;
-            this.coneInnerAngles[sourceNum] = source.data.coneInnerAngle;
-            this.coneOuterAngles[sourceNum] = source.data.coneOuterAngle;
+            this.maxDistances[sourceNum] = panner.maxDistance;
+            this.refDistances[sourceNum] = panner.refDistance;
+            this.rolloffFactors[sourceNum] = panner.rolloffFactor;
+            this.coneInnerAngles[sourceNum] = panner.coneInnerAngle;
+            this.coneOuterAngles[sourceNum] = panner.coneOuterAngle;
+
+            // TODO: Gain
             this.gains[sourceNum] = source.data.gain;
             this.clipped[sourceNum] = source.data.isClipped;
             sourceNum++;

--- a/src/systems/audio-debug-system.js
+++ b/src/systems/audio-debug-system.js
@@ -7,6 +7,15 @@ import { getMeshes } from "../utils/aframe-utils";
 
 const MAX_DEBUG_SOURCES = 64;
 
+const fakePanner = {
+  distanceModel: DistanceModelType.Inverse,
+  maxDistance: 0,
+  refDistance: 0,
+  rolloffFactor: 0,
+  coneInnerAngle: 0,
+  coneOuterAngle: 0
+};
+
 AFRAME.registerSystem("audio-debug", {
   schema: {
     enabled: { default: false }
@@ -110,14 +119,7 @@ AFRAME.registerSystem("audio-debug", {
         this.sourcePositions[sourceNum] = sourcePos.clone(); // TODO: Use Vector3 pool
         this.sourceOrientations[sourceNum] = sourceDir.clone();
 
-        const panner = audio.panner || {
-          distanceModel: DistanceModelType.Inverse,
-          maxDistance: 0,
-          refDistance: 0,
-          rolloffFactor: 0,
-          coneInnerAngle: 0,
-          coneOuterAngle: 0
-        };
+        const panner = audio.panner || fakePanner;
 
         this.distanceModels[sourceNum] = 0;
         if (panner.distanceModel === DistanceModelType.Linear) {

--- a/src/systems/audio-debug-system.js
+++ b/src/systems/audio-debug-system.js
@@ -151,7 +151,7 @@ AFRAME.registerSystem("audio-debug", {
 
             // TODO: Gain
             this.gains[sourceNum] = source.data.gain;
-            this.clipped[sourceNum] = source.data.isClipped;
+            this.clipped[sourceNum] = APP.clippingState.has(source.el);
             sourceNum++;
           }
         }

--- a/src/systems/audio-debug-system.js
+++ b/src/systems/audio-debug-system.js
@@ -115,7 +115,7 @@ AFRAME.registerSystem("audio-debug", {
 
       let sourceNum = 0;
       this.sources.forEach(source => {
-        if (source.data.enabled && source.audioRef) {
+        if (source.audioRef) {
           if (sourceNum < MAX_DEBUG_SOURCES) {
             const audio = APP.audios.get(source.el);
             if (!audio) {

--- a/src/systems/audio-debug-system.js
+++ b/src/systems/audio-debug-system.js
@@ -149,8 +149,7 @@ AFRAME.registerSystem("audio-debug", {
             this.coneInnerAngles[sourceNum] = panner.coneInnerAngle;
             this.coneOuterAngles[sourceNum] = panner.coneOuterAngle;
 
-            // TODO: Gain
-            this.gains[sourceNum] = source.data.gain;
+            this.gains[sourceNum] = audio.gain.gain.value;
             this.clipped[sourceNum] = APP.clippingState.has(source.el);
             sourceNum++;
           }

--- a/src/systems/audio-debug-system.js
+++ b/src/systems/audio-debug-system.js
@@ -103,6 +103,7 @@ AFRAME.registerSystem("audio-debug", {
       let sourceNum = 0;
       for (const [el, audio] of APP.audios.entries()) {
         if (sourceNum >= MAX_DEBUG_SOURCES) continue;
+        if (APP.isAudioPaused.has(el)) continue;
 
         audio.getWorldPosition(sourcePos);
         audio.getWorldDirection(sourceDir);

--- a/src/systems/audio-gain-system.js
+++ b/src/systems/audio-gain-system.js
@@ -28,14 +28,15 @@ const updateAttenuation = (() => {
   const sourcePos = new THREE.Vector3();
   return source => {
     source.el.sceneEl.audioListener.getWorldPosition(listenerPos);
-    source.audioRef.getWorldPosition(sourcePos);
+    const audio = APP.audios.get(source.el);
+    audio.getWorldPosition(sourcePos);
     const distance = sourcePos.distanceTo(listenerPos);
-    if (source.audioRef.panner) {
-      return distanceModels[source.audioRef.panner.distanceModel](
+    if (audio.panner) {
+      return distanceModels[audio.panner.distanceModel](
         distance,
-        source.audioRef.panner.rolloffFactor,
-        source.audioRef.panner.refDistance,
-        source.audioRef.panner.maxDistance
+        audio.panner.rolloffFactor,
+        audio.panner.refDistance,
+        audio.panner.maxDistance
       );
     } else {
       return 1.0;
@@ -69,20 +70,21 @@ export class GainSystem {
     const clippingThreshold = getClippingThreshold();
     this.sources.forEach(source => {
       const isClipped = APP.clippingState.has(source.el);
-      if (source.audioRef && clippingEnabled) {
+      const audio = APP.audios.get(source.el);
+      if (audio && clippingEnabled) {
         const att = updateAttenuation(source);
         if (att < clippingThreshold) {
           if (!isClipped) {
             APP.clippingState.add(source.el);
-            updateAudioSettings(source.el, source.audioRef);
+            updateAudioSettings(source.el, audio);
           }
         } else if (isClipped) {
           APP.clippingState.delete(source.el);
-          updateAudioSettings(source.el, source.audioRef);
+          updateAudioSettings(source.el, audio);
         }
       } else if (isClipped) {
         APP.clippingState.delete(source.el);
-        updateAudioSettings(source.el, source.audioRef);
+        updateAudioSettings(source.el, audio);
       }
     });
   }

--- a/src/systems/audio-gain-system.js
+++ b/src/systems/audio-gain-system.js
@@ -47,7 +47,7 @@ export class GainSystem {
   tick() {
     const clippingEnabled = isClippingEnabled();
     const clippingThreshold = getClippingThreshold();
-    for (const [el, audio] of APP.audios.entries) {
+    for (const [el, audio] of APP.audios.entries()) {
       const isClipped = APP.clippingState.has(el);
       if (audio && clippingEnabled) {
         const att = updateAttenuation(el, audio);

--- a/src/systems/audio-gain-system.js
+++ b/src/systems/audio-gain-system.js
@@ -23,7 +23,7 @@ const distanceModels = {
   }
 };
 
-const updateAttenuation = (() => {
+const calculateAttenuation = (() => {
   const listenerPos = new THREE.Vector3();
   const sourcePos = new THREE.Vector3();
   return (el, audio) => {
@@ -49,19 +49,13 @@ export class GainSystem {
     const clippingThreshold = getClippingThreshold();
     for (const [el, audio] of APP.audios.entries()) {
       const isClipped = APP.clippingState.has(el);
-      if (audio && clippingEnabled) {
-        const att = updateAttenuation(el, audio);
-        if (att < clippingThreshold) {
-          if (!isClipped) {
-            APP.clippingState.add(el);
-            updateAudioSettings(el, audio);
-          }
-        } else if (isClipped) {
+      const shouldBeClipped = clippingEnabled && calculateAttenuation(el, audio) < clippingThreshold;
+      if (isClipped !== shouldBeClipped) {
+        if (shouldBeClipped) {
+          APP.clippingState.add(el);
+        } else {
           APP.clippingState.delete(el);
-          updateAudioSettings(el, audio);
         }
-      } else if (isClipped) {
-        APP.clippingState.delete(el);
         updateAudioSettings(el, audio);
       }
     }

--- a/src/systems/audio-gain-system.js
+++ b/src/systems/audio-gain-system.js
@@ -27,7 +27,7 @@ export class GainSystem {
   tick() {
     this.sources.forEach(source => {
       if (source.data.clippingEnabled) {
-        const audio = source.getAudio();
+        const audio = source.audioRef;
         if (source.data.attenuation < source.data.clippingThreshold) {
           if (audio.gain.gain.value > 0 && !source.data.isClipped) {
             source.clipGain(CLIPPING_GAIN);

--- a/src/systems/audio-settings-system.js
+++ b/src/systems/audio-settings-system.js
@@ -6,6 +6,7 @@ export class AudioSettingsSystem {
     this.sceneEl = sceneEl;
     // TODO: Clean this up
     this.defaultSettings = {
+      avatarVolume: AvatarAudioDefaults.gain,
       avatarDistanceModel: AvatarAudioDefaults.distanceModel,
       avatarRolloffFactor: AvatarAudioDefaults.rolloffFactor,
       avatarRefDistance: AvatarAudioDefaults.refDistance,
@@ -13,7 +14,7 @@ export class AudioSettingsSystem {
       avatarConeInnerAngle: AvatarAudioDefaults.coneInnerAngle,
       avatarConeOuterAngle: AvatarAudioDefaults.coneOuterAngle,
       avatarConeOuterGain: AvatarAudioDefaults.coneOuterGain,
-      mediaVolume: MediaAudioDefaults.VOLUME,
+      mediaVolume: MediaAudioDefaults.gain,
       mediaDistanceModel: MediaAudioDefaults.distanceModel,
       mediaRolloffFactor: MediaAudioDefaults.rolloffFactor,
       mediaRefDistance: MediaAudioDefaults.refDistance,
@@ -91,7 +92,7 @@ export class AudioSettingsSystem {
       coneInnerAngle: settings.mediaConeInnerAngle,
       coneOuterAngle: settings.mediaConeOuterAngle,
       coneOuterGain: settings.mediaConeOuterGain,
-      VOLUME: settings.mediaVolume
+      gain: settings.mediaVolume
     });
     APP.sceneAudioDefaults.set(SourceType.AVATAR_AUDIO_SOURCE, {
       distanceModel: settings.avatarDistanceModel,
@@ -101,7 +102,8 @@ export class AudioSettingsSystem {
       coneInnerAngle: settings.avatarConeInnerAngle,
       coneOuterAngle: settings.avatarConeOuterAngle,
       coneOuterGain: settings.avatarConeOuterGain,
-      VOLUME: settings.avatarVolume
+      // audio-settings component doesn't have a avatarVolume property so we need to handle that case
+      gain: settings.avatarVolume === undefined ? AvatarAudioDefaults.gain : settings.avatarVolume
     });
 
     // TODO: Clean this up. Should not need it anymore

--- a/src/systems/audio-settings-system.js
+++ b/src/systems/audio-settings-system.js
@@ -92,7 +92,7 @@ export class AudioSettingsSystem {
       coneInnerAngle: settings.mediaConeInnerAngle,
       coneOuterAngle: settings.mediaConeOuterAngle,
       coneOuterGain: settings.mediaConeOuterGain,
-      gain: settings.mediaVolume
+      gain: settings.mediaVolume === undefined ? MediaAudioDefaults.gain : settings.mediaVolume
     });
     APP.sceneAudioDefaults.set(SourceType.AVATAR_AUDIO_SOURCE, {
       distanceModel: settings.avatarDistanceModel,

--- a/src/systems/audio-settings-system.js
+++ b/src/systems/audio-settings-system.js
@@ -50,6 +50,7 @@ export class AudioSettingsSystem {
       const shouldUpdateAudioSettings = this.audioOutputMode !== newPref;
       this.audioOutputMode = newPref;
       if (shouldUpdateAudioSettings) {
+        // MM Here we are updating the settings in case we changed global output mode but we are not reacting to that specific change anywhere
         this.updateAudioSettings(this.audioSettings);
       }
     };

--- a/src/systems/audio-settings-system.js
+++ b/src/systems/audio-settings-system.js
@@ -1,34 +1,11 @@
-import { SourceType, AvatarAudioDefaults, MediaAudioDefaults } from "../components/audio-params";
+import { SourceType } from "../components/audio-params";
 import { updateAudioSettings } from "../update-audio-settings";
 
 export class AudioSettingsSystem {
   constructor(sceneEl) {
-    this.sceneEl = sceneEl;
-    // TODO: Clean this up
-    this.defaultSettings = {
-      avatarVolume: AvatarAudioDefaults.gain,
-      avatarDistanceModel: AvatarAudioDefaults.distanceModel,
-      avatarRolloffFactor: AvatarAudioDefaults.rolloffFactor,
-      avatarRefDistance: AvatarAudioDefaults.refDistance,
-      avatarMaxDistance: AvatarAudioDefaults.maxDistance,
-      avatarConeInnerAngle: AvatarAudioDefaults.coneInnerAngle,
-      avatarConeOuterAngle: AvatarAudioDefaults.coneOuterAngle,
-      avatarConeOuterGain: AvatarAudioDefaults.coneOuterGain,
-      mediaVolume: MediaAudioDefaults.gain,
-      mediaDistanceModel: MediaAudioDefaults.distanceModel,
-      mediaRolloffFactor: MediaAudioDefaults.rolloffFactor,
-      mediaRefDistance: MediaAudioDefaults.refDistance,
-      mediaMaxDistance: MediaAudioDefaults.maxDistance,
-      mediaConeInnerAngle: MediaAudioDefaults.coneInnerAngle,
-      mediaConeOuterAngle: MediaAudioDefaults.coneOuterAngle,
-      mediaConeOuterGain: MediaAudioDefaults.coneOuterGain
-    };
-    this.audioSettings = this.defaultSettings;
-    this.mediaVideos = [];
-    this.avatarAudioSources = [];
+    sceneEl.addEventListener("reset_scene", this.onSceneReset);
 
-    this.sceneEl.addEventListener("reset_scene", this.onSceneReset);
-
+    // TODO: Remove these hacks
     if (
       !window.APP.store.state.preferences.audioOutputMode ||
       window.APP.store.state.preferences.audioOutputMode === "audio"
@@ -44,132 +21,13 @@ export class AudioSettingsSystem {
         preferences: { audioNormalization: 0.0 }
       });
     }
-
-    this.audioOutputMode = window.APP.store.state.preferences.audioOutputMode;
-    this.onPreferenceChanged = () => {
-      const newPref = window.APP.store.state.preferences.audioOutputMode;
-      const shouldUpdateAudioSettings = this.audioOutputMode !== newPref;
-      this.audioOutputMode = newPref;
-      if (shouldUpdateAudioSettings) {
-        // MM Here we are updating the settings in case we changed global output mode but we are not reacting to that specific change anywhere
-        this.updateAudioSettings(this.audioSettings);
-      }
-    };
-    window.APP.store.addEventListener("statechanged", this.onPreferenceChanged);
-  }
-
-  registerMediaAudioSource(mediaVideo) {
-    const index = this.mediaVideos.indexOf(mediaVideo);
-    if (index === -1) {
-      this.mediaVideos.push(mediaVideo);
-    }
-  }
-
-  unregisterMediaAudioSource(mediaVideo) {
-    this.mediaVideos.splice(this.mediaVideos.indexOf(mediaVideo), 1);
-  }
-
-  registerAvatarAudioSource(avatarAudioSource) {
-    const index = this.avatarAudioSources.indexOf(avatarAudioSource);
-    if (index === -1) {
-      this.avatarAudioSources.push(avatarAudioSource);
-    }
-  }
-
-  unregisterAvatarAudioSource(avatarAudioSource) {
-    const index = this.avatarAudioSources.indexOf(avatarAudioSource);
-    if (index !== -1) {
-      this.avatarAudioSources.splice(index, 1);
-    }
-  }
-
-  updateAudioSettings(settings) {
-    APP.sceneAudioDefaults.set(SourceType.MEDIA_VIDEO, {
-      distanceModel: settings.mediaDistanceModel,
-      rolloffFactor: settings.mediaRolloffFactor,
-      refDistance: settings.mediaRefDistance,
-      maxDistance: settings.mediaMaxDistance,
-      coneInnerAngle: settings.mediaConeInnerAngle,
-      coneOuterAngle: settings.mediaConeOuterAngle,
-      coneOuterGain: settings.mediaConeOuterGain,
-      gain: settings.mediaVolume === undefined ? MediaAudioDefaults.gain : settings.mediaVolume
-    });
-    APP.sceneAudioDefaults.set(SourceType.AVATAR_AUDIO_SOURCE, {
-      distanceModel: settings.avatarDistanceModel,
-      rolloffFactor: settings.avatarRolloffFactor,
-      refDistance: settings.avatarRefDistance,
-      maxDistance: settings.avatarMaxDistance,
-      coneInnerAngle: settings.avatarConeInnerAngle,
-      coneOuterAngle: settings.avatarConeOuterAngle,
-      coneOuterGain: settings.avatarConeOuterGain,
-      // audio-settings component doesn't have a avatarVolume property so we need to handle that case
-      gain: settings.avatarVolume === undefined ? AvatarAudioDefaults.gain : settings.avatarVolume
-    });
-
-    // TODO: Clean this up. Should not need it anymore
-    this.audioSettings = Object.assign({}, this.defaultSettings, settings);
-
-    // TODO: Loop over all the audios in the scene. It's simpler and we can remove this
-    // book keeping code
-    for (const mediaVideo of this.mediaVideos) {
-      // TODO: Rename this function. Very confusing. This is NOT the member function it's in.
-      const audio = APP.audios.get(mediaVideo.el);
-      if (audio) {
-        updateAudioSettings(mediaVideo.el, audio);
-      }
-    }
-
-    for (const avatarAudioSource of this.avatarAudioSources) {
-      // TODO: Rename this function. Very confusing. This is NOT the member function it's in.
-      const audio = APP.audios.get(avatarAudioSource.el);
-      if (audio) {
-        updateAudioSettings(avatarAudioSource.el, audio);
-      }
-    }
   }
 
   onSceneReset = () => {
     APP.sceneAudioDefaults.delete(SourceType.AVATAR_AUDIO_SOURCE);
     APP.sceneAudioDefaults.delete(SourceType.MEDIA_VIDEO);
-    // TODO: update all the audios in the app
-    for (const mediaVideo of this.mediaVideos) {
-      // TODO: Rename this function. Very confusing. This is NOT the member function it's in.
-      const audio = APP.audios.get(mediaVideo.el);
-      if (audio) {
-        updateAudioSettings(mediaVideo.el, audio);
-      }
-    }
-
-    for (const avatarAudioSource of this.avatarAudioSources) {
-      // TODO: Rename this function. Very confusing. This is NOT the member function it's in.
-      const audio = APP.audios.get(avatarAudioSource.el);
-      if (audio) {
-        updateAudioSettings(avatarAudioSource.el, audio);
-      }
+    for (const [el, audio] of APP.audios.entries()) {
+      updateAudioSettings(el, audio);
     }
   };
 }
-
-AFRAME.registerComponent("use-audio-system-settings", {
-  init() {
-    this.onVideoLoaded = this.onVideoLoaded.bind(this);
-    this.el.addEventListener("video-loaded", this.onVideoLoaded);
-  },
-
-  onVideoLoaded() {
-    const audioSettingsSystem = this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem;
-    if (this.mediaVideo) {
-      audioSettingsSystem.unregisterMediaAudioSource(this.mediaVideo);
-    }
-    this.mediaVideo = this.el.components["media-video"];
-    audioSettingsSystem.registerMediaAudioSource(this.mediaVideo);
-  },
-
-  remove() {
-    const audioSettingsSystem = this.el.sceneEl.systems["hubs-systems"].audioSettingsSystem;
-    if (this.mediaVideo) {
-      audioSettingsSystem.unregisterMediaAudioSource(this.mediaVideo);
-    }
-    this.el.removeEventListener("video-loaded", this.onVideoLoaded);
-  }
-});

--- a/src/systems/audio-system.js
+++ b/src/systems/audio-system.js
@@ -1,10 +1,5 @@
 import { LogMessageType } from "../react-components/room/ChatSidebar";
-import { GAIN_TIME_CONST } from "../components/audio-params";
-
-export const MixerType = Object.freeze({
-  AVATAR: 0,
-  MEDIA: 1
-});
+import { GAIN_TIME_CONST, SourceType } from "../components/audio-params";
 
 let delayedReconnectTimeout = null;
 function performDelayedReconnect(gainNode) {
@@ -144,11 +139,11 @@ export class AudioSystem {
     this.audioContextNeedsToBeResumed = false;
 
     this.mixer = {
-      [MixerType.AVATAR]: this.audioContext.createGain(),
-      [MixerType.MEDIA]: this.audioContext.createGain()
+      [SourceType.AVATAR_AUDIO_SOURCE]: this.audioContext.createGain(),
+      [SourceType.MEDIA_VIDEO]: this.audioContext.createGain()
     };
-    this.mixer[MixerType.MEDIA].connect(this._sceneEl.audioListener.getInput());
-    this.mixer[MixerType.AVATAR].connect(this._sceneEl.audioListener.getInput());
+    this.mixer[SourceType.AVATAR_AUDIO_SOURCE].connect(this._sceneEl.audioListener.getInput());
+    this.mixer[SourceType.MEDIA_VIDEO].connect(this._sceneEl.audioListener.getInput());
 
     // Webkit Mobile fix
     this._safariMobileAudioInterruptionFix();
@@ -194,10 +189,14 @@ export class AudioSystem {
   updatePrefs() {
     const { globalVoiceVolume, globalMediaVolume } = window.APP.store.state.preferences;
     let newGain = (globalMediaVolume !== undefined ? globalMediaVolume : 100) / 100;
-    this.mixer[MixerType.MEDIA].gain.setTargetAtTime(newGain, this.audioContext.currentTime, GAIN_TIME_CONST);
+    this.mixer[SourceType.MEDIA_VIDEO].gain.setTargetAtTime(newGain, this.audioContext.currentTime, GAIN_TIME_CONST);
 
     newGain = (globalVoiceVolume !== undefined ? globalVoiceVolume : 100) / 100;
-    this.mixer[MixerType.AVATAR].gain.setTargetAtTime(newGain, this.audioContext.currentTime, GAIN_TIME_CONST);
+    this.mixer[SourceType.AVATAR_AUDIO_SOURCE].gain.setTargetAtTime(
+      newGain,
+      this.audioContext.currentTime,
+      GAIN_TIME_CONST
+    );
   }
 
   /**

--- a/src/systems/audio-system.js
+++ b/src/systems/audio-system.js
@@ -178,11 +178,11 @@ export class AudioSystem {
 
   addAudio(mixerTrack, audioNode) {
     this.removeAudio(audioNode);
-    audioNode.getOutput().connect(this.mixer[mixerTrack]);
+    audioNode.gain.connect(this.mixer[mixerTrack]);
   }
 
   removeAudio(audioNode) {
-    audioNode.getOutput().disconnect();
+    audioNode.gain.disconnect();
     audioNode.sourceType !== "empty" && audioNode.disconnect();
   }
 

--- a/src/systems/audio-zones-system.js
+++ b/src/systems/audio-zones-system.js
@@ -87,16 +87,7 @@ const updateSource = (function() {
     }
   };
 })();
-/**
- * This system updates audio-zone-sources audio-params based on the audioListener position.
- * On every tick it computes the audio-zone-source and audioListeners positions to check
- * if the listener is inside/outside an audio-zone and applies the zone's audio parameters.
- * It only updates when a source or the listener has changed which zones they are in.
- * If several audio-zones are in between the audioListener and the audio-zone-source, the applied
- * audio parameters is a reduction of the audio-zones most restrictive audio parameters.
- * i.e. If there are two audio-zones in between the listener and the source and the first one has gain == 0.1
- * and the other has gain == 1.0, gain == 0.1 is applied to the source.
- */
+
 export class AudioZonesSystem {
   constructor() {
     this.zones = [];

--- a/src/systems/linked-media.js
+++ b/src/systems/linked-media.js
@@ -50,7 +50,7 @@ AFRAME.registerSystem("linked-media", {
     elA.setAttribute("linked-media", "");
     elB.setAttribute("linked-media", "");
 
-    // As a convenience, if elA is a video, we turn its volume off so we don't hear it twice
+    // As a convenience, if elA has audio, we turn its volume off so we don't hear it twice
     APP.linkedMutedState.add(elA);
     const audio = APP.audios.get(elA);
     if (audio) {
@@ -68,7 +68,6 @@ AFRAME.registerSystem("linked-media", {
         elB.removeEventListener("componentchanged", handlerB);
       }
 
-      // As a convenience, if elA is a video, we restore its volume to 50% since we muted it upon link.
       APP.linkedMutedState.delete(elA);
       const audio = APP.audios.get(elA);
       if (audio) {

--- a/src/systems/linked-media.js
+++ b/src/systems/linked-media.js
@@ -6,6 +6,9 @@
 // - Sync is bidirectional, however, elB is assumed to be a 'derivate of' elA. this means:
 //   - for the video case, elA will have its volume set to zero and restored if elB is removed
 //   - when elA is removed, elB will be removed (done in media-loader) but not vice-versa
+
+import { updateAudioSettings } from "../update-audio-settings";
+
 //
 AFRAME.registerSystem("linked-media", {
   init: function() {
@@ -48,8 +51,10 @@ AFRAME.registerSystem("linked-media", {
     elB.setAttribute("linked-media", "");
 
     // As a convenience, if elA is a video, we turn its volume off so we don't hear it twice
-    if (elA.components["media-video"]) {
-      elA.setAttribute("audio-params", "gain", 0);
+    APP.linkedMutedState.add(elA);
+    const audio = APP.audios.get(elA);
+    if (audio) {
+      updateAudioSettings(elA, audio);
     }
 
     this.handlers.push([elA, elB, handlerA, handlerB]);
@@ -64,8 +69,10 @@ AFRAME.registerSystem("linked-media", {
       }
 
       // As a convenience, if elA is a video, we restore its volume to 50% since we muted it upon link.
-      if (elA.components["audio-params"]) {
-        elA.setAttribute("audio-params", "gain", 0.5);
+      APP.linkedMutedState.delete(elA);
+      const audio = APP.audios.get(elA);
+      if (audio) {
+        updateAudioSettings(elA, audio);
       }
     }
 

--- a/src/update-audio-settings.js
+++ b/src/update-audio-settings.js
@@ -46,7 +46,6 @@ export function getCurrentAudioSettingsForSourceType(sourceType) {
   return Object.assign({}, defaults, sceneOverrides, audioDebugPanelOverrides);
 }
 
-// TODO: Change this name or the name of the function on audio-settings-system
 export function updateAudioSettings(el, audio) {
   // Follow these rules and you'll have a good time:
   // - If a THREE.Audio or THREE.PositionalAudio is created, call this function.

--- a/src/update-audio-settings.js
+++ b/src/update-audio-settings.js
@@ -25,9 +25,9 @@ export function getCurrentAudioSettings(el) {
   const sourceType = APP.sourceType.get(el);
   const defaults = defaultSettingsForSourceType.get(sourceType);
   const sceneOverrides = APP.sceneAudioDefaults.get(sourceType);
+  const audioDebugPanelOverrides = APP.audioDebugPanelOverrides.get(sourceType);
   const audioOverrides = APP.audioOverrides.get(el);
   const zoneSettings = APP.zoneOverrides.get(el);
-  const audioDebugPanelOverrides = APP.audioDebugPanelOverrides.get(sourceType);
   const settings = Object.assign({}, defaults, sceneOverrides, audioDebugPanelOverrides, audioOverrides, zoneSettings);
 
   if (APP.clippingState.has(el) || APP.linkedMutedState.has(el)) {

--- a/src/update-audio-settings.js
+++ b/src/update-audio-settings.js
@@ -1,6 +1,6 @@
 import { SourceType, MediaAudioDefaults, AvatarAudioDefaults, TargetAudioDefaults } from "./components/audio-params";
 
-function applySettings(audio, settings) {
+function applySettings(el, audio, settings) {
   if (audio.panner) {
     audio.setDistanceModel(settings.distanceModel);
     audio.setRolloffFactor(settings.rolloffFactor);
@@ -12,6 +12,11 @@ function applySettings(audio, settings) {
   }
 
   // TODO: Apply gain
+  if (APP.clippingState.has(el)) {
+    // Apply zero gain
+  } else {
+    // Apply settings gain
+  }
 }
 
 const defaultSettingsForSourceType = new Map([
@@ -67,7 +72,7 @@ export function updateAudioSettings(el, audio) {
   // - If you audio settings change, call this function.
   const settings = getCurrentAudioSettings(el);
   if (settings) {
-    applySettings(audio, settings);
+    applySettings(el, audio, settings);
     return;
   }
 

--- a/src/update-audio-settings.js
+++ b/src/update-audio-settings.js
@@ -43,6 +43,6 @@ export function getCurrentAudioSettings(el) {
 export function updateAudioSettings(el, audio) {
   // Follow these rules and you'll have a good time:
   // - If a THREE.Audio or THREE.PositionalAudio is created, call this function.
-  // - If you audio settings change, call this function.
+  // - If audio settings change, call this function.
   applySettings(audio, getCurrentAudioSettings(el));
 }

--- a/src/update-audio-settings.js
+++ b/src/update-audio-settings.js
@@ -1,5 +1,7 @@
 import { SourceType, MediaAudioDefaults, AvatarAudioDefaults, TargetAudioDefaults } from "./components/audio-params";
 
+export const GAIN_TIME_CONST = 0.2;
+
 function applySettings(el, audio, settings) {
   if (audio.panner) {
     audio.setDistanceModel(settings.distanceModel);
@@ -11,12 +13,11 @@ function applySettings(el, audio, settings) {
     audio.panner.coneOuterGain = settings.coneOuterGain;
   }
 
-  // TODO: Apply gain
-  if (APP.clippingState.has(el)) {
-    // Apply zero gain
-  } else {
-    // Apply settings gain
-  }
+  // We don't deal with the audioOutputMode here anymore, we just apply the gain.
+  // TODO Remove audioOutputMode from the rest of the app.
+  const gainMultiplier = APP.gainMultipliers.has(el) ? APP.gainMultipliers.get(el) : 1;
+  const gain = APP.clippingState.has(el) || APP.linkedMutedState.has(el) ? 0 : gainMultiplier * settings.gain;
+  audio.gain.gain.setTargetAtTime(gain, audio.context.currentTime, GAIN_TIME_CONST);
 }
 
 const defaultSettingsForSourceType = new Map([

--- a/src/update-audio-settings.js
+++ b/src/update-audio-settings.js
@@ -1,8 +1,14 @@
 import { SourceType, MediaAudioDefaults, AvatarAudioDefaults, TargetAudioDefaults } from "./components/audio-params";
 
-export const GAIN_TIME_CONST = 0.2;
+const defaultSettingsForSourceType = Object.freeze(
+  new Map([
+    [SourceType.MEDIA_VIDEO, MediaAudioDefaults],
+    [SourceType.AVATAR_AUDIO_SOURCE, AvatarAudioDefaults],
+    [SourceType.AUDIO_TARGET, TargetAudioDefaults]
+  ])
+);
 
-function applySettings(el, audio, settings) {
+function applySettings(audio, settings) {
   if (audio.panner) {
     audio.setDistanceModel(settings.distanceModel);
     audio.setRolloffFactor(settings.rolloffFactor);
@@ -12,58 +18,25 @@ function applySettings(el, audio, settings) {
     audio.panner.coneOuterAngle = settings.coneOuterAngle;
     audio.panner.coneOuterGain = settings.coneOuterGain;
   }
-
-  // We don't deal with the audioOutputMode here anymore, we just apply the gain.
-  // TODO Remove audioOutputMode from the rest of the app.
-  const gainMultiplier = APP.gainMultipliers.has(el) ? APP.gainMultipliers.get(el) : 1;
-  const gain = APP.clippingState.has(el) || APP.linkedMutedState.has(el) ? 0 : gainMultiplier * settings.gain;
-  audio.gain.gain.setTargetAtTime(gain, audio.context.currentTime, GAIN_TIME_CONST);
+  audio.gain.gain.setTargetAtTime(settings.gain, audio.context.currentTime, 0.1);
 }
 
-const defaultSettingsForSourceType = new Map([
-  [SourceType.MEDIA_VIDEO, MediaAudioDefaults],
-  [SourceType.AVATAR_AUDIO_SOURCE, AvatarAudioDefaults],
-  [SourceType.AUDIO_TARGET, TargetAudioDefaults]
-]);
-
 export function getCurrentAudioSettings(el) {
-  // -- Highest Precedence --
-  //
-  //  DEBUG PANEL
-  //  AUDIO ZONE
-  //  PER-OBJECT OVERRIDES
-  //  SCENE OVERRIDES
-  //  APP DEFAULTS
-  //
-  // -- Lowest Precedence --
-
   // TODO: Add the DEBUG PANEL settings.
-  // TODO: The DEBUG PANEL only wants to set a few settings at a time
-  // TODO: Perhaps AUDIO ZONEs should be allowed to affect only a few settings at a time
-
-  const zoneSettings = APP.zoneOverrides.get(el);
-  if (zoneSettings) {
-    return zoneSettings;
-  }
-
-  const audioOverrides = APP.audioOverrides.get(el);
-  if (audioOverrides) {
-    return audioOverrides;
-  }
-
   const sourceType = APP.sourceType.get(el);
-  if (sourceType !== undefined) {
-    const sceneOverrides = APP.sceneAudioDefaults.get(sourceType);
-    if (sceneOverrides) {
-      return sceneOverrides;
-    }
+  const defaults = defaultSettingsForSourceType.get(sourceType);
+  const sceneOverrides = APP.sceneAudioDefaults.get(sourceType);
+  const audioOverrides = APP.audioOverrides.get(el);
+  const zoneSettings = APP.zoneOverrides.get(el);
+  const settings = Object.assign({}, defaults, sceneOverrides, audioOverrides, zoneSettings);
 
-    const defaults = defaultSettingsForSourceType.get(sourceType);
-    if (defaults) {
-      return defaults;
-    }
+  if (APP.clippingState.has(el) || APP.linkedMutedState.has(el)) {
+    settings.gain = 0;
+  } else if (APP.gainMultipliers.has(el)) {
+    settings.gain = settings.gain * APP.gainMultipliers.get(el);
   }
-  return null;
+
+  return settings;
 }
 
 // TODO: Change this name or the name of the function on audio-settings-system
@@ -71,11 +44,5 @@ export function updateAudioSettings(el, audio) {
   // Follow these rules and you'll have a good time:
   // - If a THREE.Audio or THREE.PositionalAudio is created, call this function.
   // - If you audio settings change, call this function.
-  const settings = getCurrentAudioSettings(el);
-  if (settings) {
-    applySettings(el, audio, settings);
-    return;
-  }
-
-  console.error("Uh oh! Had no settings to apply", el, audio);
+  applySettings(audio, getCurrentAudioSettings(el));
 }

--- a/src/update-audio-settings.js
+++ b/src/update-audio-settings.js
@@ -1,0 +1,75 @@
+import { SourceType, MediaAudioDefaults, AvatarAudioDefaults, TargetAudioDefaults } from "./components/audio-params";
+
+function applySettings(audio, settings) {
+  if (audio.panner) {
+    audio.setDistanceModel(settings.distanceModel);
+    audio.setRolloffFactor(settings.rolloffFactor);
+    audio.setRefDistance(settings.refDistance);
+    audio.setMaxDistance(settings.maxDistance);
+    audio.panner.coneInnerAngle = settings.coneInnerAngle;
+    audio.panner.coneOuterAngle = settings.coneOuterAngle;
+    audio.panner.coneOuterGain = settings.coneOuterGain;
+  }
+
+  // TODO: Apply gain
+}
+
+const defaultSettingsForSourceType = new Map([
+  [SourceType.MEDIA_VIDEO, MediaAudioDefaults],
+  [SourceType.AVATAR_AUDIO_SOURCE, AvatarAudioDefaults],
+  [SourceType.AUDIO_TARGET, TargetAudioDefaults]
+]);
+
+export function getCurrentAudioSettings(el) {
+  // -- Highest Precedence --
+  //
+  //  DEBUG PANEL
+  //  AUDIO ZONE
+  //  PER-OBJECT OVERRIDES
+  //  SCENE OVERRIDES
+  //  APP DEFAULTS
+  //
+  // -- Lowest Precedence --
+
+  // TODO: Add the DEBUG PANEL settings.
+  // TODO: The DEBUG PANEL only wants to set a few settings at a time
+  // TODO: Perhaps AUDIO ZONEs should be allowed to affect only a few settings at a time
+
+  const zoneSettings = APP.zoneOverrides.get(el);
+  if (zoneSettings) {
+    return zoneSettings;
+  }
+
+  const audioOverrides = APP.audioOverrides.get(el);
+  if (audioOverrides) {
+    return audioOverrides;
+  }
+
+  const sourceType = APP.sourceType.get(el);
+  if (sourceType !== undefined) {
+    const sceneOverrides = APP.sceneAudioDefaults.get(sourceType);
+    if (sceneOverrides) {
+      return sceneOverrides;
+    }
+
+    const defaults = defaultSettingsForSourceType.get(sourceType);
+    if (defaults) {
+      return defaults;
+    }
+  }
+  return null;
+}
+
+// TODO: Change this name or the name of the function on audio-settings-system
+export function updateAudioSettings(el, audio) {
+  // Follow these rules and you'll have a good time:
+  // - If a THREE.Audio or THREE.PositionalAudio is created, call this function.
+  // - If you audio settings change, call this function.
+  const settings = getCurrentAudioSettings(el);
+  if (settings) {
+    applySettings(audio, settings);
+    return;
+  }
+
+  console.error("Uh oh! Had no settings to apply", el, audio);
+}

--- a/src/update-audio-settings.js
+++ b/src/update-audio-settings.js
@@ -22,13 +22,13 @@ function applySettings(audio, settings) {
 }
 
 export function getCurrentAudioSettings(el) {
-  // TODO: Add the DEBUG PANEL settings.
   const sourceType = APP.sourceType.get(el);
   const defaults = defaultSettingsForSourceType.get(sourceType);
   const sceneOverrides = APP.sceneAudioDefaults.get(sourceType);
   const audioOverrides = APP.audioOverrides.get(el);
   const zoneSettings = APP.zoneOverrides.get(el);
-  const settings = Object.assign({}, defaults, sceneOverrides, audioOverrides, zoneSettings);
+  const audioDebugPanelOverrides = APP.audioDebugPanelOverrides.get(sourceType);
+  const settings = Object.assign({}, defaults, sceneOverrides, audioDebugPanelOverrides, audioOverrides, zoneSettings);
 
   if (APP.clippingState.has(el) || APP.linkedMutedState.has(el)) {
     settings.gain = 0;
@@ -37,6 +37,13 @@ export function getCurrentAudioSettings(el) {
   }
 
   return settings;
+}
+
+export function getCurrentAudioSettingsForSourceType(sourceType) {
+  const defaults = defaultSettingsForSourceType.get(sourceType);
+  const sceneOverrides = APP.sceneAudioDefaults.get(sourceType);
+  const audioDebugPanelOverrides = APP.audioDebugPanelOverrides.get(sourceType);
+  return Object.assign({}, defaults, sceneOverrides, audioDebugPanelOverrides);
 }
 
 // TODO: Change this name or the name of the function on audio-settings-system


### PR DESCRIPTION
This PR removes the `audio-params` aframe component and introduces a simple contract for handling audio nodes and audio settings. 

The contract is:
- When a `THREE.Audio` is created, we put it in `APP.audios` and we call `updateAudioSettings`.
- We put any state that affects audio settings into various collections (`APP.sceneOverrides`, `APP.zoneOverrides`, etc). When state is added or removed from these collections, we call `updateAudioSettings`.

The `updateAudioSettings` function reduces over the collections to determine what the audio settings _should be_ and then applies them. When reviewing this PR, I recommend that you start by reading `updateAudioSettings`: https://github.com/mozilla/hubs/blob/audio-refactor-v1/src/update-audio-settings.js

This fixes a few problems:
- In the previous code, whichever "layer" of audio settings were set most recently overwrites all previous state. For example, the user might enter an audio zone which affects the `gain` of an audio node. Then, the user might dismiss a linked copy of that node (via `linked-media`) and reset the `gain` to 0.5. The effect from the zone is overwritten (which is not desired). This type of problem is repeated at every "layer".
- In the previous code, we kept duplicate copies of panner node data in the `audio-params` component. This meant we had a bunch of book-keeping code to keep data in sync. There were subtle bugs in that book-keeping code that meant the two diverged. This is fixed by getting rid of the indirection and second copies of the "same" data.
- In the previous code, we had bugs related to the initialization order of aframe components. One component looked for properties of another component that may not have been initialized yet. (For example, https://github.com/mozilla/hubs/issues/4456 ). In this PR, whenever we have a new setting for audio, we can confidently store it in our collections (whether the audio for the element in question exists yet or not). If there exists an audio, we update its settings. If not, we know that our settings were stored in the collection and will be used once the audio is created.
- Similarly, in the previous code, any settings that affects an element's audio node would be lost if we replace that element's audio node with a new one (as in the case of switching from a `PositionalAudio` to a regular `Audio`). Although the code paths that handle this kind of replacement need further investigation, it is easy to tell what _should_ happen in these cases: The node should be replaced and the associated settings should be applied to the new node.

The `AudioNormalization` code is no longer being used and should be re-introduced in a followup PR.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/HUBS-754)
