### PR TITLE
fix name tags not updating

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -1207,6 +1207,16 @@ document.addEventListener("DOMContentLoaded", async () => {
       });
     }
   });
+  events.on(`hub:change`, ({ key, current }) => {
+    scene.emit("presence_updated", {
+      sessionId: key,
+      profile: current.profile,
+      roles: current.roles,
+      permissions: current.permissions,
+      streaming: current.streaming,
+      recording: current.recording
+    });
+  });
 
   // We need to be able to wait for initial presence syncs across reconnects and socket migrations,
   // so we create this object in the outer scope and assign it a new promise on channel join.


### PR DESCRIPTION
This fixes a regression that causes name tags to not update on name or permissions changes, by restoring emitting `presence_updated` on `hub:change`.

Fixes issues #4515 and #4534
