### PR TITLE
Tweak media query and avatar settings heights to avoid cutoff and scrolling

### DIFF
--- a/src/react-components/input/InputField.scss
+++ b/src/react-components/input/InputField.scss
@@ -29,3 +29,7 @@
   color: theme.$text3-color;
   align-self: flex-start;
 }
+
+:local(.info), :local(.error) {
+  font-size: 10px;
+}

--- a/src/react-components/room/AvatarSettingsContent.scss
+++ b/src/react-components/room/AvatarSettingsContent.scss
@@ -16,9 +16,12 @@
 
   /* TODO: This styling into AvatarPreview */
   & > :first-child {
+    /*
+    We need to set dimensions explicitly here, since AvatarPreview
+    resizes itself to its container's dimensions.
+    */
     width: 168px;
     height: 250px;
-    min-height: 250px;
     border-radius: 8px;
     background-color: theme.$tile-bg-color;
   }

--- a/src/react-components/room/AvatarSettingsContent.scss
+++ b/src/react-components/room/AvatarSettingsContent.scss
@@ -2,7 +2,7 @@
 
 :local(.content) {
   align-items: center;
-  padding: 24px;
+  padding: 10px;
   text-align: center;
 }
 
@@ -16,8 +16,8 @@
   /* TODO: This styling into AvatarPreview */
   & > :first-child {
     width: 168px;
-    height: 300px;
-    min-height: 300px;
+    height: 250px;
+    min-height: 250px;
     border-radius: 8px;
     background-color: theme.$tile-bg-color;
   }

--- a/src/react-components/room/AvatarSettingsContent.scss
+++ b/src/react-components/room/AvatarSettingsContent.scss
@@ -2,7 +2,8 @@
 
 :local(.content) {
   align-items: center;
-  padding: 10px;
+  padding: 24px;
+  padding-top: 10px;
   text-align: center;
 }
 

--- a/src/react-components/styles/theme.scss
+++ b/src/react-components/styles/theme.scss
@@ -4,7 +4,7 @@ $breakpoint-md: 768px; // Tablets
 $breakpoint-lg: 992px; // Desktops
 $breakpoint-xl: 1200px; // Large Desktops
 $breakpoint-xxl: 1600px; // Extra Large Desktops
-$breakpoint-vr: 500px; // Standalone VR Browsers
+$breakpoint-vr: 600px; // Standalone VR Browsers
 
 $transparent: transparent;
 $transparent-hover: rgba(0, 0, 0, 0.08);


### PR DESCRIPTION
Fixes #4615

- Increase "breakpoint-vr" cutoff, so that we use mobile screens on Oculus Browser's new 1000x505px default resolution
- Also reduce heights of elements in the Avatar Setup panel, in order to avoid having to scroll the dialog

Before:
![image](https://user-images.githubusercontent.com/79419/132412158-a82dad79-8e79-40ed-9892-da413eae0ebd.png)

After:
![image](https://user-images.githubusercontent.com/79419/132411755-60a50316-47c2-434b-8410-3fe1d11cf756.png)