### PR TITLE
Fix audio-only elements not playing

### DIFF
--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -547,13 +547,18 @@ export function closeExistingMediaMirror() {
 
 export function hasAudioTracks(el) {
   if (!el) return false;
-  // At some point browsers will implement the audioTracks property
+
+  // `audioTracks` is the "correct" way to check this but is not implemented by most browsers
   if (el.audioTracks !== undefined) {
     return el.audioTracks.length > 0;
-  } else if (el.webkitAudioDecodedByteCount !== undefined) {
-    return el.webkitAudioDecodedByteCount > 0;
   } else if (el.mozHasAudio !== undefined) {
     return el.mozHasAudio;
+  } else if (el.videoWidth === 0 && el.videoHeight === 0) {
+    return true;
+  } else if (el.webkitAudioDecodedByteCount !== undefined) {
+    // This is definitely a bit of a race condition. In practice we wait for the first
+    // frame of video so we should have some audio data by then as well.
+    return el.webkitAudioDecodedByteCount > 0;
   } else {
     return false;
   }


### PR DESCRIPTION
There was a regression in #4640 that caused audio-only elements (like pasting in an mp3 file directly) from playing correctly. This is due to a race in `hasAudioTracks`. This "fixes" that race by avoiding the check for 0 size videos (which by our other checks means it is an audio-only element). 