### PR TITLE
Expose left/right panning as a pref

### DIFF
--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -100,11 +100,11 @@ AFRAME.registerComponent("avatar-audio-source", {
     APP.dialog.on("stream_updated", this._onStreamUpdated, this);
     this.createAudio();
 
-    let audioOutputModePref = APP.store.state.preferences.audioOutputMode;
+    let disableLeftRightPanningPref = APP.store.state.preferences.disableLeftRightPanning === true;
     this.onPreferenceChanged = () => {
-      const newPref = APP.store.state.preferences.audioOutputMode;
-      const shouldRecreateAudio = audioOutputModePref !== newPref && !this.isCreatingAudio;
-      audioOutputModePref = newPref;
+      const newPref = APP.store.state.preferences.disableLeftRightPanning;
+      const shouldRecreateAudio = disableLeftRightPanningPref !== newPref && !this.isCreatingAudio;
+      disableLeftRightPanningPref = newPref;
       if (shouldRecreateAudio) {
         this.createAudio();
       }

--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -100,7 +100,7 @@ AFRAME.registerComponent("avatar-audio-source", {
     APP.dialog.on("stream_updated", this._onStreamUpdated, this);
     this.createAudio();
 
-    let disableLeftRightPanningPref = APP.store.state.preferences.disableLeftRightPanning === true;
+    let disableLeftRightPanningPref = APP.store.state.preferences.disableLeftRightPanning;
     this.onPreferenceChanged = () => {
       const newPref = APP.store.state.preferences.disableLeftRightPanning;
       const shouldRecreateAudio = disableLeftRightPanningPref !== newPref && !this.isCreatingAudio;

--- a/src/components/media-video.js
+++ b/src/components/media-video.js
@@ -166,7 +166,7 @@ AFRAME.registerComponent("media-video", {
       evt.detail.cameraEl.getObject3D("camera").add(sceneEl.audioListener);
     });
 
-    let disableLeftRightPanningPref = APP.store.state.preferences.disableLeftRightPanning === true;
+    let disableLeftRightPanningPref = APP.store.state.preferences.disableLeftRightPanning;
     this.onPreferenceChanged = () => {
       const newPref = APP.store.state.preferences.disableLeftRightPanning;
       const shouldRecreateAudio = disableLeftRightPanningPref !== newPref && this.audio && this.mediaElementAudioSource;

--- a/src/components/media-video.js
+++ b/src/components/media-video.js
@@ -166,11 +166,11 @@ AFRAME.registerComponent("media-video", {
       evt.detail.cameraEl.getObject3D("camera").add(sceneEl.audioListener);
     });
 
-    let audioOutputModePref = APP.store.state.preferences.audioOutputMode;
+    let disableLeftRightPanningPref = APP.store.state.preferences.disableLeftRightPanning === true;
     this.onPreferenceChanged = () => {
-      const newPref = APP.store.state.preferences.audioOutputMode;
-      const shouldRecreateAudio = audioOutputModePref !== newPref && this.audio && this.mediaElementAudioSource;
-      audioOutputModePref = newPref;
+      const newPref = APP.store.state.preferences.disableLeftRightPanning;
+      const shouldRecreateAudio = disableLeftRightPanningPref !== newPref && this.audio && this.mediaElementAudioSource;
+      disableLeftRightPanningPref = newPref;
       if (shouldRecreateAudio) {
         this.setupAudio();
       }

--- a/src/message-dispatch.js
+++ b/src/message-dispatch.js
@@ -66,8 +66,7 @@ export default class MessageDispatch extends EventTarget {
     uiRoot = uiRoot || document.getElementById("ui-root");
     const isGhost = !entered && uiRoot && uiRoot.firstChild && uiRoot.firstChild.classList.contains("isGhost");
 
-    // TODO: Some of the commands below should be available without requiring
-    //       room entry. For example, audiomode should not require room entry.
+    // TODO: Some of the commands below should be available without requiring room entry.
     if (!entered && (!isGhost || command === "duck")) {
       this.log(LogMessageType.roomEntryRequired);
       return;
@@ -170,13 +169,6 @@ export default class MessageDispatch extends EventTarget {
             captureSystem.start();
             this.log(LogMessageType.captureStarted);
           }
-        }
-        break;
-      case "audiomode":
-        {
-          window.APP.store.update({
-            preferences: { disableLeftRightPanning: args[0] === "panner" ? false : true }
-          });
         }
         break;
       case "audioNormalization":

--- a/src/message-dispatch.js
+++ b/src/message-dispatch.js
@@ -174,20 +174,9 @@ export default class MessageDispatch extends EventTarget {
         break;
       case "audiomode":
         {
-          const shouldEnablePositionalAudio = window.APP.store.state.preferences.audioOutputMode === "audio";
           window.APP.store.update({
-            // TODO: This should probably just be a boolean to disable panner node settings
-            // and even if it's not, "audio" is a weird name for the "audioOutputMode" that means
-            // "stereo" / "not panner".
-            preferences: { audioOutputMode: shouldEnablePositionalAudio ? "panner" : "audio" }
+            preferences: { disableLeftRightPanning: args[0] === "panner" ? false : true }
           });
-          // TODO: The user message here is a little suspicious. We might be ignoring the
-          // user preference (e.g. if panner nodes are broken in safari, then we never create
-          // panner nodes, regardless of user preference.)
-          // Warning: This comment may be out of date when you read it.
-          this.log(
-            shouldEnablePositionalAudio ? LogMessageType.positionalAudioEnabled : LogMessageType.positionalAudioDisabled
-          );
         }
         break;
       case "audioNormalization":

--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -513,6 +513,10 @@ const preferenceLabels = defineMessages({
   lazyLoadSceneMedia: {
     id: "preferences-screen.preference.lazy-load-scene-media",
     defaultMessage: "Enable Scene Media Lazy Loading"
+  },
+  disableLeftRightPanning: {
+    id: "preferences-screen.preference.disable-panning",
+    defaultMessage: "Disable audio left/right panning"
   }
 });
 
@@ -627,13 +631,15 @@ const CATEGORY_CONTROLS = 1;
 const CATEGORY_MISC = 2;
 const CATEGORY_MOVEMENT = 3;
 const CATEGORY_TOUCHSCREEN = 4;
+const CATEGORY_ACCESSIBILITY = 5;
 const TOP_LEVEL_CATEGORIES = [CATEGORY_AUDIO, CATEGORY_CONTROLS, CATEGORY_MISC];
 const categoryNames = defineMessages({
   [CATEGORY_AUDIO]: { id: "preferences-screen.category.audio", defaultMessage: "Audio" },
   [CATEGORY_CONTROLS]: { id: "preferences-screen.category.controls", defaultMessage: "Controls" },
   [CATEGORY_MISC]: { id: "preferences-screen.category.misc", defaultMessage: "Misc" },
   [CATEGORY_MOVEMENT]: { id: "preferences-screen.category.movement", defaultMessage: "Movement" },
-  [CATEGORY_TOUCHSCREEN]: { id: "preferences-screen.category.touchscreen", defaultMessage: "Touchscreen" }
+  [CATEGORY_TOUCHSCREEN]: { id: "preferences-screen.category.touchscreen", defaultMessage: "Touchscreen" },
+  [CATEGORY_ACCESSIBILITY]: { id: "preferences-screen.category.accessibility", defaultMessage: "Accessibility" }
 });
 
 function NavItem({ ariaLabel, title, onClick, selected }) {
@@ -1099,6 +1105,16 @@ class PreferencesScreen extends Component {
           { key: "showFPSCounter", prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX, defaultBool: false },
           { key: "showRtcDebugPanel", prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX, defaultBool: false }
         ]
+      ],
+      [
+        CATEGORY_ACCESSIBILITY,
+        [
+          {
+            key: "disableLeftRightPanning",
+            prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX,
+            defaultBool: false
+          }
+        ]
       ]
     ]);
 
@@ -1111,7 +1127,16 @@ class PreferencesScreen extends Component {
     }
 
     return new Map([
-      [CATEGORY_AUDIO, [{ items: items.get(CATEGORY_AUDIO) }]],
+      [
+        CATEGORY_AUDIO,
+        [
+          { items: items.get(CATEGORY_AUDIO) },
+          {
+            name: intl.formatMessage(categoryNames[CATEGORY_ACCESSIBILITY]),
+            items: items.get(CATEGORY_ACCESSIBILITY)
+          }
+        ]
+      ],
       [
         CATEGORY_CONTROLS,
         [

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -364,6 +364,7 @@ export default class Store extends EventTarget {
     // Cleanup unsupported properties
     if (!valid) {
       errors.forEach(error => {
+        console.error(`Removing invalid preference from store: ${error.message}`);
         delete error.instance[error.argument];
       });
     }

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -96,6 +96,7 @@ export const SCHEMA = {
         preferredMic: { type: "string" },
         preferredCamera: { type: "string" },
         muteMicOnEntry: { type: "bool" },
+        disableLeftRightPanning: { type: "bool" },
         audioNormalization: { type: "bool" },
         invertTouchscreenCameraMove: { type: "bool" },
         enableOnScreenJoystickLeft: { type: "bool" },

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -96,7 +96,6 @@ export const SCHEMA = {
         preferredMic: { type: "string" },
         preferredCamera: { type: "string" },
         muteMicOnEntry: { type: "bool" },
-        audioOutputMode: { type: "string" },
         audioNormalization: { type: "bool" },
         invertTouchscreenCameraMove: { type: "bool" },
         enableOnScreenJoystickLeft: { type: "bool" },

--- a/src/systems/audio-settings-system.js
+++ b/src/systems/audio-settings-system.js
@@ -5,17 +5,6 @@ export class AudioSettingsSystem {
   constructor(sceneEl) {
     sceneEl.addEventListener("reset_scene", this.onSceneReset);
 
-    // HACK We are scared that users are going to set this preference and then
-    // forget about it and have a bad time, so we always remove the preference
-    // whenever the user refreshes the page.
-    // TODO: This is pretty weird and surprising. If the preference is exposed
-    // in the preference screen, then we would not be so scared about this.
-    // Also, if we feel so concerned about people using it, we should consider
-    // ways to make it safer or remove it.
-    window.APP.store.update({
-      preferences: { audioOutputMode: undefined }
-    });
-
     if (window.APP.store.state.preferences.audioNormalization !== 0.0) {
       //hack to always reset to 0.0 (disabled)
       window.APP.store.update({

--- a/src/systems/sound-effects-system.js
+++ b/src/systems/sound-effects-system.js
@@ -138,7 +138,7 @@ export class SoundEffectsSystem {
     const audioBuffer = this.sounds.get(sound);
     if (!audioBuffer) return null;
 
-    const disablePositionalAudio = isSafari() || window.APP.store.state.preferences.disableLeftRightPanning === true;
+    const disablePositionalAudio = isSafari() || window.APP.store.state.preferences.disableLeftRightPanning;
     const positionalAudio = disablePositionalAudio
       ? new THREE.Audio(this.scene.audioListener)
       : new THREE.PositionalAudio(this.scene.audioListener);

--- a/src/systems/sound-effects-system.js
+++ b/src/systems/sound-effects-system.js
@@ -138,7 +138,7 @@ export class SoundEffectsSystem {
     const audioBuffer = this.sounds.get(sound);
     if (!audioBuffer) return null;
 
-    const disablePositionalAudio = isSafari() || window.APP.store.state.preferences.audioOutputMode === "audio";
+    const disablePositionalAudio = isSafari() || window.APP.store.state.preferences.disableLeftRightPanning === true;
     const positionalAudio = disablePositionalAudio
       ? new THREE.Audio(this.scene.audioListener)
       : new THREE.PositionalAudio(this.scene.audioListener);

--- a/src/update-audio-settings.js
+++ b/src/update-audio-settings.js
@@ -35,8 +35,9 @@ export function getCurrentAudioSettings(el) {
   const audioOverrides = APP.audioOverrides.get(el);
   const audioDebugPanelOverrides = APP.audioDebugPanelOverrides.get(sourceType);
   const zoneSettings = APP.zoneOverrides.get(el);
-  const preferencesOverrides =
-    APP.store.state.preferences.disableLeftRightPanning === true ? { audioType: AudioType.Stereo } : {};
+  const preferencesOverrides = APP.store.state.preferences.disableLeftRightPanning
+    ? { audioType: AudioType.Stereo }
+    : {};
   const safariOverrides = isSafari() ? { audioType: AudioType.Stereo } : {};
   const settings = Object.assign(
     {},

--- a/src/update-audio-settings.js
+++ b/src/update-audio-settings.js
@@ -36,7 +36,7 @@ export function getCurrentAudioSettings(el) {
   const audioDebugPanelOverrides = APP.audioDebugPanelOverrides.get(sourceType);
   const zoneSettings = APP.zoneOverrides.get(el);
   const preferencesOverrides =
-    APP.store.state.preferences.audioOutputMode === "audio" ? { audioType: AudioType.Stereo } : {};
+    APP.store.state.preferences.disableLeftRightPanning === true ? { audioType: AudioType.Stereo } : {};
   const safariOverrides = isSafari() ? { audioType: AudioType.Stereo } : {};
   const settings = Object.assign(
     {},
@@ -84,7 +84,7 @@ export function shouldAddSupplementaryAttenuation(el, audio) {
   // This function must distinguish between Audios that are "incidentally"
   // not PositionalAudios from Audios that are "purposefully" not PositionalAudios:
   // - An audio is "incidentally" non-positional if it only non-positional
-  //     because the audioOutputMode pref is set to "audio", or
+  //     because the disableLeftRightPanning pref is set to true, or
   //     because panner nodes are broken on a particular platform, or
   //     because of something else like that.
   // - An audio is "purposefully" non-positional if it was authored to be
@@ -101,7 +101,7 @@ export function shouldAddSupplementaryAttenuation(el, audio) {
   //
   // Instead, we determine what the audioType would be if it were not for the
   // "incidental" factors. In particular, we check if the audioType would have
-  // been PannerNode if we ignored the overrides due to audioOutputMode and platform
+  // been PannerNode if we ignored the overrides due to disableLeftRightPanning and platform
   // problems (e.g. Safari).
   //
   // If the audioType would have been PannerNode, then we should apply "fake",


### PR DESCRIPTION
Closes #4639

This PR exposes Left/Right panning as an accessibility setting. Thing to note:
- We no longer use the `audioOutputMode` preference as it has been outlined in the code comments as confusing, now we have a `disableLeftRightPanning` setting and the `audiomode` command updates that pref.
https://github.com/mozilla/hubs/blob/fcf78a30652cb745f90d8e20159ade3031157d2a/src/message-dispatch.js#L179-L181
- This PR removes the initial panning mode pref resetting that was happening before.
https://github.com/mozilla/hubs/blob/fcf78a30652cb745f90d8e20159ade3031157d2a/src/systems/audio-settings-system.js#L8-L17
- Also we no longer log in the console when the mode is changed (we don't do that for any other pref either so it kind of makes sense now that it has graduated to pref)