### PR TITLE
Fix Sign-in prompt flow issues

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -804,7 +804,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         if (visible) {
           remountUI({ showSignInDialog: true });
         } else {
-          remountUI({ showSignInDialog: false });
+          remountUI({ showSignInDialog: false, onContinueAfterSignIn: null });
         }
       }
     });

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -397,8 +397,11 @@ class UIRoot extends Component {
   };
 
   showContextualSignInDialog = () => {
-    const { signInMessage, authChannel, onContinueAfterSignIn } = this.props;
-
+    const { signInMessage, authChannel } = this.props;
+    const onCallback = () => {
+      const { onContinueAfterSignIn } = this.props;
+      (onContinueAfterSignIn && onContinueAfterSignIn()) || this.closeDialog();
+    };
     this.showNonHistoriedDialog(RoomSignInModalContainer, {
       step: SignInStep.submit,
       message: signInMessage,
@@ -407,7 +410,7 @@ class UIRoot extends Component {
 
         this.showNonHistoriedDialog(RoomSignInModalContainer, {
           step: SignInStep.waitForVerification,
-          onClose: onContinueAfterSignIn || this.closeDialog
+          onClose: onCallback
         });
 
         await authComplete;
@@ -415,11 +418,11 @@ class UIRoot extends Component {
         this.setState({ signedIn: true });
         this.showNonHistoriedDialog(RoomSignInModalContainer, {
           step: SignInStep.complete,
-          onClose: onContinueAfterSignIn || this.closeDialog,
-          onContinue: onContinueAfterSignIn || this.closeDialog
+          onClose: onCallback,
+          onContinue: onCallback
         });
       },
-      onClose: onContinueAfterSignIn || this.closeDialog
+      onClose: onCallback
     });
   };
 
@@ -651,8 +654,6 @@ class UIRoot extends Component {
   closeDialog = () => {
     if (this.state.dialog) {
       this.setState({ dialog: null });
-    } else {
-      this.props.history.goBack();
     }
 
     const { onSignInDialogVisibilityChanged } = this.props;


### PR DESCRIPTION
This PR's first commit Fixes #4695 We were using the `showSignInDialog` prop for showing/hiding the sign in dialog but in some cases we are updating that state from inside UIRoot and when updating the prop from outside again it was out of sync. That commit aims at keeping the prop always in sync with the actual dialog visible state.

The second commit cancels the actual associated action in case the dialog is cancelled to avoid the scenario where the user starts a sign-in flow through a conditional action (ie list favorite rooms) but cancels it and later starts a new unconditional sign in flow through the sign in button.

These other two issues are also fixed by this PR:
Fixes #4367
Fixes #3886