### PR TITLE
Add pref and logic to invert y cursor when looking

### DIFF
--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -442,6 +442,10 @@ const preferenceLabels = defineMessages({
     id: "preferences-screen.preference.invert-touchscreen-camera-move",
     defaultMessage: "Invert direction of camera movement for touchscreens"
   },
+  invertCursorY: {
+    id: "preferences-screen.preference.invert-cursor-y",
+    defaultMessage: "Invert cursor Y-axis"
+  },
   locale: {
     id: "preferences-screen.preference.locale",
     defaultMessage: "Language"
@@ -969,7 +973,8 @@ class PreferencesScreen extends Component {
             step: 0.1,
             digits: 1,
             defaultNumber: 1
-          }
+          },
+          { key: "invertCursorY", prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX, defaultBool: false }
         ]
       ],
       [

--- a/src/systems/userinput/devices/mouse.js
+++ b/src/systems/userinput/devices/mouse.js
@@ -66,6 +66,9 @@ export class MouseDevice {
     // This works with the current sidebar and toolbar layout.
     this.coords[0] = (event.clientX / this.canvas.clientWidth) * 2 - 1;
     this.coords[1] = -(event.clientY / this.canvas.clientHeight) * 2 + 1;
+    if (window.APP.store.state.preferences.invertCursorY && this.buttonLeft) {
+      this.coords[1] = +(event.clientY / this.canvas.clientHeight) * 2 - 1;
+    }
     this.movementXY[0] += event.movementX;
     this.movementXY[1] += event.movementY;
     if (event.type === "mousedown" && left) {


### PR DESCRIPTION
Resolves #3877

We have had several requests for an invert-y option across various forums.

It might be a good idea to apply this to the camera joysticks on various controllers as well but this PR just covers the mouse.  


