### PR TITLE
Allow dark mode in the local dev test

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -137,7 +137,7 @@ function createDefaultAppConfig() {
   if (fs.existsSync(themesPath)) {
     const themesString = fs.readFileSync(themesPath).toString();
     const themes = JSON.parse(themesString);
-    appConfig.themes = themes;
+    appConfig.theme.themes = themes;
   }
 
   return appConfig;


### PR DESCRIPTION
Currently in the local dev test which is started with `npm run dev` doesn't enable to select the theme as you see in the following screenshot, it only has browser default theme.

![image](https://user-images.githubusercontent.com/7637832/131580538-f557256f-5737-4566-9144-2058ef8af869.png)

The root issue seems that themes setup in `webpack.config.js` is wrong. If I'm right it should set up `appConfig.theme.themes` but it wrongly sets up `appConfig.themes`.

This PR fixes it and allows to select Hubs dark mode theme even in the local dev test.