### PR TITLE
Fix cannot activate mic if last used mic no longer available

### DIFF
--- a/src/utils/media-devices-manager.js
+++ b/src/utils/media-devices-manager.js
@@ -112,7 +112,7 @@ export default class MediaDevicesManager {
     console.log("Starting microphone sharing");
     let constraints = { audio: {} };
     if (deviceId) {
-      constraints = { audio: { deviceId: { exact: [deviceId] } } };
+      constraints = { audio: { deviceId: { ideal: [deviceId] } } };
     }
 
     const result = await this._startMicShare(constraints);


### PR DESCRIPTION
![FF Hubs cannot activate mic](https://user-images.githubusercontent.com/10034859/135657044-b70638f5-7e02-4427-9380-c5f5ee19cf6f.png)

Had an issue where I couldn't activate mic on Firefox, it traced to this feature that pulls the last used mic from local storage to reselect it, but the mic was no longer available. This happened to me and a colleague on different OSes (Linux, Windows) at the same time, so I suspect an FF update may have changed the device id hashing. In testing I could also repro by unplugging  mic or altering the saved mic id. 

This PR changes the media device query to substitute another mic if the requested one is not available (rather than fail). Oddly, I could only repro on my outdated Hubs cloud. Could not repro master or on the latest Hubs cloud, but I also couldn't identify any changes that would have solved it, so I thought I'd submit the fix anyway since it's so innocuous. 