### PR TITLE
fix error when loading on mobile with query vr_entry_mode=2d_now

### DIFF
--- a/src/utils/fullscreen.js
+++ b/src/utils/fullscreen.js
@@ -5,7 +5,13 @@ let hasEnteredFullScreenThisSession = false;
 
 function shouldShowFullScreen() {
   // Disable full screen on iOS, since Safari's fullscreen mode does not let you prevent native pinch-to-zoom gestures.
-  return (AFRAME.utils.device.isMobile() || AFRAME.utils.device.isMobileVR()) && !isIOS() && screenfull.enabled;
+  // Disable full screen if in an iframe to prevent conflicts
+  return ( ( window.location == window.parent.location ) && AFRAME.utils.device.isMobile() || AFRAME.utils.device.isMobileVR()) && !isIOS() && screenfull.enabled;
+}
+
+async function retryScreenFull(){
+  await screenfull.request();
+  document.body.removeEventListener("click",retryScreenFull);
 }
 
 export function willRequireUserGesture() {
@@ -15,7 +21,13 @@ export function willRequireUserGesture() {
 export async function showFullScreenIfAvailable() {
   if (shouldShowFullScreen()) {
     hasEnteredFullScreenThisSession = true;
-    await screenfull.request();
+    try{
+      await screenfull.request();
+    }catch(e) {
+      // prevent crash when entering without user interaction
+      document.body.addEventListener("click",retryScreenFull)
+    }
+
   }
 }
 


### PR DESCRIPTION
It is a fix for the issue https://github.com/mozilla/hubs/issues/4697
