### PR TITLE
Make Hubs version number obvious to HC users

### DIFF
--- a/admin/src/react-components/system-editor.js
+++ b/admin/src/react-components/system-editor.js
@@ -344,10 +344,13 @@ class SystemEditorComponent extends Component {
             {configs.IS_LOCAL_OR_CUSTOM_CLIENT ? (
               <>
                 <Typography variant="body1" gutterBottom>
-                  {`App client: Custom client`}
+                  App client: Custom client
                 </Typography>
                 <Typography variant="body1" gutterBottom>
-                  {`(Undeploy custom client to run build v${process.env.BUILD_VERSION || "?"})`}
+                  {`(Undeploy custom client to run build ${process.env.BUILD_VERSION || "?"})`}
+                </Typography>
+                <Typography variant="body1" gutterBottom>
+                  {`(Remember to regularly pull in upstream changes from the "hubs-cloud" branch: https://github.com/mozilla/hubs)`}
                 </Typography>
               </>
             ) : (

--- a/admin/src/react-components/system-editor.js
+++ b/admin/src/react-components/system-editor.js
@@ -339,13 +339,22 @@ class SystemEditorComponent extends Component {
           <Title title="Hubs Cloud" />
           <CardContent className={this.props.classes.info}>
             <Typography variant="title" gutterBottom>
-              Your hub versions:
+              Your hub version:
             </Typography>
-            <Typography variant="body1" gutterBottom>
-              {`App Client: ${
-                configs.IS_LOCAL_OR_CUSTOM_CLIENT ? "Custom client or local client" : process.env.BUILD_VERSION || "?"
-              }`}
-            </Typography>
+            {configs.IS_LOCAL_OR_CUSTOM_CLIENT ? (
+              <>
+                <Typography variant="body1" gutterBottom>
+                  {`App client: Custom client`}
+                </Typography>
+                <Typography variant="body1" fontStyle="italic" gutterBottom>
+                  {`(Undeploy custom client to run build v${process.env.BUILD_VERSION || "?"})`}
+                </Typography>
+              </>
+            ) : (
+              <Typography variant="body1" gutterBottom>
+                {`App client: ${process.env.BUILD_VERSION || "?"}`}
+              </Typography>
+            )}
           </CardContent>
         </Card>
       </>

--- a/admin/src/react-components/system-editor.js
+++ b/admin/src/react-components/system-editor.js
@@ -346,7 +346,7 @@ class SystemEditorComponent extends Component {
                 <Typography variant="body1" gutterBottom>
                   {`App client: Custom client`}
                 </Typography>
-                <Typography variant="body1" fontStyle="italic" gutterBottom>
+                <Typography variant="body1" gutterBottom>
                   {`(Undeploy custom client to run build v${process.env.BUILD_VERSION || "?"})`}
                 </Typography>
               </>

--- a/admin/src/react-components/system-editor.js
+++ b/admin/src/react-components/system-editor.js
@@ -20,6 +20,7 @@ import Info from "@material-ui/icons/Info";
 import { fetchReticulumAuthenticated } from "hubs/src/utils/phoenix-utils";
 import withCommonStyles from "../utils/with-common-styles";
 import { getAdminInfo, getEditableConfig } from "../utils/ita";
+import configs from "../utils/configs";
 
 // Send quota to use as heuristic for checking if in SES sandbox
 // https://forums.aws.amazon.com/thread.jspa?threadID=61090
@@ -333,6 +334,19 @@ class SystemEditorComponent extends Component {
               />
             </ListItem>
           </List>
+        </Card>
+        <Card className={this.props.classes.container}>
+          <Title title="Hubs Cloud" />
+          <CardContent className={this.props.classes.info}>
+            <Typography variant="title" gutterBottom>
+              Your hub versions:
+            </Typography>
+            <Typography variant="body1" gutterBottom>
+              {`App Client: ${
+                configs.IS_LOCAL_OR_CUSTOM_CLIENT ? "Custom client or local client" : process.env.BUILD_VERSION || "?"
+              }`}
+            </Typography>
+          </CardContent>
         </Card>
       </>
     );

--- a/admin/src/utils/configs.js
+++ b/admin/src/utils/configs.js
@@ -6,4 +6,6 @@ const configs = {};
   configs[x] = el ? el.getAttribute("content") : process.env[x];
 });
 
+configs.IS_LOCAL_OR_CUSTOM_CLIENT = document.querySelector("meta[name='env:reticulum_server']") ? false : true;
+
 export default configs;

--- a/admin/src/utils/configs.js
+++ b/admin/src/utils/configs.js
@@ -6,6 +6,8 @@ const configs = {};
   configs[x] = el ? el.getAttribute("content") : process.env[x];
 });
 
-configs.IS_LOCAL_OR_CUSTOM_CLIENT = document.querySelector("meta[name='env:reticulum_server']") ? false : true;
+// Custom clients do not use <meta> tags for passing data, so if reticulum_server meta tag exists, it is not a custom client
+const hasReticulumServerMetaTag = !!document.querySelector("meta[name='env:reticulum_server']");
+configs.IS_LOCAL_OR_CUSTOM_CLIENT = !hasReticulumServerMetaTag;
 
 export default configs;

--- a/src/hub.js
+++ b/src/hub.js
@@ -10,6 +10,7 @@ import "./utils/theme";
 import "@babel/polyfill";
 
 console.log(`App version: ${process.env.BUILD_VERSION || "?"}`);
+console.log(`is custom client ${process.env.IS_CUSTOM_CLIENT}`);
 
 import "./react-components/styles/global.scss";
 import "./assets/stylesheets/globals.scss";

--- a/src/hub.js
+++ b/src/hub.js
@@ -9,8 +9,19 @@ import configs from "./utils/configs";
 import "./utils/theme";
 import "@babel/polyfill";
 
-console.log(`App version: ${process.env.BUILD_VERSION || "?"}`);
-console.log(`is custom client ${process.env.IS_CUSTOM_CLIENT}`);
+console.log(
+  `App version: ${
+    document.querySelector(`meta[name='env:THUMBNAIL_SERVER']`)
+      ? process.env.BUILD_VERSION || "?"
+      : "Custom client or local client"
+  }`
+);
+console.log(
+  `returned from : ${
+    document.querySelector(`meta[name='env:THUMBNAIL_SERVER']`) ? process.env.BUILD_VERSION || "?" : "custom client"
+  }`
+);
+console.log(process.env.BUILD_VERSION);
 
 import "./react-components/styles/global.scss";
 import "./assets/stylesheets/globals.scss";

--- a/src/hub.js
+++ b/src/hub.js
@@ -12,7 +12,7 @@ import "@babel/polyfill";
 console.log(
   `App version: ${
     configs.IS_LOCAL_OR_CUSTOM_CLIENT
-      ? `Custom client or local client (undeploy custom client to run build v${process.env.BUILD_VERSION})`
+      ? `Custom client or local client (undeploy custom client to run build ${process.env.BUILD_VERSION})`
       : process.env.BUILD_VERSION || "?"
   }`
 );

--- a/src/hub.js
+++ b/src/hub.js
@@ -11,16 +11,10 @@ import "@babel/polyfill";
 
 console.log(
   `App version: ${
-    document.querySelector(`meta[name='env:THUMBNAIL_SERVER']`)
-      ? process.env.BUILD_VERSION || "?"
-      : "Custom client or local client"
+    configs.IS_LOCAL_OR_CUSTOM_CLIENT ? "Custom client or local client" : process.env.BUILD_VERSION || "?"
   }`
 );
-console.log(
-  `returned from : ${
-    document.querySelector(`meta[name='env:THUMBNAIL_SERVER']`) ? process.env.BUILD_VERSION || "?" : "custom client"
-  }`
-);
+console.log(`returned from : ${document.querySelector("meta[name='env:thumbnail_server']")}`);
 console.log(process.env.BUILD_VERSION);
 
 import "./react-components/styles/global.scss";

--- a/src/hub.js
+++ b/src/hub.js
@@ -14,8 +14,6 @@ console.log(
     configs.IS_LOCAL_OR_CUSTOM_CLIENT ? "Custom client or local client" : process.env.BUILD_VERSION || "?"
   }`
 );
-console.log(`returned from : ${document.querySelector("meta[name='env:thumbnail_server']")}`);
-console.log(process.env.BUILD_VERSION);
 
 import "./react-components/styles/global.scss";
 import "./assets/stylesheets/globals.scss";

--- a/src/hub.js
+++ b/src/hub.js
@@ -11,7 +11,9 @@ import "@babel/polyfill";
 
 console.log(
   `App version: ${
-    configs.IS_LOCAL_OR_CUSTOM_CLIENT ? "Custom client or local client" : process.env.BUILD_VERSION || "?"
+    configs.IS_LOCAL_OR_CUSTOM_CLIENT
+      ? `Custom client or local client (undeploy custom client to run build v${process.env.BUILD_VERSION})`
+      : process.env.BUILD_VERSION || "?"
   }`
 );
 

--- a/src/utils/configs.js
+++ b/src/utils/configs.js
@@ -27,6 +27,8 @@ let isAdmin = false;
   }
 });
 
+configs.IS_LOCAL_OR_CUSTOM_CLIENT = document.querySelector("meta[name='env:thumbnail_server']") ? false : true;
+
 // Also include configs that reticulum injects as a script in the page head.
 
 configs.AVAILABLE_INTEGRATIONS = window.AVAILABLE_INTEGRATIONS || {};

--- a/src/utils/configs.js
+++ b/src/utils/configs.js
@@ -7,7 +7,7 @@ import { getLocale, getMessage } from "./i18n";
 // Read configs from global variable if available, otherwise use the process.env injected from build.
 const configs = {};
 let isAdmin = false;
-
+let isCustomClient = false;
 [
   "RETICULUM_SERVER",
   "THUMBNAIL_SERVER",
@@ -21,12 +21,19 @@ let isAdmin = false;
 ].forEach(x => {
   const el = document.querySelector(`meta[name='env:${x.toLowerCase()}']`);
   configs[x] = el ? el.getAttribute("content") : process.env[x];
+  if (!el && isCustomClient === false) {
+    // Custom clients use the webpack injected process.env from webpack that's bundled
+    // Not custom clients use the meta tags
+    // If any meta tags do not exist, custom client = true
+    isCustomClient = true;
+  }
 
   if (x === "BASE_ASSETS_PATH" && configs[x]) {
     // eslint-disable-next-line no-undef
     __webpack_public_path__ = configs[x];
   }
 });
+configs["IS_CUSTOM_CLIENT"] = isCustomClient;
 
 // Also include configs that reticulum injects as a script in the page head.
 

--- a/src/utils/configs.js
+++ b/src/utils/configs.js
@@ -7,7 +7,6 @@ import { getLocale, getMessage } from "./i18n";
 // Read configs from global variable if available, otherwise use the process.env injected from build.
 const configs = {};
 let isAdmin = false;
-let isCustomClient = false;
 [
   "RETICULUM_SERVER",
   "THUMBNAIL_SERVER",
@@ -21,19 +20,12 @@ let isCustomClient = false;
 ].forEach(x => {
   const el = document.querySelector(`meta[name='env:${x.toLowerCase()}']`);
   configs[x] = el ? el.getAttribute("content") : process.env[x];
-  if (!el && isCustomClient === false) {
-    // Custom clients use the webpack injected process.env from webpack that's bundled
-    // Not custom clients use the meta tags
-    // If any meta tags do not exist, custom client = true
-    isCustomClient = true;
-  }
 
   if (x === "BASE_ASSETS_PATH" && configs[x]) {
     // eslint-disable-next-line no-undef
     __webpack_public_path__ = configs[x];
   }
 });
-configs["IS_CUSTOM_CLIENT"] = isCustomClient;
 
 // Also include configs that reticulum injects as a script in the page head.
 

--- a/src/utils/configs.js
+++ b/src/utils/configs.js
@@ -27,7 +27,9 @@ let isAdmin = false;
   }
 });
 
-configs.IS_LOCAL_OR_CUSTOM_CLIENT = document.querySelector("meta[name='env:thumbnail_server']") ? false : true;
+// Custom clients do not use <meta> tags for passing data, so if thumbnail_server meta tag exists, it is not a custom client
+const hasThumbnailServerMetaTag = !!document.querySelector("meta[name='env:thumbnail_server']");
+configs.IS_LOCAL_OR_CUSTOM_CLIENT = !hasThumbnailServerMetaTag;
 
 // Also include configs that reticulum injects as a script in the page head.
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -230,8 +230,7 @@ module.exports = async (env, argv) => {
         RETICULUM_SERVER: "hubs.local:4000",
         POSTGREST_SERVER: "",
         ITA_SERVER: "",
-        UPLOADS_HOST: "https://hubs.local:4000",
-        IS_CUSTOM_CLIENT: false
+        UPLOADS_HOST: "https://hubs.local:4000"
       });
     }
   }
@@ -646,7 +645,6 @@ module.exports = async (env, argv) => {
           GA_TRACKING_ID: process.env.GA_TRACKING_ID,
           POSTGREST_SERVER: process.env.POSTGREST_SERVER,
           UPLOADS_HOST: process.env.UPLOADS_HOST,
-          IS_CUSTOM_CLIENT: process.env.IS_CUSTOM_CLIENT,
           APP_CONFIG: appConfig
         })
       })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -230,7 +230,8 @@ module.exports = async (env, argv) => {
         RETICULUM_SERVER: "hubs.local:4000",
         POSTGREST_SERVER: "",
         ITA_SERVER: "",
-        UPLOADS_HOST: "https://hubs.local:4000"
+        UPLOADS_HOST: "https://hubs.local:4000",
+        IS_CUSTOM_CLIENT: false
       });
     }
   }
@@ -645,6 +646,7 @@ module.exports = async (env, argv) => {
           GA_TRACKING_ID: process.env.GA_TRACKING_ID,
           POSTGREST_SERVER: process.env.POSTGREST_SERVER,
           UPLOADS_HOST: process.env.UPLOADS_HOST,
+          IS_CUSTOM_CLIENT: process.env.IS_CUSTOM_CLIENT,
           APP_CONFIG: appConfig
         })
       })


### PR DESCRIPTION
Let's the user know whether a custom client is deployed or not in both the admin panel and in a hubs room via console.log.

In Admin Panel:
If no custom client: 
<img width="499" alt="image" src="https://user-images.githubusercontent.com/29560735/131903445-a3de89dd-8f86-4473-8853-8090210f559d.png">

If yes custom client:
<img width="878" alt="image" src="https://user-images.githubusercontent.com/29560735/131920063-be6721fe-a43b-4e32-8cbc-ff4e3ba9bfbf.png">

QA TEST:
Ensure when a custom client is deployed, it shows this admin panel message. When it is undeployed it does not show this message in the admin panel landing page.