### PR TITLE
add toolbar labels and button borders to theming w/ dark mode edits

### DIFF
--- a/src/react-components/input/Button.scss
+++ b/src/react-components/input/Button.scss
@@ -25,7 +25,7 @@
 
 :local(.basic), :local(.transparent) {
   color: theme.$text4-color;
-  border: 1px solid theme.$basic-border-color;
+  border: 2px solid theme.$basic-border-color;
   background-color: theme.$basic-color;
 
   svg {
@@ -82,7 +82,8 @@
 :local(.accept) {
   color: theme.$text5-color;
   background-color: theme.$accept-color;
-
+  border: 2px solid theme.$accept-border-color;
+  
   svg {
     *[stroke=\#000] {
       stroke: theme.$text5-color;
@@ -96,6 +97,7 @@
   &:hover {
     color: theme.$text5-color-hover;
     background-color: theme.$accept-color-hover;
+    border: 2px solid theme.$accept-border-color;
   }
 
   &:active {
@@ -157,6 +159,7 @@
 :local(.accent2) {
   color: theme.$text5-color;
   background-color: theme.$accent2-color;
+  border: 2px solid theme.$accent2-border-color;
 
   svg {
     *[stroke=\#000] {
@@ -171,6 +174,7 @@
   &:hover {
     color: theme.$text5-color-hover;
     background-color: theme.$accent2-color-hover;
+    border: 2px solid theme.$accent2-border-color
   }
 
   &:active {
@@ -207,6 +211,7 @@
 :local(.accent4) {
   color: theme.$text5-color;
   background-color: theme.$accent4-color;
+  border: 2px solid theme.$accent4-border-color;
 
   svg {
     *[stroke=\#000] {
@@ -221,6 +226,7 @@
   &:hover {
     color: theme.$text5-color-hover;
     background-color: theme.$accent4-color-hover;
+    border: 2px solid theme.$accent4-border-color;
   }
 
   &:active {
@@ -232,6 +238,7 @@
 :local(.accent5) {
   color: theme.$text5-color;
   background-color: theme.$accent5-color;
+  border: 2px solid theme.$accent5-border-color;
 
   svg {
     *[stroke=\#000] {
@@ -246,6 +253,7 @@
   &:hover {
     color: theme.$text5-color-hover;
     background-color: theme.$accent5-color-hover;
+    border: 2px solid theme.$accent5-border-color;
   }
 
   &:active {

--- a/src/react-components/input/TextInput.scss
+++ b/src/react-components/input/TextInput.scss
@@ -34,6 +34,12 @@ $input-height: 40px;
     padding: 0 16px;
     border-width: 0;
     min-height: auto;
+    border: none;
+    
+    &:hover {
+      border:none;
+    }
+    
 
     :global(.keyboard-user) &:focus {
       border-width: 0;
@@ -52,6 +58,7 @@ $input-height: 40px;
         border-bottom-right-radius: theme.$border-radius-regular;
       }
     }
+    
   }
 
   :local(.icon-button), & > svg  {

--- a/src/react-components/input/ToolbarButton.scss
+++ b/src/react-components/input/ToolbarButton.scss
@@ -77,6 +77,15 @@
       border-color: transparent;
       background-color: theme.$toolbar-icon-selected-bg;
     }
+    svg {
+      *[stroke=\#000] {
+        stroke: theme.$toolbar-basic-selected-icon-color;
+      }
+  
+      *[fill=\#000] {
+        fill: theme.$toolbar-basic-selected-icon-color;
+      }
+    }
 
     label {
       color: theme.$text4-color;
@@ -120,11 +129,11 @@
 
       svg {
         *[stroke=\#000] {
-          stroke: theme.$primary-color;
+          stroke: theme.$toolbar-basic-icon-color;
         }
     
         *[fill=\#000] {
-          fill: theme.$primary-color;
+          fill: theme.$toolbar-basic-icon-color;
         }
       }
     }
@@ -136,6 +145,7 @@
     &:hover {
       :local(.icon-container) {
         border-color: theme.$primary-color-hover;
+        background-color: theme.$toolbar-basic-color-hover;
 
         svg {
           *[stroke=\#000] {
@@ -333,7 +343,7 @@
     }
 
     label {
-      color: theme.$accent1-color;
+      color: theme.$toolbar-label-accent1;
     }
 
     &:hover {
@@ -401,7 +411,7 @@
     }
 
     label {
-      color: theme.$accent2-color;
+      color: theme.$toolbar-label-accent2;
     }
 
     &:hover {
@@ -469,7 +479,7 @@
     }
 
     label {
-      color: theme.$accent3-color;
+      color: theme.$toolbar-label-accent3;
     }
 
     &:hover {
@@ -537,7 +547,7 @@
     }
 
     label {
-      color: theme.$accent4-color;
+      color: theme.$toolbar-label-accent4;
     }
 
     &:hover {
@@ -605,7 +615,7 @@
     }
 
     label {
-      color: theme.$accent5-color;   
+      color: theme.$toolbar-label-accent5;   
     }
 
     &:hover {

--- a/src/react-components/styles/global.scss
+++ b/src/react-components/styles/global.scss
@@ -165,10 +165,16 @@
   --toolbar-icon-color: var(--text5-color);
   --toolbar-icon-selected-bg: var(--transparent); 
   --toolbar-basic-icon-color: var(--text1-color);
+  --toolbar-basic-selected-icon-color: var(--text1-color);
   --toolbar-basic-color: var(--secondary-color);
   --toolbar-basic-color-hover: var(--secondary-color-hover);
   --toolbar-basic-color-pressed: var(--secondary-color-pressed);
   --toolbar-basic-border-color: var(--basic-border-color);
+  --toolbar-label-accent1: var(--accent1-color);
+  --toolbar-label-accent2: var(--accent2-color);
+  --toolbar-label-accent3: var(--accent3-color);
+  --toolbar-label-accent4: var(--accent4-color);
+  --toolbar-label-accent5: var(--accent5-color);
 
   --tile-text-color: var(--text4-color);
   --tile-bg-color: var(--secondary-color);

--- a/src/react-components/styles/theme.scss
+++ b/src/react-components/styles/theme.scss
@@ -249,11 +249,16 @@ $overlay-outline-color: var(--overlay-outline-color);
 $toolbar-icon-color: var(--toolbar-icon-color);
 $toolbar-icon-selected-bg: var(--toolbar-icon-selected-bg);
 $toolbar-basic-icon-color: var(--toolbar-basic-icon-color);
+$toolbar-basic-selected-icon-color: var(--toolbar-basic-selected-icon-color);
 $toolbar-basic-color: var(--toolbar-basic-color);
 $toolbar-basic-color-hover: var(--toolbar-basic-color-hover);
 $toolbar-basic-color-pressed: var(--toolbar-basic-color-pressed);
 $toolbar-basic-border-color: var(--toolbar-basic-border-color);
-
+$toolbar-label-accent1: var(--toolbar-label-accent1);
+$toolbar-label-accent2: var(--toolbar-label-accent2);
+$toolbar-label-accent3: var(--toolbar-label-accent3);
+$toolbar-label-accent4: var(--toolbar-label-accent4);
+$toolbar-label-accent5: var(--toolbar-label-accent5);
 
 $tile-text-color: var(--tile-text-color);
 $tile-bg-color: var(--tile-bg-color);

--- a/themes.json
+++ b/themes.json
@@ -72,7 +72,15 @@
       "action-color-highlight": "#149ce2",
       "action-label-color": "#5634ff",
       "notice-background-color": "#000000",
-      "toolbar-icon-selected-bg": "#ffffff"
+      "toolbar-icon-selected-bg": "#ffffff",
+      "toolbar-basic-icon-color": "#ffffff",
+      "toolbar-basic-selected-icon-color": "#2B313B",
+      "toolbar-basic-color-hover": "#ffffff",
+      "toolbar-label-accent1": "#ffffff",
+      "toolbar-label-accent2": "#ffffff",
+      "toolbar-label-accent3": "#ffffff",
+      "toolbar-label-accent4": "#ffffff",
+      "toolbar-label-accent5": "#ffffff"
     }
   }
 ]


### PR DESCRIPTION
Adds more custom theme variables for toolbar labels, the basic toolbar and allows for accent specific borders on buttons. While adding more variables will create more maintenance and further complicates our theming, it also affords theme creators more control over ui colors. Screen shots below of dark mode with this PR. 

Changed button borders to 2px to better match our dark mode mock. 

In the case of buttons inside an input (e.g: the invite popover), I set the border to none to avoid breaking input buttons with borders.

![Screen Shot 2021-10-11 at 5 02 46 PM](https://user-images.githubusercontent.com/4493657/136879705-23459f71-ef59-4675-8188-f989e3f810df.png)
![Screen Shot 2021-10-11 at 7 03 36 PM](https://user-images.githubusercontent.com/4493657/136879707-bbaf7b6e-750d-44bc-a8dd-e07d791a953c.png)
![Screen Shot 2021-10-11 at 7 03 17 PM](https://user-images.githubusercontent.com/4493657/136879699-80046cc6-7436-44c0-a40c-428bcfc60e11.png)
![Screen Shot 2021-10-11 at 5 02 01 PM](https://user-images.githubusercontent.com/4493657/136879703-e0cf7df0-bda2-419d-95e6-ad3322666945.png)
![Screen Shot 2021-10-11 at 5 02 30 PM](https://user-images.githubusercontent.com/4493657/136879704-a3571d2a-518b-4ca4-9499-4631b720b61c.png)
