### PR TITLE
scene link screen fixes

### DIFF
--- a/src/assets/stylesheets/scene-ui.scss
+++ b/src/assets/stylesheets/scene-ui.scss
@@ -12,53 +12,44 @@
   color: white;
 }
 
-:local(.whiteOverlay) {
-  background-color: rgba(255, 255, 255, 0.2);
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  position: absolute;
-}
-
 :local(.grid) {
   display: grid;
-  grid-template-columns: 1fr 20px minmax(200px, 400px) 20px 1fr;
-  grid-template-rows: 1fr 3fr 1fr;
+  grid-template-rows: 10vh 69vh 1fr;
   width: 100%;
   height: 100%;
+  @media (min-height: theme.$breakpoint-vr) {
+    grid-template-rows: 17vh 69vh 1fr;
+  }
 }
 
 :local(.mainPanel) {
-  grid-column: 3;
+  margin: auto;
+  width: clamp(300px, 100%, 80vw);
   grid-row: 2;
   position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  align-items: center;
   pointer-events: auto;
-
 }
 
 :local(.logoTagline) {
-  color: black;
-  text-shadow: 0px 0px 10px #888;
+  color: theme.$text1-color;
+  text-shadow: 0px 0px 10px theme.$text-inverted-color;
   font-weight: bold;
   text-align: center;
-  white-space: nowrap;
   display: flex;
   justify-content: center;
   font-size: 1.2em;
-  margin-bottom: 32px;
+  margin: 30px 0;
 }
 
 
 :local(.logo) {
-  width: 100%;
+  width: clamp(200px, 100%, 17vw);
   display: block;
-  filter: drop-shadow(0 0 4px #888);
-  padding-bottom: 1em;
-
+  filter: drop-shadow(0 0 4px theme.$text-inverted-color);
+  
   img {
     width: 100%;
   }
@@ -69,13 +60,18 @@
 }
 
 :local(.info) {
-  position: absolute;
-  color: black;
-  text-shadow: 0px 0px 10px #888;
-  bottom: 12px;
-  left: 12px;
+  grid-row: 3;
+  color: theme.$text1-color;
+  text-shadow: 0px 0px 10px theme.$text-inverted-color;
   display: flex;
   flex-direction: column;
+  align-items: center;
+  align-self: center;
+  @media (min-width: theme.$breakpoint-lg) {
+    align-items: flex-start;
+    align-self: left;
+    margin-left: 16px;
+  }
 }
 
 :local(.name) {
@@ -120,36 +116,6 @@
   transition: visibility 0s 0.5s, opacity 0.5s linear;
 }
 
-:local(.spoke) {
-  @media(max-width: 768px) {
-    display: none;
-  }
-
-  pointer-events: auto;
-  position: absolute;
-  right: 12px;
-  bottom: 8px;
-  display: flex;
-  flex-direction: column;
-  text-align: left;
-  font-size: 0.8em;
-  font-weight: bold;
-
-  :local(.madeWith) {
-    color: black;
-    text-shadow: 0px 0px 4px #333;
-    margin-left: 4px;
-    position: absolute;
-    top: -1em;
-    left: 0;
-  }
-
-  img {
-    width: 200px;
-  }
-}
-
-
 :local(.scenePreviewButtonWrapper) {
   margin: auto;
   display: flex;
@@ -169,6 +135,7 @@
   box-sizing: border-box;
   border-radius: 13px;
   margin: .5rem 0 .5rem 0;
+  white-space: nowrap;
   svg {
     margin-right: 8px;
     *[stroke=\#000] {
@@ -199,7 +166,7 @@
 }
 
 :local(.unavailable) {
-  color: theme.$text1-color;
+  color: theme.$text5-color;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/react-components/scene-ui.js
+++ b/src/react-components/scene-ui.js
@@ -212,7 +212,6 @@ class SceneUI extends Component {
         >
           {this.state.showScreenshot && <img src={this.props.sceneScreenshotURL} />}
         </div>
-        <div className={styles.whiteOverlay} />
         <div className={styles.grid}>
           <div className={styles.mainPanel}>
             <a href="/" className={styles.logo}>
@@ -273,28 +272,11 @@ class SceneUI extends Component {
               </a>
             </div>
           </div>
-        </div>
-        <div className={styles.info}>
-          <div className={styles.name}>{this.props.sceneName}</div>
-          <div className={styles.attribution}>{attributions}</div>
-        </div>
-        <IfFeature name="enable_spoke">
-          <div className={styles.spoke}>
-            <div className={styles.madeWith}>
-              <FormattedMessage
-                id="scene-page.made-with"
-                defaultMessage="made with <a/>"
-                values={{
-                  a: () => (
-                    <a href="/spoke">
-                      <img src={configs.image("editor_logo")} />
-                    </a>
-                  )
-                }}
-              />
-            </div>
+          <div className={styles.info}>
+            <div className={styles.name}>{this.props.sceneName}</div>
+            <div className={styles.attribution}>{attributions}</div>
           </div>
-        </IfFeature>
+        </div>
       </div>
     );
   }

--- a/src/react-components/styles/global.scss
+++ b/src/react-components/styles/global.scss
@@ -23,9 +23,8 @@
   --text5-color: #{theme.$white};
   --text5-color-hover: var(--text5-color);
   --text5-color-pressed: var(--text5-color);
-  --text6-color: #{theme.$black};
-  --text6-color-hover: var(--text6-color);
-  --text6-color-pressed: var(--text6-color);
+  --text-inverted-color: #{theme.$white};
+ 
 
   --link-color: #{theme.$blue};
   --link-color-hover: #{theme.$blue-hover};

--- a/src/react-components/styles/theme.scss
+++ b/src/react-components/styles/theme.scss
@@ -110,6 +110,7 @@ $text4-color-pressed: var(--text4-color-pressed);
 $text5-color: var(--text5-color);
 $text5-color-hover: var(--text5-color-hover);
 $text5-color-pressed: var(--text5-color-pressed);
+$text-inverted-color: var(--text-inverted-color);
 
 $link-color: var(--link-color);
 $link-color-hover: var(--link-color-hover);

--- a/themes.json
+++ b/themes.json
@@ -51,6 +51,7 @@
       "text2-color": "#E7E7E7",
       "text3-color": "#BBBBBB",
       "text4-color": "#BBBBBB",
+      "text-inverted-color": "#000000",
       "secondary-color": "#3A4048",
       "secondary-color-hover": "#5D646C",
       "border1-color": "#3A4048",


### PR DESCRIPTION
This PR addresses several issues with the scene screen, a screen that serves as a common entry point for many hubs users. Detailed notes can be found below.  [Design Link (requires access)](https://www.figma.com/file/J6YKkb2vWDlk81zm4kxUzA/Hubs-discoverability-and-onboarding?node-id=903%3A1324)

This PR does not include every design recommendation but resolves the issues outlined in #4897. The attribution issue mentioned in #4897  should be caught on the publishing side and is not addressed here.

| Mobile Scene Screen Before    | Mobile Scene Screen After  |
| ----------- | ----------- |
|![s5 before](https://user-images.githubusercontent.com/4493657/147016297-e8cc7f85-2d34-487d-928a-efce4154a780.png)|![s5 after](https://user-images.githubusercontent.com/4493657/147016380-6310df59-86c9-4b2a-a406-c6cc11500118.png)|


Notes:

- removed the spoke call out
    the lower right hand spoke call out has been removed from the [design](https://www.figma.com/file/J6YKkb2vWDlk81zm4kxUzA/Hubs-discoverability-and-onboarding?node-id=903%3A1324)

- use theme values for text color and shadow color
     note on shadow color: AFAIK we don't have an explicit inverted text color and that is effectively what we want. Adding 
     a text-inverted-color theme to accommodate a variety of themes and I removed text6 as we don't seem to be using 
     that variable anywhere. An alternative to consider might be to use filter() on the existing dominate text color.   
          
- removed white overlay on scene image

-  [clamped](https://caniuse.com/?search=clamp()) the width for logo
    these values look reasonable to me but feedback welcome  

- changed grid values and scene info to inside the grid for more control over it's layout.
     this piece was previously positioned absolutely, added a media query to changed alignment for mobile

- set a media query on the grid to lower the top row height when we are below the vr height breakpoint

- adjusted padding for tagline 

- removed now irrelevant positioning CSS on values that were previously positioned absolutely