### PR TITLE
GLTF loader Draco support

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -9,6 +9,7 @@ import HubsTextureLoader from "../loaders/HubsTextureLoader";
 import { KTX2Loader } from "three/examples/jsm/loaders/KTX2Loader";
 import { RGBELoader } from "three/examples/jsm/loaders/RGBELoader";
 import { BasisTextureLoader } from "three/examples/jsm/loaders/BasisTextureLoader";
+import { DRACOLoader } from "three/examples/jsm/loaders/DRACOLoader";
 
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
 
@@ -345,6 +346,7 @@ function runMigration(version, json) {
 }
 
 let ktxLoader;
+let dracoLoader;
 
 class GLTFHubsPlugin {
   constructor(parser, jsonPreprocessor) {
@@ -631,9 +633,15 @@ export async function loadGLTF(src, contentType, onProgress, jsonPreprocessor) {
   if (!ktxLoader && AFRAME && AFRAME.scenes && AFRAME.scenes[0]) {
     ktxLoader = new KTX2Loader(loadingManager).detectSupport(AFRAME.scenes[0].renderer);
   }
+  if (!dracoLoader && AFRAME && AFRAME.scenes && AFRAME.scenes[0]) {
+    dracoLoader = new DRACOLoader(loadingManager);
+  }
 
   if (ktxLoader) {
     gltfLoader.setKTX2Loader(ktxLoader);
+  }
+  if (dracoLoader) {
+    gltfLoader.setDRACOLoader(dracoLoader);
   }
 
   return new Promise((resolve, reject) => {

--- a/src/utils/media-url-utils.js
+++ b/src/utils/media-url-utils.js
@@ -102,6 +102,8 @@ export function getAbsoluteHref(baseUrl, relativeUrl) {
 // Note this file is configured in webpack.config.js to be handled with file-loader, so this will be a string containing the file path
 import basisJsUrl from "three/examples/js/libs/basis/basis_transcoder.js";
 import basisWasmUrl from "three/examples/js/libs/basis/basis_transcoder.wasm";
+import dracoWrapperJsUrl from "three/examples/js/libs/draco/gltf/draco_wasm_wrapper.js";
+import dracoWasmUrl from "three/examples/js/libs/draco/gltf/draco_decoder.wasm";
 
 export const rewriteBasisTranscoderUrls = function(url) {
   if (url === "basis_transcoder.js") {
@@ -118,6 +120,10 @@ export const getCustomGLTFParserURLResolver = gltfUrl => url => {
     return basisJsUrl;
   } else if (url === "basis_transcoder.wasm") {
     return basisWasmUrl;
+  } else if (url === "draco_wasm_wrapper.js") {
+    return dracoWrapperJsUrl;
+  } else if (url === "draco_decoder.wasm") {
+    return dracoWasmUrl;
   }
 
   if (typeof url !== "string" || url === "") return "";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -382,7 +382,29 @@ module.exports = async (env, argv) => {
         // Some JS assets are loaded at runtime and should be coppied unmodified and loaded using file-loader
         {
           test: [
-            path.resolve(__dirname, "node_modules", "three", "examples", "js", "libs", "basis", "basis_transcoder.js")
+            path.resolve(__dirname, "node_modules", "three", "examples", "js", "libs", "basis", "basis_transcoder.js"),
+            path.resolve(
+              __dirname,
+              "node_modules",
+              "three",
+              "examples",
+              "js",
+              "libs",
+              "draco",
+              "gltf",
+              "draco_decoder.js"
+            ),
+            path.resolve(
+              __dirname,
+              "node_modules",
+              "three",
+              "examples",
+              "js",
+              "libs",
+              "draco",
+              "gltf",
+              "draco_wasm_wrapper.js"
+            )
           ],
           loader: "file-loader",
           options: {


### PR DESCRIPTION
Add support for Draco compressed geometry int he GLTF loader. You can test it exporting any glb from Blender enabling the geometry compression.