### PR TITLE
Allow objects to opt out of frustrum culling

### DIFF
--- a/src/components/frustrum.js
+++ b/src/components/frustrum.js
@@ -1,0 +1,24 @@
+/**
+ * Frustrum-based object visibilty
+ * @component frustrum
+ */
+ AFRAME.registerComponent('frustrum', {
+  schema: {
+    culled: { type: "boolean", default: true },
+  },
+
+  update: function () {
+    this.updateDescendants(this.data.culled);
+  },
+
+  remove: function () {
+    this.updateDescendants(true);
+  },
+
+  updateDescendants: function (culled) {
+    this.el.object3D.traverse(function (node) {
+      if (!(node instanceof THREE.Mesh)) { return; }
+      node.frustumCulled = culled;
+    });
+  }
+});

--- a/src/components/scene-components.js
+++ b/src/components/scene-components.js
@@ -29,3 +29,4 @@ import "./video-pause-state";
 import "./particle-emitter";
 import "./audio-zone";
 import "./audio-zone-source";
+import "./frustrum";

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -83,6 +83,7 @@ AFRAME.GLTFModelPlus.registerComponent("morph-audio-feedback", "morph-audio-feed
 AFRAME.GLTFModelPlus.registerComponent("animation-mixer", "animation-mixer");
 AFRAME.GLTFModelPlus.registerComponent("loop-animation", "loop-animation");
 AFRAME.GLTFModelPlus.registerComponent("uv-scroll", "uv-scroll");
+AFRAME.GLTFModelPlus.registerComponent("frustrum", "frustrum");
 AFRAME.GLTFModelPlus.registerComponent(
   "box-collider",
   "shape-helper",


### PR DESCRIPTION
Frustrum culling can cause some animated models to disappear. While this situation could possibly be improved, it appears that extreme changes of mesh vertex positions due to skinning could not easily be accounted for.

This change allows the designer to force the animated model to be displayed regardless of whether the renderer thinks it is inside the frustrum or not.