### PR TITLE
Transform the audio source position to navmesh local coordinates system when drawing

### DIFF
--- a/src/systems/audio-debug-system.js
+++ b/src/systems/audio-debug-system.js
@@ -116,8 +116,8 @@ AFRAME.registerSystem("audio-debug", {
 
         audio.getWorldPosition(sourcePos);
         audio.getWorldDirection(sourceDir);
-        this.sourcePositions[sourceNum] = sourcePos.clone(); // TODO: Use Vector3 pool
-        this.sourceOrientations[sourceNum] = sourceDir.clone();
+        this.sourcePositions[sourceNum] = this.navMeshObject.worldToLocal(sourcePos).clone(); // TODO: Use Vector3 pool
+        this.sourceOrientations[sourceNum] = this.navMeshObject.worldToLocal(sourcePos).clone();
 
         const panner = audio.panner || fakePanner;
 


### PR DESCRIPTION
We need to transform the audio source position to local coordinates system otherwise it only works for the Spoke floor plan which is world aligned.