### PR TITLE
Fix media-video audioSrc set up in media-loader

### DIFF
--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -365,7 +365,7 @@ AFRAME.registerComponent("media-loader", {
       }
 
       let canonicalUrl = src;
-      let canonicalAudioUrl = null;
+      let canonicalAudioUrl = null; // set non-null only if audio track is separated from video track (eg. 360 video)
       let accessibleUrl = src;
       let contentType = this.data.contentType;
       let thumbnail;

--- a/src/components/media-views.js
+++ b/src/components/media-views.js
@@ -259,7 +259,7 @@ const MAX_MULTIPLIER = 2;
 AFRAME.registerComponent("media-video", {
   schema: {
     src: { type: "string" },
-    audioSrc: { type: "string" },
+    audioSrc: { type: "string" }, // set only if audio track is separated from video track (eg. 360 video)
     contentType: { type: "string" },
     loop: { type: "boolean", default: true },
     hidePlaybackControls: { type: "boolean", default: false },
@@ -848,7 +848,9 @@ AFRAME.registerComponent("media-video", {
         videoEl.src = url;
         videoEl.onerror = failLoad;
 
+        // audioSrc is non-empty only if audio track is separated from video track (eg. 360 video)
         if (this.data.audioSrc) {
+          // Mute video track just in case
           videoEl.muted = true;
 
           // If there's an audio src, create an audio element to play it that we keep in sync


### PR DESCRIPTION
It looks `audioSrc` attribute in `media-video` should be non-empty only if video and audio tracks are separated (eg. 360 video). But `media-loader` seems to always set non-empty to it. This PR fixes the problem by setting up `audioSrc` only when necessary. And I added some comments about it.

Benefits:
* Currently `media-video` unnecessarily creates video and audio elements and does sync the states between them even for regular videos and audios. With this change, it will create only video element and the sync will no longer be needed. Good CPU and memory efficiency. And the logic will be simpler.
* This just one line change resolves three Safari specific audio issues (!!) #4543, #4550, #4552
