### PR TITLE
Popup window closes itself on oauth-success

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -266,8 +266,8 @@ let isOAuthModal = false;
 // TODO: Replace with a new oauth callback route that has this postMessage script.
 if (window.opener && window.opener.doingTwitterOAuth) {
   window.opener.postMessage("oauth-successful");
-  window.close();
   isOAuthModal = true;
+  window.close();
 }
 
 const isBotMode = qsTruthy("bot");

--- a/src/hub.js
+++ b/src/hub.js
@@ -266,6 +266,7 @@ let isOAuthModal = false;
 // TODO: Replace with a new oauth callback route that has this postMessage script.
 if (window.opener && window.opener.doingTwitterOAuth) {
   window.opener.postMessage("oauth-successful");
+  window.close();
   isOAuthModal = true;
 }
 

--- a/src/react-components/room/TwitterOAuthModalContainer.js
+++ b/src/react-components/room/TwitterOAuthModalContainer.js
@@ -41,7 +41,6 @@ export function TwitterOAuthModalContainer({ hubChannel, onConnected, onClose })
       function onMessage({ data }) {
         if (data === "oauth-successful") {
           onConnected();
-          popupRef.current.close();
           popupRef.current = null;
           delete window.doingTwitterOAuth;
           window.removeEventListener("message", onMessage);


### PR DESCRIPTION
Firefox blocks the twitter pop-up so Hubs loses the reference to the window and can't close it. This enables the popup oauth window to close itself on success. 