### PR TITLE
Skip pinning animations if already running

### DIFF
--- a/src/components/pinnable.js
+++ b/src/components/pinnable.js
@@ -86,7 +86,7 @@ AFRAME.registerComponent("pinnable", {
     let didFireThisFrame = false;
     if (!held && this.wasHeld && isMine) {
       didFireThisFrame = true;
-      this._fireEventsAndAnimate({ data: this.data, force: true });
+      this._fireEventsAndAnimate({ oldData: this.data, force: true });
     }
 
     this.wasHeld = held;
@@ -94,7 +94,7 @@ AFRAME.registerComponent("pinnable", {
     this.transformObjectSystem = this.transformObjectSystem || AFRAME.scenes[0].systems["transform-selected-object"];
     const transforming = this.transformObjectSystem.transforming && this.transformObjectSystem.target.el === this.el;
     if (!didFireThisFrame && !transforming && this.wasTransforming && isMine) {
-      this._fireEventsAndAnimate({ data: this.data, force: true });
+      this._fireEventsAndAnimate({ oldData: this.data, force: true });
     }
     this.wasTransforming = transforming;
   }


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/4059

When clicking on the pager next/prev while the previous animations os still running we use the updated object scale as the size reference and we end up with a different scaled object when the animations end.

This PR fixes just dropping animations if the previous animations are still running.