### PR TITLE
Track total bytes and bitrate for model downloads.

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -631,7 +631,16 @@ export async function loadGLTF(src, contentType, onProgress, jsonPreprocessor) {
 }
 
 export async function loadModel(src, contentType = null, useCache = false, jsonPreprocessor = null) {
-  console.log(`Loading model ${src}`);
+  console.log(`Loading model %c${src}`, "font-style:italic");
+  const startTime = performance.now();
+  const downloadProgressMonitor = progressEvent => {
+    if(progressEvent.total && progressEvent.loaded >= progressEvent.total) {
+      const delta = performance.now() - startTime;
+      const totalKB = progressEvent.total / 1000;
+      const rateMbps = delta > 0 ? 8 * totalKB / delta : 0;
+      console.log(`Downloaded ${totalKB.toFixed(2)}kB in ${Math.round(delta)}ms (${rateMbps.toFixed(2)}Mbps) for model %c${src}`, "font-style:italic");      
+    }
+  }
   if (useCache) {
     if (gltfCache.has(src)) {
       gltfCache.retain(src);
@@ -642,7 +651,7 @@ export async function loadModel(src, contentType = null, useCache = false, jsonP
         gltfCache.retain(src);
         return cloneGltf(gltf);
       } else {
-        const promise = loadGLTF(src, contentType, null, jsonPreprocessor);
+        const promise = loadGLTF(src, contentType, downloadProgressMonitor, jsonPreprocessor);
         inflightGltfs.set(src, promise);
         const gltf = await promise;
         inflightGltfs.delete(src);
@@ -651,7 +660,7 @@ export async function loadModel(src, contentType = null, useCache = false, jsonP
       }
     }
   } else {
-    return loadGLTF(src, contentType, null, jsonPreprocessor);
+    return loadGLTF(src, contentType, downloadProgressMonitor, jsonPreprocessor);
   }
 }
 


### PR DESCRIPTION
Simple tracking of download stats for model downloads using the `onProgress` callback event:

<img width="583" alt="Screenshot 2021-09-02 at 13 59 22" src="https://user-images.githubusercontent.com/303516/131847853-a57b9a30-7326-4235-8d79-0a6609f6a091.png">

It's useful for debugging and optimizing start times, particularly where scene assets are large or customer bandwidth is limited.