### PR TITLE
getThemeColor() fix if localStorage has no theme id defined.

### DIFF
--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -20,7 +20,9 @@ const DEFAULT_COLORS = {
 function getThemeColor(name) {
   const themeId = window.APP?.store?.state?.preferences?.theme;
 
-  const theme = themeId && configs.APP_CONFIG?.theme?.themes?.find(theme => theme.id === themeId);
+  const theme =
+    (themeId && configs.APP_CONFIG?.theme?.themes?.find(theme => theme.id === themeId)) ||
+    configs.APP_CONFIG?.theme?.themes?.find(theme => theme.default === true);
   if (theme?.variables?.[name]) {
     return theme.variables[name];
   }


### PR DESCRIPTION
Described the issue here: #4918

The changes achieve, that the getThemeColor() function looks for a default theme, if no preferences are defined in the localStorage.