### PR TITLE
Fix deprecated Three.js Quaternion API in three-utils.js

### DIFF
--- a/src/utils/three-utils.js
+++ b/src/utils/three-utils.js
@@ -223,7 +223,7 @@ export const interpolateAffine = (function() {
   return function(startMat4, endMat4, progress, outMat4) {
     start.quaternion.setFromRotationMatrix(mat4.extractRotation(startMat4));
     end.quaternion.setFromRotationMatrix(mat4.extractRotation(endMat4));
-    THREE.Quaternion.slerp(start.quaternion, end.quaternion, interpolated.quaternion, progress);
+    interpolated.quaternion.slerpQuaternions(start.quaternion, end.quaternion, progress);
     interpolated.position.lerpVectors(
       start.position.setFromMatrixColumn(startMat4, 3),
       end.position.setFromMatrixColumn(endMat4, 3),


### PR DESCRIPTION
This PR fixes deprecated Three.js Quaternion API in three-utils.js, which was I have missed when I upgraded Three.js.