### PR TITLE
Fix material components using __mhc_link_type (video texture target in latest Blender exporter)

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -414,7 +414,11 @@ class GLTFHubsPlugin {
     }
 
     // TODO decide if thse should get put into the GLTF loader itself
-    return Promise.all([hookDef("scenes", "extendScene"), hookDef("nodes", "extendNode")]);
+    return Promise.all([
+      hookDef("scenes", "extendScene"),
+      hookDef("nodes", "extendNode"),
+      hookDef("materials", "extendMaterial")
+    ]);
   }
 
   afterRoot(gltf) {
@@ -466,6 +470,11 @@ class GLTFHubsComponentsExtension {
 
   extendNode(nodeIdx) {
     const ext = this.parser.json.nodes[nodeIdx]?.extensions?.MOZ_hubs_components;
+    if (ext) return this.resolveComponentLinks(ext);
+  }
+
+  extendMaterial(materialIdx) {
+    const ext = this.parser.json.materials[materialIdx]?.extensions?.MOZ_hubs_components;
     if (ext) return this.resolveComponentLinks(ext);
   }
 


### PR DESCRIPTION
The latest version of the blender exporter changed how components reference other assets in GLTF files like nodes and images. Hubs was updated to handle this new format for components on nodes and scenes, but not materials. This broke video-texture-target on models exported from the latest exporter.

Related https://github.com/MozillaReality/hubs-blender-exporter/issues/43