### PR TITLE
Fix default dev proxy

### DIFF
--- a/.defaults.env
+++ b/.defaults.env
@@ -8,7 +8,7 @@ SHORTLINK_DOMAIN="hub.link"
 RETICULUM_SERVER="dev.reticulum.io"
 
 # CORS proxy.
-CORS_PROXY_SERVER="cors-proxy-dev.reticulum.io"
+CORS_PROXY_SERVER="hubs-proxy.com"
 
 # The thumbnailing backend to connect to.
 # See here for the server code: https://github.com/MozillaReality/farspark or https://github.com/MozillaReality/nearspark


### PR DESCRIPTION
We've change the configuration on dev.reticulum.io to use hubs-proxy.com instead of cors-proxy-dev.reticulum.io. This PR changes the default environment variable to reflect that, so that proxying works correctly when using `npm run dev`.