### PR TITLE
Fix chrome camera recording issues with muted audio tracks

### DIFF
--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -427,10 +427,7 @@ AFRAME.registerComponent("camera-tool", {
     const chunks = [];
     const recordingStartTime = performance.now();
 
-    this.videoRecorder.ondataavailable = e => {
-      console.log("Camera Tool: ondataavailable => " + e.data?.size);
-      chunks.push(e.data);
-    };
+    this.videoRecorder.ondataavailable = e => chunks.push(e.data);
 
     this.updateRenderTargetNextTick = true;
 

--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -378,7 +378,9 @@ AFRAME.registerComponent("camera-tool", {
     const track = this.videoCanvas.captureStream(VIDEO_FPS).getVideoTracks()[0];
 
     // This adds hacks for current browser issues with media recordings when audio tracks are muted or missing.
-    const fixAudioTracks = () => {
+    const attachBlankAudio = () => {
+      // Chrome has issues when the audio tracks are silent so we only do this for FF.
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=1223382
       if (isFirefox) {
         // FF 73+ seems to fail to decode videos with no audio track, so we always include a silent track.
         const context = THREE.AudioContext.getContext();
@@ -389,10 +391,6 @@ AFRAME.registerComponent("camera-tool", {
         oscillator.connect(destination);
         gain.connect(destination);
         stream.addTrack(destination.stream.getAudioTracks()[0]);
-      } else {
-        // Chrome has issues when the audio tracks are muted.
-        // https://bugs.chromium.org/p/chromium/issues/detail?id=1223382
-        stream.getAudioTracks().forEach(t => stream.removeTrack(t));
       }
     };
 
@@ -416,10 +414,10 @@ AFRAME.registerComponent("camera-tool", {
         const audio = destination.stream.getAudioTracks()[0];
         stream.addTrack(audio);
       } else {
-        fixAudioTracks();
+        attachBlankAudio();
       }
     } else {
-      fixAudioTracks();
+      attachBlankAudio();
     }
 
     stream.addTrack(track);


### PR DESCRIPTION
Browsers seem to have issues recording videos that have empty or muted audio tracks. We had a hack in place for both FF and Chrome but it seems to have stopped working for Chrome at some point

This PR adds a Chrome specific hack that removes the audio tracks when there is none available as with the previous hack we were missing data chunks and ended up generating partial or empty videos.

To test the Chrome issues before this PR:
- Open the Camera Tool
- Change the video recording time to 60
- Mute your mic
- Start a video recording

The resulting video is empty or partial.

Related: https://github.com/mozilla/hubs/pull/4987