### PR TITLE
Notify avatar changes

### DIFF
--- a/src/react-components/room/ChatSidebar.js
+++ b/src/react-components/room/ChatSidebar.js
@@ -144,7 +144,8 @@ export const LogMessageType = {
   invalidAudioNormalizationRange: "invalidAudioNormalizationRange",
   audioSuspended: "audioSuspended",
   audioResumed: "audioResumed",
-  joinFailed: "joinFailed"
+  joinFailed: "joinFailed",
+  avatarChanged: "avatarChanged"
 };
 
 const logMessages = defineMessages({
@@ -228,6 +229,10 @@ const logMessages = defineMessages({
   [LogMessageType.joinFailed]: {
     id: "chat-sidebar.log-message.join-failed",
     defaultMessage: "Failed to join room: {message}"
+  },
+  [LogMessageType.avatarChanged]: {
+    id: "chat-sidebar.log-message.avatar-changed",
+    defaultMessage: "Your avatar has been changed."
   }
 });
 

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -21,6 +21,7 @@ import {
 import { ObjectContentOrigins } from "./object-types";
 import { getAvatarSrc, getAvatarType } from "./utils/avatar-utils";
 import { SOUND_ENTER_SCENE } from "./systems/sound-effects-system";
+import { LogMessageType } from "./react-components/room/ChatSidebar";
 
 const isIOS = AFRAME.utils.device.isIOS();
 
@@ -156,7 +157,7 @@ export default class SceneEntryManager {
     this._setPlayerInfoFromProfile();
 
     // Explict user action changed avatar or updated existing avatar.
-    this.scene.addEventListener("avatar_updated", () => this._setPlayerInfoFromProfile(true));
+    this.scene.addEventListener("avatar_updated", () => this._setPlayerInfoFromProfile(true, true));
 
     // Store updates can occur to avatar id in cases like error, auth reset, etc.
     this.store.addEventListener("statechanged", () => this._setPlayerInfoFromProfile());
@@ -167,7 +168,7 @@ export default class SceneEntryManager {
     }
   };
 
-  _setPlayerInfoFromProfile = async (force = false) => {
+  _setPlayerInfoFromProfile = async (force = false, log = false) => {
     const avatarId = this.store.state.profile.avatarId;
     if (!force && this._lastFetchedAvatarId === avatarId) return; // Avoid continually refetching based upon state changing
 
@@ -175,6 +176,7 @@ export default class SceneEntryManager {
     const avatarSrc = await getAvatarSrc(avatarId);
 
     this.avatarRig.setAttribute("player-info", { avatarSrc, avatarType: getAvatarType(avatarId) });
+    log && APP.messageDispatch.log(LogMessageType.avatarChanged);
   };
 
   _setupKicking = () => {


### PR DESCRIPTION
Fixes #4623

This PR logs a message when the user's avatar has changed. Note that this is not broadcasted to the rest of the people in the room, it's just a local message.