### PR TITLE
Fix bug where theme updates did not change sprites

### DIFF
--- a/src/components/pin-networked-object-button.js
+++ b/src/components/pin-networked-object-button.js
@@ -47,6 +47,8 @@ AFRAME.registerComponent("pin-networked-object-button", {
         this.el.sceneEl.systems["hubs-systems"].soundEffectsSystem.playSoundOneShot(SOUND_PIN);
       }
     };
+
+    APP.store.addEventListener("themechanged", this._updateUI);
   },
 
   play() {

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -254,6 +254,18 @@ export default class Store extends EventTarget {
     }
 
     this._signOutOnExpiredAuthToken();
+
+    const maybeDispatchThemeChanged = (() => {
+      let previous;
+      return () => {
+        const current = this.state.preferences.theme;
+        if ((previous || current) && previous !== current) {
+          this.dispatchEvent(new CustomEvent("themechanged", { detail: { current, previous } }));
+        }
+        previous = current;
+      };
+    })();
+    this.addEventListener("statechanged", maybeDispatchThemeChanged);
   }
 
   _signOutOnExpiredAuthToken = () => {

--- a/src/systems/sprites.js
+++ b/src/systems/sprites.js
@@ -260,6 +260,28 @@ export class SpriteSystem {
         );
       }
     });
+
+    async function regenerateImageTextures() {
+      for (const [spritesheetPng, type] of [[spritesheetActionPng, "action"], [spritesheetNoticePng, "notice"]]) {
+        if (this.meshes[type]) {
+          const newTexture = await createImageTexture(spritesheetPng, getThemeColorShifter(type));
+
+          this.meshes[type].material.uniforms.u_spritesheet.value = newTexture;
+          this.meshes[type].material.uniformsNeedUpdate = true;
+        }
+      }
+    }
+    const onStoreChanged = (function() {
+      let themeId;
+      return function onStoreChanged() {
+        const newThemeId = window.APP?.store?.state?.preferences?.theme;
+        if (themeId !== newThemeId) {
+          themeId = newThemeId;
+          regenerateImageTextures();
+        }
+      };
+    })();
+    APP.store.addEventListener("statechanged", onStoreChanged);
   }
 
   tick(t) {

--- a/src/systems/sprites.js
+++ b/src/systems/sprites.js
@@ -267,15 +267,12 @@ export class SpriteSystem {
     APP.store.addEventListener("themechanged", async () => {
       for (const [spritesheetPng, type] of pngs) {
         if (this.meshes[type]) {
+          const newTexture = await createImageTexture(spritesheetPng, getThemeColorShifter(type));
           const oldTexture = this.meshes[type].material.uniforms.u_spritesheet.value;
           if (oldTexture) {
             disposeTexture(oldTexture);
           }
-
-          this.meshes[type].material.uniforms.u_spritesheet.value = await createImageTexture(
-            spritesheetPng,
-            getThemeColorShifter(type)
-          );
+          this.meshes[type].material.uniforms.u_spritesheet.value = newTexture;
           this.meshes[type].material.uniformsNeedUpdate = true;
         }
       }


### PR DESCRIPTION
We need to recolorize sprites and in-world menus when the user chooses a new theme.