### PR TITLE
Remove audio type change event from audio-target

### DIFF
--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -290,6 +290,7 @@ AFRAME.registerComponent("audio-target", {
     this.removeAudio();
 
     this.el.removeAttribute("audio-zone-source");
+    this.el.removeEventListener("audio_type_changed", this.createAudio);
   },
 
   createAudio: function() {


### PR DESCRIPTION
Remove audio type change event from audio-target.

Missing part from https://github.com/mozilla/hubs/pull/4838