### PR TITLE
Workaround for range request redirect problem on Safari

### DIFF
--- a/src/components/media-video.js
+++ b/src/components/media-video.js
@@ -19,6 +19,7 @@ import { getCurrentAudioSettings, updateAudioSettings } from "../update-audio-se
 import { SourceType, AudioType } from "./audio-params";
 import { errorTexture } from "../utils/error-texture";
 import { scaleToAspectRatio } from "../utils/scale-to-aspect-ratio";
+import { isSafari } from "../utils/detect-safari";
 
 import qsTruthy from "../utils/qs_truthy";
 
@@ -645,7 +646,30 @@ AFRAME.registerComponent("media-video", {
         }
       } else {
         videoEl.src = url;
-        videoEl.onerror = failLoad;
+
+        // Workaround for Safari.
+        // Safari seems to have a bug that it doesn't transfer range property in HTTP request header
+        // for redirects if crossOrigin is set (while other major browsers do).
+        // So Safari can fail to load video if the server responds redirect because
+        // it expects 206 HTTP status code but gets 200.
+        // If we fail to load video on Safari we retry with fetch() and videoEl.srcObject
+        // which may avoid the problem.
+        // Refer to #4516 for the details.
+        if (isSafari()) {
+          // There seems no way to detect whether the error is caused by the problem mentioned above.
+          // So always retrying.
+          videoEl.onerror = async () => {
+            videoEl.onerror = failLoad;
+            try {
+              const res = await fetch(url);
+              videoEl.srcObject = await res.blob();
+            } catch (e) {
+              failLoad(e);
+            }
+          };
+        } else {
+          videoEl.onerror = failLoad;
+        }
 
         // audioSrc is non-empty only if audio track is separated from video track (eg. 360 video)
         if (this.data.audioSrc) {


### PR DESCRIPTION
Resolves #4516 

Refer to https://github.com/mozilla/hubs/issues/4516#issuecomment-917324272 for the details.

**Change**

As I wrote in https://github.com/mozilla/hubs/issues/4516#issuecomment-917324272, `fetch` + `videoEl.srcObject = await.res.blob()` can have a disadvantage, so  it would be good to first try `videoEl.src = url`, and the retry with `fetch` + `videoEl.srcObject` if failed.

```
videoEl.src = url;
if (isSafari()) {
  // There seems no way to detect whether the error is caused by the problem mentioned above.
  // So always retrying.
  videoEl.onerror = async () => {
    videoEl.onerror = failLoad;
    try {
      const res = await fetch(url);
      videoEl.srcObject = await res.blob();
    } catch (e) {
      failLoad(e);
    }
  };
} else {
  videoEl.onerror = failLoad;
}
```

**How to test**

The problem seems to be caused only with `hubs-proxy.com` but I don't have a testing environment with `hubs-proxy.com`. So this PR is still draft. Let me internally discuss how to test.
