### PR TITLE
Show audio controls for media only if there are audio tracks

### DIFF
--- a/src/components/media-video.js
+++ b/src/components/media-video.js
@@ -4,7 +4,7 @@ import audioIcon from "../assets/images/audio.png";
 import { paths } from "../systems/userinput/paths";
 import HLS from "hls.js";
 import { MediaPlayer } from "dashjs";
-import { addAndArrangeMedia, createVideoOrAudioEl } from "../utils/media-utils";
+import { addAndArrangeMedia, createVideoOrAudioEl, hasAudioTracks } from "../utils/media-utils";
 import { disposeTexture } from "../utils/material-utils";
 import { proxiedUrlFor } from "../utils/media-url-utils";
 import { buildAbsoluteURL } from "url-toolkit";
@@ -94,6 +94,7 @@ AFRAME.registerComponent("media-video", {
     this.isSnapping = false;
     this.videoIsLive = null; // value null until we've determined if the video is live or not.
     this.onSnapImageLoaded = () => (this.isSnapping = false);
+    this.hasAudioTracks = false;
 
     this.el.setAttribute("hover-menu__video", { template: "#video-hover-menu", isFlat: true });
     this.el.components["hover-menu__video"].getHoverMenu().then(menu => {
@@ -390,6 +391,8 @@ AFRAME.registerComponent("media-video", {
         }
       }
 
+      this.hasAudioTracks = hasAudioTracks(audioSourceEl);
+
       // No way to cancel promises, so if src has changed while we were creating the texture just throw it away.
       if (this.data.src !== src) {
         disposeTexture(texture);
@@ -405,7 +408,7 @@ AFRAME.registerComponent("media-video", {
             linkedMediaElementAudioSource ||
             this.el.sceneEl.audioListener.context.createMediaElementSource(audioSourceEl);
 
-          this.setupAudio();
+          this.hasAudioTracks && this.setupAudio();
         }
       }
 
@@ -702,6 +705,8 @@ AFRAME.registerComponent("media-video", {
     const isPinned = pinnableElement.components.pinnable && pinnableElement.components.pinnable.data.pinned;
     this.playbackControls.object3D.visible = !this.data.hidePlaybackControls && !!this.video;
     this.timeLabel.object3D.visible = !this.data.hidePlaybackControls;
+    this.volumeLabel.object3D.visible = this.volumeUpButton.object3D.visible = this.volumeDownButton.object3D.visible =
+      this.hasAudioTracks && !this.data.hidePlaybackControls && !!this.video;
 
     this.snapButton.object3D.visible =
       !!this.video && !this.data.contentType.startsWith("audio/") && window.APP.hubChannel.can("spawn_and_move_media");

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -544,3 +544,17 @@ export function closeExistingMediaMirror() {
     });
   }
 }
+
+export function hasAudioTracks(el) {
+  if (!el) return false;
+  // At some point browsers will implement the audioTracks property
+  if (el.audioTracks !== undefined) {
+    return el.audioTracks.length > 0;
+  } else if (el.webkitAudioDecodedByteCount !== undefined) {
+    return el.webkitAudioDecodedByteCount > 0;
+  } else if (el.mozHasAudio !== undefined) {
+    return el.mozHasAudio;
+  } else {
+    return false;
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/4502

This PR adds support for detecting if an audio element has audio tracks and depending on that:
- Create or not a audio THREE audio element
- Show/Hide audio controls