### PR TITLE
Fix admin 403 images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,6 +34,8 @@ pipeline {
           def disableDeploy = env.DISABLE_DEPLOY
           def showQAPromoteCommand = env.SHOW_QA_PROMOTE_COMMAND
           def qaBuildsSlackChannel = env.QA_BUILDS_SLACK_CHANNEL
+          def qaBuildsSlackChannel = env.QA_BUILDS_SLACK_CHANNEL
+          def uploadsHost = env.UPLOADS_HOST
 
           def habCommand = (
             "/bin/bash scripts/hab-build-and-push.sh "
@@ -49,6 +51,7 @@ pipeline {
             + "\\\"${buildNumber}\\\" "
             + "\\\"${gitCommit}\\\" "
             + "\\\"${disableDeploy}\\\" "
+            + "\\\"${uploadsHost}\\\" "
           )
           runCommand(habCommand)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,6 @@ pipeline {
           def disableDeploy = env.DISABLE_DEPLOY
           def showQAPromoteCommand = env.SHOW_QA_PROMOTE_COMMAND
           def qaBuildsSlackChannel = env.QA_BUILDS_SLACK_CHANNEL
-          def qaBuildsSlackChannel = env.QA_BUILDS_SLACK_CHANNEL
           def uploadsHost = env.UPLOADS_HOST
 
           def habCommand = (

--- a/admin/src/react-components/fields.js
+++ b/admin/src/react-components/fields.js
@@ -68,6 +68,7 @@ OwnedFileImage.propTypes = {
 };
 
 function OwnedFileDownloadFieldInternal({ fileName, record, source }) {
+  console.log("OwnedFileDownloadFieldInternal()");
   return (
     <a
       download={fileName || true}

--- a/admin/src/react-components/fields.js
+++ b/admin/src/react-components/fields.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core/styles";
 import LaunchIcon from "@material-ui/icons/Launch";
-import { getReticulumFetchUrl, getAssetsFetchUrl } from "hubs/src/utils/phoenix-utils";
+import { getReticulumFetchUrl, getUploadsUrl } from "hubs/src/utils/phoenix-utils";
 import { ReferenceField } from "react-admin";
 
 const styles = {
@@ -39,7 +39,7 @@ ConditionalReferenceField.propTypes = {
 };
 
 const OwnedFileImageInternal = withStyles(styles)(({ record = {}, aspect = "wide", classes }) => {
-  const src = getAssetsFetchUrl(`/files/${record.owned_file_uuid}`);
+  const src = getUploadsUrl(`/files/${record.owned_file_uuid}`);
   return <img src={src} className={classes[`ownedFileImageAspect_${aspect}`]} />;
 });
 
@@ -67,7 +67,7 @@ function OwnedFileDownloadFieldInternal({ fileName, record, source }) {
   return (
     <a
       download={fileName || true}
-      href={getAssetsFetchUrl(`/files/${record[source]}`)}
+      href={getUploadsUrl(`/files/${record[source]}`)}
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/admin/src/react-components/fields.js
+++ b/admin/src/react-components/fields.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core/styles";
 import LaunchIcon from "@material-ui/icons/Launch";
-import { getReticulumFetchUrl } from "hubs/src/utils/phoenix-utils";
+import { getReticulumFetchUrl, getAssetsFetchUrl } from "hubs/src/utils/phoenix-utils";
 import { ReferenceField } from "react-admin";
 
 const styles = {
@@ -39,7 +39,7 @@ ConditionalReferenceField.propTypes = {
 };
 
 const OwnedFileImageInternal = withStyles(styles)(({ record = {}, aspect = "wide", classes }) => {
-  const src = getReticulumFetchUrl(`/files/${record.owned_file_uuid}`);
+  const src = getAssetsFetchUrl(`/files/${record.owned_file_uuid}`);
   return <img src={src} className={classes[`ownedFileImageAspect_${aspect}`]} />;
 });
 

--- a/admin/src/react-components/fields.js
+++ b/admin/src/react-components/fields.js
@@ -44,10 +44,6 @@ const OwnedFileImageInternal = withStyles(styles)(({ record = {}, aspect = "wide
 });
 
 export const OwnedFileImage = withStyles(styles)(({ basePath, record, source, aspect, classes, defaultImage }) => {
-  console.log(basePath);
-  console.log(source);
-  console.log(defaultImage);
-
   return (
     <ConditionalReferenceField
       basePath={basePath}
@@ -68,7 +64,6 @@ OwnedFileImage.propTypes = {
 };
 
 function OwnedFileDownloadFieldInternal({ fileName, record, source }) {
-  console.log("OwnedFileDownloadFieldInternal()");
   return (
     <a
       download={fileName || true}

--- a/admin/webpack.config.js
+++ b/admin/webpack.config.js
@@ -225,7 +225,7 @@ module.exports = (env, argv) => {
           RETICULUM_SERVER: process.env.RETICULUM_SERVER,
           CORS_PROXY_SERVER: process.env.CORS_PROXY_SERVER,
           POSTGREST_SERVER: process.env.POSTGREST_SERVER,
-          BASE_ASSETS_PATH: process.env.BASE_ASSETS_PATH
+          UPLOADS_HOST: process.env.UPLOADS_HOST
         })
       })
     ]

--- a/scripts/hab-build-and-push.sh
+++ b/scripts/hab-build-and-push.sh
@@ -12,6 +12,7 @@ export GA_TRACKING_ID=$9
 export BUILD_NUMBER=${10}
 export GIT_COMMIT=${11}
 export DISABLE_DEPLOY=${12}
+export UPLOADS_HOST=${13}
 export BUILD_VERSION="${BUILD_NUMBER} (${GIT_COMMIT})"
 
 # Build the package, upload it, and start the service so we deploy to staging target.
@@ -53,6 +54,7 @@ cors_proxy_server = $CORS_PROXY_SERVER
 non_cors_proxy_domains = $NON_CORS_PROXY_DOMAINS
 sentry_dsn = $SENTRY_DSN
 ga_tracking_id = $GA_TRACKING_ID
+uploads_host = $UPLOADS_HOST
 
 [deploy]
 type = "$DEPLOY_TYPE"

--- a/src/utils/configs.js
+++ b/src/utils/configs.js
@@ -16,7 +16,8 @@ let isAdmin = false;
   "SENTRY_DSN",
   "GA_TRACKING_ID",
   "SHORTLINK_DOMAIN",
-  "BASE_ASSETS_PATH"
+  "BASE_ASSETS_PATH",
+  "UPLOADS_HOST"
 ].forEach(x => {
   const el = document.querySelector(`meta[name='env:${x.toLowerCase()}']`);
   configs[x] = el ? el.getAttribute("content") : process.env[x];

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -61,17 +61,10 @@ export function getAssetsFetchUrl(path, absolute = false, host = null, port = nu
   console.log("Inside getAssetsFetchUrl()");
   console.log("UPLOADS_HOST");
   console.log(configs.UPLOADS_HOST);
-  if (configs.UPLOADS_HOST || host || hasReticulumServer()) {
-    console.log("getAssetsFetchUrl 1");
-    return `https://${configs.UPLOADS_HOST}${port ? `:${port}` : ""}${path}`;
-  } else if (absolute) {
-    console.log("getAssetsFetchUrl 2");
-    resolverLink.href = path;
-    return resolverLink.href;
-  } else {
-    console.log("getAssetsFetchUrl 3");
-    return path;
-  }
+  console.log(typeof configs.UPLOADS_HOST);
+  return configs.UPLOADS_HOST
+    ? `https://${configs.UPLOADS_HOST}${port ? `:${port}` : ""}${path}`
+    : getReticulumFetchUrl(path, absolute, host, port);
 }
 
 export async function getReticulumMeta() {

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -46,7 +46,7 @@ let invalidatedReticulumMetaThisSession = false;
 
 export function getReticulumFetchUrl(path, absolute = false, host = null, port = null) {
   console.log(configs);
-
+  console.log("Inside getReticulumFetchUrl()");
   if (host || hasReticulumServer()) {
     return `https://${host || configs.RETICULUM_SERVER}${port ? `:${port}` : ""}${path}`;
   } else if (absolute) {
@@ -58,12 +58,18 @@ export function getReticulumFetchUrl(path, absolute = false, host = null, port =
 }
 
 export function getAssetsFetchUrl(path, absolute = false, host = null, port = null) {
+  console.log("Inside getAssetsFetchUrl()");
+  console.log("UPLOADS_HOST");
+  console.log(configs.UPLOADS_HOST);
   if (configs.UPLOADS_HOST || host || hasReticulumServer()) {
-    return `https://${configs.UPLOADS_HOST || host}${port ? `:${port}` : ""}${path}`;
+    console.log("getAssetsFetchUrl 1");
+    return `https://${configs.UPLOADS_HOST}${port ? `:${port}` : ""}${path}`;
   } else if (absolute) {
+    console.log("getAssetsFetchUrl 2");
     resolverLink.href = path;
     return resolverLink.href;
   } else {
+    console.log("getAssetsFetchUrl 3");
     return path;
   }
 }

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -45,8 +45,6 @@ let reticulumMeta = null;
 let invalidatedReticulumMetaThisSession = false;
 
 export function getReticulumFetchUrl(path, absolute = false, host = null, port = null) {
-  console.log(configs);
-  console.log("Inside getReticulumFetchUrl()");
   if (host || hasReticulumServer()) {
     return `https://${host || configs.RETICULUM_SERVER}${port ? `:${port}` : ""}${path}`;
   } else if (absolute) {
@@ -58,10 +56,6 @@ export function getReticulumFetchUrl(path, absolute = false, host = null, port =
 }
 
 export function getAssetsFetchUrl(path, absolute = false, host = null, port = null) {
-  console.log("Inside getAssetsFetchUrl()");
-  console.log("UPLOADS_HOST");
-  console.log(configs.UPLOADS_HOST);
-  console.log(typeof configs.UPLOADS_HOST);
   return configs.UPLOADS_HOST
     ? `https://${configs.UPLOADS_HOST}${port ? `:${port}` : ""}${path}`
     : getReticulumFetchUrl(path, absolute, host, port);

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -55,6 +55,17 @@ export function getReticulumFetchUrl(path, absolute = false, host = null, port =
   }
 }
 
+export function getAssetsFetchUrl(path, absolute = false, host = null, port = null) {
+  if (configs.UPLOADS_HOST || host || hasReticulumServer()) {
+    return `https://${configs.UPLOADS_HOST || host}${port ? `:${port}` : ""}${path}`;
+  } else if (absolute) {
+    resolverLink.href = path;
+    return resolverLink.href;
+  } else {
+    return path;
+  }
+}
+
 export async function getReticulumMeta() {
   if (!reticulumMeta) {
     // Initially look up version based upon page, avoiding round-trip, otherwise fetch.

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -55,7 +55,7 @@ export function getReticulumFetchUrl(path, absolute = false, host = null, port =
   }
 }
 
-export function getAssetsFetchUrl(path, absolute = false, host = null, port = null) {
+export function getUploadsUrl(path, absolute = false, host = null, port = null) {
   return configs.UPLOADS_HOST
     ? `https://${configs.UPLOADS_HOST}${port ? `:${port}` : ""}${path}`
     : getReticulumFetchUrl(path, absolute, host, port);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -229,7 +229,8 @@ module.exports = async (env, argv) => {
         BASE_ASSETS_PATH: "https://hubs.local:8080/",
         RETICULUM_SERVER: "hubs.local:4000",
         POSTGREST_SERVER: "",
-        ITA_SERVER: ""
+        ITA_SERVER: "",
+        UPLOADS_HOST: "https://hubs.local:4000"
       });
     }
   }
@@ -643,6 +644,7 @@ module.exports = async (env, argv) => {
           SENTRY_DSN: process.env.SENTRY_DSN,
           GA_TRACKING_ID: process.env.GA_TRACKING_ID,
           POSTGREST_SERVER: process.env.POSTGREST_SERVER,
+          UPLOADS_HOST: process.env.UPLOADS_HOST,
           APP_CONFIG: appConfig
         })
       })


### PR DESCRIPTION
HMC admin panel images were showing a 403 because the root url was hosting the images. This PR changes it so the admin panel images are being requested from the UPLOADS_HOST url.

Adds UPLOADS_HOST defined in Jenkins for HMC.
Will need to define UPLOADS_HOST in HC template for HC before sending deploying it to HC.