### PR TITLE
Fix errors in the scene page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,5 +8,19 @@ export class App {
     this.mediaSearchStore = new MediaSearchStore();
     this.hubChannel = null;
     this.mediaDevicesManager = null;
+
+    // TODO: Remove comments
+    // TODO: Rename or reconfigure these as needed
+    this.audios = new Map(); //                           el -> (THREE.Audio || THREE.PositionalAudio)
+    this.sourceType = new Map(); //                       el -> SourceType
+    this.audioOverrides = new Map(); //                   el -> AudioSettings
+    this.zoneOverrides = new Map(); //                    el -> AudioSettings
+    this.audioDebugPanelOverrides = new Map(); // SourceType -> AudioSettings
+    this.sceneAudioDefaults = new Map(); //       SourceType -> AudioSettings
+    this.gainMultipliers = new Map(); //                  el -> Number
+    this.supplementaryAttenuation = new Map(); //         el -> Number
+    this.clippingState = new Set();
+    this.linkedMutedState = new Set();
+    this.isAudioPaused = new Set();
   }
 }

--- a/src/components/audio-zone-source.js
+++ b/src/components/audio-zone-source.js
@@ -4,12 +4,12 @@ import { updateAudioSettings } from "../update-audio-settings";
 AFRAME.registerComponent("audio-zone-source", {
   init() {
     this.originalAudioParamsData = null;
-    this.el.sceneEl.systems["hubs-systems"].audioZonesSystem.registerSource(this);
+    this.el.sceneEl.systems["hubs-systems"]?.audioZonesSystem.registerSource(this);
   },
 
   remove() {
     APP.zoneOverrides.delete(this.el);
-    this.el.sceneEl.systems["hubs-systems"].audioZonesSystem.unregisterSource(this);
+    this.el.sceneEl.systems["hubs-systems"]?.audioZonesSystem.unregisterSource(this);
   },
 
   getPosition: (() => {

--- a/src/components/audio-zone.js
+++ b/src/components/audio-zone.js
@@ -23,15 +23,15 @@ AFRAME.registerComponent("audio-zone", {
     this.el.object3D.add(debugBBAA);
     this.el.object3D.updateMatrixWorld(true);
 
-    this.el.sceneEl?.systems["audio-debug"].registerZone(this);
-    this.el.sceneEl?.systems["hubs-systems"].audioZonesSystem.registerZone(this);
+    this.el.sceneEl.systems["audio-debug"]?.registerZone(this);
+    this.el.sceneEl.systems["hubs-systems"]?.audioZonesSystem.registerZone(this);
 
     this.enableDebug(window.APP.store.state.preferences.showAudioDebugPanel);
   },
 
   remove() {
-    this.el.sceneEl?.systems["audio-debug"].unregisterZone(this);
-    this.el.sceneEl?.systems["hubs-systems"].audioZonesSystem.unregisterZone(this);
+    this.el.sceneEl.systems["audio-debug"]?.unregisterZone(this);
+    this.el.sceneEl.systems["hubs-systems"]?.audioZonesSystem.unregisterZone(this);
   },
 
   update() {

--- a/src/components/audio-zone.js
+++ b/src/components/audio-zone.js
@@ -23,6 +23,8 @@ AFRAME.registerComponent("audio-zone", {
     this.el.object3D.add(debugBBAA);
     this.el.object3D.updateMatrixWorld(true);
 
+    // In some cases (ie. the scene page) these systems might not exist
+    // so we need to check if the do before registering.
     this.el.sceneEl.systems["audio-debug"]?.registerZone(this);
     this.el.sceneEl.systems["hubs-systems"]?.audioZonesSystem.registerZone(this);
 
@@ -30,6 +32,8 @@ AFRAME.registerComponent("audio-zone", {
   },
 
   remove() {
+    // In some cases (ie. the scene page) these systems might not exist
+    // so we need to check if the do before unregistering.
     this.el.sceneEl.systems["audio-debug"]?.unregisterZone(this);
     this.el.sceneEl.systems["hubs-systems"]?.audioZonesSystem.unregisterZone(this);
   },

--- a/src/hub.js
+++ b/src/hub.js
@@ -207,20 +207,6 @@ window.APP.RENDER_ORDER = {
   CURSOR: 3
 };
 
-// TODO: Remove comments
-// TODO: Rename or reconfigure these as needed
-APP.audios = new Map(); //                           el -> (THREE.Audio || THREE.PositionalAudio)
-APP.sourceType = new Map(); //                       el -> SourceType
-APP.audioOverrides = new Map(); //                   el -> AudioSettings
-APP.zoneOverrides = new Map(); //                    el -> AudioSettings
-APP.audioDebugPanelOverrides = new Map(); // SourceType -> AudioSettings
-APP.sceneAudioDefaults = new Map(); //       SourceType -> AudioSettings
-APP.gainMultipliers = new Map(); //                  el -> Number
-APP.supplementaryAttenuation = new Map(); //         el -> Number
-APP.clippingState = new Set();
-APP.linkedMutedState = new Set();
-APP.isAudioPaused = new Set();
-
 const store = window.APP.store;
 store.update({ preferences: { shouldPromptForRefresh: undefined } }); // Clear flag that prompts for refresh from preference screen
 const mediaSearchStore = window.APP.mediaSearchStore;


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/4617

After the latest audio refactors an additions there are some components and systems that might be used in the scene page but are not available there. This PR moves the audio related sets creation to the APP class so it's available for both the hub and scene pages and also adds some checks to components that register in systems that don't exist in that context.