### PR TITLE
Fix for URL waypoint fragments when using fast switching

### DIFF
--- a/src/systems/waypoint-system.js
+++ b/src/systems/waypoint-system.js
@@ -298,6 +298,9 @@ export class WaypointSystem {
         this.nextMoveToSpawnResolve = resolve;
       });
     }
+    // Reset system state to allow for waypoint selection based on URL fragments 
+    this.previousWaypointHash = null;
+    this.initialSpawnHappened = false;
     return this.nextMoveToSpawn;
   }
   moveToWaypoint(waypointComponent, instant) {


### PR DESCRIPTION
Fast room switching isn't currently working with URL fragments that deep-link to named waypoints.

This [example room](https://hubs.mozilla.com/CPMwEKv/stunning-dimwitted-assembly) contains two links to another Hubs room, but each link has a different fragment that corresponds to a particular named waypoint within the scene. Clicking on either link takes you to the same default position in the room rather than the intended waypoint.

This appears to be because of an assumption in the rather complicated waypoint system logic, in which fragment navigation is ignored until the first waypoint navigation has occurred, presumably to avoid this initial navigation overriding the one from the fragment.

The proposed change resets the waypoint system state when `moveToSpawnPoint` is called, which is done after the new environment model has finished loading.

Note that this is a different issue to the one preventing deep-linking working on initial load, which is covered by this PR https://github.com/mozilla/hubs/pull/4328.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/HUBS-876)
