### PR TITLE
Allow null distance model

### DIFF
--- a/src/systems/audio-gain-system.js
+++ b/src/systems/audio-gain-system.js
@@ -44,6 +44,16 @@ const calculateAttenuation = (() => {
       );
     } else {
       const { distanceModel, rolloffFactor, refDistance, maxDistance } = getCurrentAudioSettings(el);
+      if (!distanceModel) {
+        // Apparently, it is valid to give null as your distanceModel
+        return 1.0;
+      }
+      if (!distanceModels[distanceModel]) {
+        // TODO: Validate properties earlier in the process.
+        console.error("Unrecognized distance model.");
+        return 1.0;
+      }
+
       return distanceModels[distanceModel](distance, rolloffFactor, refDistance, maxDistance);
     }
   };


### PR DESCRIPTION
Fix audio for nodes with these properties:

```js
{ audioType: "stereo", distanceModel: null, rolloffFactor: null, refDistance: null, maxDistance: null, coneInnerAngle: null, coneOuterAngle: null, coneOuterGain: null, gain: 0.032999999821186066 }
```

See also https://discord.com/channels/498741086295031808/883002604735582254/883551582019530812