### PR TITLE
Scene must be reset when fast switching

### DIFF
--- a/src/change-hub.js
+++ b/src/change-hub.js
@@ -75,6 +75,7 @@ export async function changeHub(hubId, addToHistory = true) {
   ) {
     const fader = document.getElementById("viewing-camera").components["fader"];
     fader.fadeOut().then(() => {
+      scene.emit("reset_scene");
       updateEnvironmentForHub(hub, APP.entryManager);
     });
   }


### PR DESCRIPTION
A number of components expect the `reset_scene` event to fire when the scene is changed as seen [in the hub refresh handler](https://github.com/mozilla/hubs/blob/master/src/hub.js#L1307). The fast scene change code didn't include this event, so some components were not given a chance to reset. This leads to warnings in the console regarding duplicate navigation meshes, residual fog from previous scenes, and possibly some spatial audio issues.

The scene in [this example room](https://hubs.mozilla.com/CPMwEKv/stunning-dimwitted-assembly) has fog and if you follow either of the links to [this room](https://hubs.mozilla.com/LLmN62m/nautical-modern-room) the fog remains despite it not being defined.
