### PR TITLE
Update to ThreeJS 133

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36307,7 +36307,7 @@
       "dev": true
     },
     "three": {
-      "version": "github:mozillareality/three.js#5415954e75dd12b3539339f7b7049ca655cf0330",
+      "version": "github:mozillareality/three.js#b383b75d067c9ca2f1c27de6545531287c8d53a8",
       "from": "github:mozillareality/three.js#hubs-patches-133"
     },
     "three-ammo": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27749,12 +27749,13 @@
       "version": "github:mozillareality/networked-aframe#ae8ca30fcded2369c8702686b07cce46dfc16306",
       "from": "github:mozillareality/networked-aframe#master",
       "requires": {
-        "buffered-interpolation": "github:Infinitelee/buffered-interpolation#5bb18421ebf2bf11664645cdc7a15bd77ee2156b",
+        "buffered-interpolation": "^0.2.5",
         "easyrtc": "1.1.0"
       },
       "dependencies": {
         "buffered-interpolation": {
-          "version": "github:infinitelee/buffered-interpolation#5bb18421ebf2bf11664645cdc7a15bd77ee2156b"
+          "version": "0.2.5",
+          "resolved": "github:Infinitelee/buffered-interpolation#5bb18421ebf2bf11664645cdc7a15bd77ee2156b"
         }
       }
     },
@@ -36334,9 +36335,9 @@
       }
     },
     "three-mesh-bvh": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.3.7.tgz",
-      "integrity": "sha512-veRJRj0mY2rBj9yRZVg/E98wd6e7AzqzTq/+6ispY6m50gYuGitUNih2dRQzbkMcwRECLURvuudb9BFW3/swAw=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.5.0.tgz",
+      "integrity": "sha512-CvWHCltKn7oVY5ckcA0QC5GtkfwWcnOxUuazrTKvAB0OroFV2hOKj974Oh0Gi7MvNiqFYkHYgxnUSaUQzlAfgQ=="
     },
     "three-pathfinding": {
       "version": "0.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36306,8 +36306,8 @@
       "dev": true
     },
     "three": {
-      "version": "github:mozillareality/three.js#b5451470eb62c17aec7d051139aefa0410aa088b",
-      "from": "github:mozillareality/three.js#hubs-patches"
+      "version": "github:mozillareality/three.js#5415954e75dd12b3539339f7b7049ca655cf0330",
+      "from": "github:mozillareality/three.js#hubs-patches-133"
     },
     "three-ammo": {
       "version": "github:infinitelee/three-ammo#db3ad1104b258d963ca66165f9fbed4013faa32a",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "screenfull": "^4.0.1",
     "sdp-transform": "^2.14.1",
     "semver": "^7.3.2",
-    "three": "github:mozillareality/three.js#hubs-patches",
+    "three": "github:mozillareality/three.js#hubs-patches-133",
     "three-ammo": "github:infinitelee/three-ammo",
     "three-bmfont-text": "github:mozillareality/three-bmfont-text#hubs/master",
     "three-mesh-bvh": "^0.3.7",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "three": "github:mozillareality/three.js#hubs-patches-133",
     "three-ammo": "github:infinitelee/three-ammo",
     "three-bmfont-text": "github:mozillareality/three-bmfont-text#hubs/master",
-    "three-mesh-bvh": "^0.3.7",
+    "three-mesh-bvh": "^0.5.0",
     "three-pathfinding": "^0.14.1",
     "three-to-ammo": "github:infinitelee/three-to-ammo",
     "use-clipboard-copy": "^0.1.2",

--- a/src/systems/audio-debug-system.js
+++ b/src/systems/audio-debug-system.js
@@ -181,7 +181,6 @@ AFRAME.registerSystem("audio-debug", {
               obj._hubs_audio_debug_prev_material = null;
               obj.material.needsUpdate = true;
             }
-            obj.geometry.computeFaceNormals();
             obj.geometry.computeVertexNormals();
           }
         }

