### PR TITLE
add admin color to themes

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -39,6 +39,7 @@
       "accent5-border-color": "#13a4ed",
       "accent5-color-hover": "#5D646C",
       "accent5-color-pressed": "#21242C",
+      "admin-color": "#13a4ed",
       "text1-color": "#ffffff",
       "text1-color-hover": "#E7E7E7",
       "text1-color-pressed": "#DBDBDB",


### PR DESCRIPTION
resolves #4762
already added to our themes on hmc, updating in themes.json as our hubs dark mode source of truth.