### PR TITLE
Stop adding session id with every call to getMicrophonePresences

### DIFF
--- a/src/utils/microphone-presence.js
+++ b/src/utils/microphone-presence.js
@@ -22,7 +22,9 @@ export const getMicrophonePresences = (() => {
         if (playerInfo.isLocalPlayerInfo) {
           talking = sceneEl.systems["local-audio-analyser"].volume > MIC_PRESENCE_VOLUME_THRESHOLD;
         }
-        sessionIds.push(playerSessionId);
+        if (sessionIds.indexOf(playerSessionId) === -1) {
+          sessionIds.push(playerSessionId);
+        }
         currentSessionIds.push(playerSessionId);
         if (microphonePresences.has(playerSessionId)) {
           const presence = microphonePresences.get(playerSessionId);


### PR DESCRIPTION
There is a bug in `getMicrophonePresences` which causes it to add the `sessionId` to the `sessionIds` list every time it is called. The result is that for long lived sessions this list gets longer and longer, slowing the function down. This PR properly checks to ensure the same session id is not added twice. The reason a proper `Set` is not used (somewhat ironically) is to avoid the `for (of)` allocation that would be there since this is called on a `setTimeout`.