--- a/src/systems/environment-system.js
+++ b/src/systems/environment-system.js
@@ -165,7 +165,8 @@ export class EnvironmentSystem {
         // TODO PMREMGenerator should be fixed to not assume this
         settings.envMapTexture.flipY = true;
         // Assume texture is always an equirect for now
-        this.scene.environment = this.pmremGenerator.fromEquirectangular(settings.envMapTexture).texture;
+        settings.envMapTexture.mapping = THREE.EquirectangularReflectionMapping;
+        this.scene.environment = settings.envMapTexture;
       }
     } else if (settings.skybox) {
       if (this.prevEnvMapTextureUUID !== settings.skybox.uuid) {

--- a/src/systems/nav.js
+++ b/src/systems/nav.js
@@ -38,7 +38,7 @@ AFRAME.registerSystem("nav", {
     if (this.helperMesh) {
       this.helperMesh.material?.dispose();
       this.helperMesh.geometry?.dispose();
-      this.helperMesh.parent.remove(this.helperMesh);
+      this.helperMesh.removeFromParent();
       this.helperMesh = null;
     }
     this.mesh = null;

--- a/src/systems/sound-effects-system.js
+++ b/src/systems/sound-effects-system.js
@@ -204,7 +204,7 @@ export class SoundEffectsSystem {
         inPositionalAudio.stop();
       }
       if (inPositionalAudio.parent) {
-        inPositionalAudio.parent.remove(inPositionalAudio);
+        inPositionalAudio.removeFromParent();
       }
     }
     this.positionalAudiosStationary = this.positionalAudiosStationary.filter(

--- a/src/utils/material-utils.js
+++ b/src/utils/material-utils.js
@@ -47,9 +47,6 @@ class HubsMeshBasicMaterial extends THREE.MeshBasicMaterial {
     material.wireframeLinecap = source.wireframeLinecap;
     material.wireframeLinejoin = source.wireframeLinejoin;
 
-    material.skinning = source.skinning;
-    material.morphTargets = source.morphTargets;
-
     return material;
   }
 
@@ -157,10 +154,6 @@ class HubsMeshPhongMaterial extends THREE.MeshPhongMaterial {
     material.wireframeLinewidth = source.wireframeLinewidth;
     material.wireframeLinecap = source.wireframeLinecap;
     material.wireframeLinejoin = source.wireframeLinejoin;
-
-    material.skinning = source.skinning;
-    material.morphTargets = source.morphTargets;
-    material.morphNormals = source.morphNormals;
 
     return material;
   }

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -261,9 +261,6 @@ export const cloneMedia = (sourceEl, template, src = null, networked = true, lin
 };
 
 export function injectCustomShaderChunks(obj) {
-  const vertexRegex = /\bskinning_vertex\b/;
-  const fragRegex = /\bgl_FragColor\b/;
-
   const shaderUniforms = [];
   const batchManagerSystem = AFRAME.scenes[0].systems["hubs-systems"].batchManagerSystem;
 
@@ -295,7 +292,7 @@ export function injectCustomShaderChunks(obj) {
       const newMaterial = material.clone();
       // This will not run if the object is never rendered unbatched, since its unbatched shader will never be compiled
       newMaterial.onBeforeCompile = (shader, renderer) => {
-        if (!vertexRegex.test(shader.vertexShader)) return;
+        if (shader.vertexShader.indexOf("#include <skinning_vertex>") == -1) return;
 
         if (material.onBeforeCompile) {
           material.onBeforeCompile(shader, renderer);
@@ -310,37 +307,40 @@ export function injectCustomShaderChunks(obj) {
         shader.uniforms.hubs_HighlightInteractorTwo = { value: false };
         shader.uniforms.hubs_Time = { value: 0 };
 
-        const vchunk = `
-        if (hubs_HighlightInteractorOne || hubs_HighlightInteractorTwo || hubs_IsFrozen) {
-          vec4 wt = modelMatrix * vec4(transformed, 1);
+        shader.vertexShader =
+          [
+            "varying vec3 hubs_WorldPosition;",
+            "uniform bool hubs_IsFrozen;",
+            "uniform bool hubs_HighlightInteractorOne;",
+            "uniform bool hubs_HighlightInteractorTwo;\n"
+          ].join("\n") +
+          shader.vertexShader.replace(
+            "#include <skinning_vertex>",
+            `#include <skinning_vertex>
+             if (hubs_HighlightInteractorOne || hubs_HighlightInteractorTwo || hubs_IsFrozen) {
+              vec4 wt = modelMatrix * vec4(transformed, 1);
 
-          // Used in the fragment shader below.
-          hubs_WorldPosition = wt.xyz;
-        }
-        `;
+              // Used in the fragment shader below.
+              hubs_WorldPosition = wt.xyz;
+            }`
+          );
 
-        const vlines = shader.vertexShader.split("\n");
-        const vindex = vlines.findIndex(line => vertexRegex.test(line));
-        vlines.splice(vindex + 1, 0, vchunk);
-        vlines.unshift("varying vec3 hubs_WorldPosition;");
-        vlines.unshift("uniform bool hubs_IsFrozen;");
-        vlines.unshift("uniform bool hubs_HighlightInteractorOne;");
-        vlines.unshift("uniform bool hubs_HighlightInteractorTwo;");
-        shader.vertexShader = vlines.join("\n");
-
-        const flines = shader.fragmentShader.split("\n");
-        const findex = flines.findIndex(line => fragRegex.test(line));
-        flines.splice(findex + 1, 0, mediaHighlightFrag);
-        flines.unshift("varying vec3 hubs_WorldPosition;");
-        flines.unshift("uniform bool hubs_IsFrozen;");
-        flines.unshift("uniform bool hubs_EnableSweepingEffect;");
-        flines.unshift("uniform vec2 hubs_SweepParams;");
-        flines.unshift("uniform bool hubs_HighlightInteractorOne;");
-        flines.unshift("uniform vec3 hubs_InteractorOnePos;");
-        flines.unshift("uniform bool hubs_HighlightInteractorTwo;");
-        flines.unshift("uniform vec3 hubs_InteractorTwoPos;");
-        flines.unshift("uniform float hubs_Time;");
-        shader.fragmentShader = flines.join("\n");
+        shader.fragmentShader =
+          [
+            "varying vec3 hubs_WorldPosition;",
+            "uniform bool hubs_IsFrozen;",
+            "uniform bool hubs_EnableSweepingEffect;",
+            "uniform vec2 hubs_SweepParams;",
+            "uniform bool hubs_HighlightInteractorOne;",
+            "uniform vec3 hubs_InteractorOnePos;",
+            "uniform bool hubs_HighlightInteractorTwo;",
+            "uniform vec3 hubs_InteractorTwoPos;",
+            "uniform float hubs_Time;\n"
+          ].join("\n") +
+          shader.fragmentShader.replace(
+            "#include <output_fragment>",
+            "#include <output_fragment>\n" + mediaHighlightFrag
+          );
 
         shaderUniforms.push(shader.uniforms);
       };

--- a/src/vendor/Water.js
+++ b/src/vendor/Water.js
@@ -14,30 +14,19 @@ THREE.Water = function(geometry, options) {
 
   options = options || {};
 
-  const textureWidth =
-    options.textureWidth !== undefined ? options.textureWidth : 512;
-  const textureHeight =
-    options.textureHeight !== undefined ? options.textureHeight : 512;
+  const textureWidth = options.textureWidth !== undefined ? options.textureWidth : 512;
+  const textureHeight = options.textureHeight !== undefined ? options.textureHeight : 512;
 
   const clipBias = options.clipBias !== undefined ? options.clipBias : 0.0;
   const alpha = options.alpha !== undefined ? options.alpha : 1.0;
   const time = options.time !== undefined ? options.time : 0.0;
-  const normalSampler =
-    options.waterNormals !== undefined ? options.waterNormals : null;
+  const normalSampler = options.waterNormals !== undefined ? options.waterNormals : null;
   const sunDirection =
-    options.sunDirection !== undefined
-      ? options.sunDirection
-      : new THREE.Vector3(0.70707, 0.70707, 0.0);
-  const sunColor = new THREE.Color(
-    options.sunColor !== undefined ? options.sunColor : 0xffffff
-  );
-  const waterColor = new THREE.Color(
-    options.waterColor !== undefined ? options.waterColor : 0x7f7f7f
-  );
-  const eye =
-    options.eye !== undefined ? options.eye : new THREE.Vector3(0, 0, 0);
-  const distortionScale =
-    options.distortionScale !== undefined ? options.distortionScale : 20.0;
+    options.sunDirection !== undefined ? options.sunDirection : new THREE.Vector3(0.70707, 0.70707, 0.0);
+  const sunColor = new THREE.Color(options.sunColor !== undefined ? options.sunColor : 0xffffff);
+  const waterColor = new THREE.Color(options.waterColor !== undefined ? options.waterColor : 0x7f7f7f);
+  const eye = options.eye !== undefined ? options.eye : new THREE.Vector3(0, 0, 0);
+  const distortionScale = options.distortionScale !== undefined ? options.distortionScale : 20.0;
   const side = options.side !== undefined ? options.side : THREE.FrontSide;
   const fog = options.fog !== undefined ? options.fog : false;
 
@@ -66,16 +55,9 @@ THREE.Water = function(geometry, options) {
     stencilBuffer: false
   };
 
-  const renderTarget = new THREE.WebGLRenderTarget(
-    textureWidth,
-    textureHeight,
-    parameters
-  );
+  const renderTarget = new THREE.WebGLRenderTarget(textureWidth, textureHeight, parameters);
 
-  if (
-    !THREE.Math.isPowerOfTwo(textureWidth) ||
-    !THREE.Math.isPowerOfTwo(textureHeight)
-  ) {
+  if (!THREE.Math.isPowerOfTwo(textureWidth) || !THREE.Math.isPowerOfTwo(textureHeight)) {
     renderTarget.texture.generateMipmaps = false;
   }
 
@@ -260,24 +242,7 @@ THREE.Water = function(geometry, options) {
     mirrorCamera.projectionMatrix.copy(camera.projectionMatrix);
 
     // Update the texture matrix
-    textureMatrix.set(
-      0.5,
-      0.0,
-      0.0,
-      0.5,
-      0.0,
-      0.5,
-      0.0,
-      0.5,
-      0.0,
-      0.0,
-      0.5,
-      0.5,
-      0.0,
-      0.0,
-      0.0,
-      1.0
-    );
+    textureMatrix.set(0.5, 0.0, 0.0, 0.5, 0.0, 0.5, 0.0, 0.5, 0.0, 0.0, 0.5, 0.5, 0.0, 0.0, 0.0, 1.0);
     textureMatrix.multiply(mirrorCamera.projectionMatrix);
     textureMatrix.multiply(mirrorCamera.matrixWorldInverse);
 
@@ -286,21 +251,12 @@ THREE.Water = function(geometry, options) {
     mirrorPlane.setFromNormalAndCoplanarPoint(normal, mirrorWorldPosition);
     mirrorPlane.applyMatrix4(mirrorCamera.matrixWorldInverse);
 
-    clipPlane.set(
-      mirrorPlane.normal.x,
-      mirrorPlane.normal.y,
-      mirrorPlane.normal.z,
-      mirrorPlane.constant
-    );
+    clipPlane.set(mirrorPlane.normal.x, mirrorPlane.normal.y, mirrorPlane.normal.z, mirrorPlane.constant);
 
     const projectionMatrix = mirrorCamera.projectionMatrix;
 
-    q.x =
-      (Math.sign(clipPlane.x) + projectionMatrix.elements[8]) /
-      projectionMatrix.elements[0];
-    q.y =
-      (Math.sign(clipPlane.y) + projectionMatrix.elements[9]) /
-      projectionMatrix.elements[5];
+    q.x = (Math.sign(clipPlane.x) + projectionMatrix.elements[8]) / projectionMatrix.elements[0];
+    q.y = (Math.sign(clipPlane.y) + projectionMatrix.elements[9]) / projectionMatrix.elements[5];
     q.z = -1.0;
     q.w = (1.0 + projectionMatrix.elements[10]) / projectionMatrix.elements[14];
 

--- a/src/vendor/Water.js
+++ b/src/vendor/Water.js
@@ -327,7 +327,9 @@ THREE.Water = function(geometry, options) {
     renderer.xr.enabled = false; // Avoid camera modification and recursion
     renderer.shadowMap.autoUpdate = false; // Avoid re-computing shadows
 
-    renderer.render(scene, mirrorCamera, renderTarget, true);
+    renderer.setRenderTarget(renderTarget);
+    renderer.render(scene, mirrorCamera);
+    renderer.setRenderTarget(null);
 
     scope.visible = true;
 


### PR DESCRIPTION
Using our new update process to update to ThreeJS 133 (from 128)

See https://github.com/mrdoob/three.js/wiki/Migration-Guide#128--129 and up.

I have gone through the migration guide and list of changes in the Hubs repo, still need to check in our dependency repos, though things appear to be working correctly so far in my tests.