### PR TITLE
Fix bubble transparency issues

### DIFF
--- a/src/systems/personal-space-bubble.js
+++ b/src/systems/personal-space-bubble.js
@@ -254,7 +254,10 @@ AFRAME.registerComponent("personal-space-invader", {
           if (!material.userData.originalProps) {
             originalProps = material.userData.originalProps = {
               opacity: material.opacity,
-              transparent: material.transparent
+              transparent: material.transparent,
+              format: material.format,
+              blending: material.blending,
+              side: material.side
             };
           }
 
@@ -263,6 +266,9 @@ AFRAME.registerComponent("personal-space-invader", {
           // not across avatars in the room.
           material.opacity = invading ? this.data.invadingOpacity : originalProps.opacity;
           material.transparent = invading || originalProps.transparent;
+          material.format = invading ? THREE.RGBAFormat : originalProps.format;
+          material.blending = invading ? THREE.NormalBlending : originalProps.blending;
+          material.side = invading ? THREE.DoubleSide : originalProps.side;
         });
       });
     } else {

--- a/src/systems/personal-space-bubble.js
+++ b/src/systems/personal-space-bubble.js
@@ -267,10 +267,11 @@ AFRAME.registerComponent("personal-space-invader", {
           material.opacity = invading ? this.data.invadingOpacity : originalProps.opacity;
           material.transparent = invading || originalProps.transparent;
 
-          // Note: Since 0.132 the default format for GLTF imported opaque materials is RGBFormat
+          // Note: Since ThreeJS 0.132 the default format for GLTF imported opaque materials is RGBFormat
           // so we need to switch before enabling transparency.
           material.format = invading ? THREE.RGBAFormat : originalProps.format;
           material.blending = invading ? THREE.NormalBlending : originalProps.blending;
+          // This shouldn't be necessary but for some reason transparency doens't work on some models if they are single sided.
           material.side = invading ? THREE.DoubleSide : originalProps.side;
         });
       });

--- a/src/systems/personal-space-bubble.js
+++ b/src/systems/personal-space-bubble.js
@@ -266,6 +266,9 @@ AFRAME.registerComponent("personal-space-invader", {
           // not across avatars in the room.
           material.opacity = invading ? this.data.invadingOpacity : originalProps.opacity;
           material.transparent = invading || originalProps.transparent;
+
+          // Note: Since 0.132 the default format for GLTF imported opaque materials is RGBFormat
+          // so we need to switch before enabling transparency.
           material.format = invading ? THREE.RGBAFormat : originalProps.format;
           material.blending = invading ? THREE.NormalBlending : originalProps.blending;
           material.side = invading ? THREE.DoubleSide : originalProps.side;


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/4801

I've tracked it down to this PR: https://github.com/mrdoob/three.js/pull/22428 that affects the GLTF material import process. It seems that now the material format for GLTF imported materials is `RGBFormat` if blend mode is opaque so just enabling the transparency flag doesn't work anymore for imported materials with blend opaque modes, we need to switch to `RGBAFormat` first. It doesn't make much sense and there is an open issue about it https://github.com/mrdoob/three.js/issues/22598 so we can expect an update that fixes that soon. 

In the meantime I've patched that in the Hubs client code explicitly switching to `RGBAFormat` and also switch to `NormalBlending` (to make sure it works for all models) while the avatar is transparent. I had to also enable `DoubleSided` rendering, this shouldn't be necessary but it was failing for some models.

As far as I know this is the only place in the app where we need this patch, I can't think of any other place where we import GLTF models and we want to change their transparency on demand but I might be missing some things.