### PR TITLE
Fix background sounds

### DIFF
--- a/src/systems/audio-gain-system.js
+++ b/src/systems/audio-gain-system.js
@@ -1,5 +1,9 @@
 import { CLIPPING_THRESHOLD_ENABLED, CLIPPING_THRESHOLD_DEFAULT } from "../react-components/preferences-screen";
-import { getCurrentAudioSettings, updateAudioSettings } from "../update-audio-settings";
+import {
+  getCurrentAudioSettings,
+  shouldAddSupplementalAttenuation,
+  updateAudioSettings
+} from "../update-audio-settings";
 
 function isClippingEnabled() {
   const { enableAudioClipping } = window.APP.store.state.preferences;
@@ -53,10 +57,11 @@ export class GainSystem {
     for (const [el, audio] of APP.audios.entries()) {
       const attenuation = calculateAttenuation(el, audio);
 
-      if (!audio.panner) {
-        // For Audios that are not PositionalAudios, we reintroduce
-        // distance-based attenuation manually.
+      if (shouldAddSupplementalAttenuation(el, audio)) {
         APP.supplementaryAttenuation.set(el, attenuation);
+        updateAudioSettings(el, audio);
+      } else if (APP.supplementaryAttenuation.has(el)) {
+        APP.supplementaryAttenuation.delete(el);
         updateAudioSettings(el, audio);
       }
 

--- a/src/systems/audio-gain-system.js
+++ b/src/systems/audio-gain-system.js
@@ -1,7 +1,7 @@
 import { CLIPPING_THRESHOLD_ENABLED, CLIPPING_THRESHOLD_DEFAULT } from "../react-components/preferences-screen";
 import {
   getCurrentAudioSettings,
-  shouldAddSupplementalAttenuation,
+  shouldAddSupplementaryAttenuation,
   updateAudioSettings
 } from "../update-audio-settings";
 
@@ -57,7 +57,7 @@ export class GainSystem {
     for (const [el, audio] of APP.audios.entries()) {
       const attenuation = calculateAttenuation(el, audio);
 
-      if (shouldAddSupplementalAttenuation(el, audio)) {
+      if (shouldAddSupplementaryAttenuation(el, audio)) {
         APP.supplementaryAttenuation.set(el, attenuation);
         updateAudioSettings(el, audio);
       } else if (APP.supplementaryAttenuation.has(el)) {

--- a/src/update-audio-settings.js
+++ b/src/update-audio-settings.js
@@ -78,21 +78,21 @@ export function updateAudioSettings(el, audio) {
 
 export function shouldAddSupplementaryAttenuation(el, audio) {
   // Never add supplemental attenuation to audios that have a panner node;
-  // The panner node already adds attenuation.
+  // The panner node adds its own attenuation.
   if (audio.panner) return false;
 
-  // This function must distinguish between audios that are "incidentally"
-  // non-positional from audios that are "purposefully" non-positional:
-  // - An audio is "incidentally" non-positional if it was made non-positional
+  // This function must distinguish between Audios that are "incidentally"
+  // not PositionalAudios from Audios that are "purposefully" not PositionalAudios:
+  // - An audio is "incidentally" non-positional if it only non-positional
   //     because the audioOutputMode pref is set to "audio", or
   //     because panner nodes are broken on a particular platform, or
   //     because of something else like that.
   // - An audio is "purposefully" non-positional if it was authored to be
-  //     that way "on purpose".
+  //     a "background sound" or otherwise made that way "on purpose".
   //
   // Authoring tools like Spoke create components where "audioType : stereo"
   // is used to indicate that audio should play in the background without
-  // left/right panning and without distance-based spatialization.
+  // left/right panning and without distance-based attenuation.
   //
   // Those components also include properties like distanceModel, rolloffFactor, etc,
   // but these properties were assumed to be ignored by the client.
@@ -102,8 +102,11 @@ export function shouldAddSupplementaryAttenuation(el, audio) {
   // Instead, we determine what the audioType would be if it were not for the
   // "incidental" factors. In particular, we check if the audioType would have
   // been PannerNode if we ignored the overrides due to audioOutputMode and platform
-  // problems (isSafari). If the audioType would have been PannerNode, that means
-  // we should apply our "fake", "supplementary" attenuation.
+  // problems (e.g. Safari).
+  //
+  // If the audioType would have been PannerNode, then we should apply "fake",
+  // "supplementary" attenuation. Otherwise, the audio is purposefully a
+  // "background sound" and we should not apply supplementary attenuation.
   const sourceType = APP.sourceType.get(el);
   const defaults = defaultSettingsForSourceType.get(sourceType);
   const sceneOverrides = APP.sceneAudioDefaults.get(sourceType);

--- a/src/update-audio-settings.js
+++ b/src/update-audio-settings.js
@@ -76,7 +76,7 @@ export function updateAudioSettings(el, audio) {
   applySettings(audio, getCurrentAudioSettings(el));
 }
 
-export function shouldAddSupplementalAttenuation(el, audio) {
+export function shouldAddSupplementaryAttenuation(el, audio) {
   // Never add supplemental attenuation to audios that have a panner node;
   // The panner node already adds attenuation.
   if (audio.panner) return false;
@@ -101,8 +101,9 @@ export function shouldAddSupplementalAttenuation(el, audio) {
   //
   // Instead, we determine what the audioType would be if it were not for the
   // "incidental" factors. In particular, we check if the audioType would have
-  // been Panner if we ignored the overrides due to audioOutputMode and platform
-  // problems (isSafari).
+  // been PannerNode if we ignored the overrides due to audioOutputMode and platform
+  // problems (isSafari). If the audioType would have been PannerNode, that means
+  // we should apply our "fake", "supplementary" attenuation.
   const sourceType = APP.sourceType.get(el);
   const defaults = defaultSettingsForSourceType.get(sourceType);
   const sceneOverrides = APP.sceneAudioDefaults.get(sourceType);


### PR DESCRIPTION
This PR fixes background sounds that were broken by this recent change: https://github.com/mozilla/hubs/pull/4594

In https://github.com/mozilla/hubs/pull/4594 , I accidentally added distance-based attenuation to sounds that are meant to be played "in the background" at a constant volume. I misunderstood how those background sounds were authored. 

This PR relates to https://github.com/mozilla/hubs/pull/4608 and https://github.com/mozilla/Spoke/pull/1169 , which aim to change to the authoring side of background sounds such that `distanceModel` and relevant properties reinforce that no distance-based attenuation is desired by the author.