### PR TITLE
change avatar preview background to background theme color

### DIFF
--- a/src/react-components/avatar-preview.js
+++ b/src/react-components/avatar-preview.js
@@ -72,7 +72,7 @@ function getThemeBackground() {
   }
   for (let i = 0; i < themes.length; i++) {
     if (themes[i].id === currentTheme) {
-      let bgHex = themes[i].variables["background1-color"];
+      let bgHex = themes[i].variables["background3-color"];
       bgHex = `0x${bgHex.substring(1)}`;
       if (bgHex.length !== 8) {
         return defaultColor;

--- a/src/react-components/avatar-preview.js
+++ b/src/react-components/avatar-preview.js
@@ -64,23 +64,11 @@ function fitBoxInFrustum(camera, box, center, margin = DEFAULT_MARGIN) {
 }
 
 function getThemeBackground() {
-  const currentTheme = APP.store.state.preferences.theme;
-  const themes = window.APP_CONFIG?.theme.themes;
-  const defaultColor = 0xeaeaea;
-  if (currentTheme === "hubs-default") {
-    return defaultColor;
-  }
-  for (let i = 0; i < themes.length; i++) {
-    if (themes[i].id === currentTheme) {
-      let bgHex = themes[i].variables["background3-color"];
-      bgHex = `0x${bgHex.substring(1)}`;
-      if (bgHex.length !== 8) {
-        return defaultColor;
-      }
-      bgHex = parseInt(bgHex, 16);
-      return bgHex;
-    }
-  }
+  const currentTheme = APP?.store?.state?.preferences?.theme;
+  const themes = window.APP_CONFIG?.theme?.themes;
+  const currentThemeObject = themes?.find(t => t.id === currentTheme);
+  const previewBackgroundColor = new THREE.Color(currentThemeObject?.variables["background3-color"] || 0xeaeaea);
+  return previewBackgroundColor;
 }
 
 class AvatarPreview extends Component {

--- a/src/react-components/avatar-preview.js
+++ b/src/react-components/avatar-preview.js
@@ -64,9 +64,9 @@ function fitBoxInFrustum(camera, box, center, margin = DEFAULT_MARGIN) {
 }
 
 function getThemeBackground() {
-  let currentTheme = APP.store.state.preferences.theme;
-  let themes = APP_CONFIG.theme.themes;
-  let defaultColor = 0xeaeaea;
+  const currentTheme = APP.store.state.preferences.theme;
+  const themes = window.APP_CONFIG?.theme.themes;
+  const defaultColor = 0xeaeaea;
   if (currentTheme === "hubs-default") {
     return defaultColor;
   }

--- a/src/react-components/avatar-preview.js
+++ b/src/react-components/avatar-preview.js
@@ -63,6 +63,26 @@ function fitBoxInFrustum(camera, box, center, margin = DEFAULT_MARGIN) {
   camera.lookAt(center);
 }
 
+function getThemeBackground() {
+  let currentTheme = APP.store.state.preferences.theme;
+  let themes = APP_CONFIG.theme.themes;
+  let defaultColor = 0xeaeaea;
+  if (currentTheme === "hubs-default") {
+    return defaultColor;
+  }
+  for (let i = 0; i < themes.length; i++) {
+    if (themes[i].id === currentTheme) {
+      let bgHex = themes[i].variables["background1-color"];
+      bgHex = `0x${bgHex.substring(1)}`;
+      if (bgHex.length !== 8) {
+        return defaultColor;
+      }
+      bgHex = parseInt(bgHex, 16);
+      return bgHex;
+    }
+  }
+}
+
 class AvatarPreview extends Component {
   static propTypes = {
     avatarGltfUrl: PropTypes.string,
@@ -112,7 +132,7 @@ class AvatarPreview extends Component {
     this.snapshotRenderer.setClearAlpha(0);
 
     this.previewRenderer = createRenderer(this.canvas);
-    this.previewRenderer.setClearColor(0xeaeaea);
+    this.previewRenderer.setClearColor(getThemeBackground());
     this.previewRenderer.setAnimationLoop(() => {
       const dt = clock.getDelta();
       this.mixer && this.mixer.update(dt);


### PR DESCRIPTION
| Avatar-Preview Themed Before     | Avatar Preview Themed After  |
| ----------- | ----------- |
|![avatar pre before](https://user-images.githubusercontent.com/4493657/134544237-4ea3487e-6f09-427e-a2f2-7886bc9fc799.png)|![avatar pre after](https://user-images.githubusercontent.com/4493657/134974916-1effe15d-92c4-4fbd-b2af-469fabd4a84e.png)|

Adds a function to avatar-preview.js that checks for a theme background color (must be hex value) and updates the preview background to that color. Default preview background will remain the same for now.

Putting the Avatar in a generic 'blueprint room' scene may be a better option than using a color there as we can still have contrast issues since the color of the avatar is variable.

For now this PR is meant to bring us one step closer to 'acceptable dark mode'.


Random theme:  
![anytheme](https://user-images.githubusercontent.com/4493657/134545089-742a4f7a-f8bf-4c81-91e1-3d705daa1142.png)

Default:
![default](https://user-images.githubusercontent.com/4493657/134545078-f4f29f89-4abd-4a0d-ab3c-eadacec332da.png)

