### PR TITLE
add no wrap to label and accept theme to tooltip border

### DIFF
--- a/src/react-components/input/ToolbarButton.scss
+++ b/src/react-components/input/ToolbarButton.scss
@@ -13,6 +13,7 @@
     color: theme.$text1-color;
     margin-top: 8px;
     margin-bottom: 3px;
+    white-space: nowrap;
   }
 }
 
@@ -181,6 +182,7 @@
 :local(.accept) {
   :local(.icon-container) {
     background-color: theme.$accept-color;
+    border-color: theme.$accept-border-color;
   }  
 
   &:hover :local(.icon-container) {


### PR DESCRIPTION
Resolves #4874

I noticed another visual bug when going in to fix this. Longer labels break containers here so this PR fixes that as well.
 
![join room btn](https://user-images.githubusercontent.com/4493657/143965370-ad396835-bc0a-49cf-a648-2a6c4df3dd95.png)

![smooshed](https://user-images.githubusercontent.com/4493657/143965382-e97fd999-3587-4986-b32c-220e766f5291.png)

with no wrap and border:
![fix](https://user-images.githubusercontent.com/4493657/143965581-2fa62ee8-1423-4d95-a427-232976f6239b.png)
 