### PR TITLE
keyboard.getLayoutMap() throws an exception in iFrame on Chrome

### DIFF
--- a/src/react-components/room/TipContainer.js
+++ b/src/react-components/room/TipContainer.js
@@ -19,6 +19,9 @@ if (window.navigator.keyboard !== undefined && window.navigator.keyboard.getLayo
       "D"}`.toUpperCase();
     turnLeftKey = map.get("KeyQ")?.toUpperCase();
     turnRightKey = map.get("KeyE")?.toUpperCase();
+  }).catch(function(e) {
+    // This occurs on Chrome 93 when the Hubs page is in an iframe
+    console.warn(`Unable to remap keyboard: ${e}`);
   });
 }
 


### PR DESCRIPTION
If you host Hubs in an iframe you get a console error from keyboard.getLayoutMap():

<img width="956" alt="Screenshot 2021-08-25 at 10 50 19" src="https://user-images.githubusercontent.com/303516/130769683-2bbc0cba-310b-4829-a99b-60ec6b56b87e.png">

I can't find any definitive reference to this behaviour, but [here is an example fix](https://github.com/eclipse-theia/theia/pull/5054/files) in another code base.

Downgrading this to a warning with an explicit message at least stops us having to think about it every time it happens. The fact that keyboard remapping will not work inside an iframe on Chrome is going to be harder to actually fix.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/HUBS-773)
