### PR TITLE
add audio debug panel to sb + remove max distance from inverse/exponential

### DIFF
--- a/src/react-components/debug-panel/AudioDebugPanel.scss
+++ b/src/react-components/debug-panel/AudioDebugPanel.scss
@@ -8,6 +8,7 @@
   align-self: flex-start;
   flex: 0 1 auto;
   justify-content: center;
+  
 
   @media(max-width: 500px) {
     width: 100%;
@@ -35,7 +36,8 @@
   margin: 0;
   text-align: center;
   overflow-wrap: break-word;
-  width: 80px
+  width: 80px;
+  user-select: none;
 }
 
 :local(.value-text) {
@@ -43,4 +45,5 @@
   margin: 0;
   color: theme.$yellow;
   width: 40px;
+  user-select: none;
 }


### PR DESCRIPTION
Adds audio debugger to storybook and removes the max distance select property for inverse and exponential since we only use maxDistance to calculate linear distance models.

[![Image from Gyazo](https://i.gyazo.com/20c78cf2c834190144a9d2d566172bbf.gif)](https://gyazo.com/20c78cf2c834190144a9d2d566172bbf)