### PR TITLE
Wait until we have tracks info

### DIFF
--- a/src/components/media-video.js
+++ b/src/components/media-video.js
@@ -521,7 +521,7 @@ AFRAME.registerComponent("media-video", {
         // We want to treat audio almost exactly like video, so we mock a video texture with an image property.
         texture = new THREE.Texture();
         texture.image = videoEl;
-        isReady = () => true;
+        isReady = () => videoEl.readyState > 0;
       } else {
         texture = new THREE.VideoTexture(videoEl);
         texture.minFilter = THREE.LinearFilter;


### PR DESCRIPTION
Audio has stopped playing in Safari.

When polling for ready for audio only elements we were returning always true and media element `audioTracks` property has not yet been populated by then. That made the audio node not to be created in Safari as it supports the `audioTracks` property.

This PR fixes that waiting until we have at least meta data info for the stream and the `audioTracks`property has been populated.