### PR TITLE
Refactor how components are loaded from GLTFs (fix video-texture-target)

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -492,7 +492,7 @@ class GLTFHubsComponentsExtension {
               parser.getDependency(type, value.index).then(loadedDep => {
                 // TODO similar to above, this logic being spread out in multiple places is not great...
                 // Node refences are assumed to always be in the scene graph. These referneces are late-resolved in inflateComponents
-                // otherwise they will need to be updated when cloning (which happens as part of caching). Handled in inflateComponents.
+                // otherwise they will need to be updated when cloning (which happens as part of caching).
                 if (type === "node") return;
 
                 if (type === "texture" && !parser.json.textures[value.index].extensions?.MOZ_texture_rgbe) {

--- a/src/utils/material-utils.js
+++ b/src/utils/material-utils.js
@@ -8,13 +8,23 @@ export function forEachMaterial(object3D, fn) {
   }
 }
 
-export function mapMaterials(object3D, fn) {
+export function updateMaterials(object3D, fn) {
   if (!object3D.material) return;
+
+  if (Array.isArray(object3D.material)) {
+    object3D.material = object3D.material.map(fn);
+  } else {
+    object3D.material = fn(object3D.material);
+  }
+}
+
+export function mapMaterials(object3D, fn) {
+  if (!object3D.material) return [];
 
   if (Array.isArray(object3D.material)) {
     return object3D.material.map(fn);
   } else {
-    return fn(object3D.material);
+    return [fn(object3D.material)];
   }
 }
 

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -2,7 +2,7 @@ import { objectTypeForOriginAndContentType } from "../object-types";
 import { getReticulumFetchUrl, getDirectReticulumFetchUrl } from "./phoenix-utils";
 import { ObjectContentOrigins } from "../object-types";
 import mediaHighlightFrag from "./media-highlight-frag.glsl";
-import { mapMaterials } from "./material-utils";
+import { updateMaterials } from "./material-utils";
 import HubsTextureLoader from "../loaders/HubsTextureLoader";
 import { validMaterials } from "../components/hoverable-visuals";
 import { proxiedUrlFor, guessContentType } from "../utils/media-url-utils";
@@ -267,7 +267,7 @@ export function injectCustomShaderChunks(obj) {
   obj.traverse(object => {
     if (!object.material) return;
 
-    object.material = mapMaterials(object, material => {
+    updateMaterials(object, material => {
       if (material.hubs_InjectedCustomShaderChunks) return material;
       if (!validMaterials.includes(material.type)) {
         return material;


### PR DESCRIPTION
The latest version of ThreeJS broke node references on material components (used video-texture-target). This was due to a change inside GLTFLoader causing materials to be `.clone()`ed when they were not before (though there were certain cases in the past that would probably also trigger this bug). The implementation for `.clone()` on Material and Objec3D kills references on `userData` since it runs it through JSON.stringify/parse. Because of the timing of when this was happening relative to when we were resolving links on material components, the node reference was getting lost...

We want to run all our logic for resolving components after everything else in the GLTF has loaded, so we avoid issues like this. I took this as an opportunity to start cleaning this code up a bit and actually using "associations". This lets us get rid of the hack that had ThreeJS putting the component data into `userData` for us. We still want to skip putting it into `userData` at all, but that is a bigger change, and this gets us 1 step closer.