### PR TITLE
Fix buffered-interpolation package path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27749,13 +27749,12 @@
       "version": "github:mozillareality/networked-aframe#ae8ca30fcded2369c8702686b07cce46dfc16306",
       "from": "github:mozillareality/networked-aframe#master",
       "requires": {
-        "buffered-interpolation": "^0.2.5",
+        "buffered-interpolation": "github:Infinitelee/buffered-interpolation#5bb18421ebf2bf11664645cdc7a15bd77ee2156b",
         "easyrtc": "1.1.0"
       },
       "dependencies": {
         "buffered-interpolation": {
-          "version": "0.2.5",
-          "resolved": "github:infinitelee/buffered-interpolation#5bb18421ebf2bf11664645cdc7a15bd77ee2156b"
+          "version": "github:infinitelee/buffered-interpolation#5bb18421ebf2bf11664645cdc7a15bd77ee2156b"
         }
       }
     },


### PR DESCRIPTION
`buffered-interpolation` path in `package-lock.js` is old and the old package can cause tons of console warnings in a-frame network. This PR fixes the path and remove the warnings.