### PR TITLE
Sign out on invalid auth tokens

### DIFF
--- a/src/react-components/auth/AuthContext.js
+++ b/src/react-components/auth/AuthContext.js
@@ -33,6 +33,10 @@ async function checkIsAdmin(socket, store) {
       })
       .receive("error", error => {
         console.error("Error joining Phoenix Channel", error);
+        if (error.reason === "invalid_token") {
+          console.error("Token is invalid. Signing out.");
+          store.update({ credentials: { token: null, email: null } });
+        }
       })
       .receive("timeout", () => {
         console.error("Phoenix Channel join timed out");


### PR DESCRIPTION
This fixes an issue where the homepage doesn't render properly if the credentials saved to local storage are invalid. If the `ret` phoenix channel rejects a token with `reason: "invalid_token"` then we sign out (by deleting the offending credentials). 

Fixes https://github.com/mozilla/hubs-cloud/issues/187
