### PR TITLE
Fix major audio bug due to event handler removals

### DIFF
--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -135,7 +135,7 @@ AFRAME.registerComponent("avatar-audio-source", {
   },
 
   remove: function() {
-    APP.dialog.off("stream_updated", this._onStreamUpdated);
+    APP.dialog.off("stream_updated", this._onStreamUpdated, this);
     this.destroyAudio();
   }
 });


### PR DESCRIPTION
The `avatar-audio-source` component inadvertently removes all the `stream_updated` event handlers given it does not pass `this` as the third argument. This means that if you're in a room and someone leaves, anyone else in the room will lose audio permanently if they have to re-negotiate ICE, since the stream updated handler will no longer fire.

:grimacing: 