### PR TITLE
Reflection Probes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36306,8 +36306,8 @@
       "dev": true
     },
     "three": {
-      "version": "github:mozillareality/three.js#2ea3755b4873db768c7b9b0b30e488e97e3bb613",
-      "from": "github:mozillareality/three.js#hubs-patches-133"
+      "version": "github:mozillareality/three.js#a0b96b92ee575dafb6280014ac7ce89dc1834344",
+      "from": "github:mozillareality/three.js#multiple-envmap"
     },
     "three-ammo": {
       "version": "github:infinitelee/three-ammo#db3ad1104b258d963ca66165f9fbed4013faa32a",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36306,8 +36306,8 @@
       "dev": true
     },
     "three": {
-      "version": "github:mozillareality/three.js#a0b96b92ee575dafb6280014ac7ce89dc1834344",
-      "from": "github:mozillareality/three.js#multiple-envmap"
+      "version": "github:mozillareality/three.js#439e18371f5bd8b9a965aca6e0c3a18c8f6f019b",
+      "from": "github:mozillareality/three.js#hubs-patches-133"
     },
     "three-ammo": {
       "version": "github:infinitelee/three-ammo#db3ad1104b258d963ca66165f9fbed4013faa32a",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "screenfull": "^4.0.1",
     "sdp-transform": "^2.14.1",
     "semver": "^7.3.2",
-    "three": "github:mozillareality/three.js#hubs-patches-133",
+    "three": "github:mozillareality/three.js#multiple-envmap",
     "three-ammo": "github:infinitelee/three-ammo",
     "three-bmfont-text": "github:mozillareality/three-bmfont-text#hubs/master",
     "three-mesh-bvh": "^0.3.7",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "screenfull": "^4.0.1",
     "sdp-transform": "^2.14.1",
     "semver": "^7.3.2",
-    "three": "github:mozillareality/three.js#multiple-envmap",
+    "three": "github:mozillareality/three.js#hubs-patches-133",
     "three-ammo": "github:infinitelee/three-ammo",
     "three-bmfont-text": "github:mozillareality/three-bmfont-text#hubs/master",
     "three-mesh-bvh": "^0.3.7",

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -618,3 +618,12 @@ AFRAME.GLTFModelPlus.registerComponent(
     });
   }
 );
+
+AFRAME.GLTFModelPlus.registerComponent("reflection-probe", "reflection-probe", (el, componentName, componentData) => {
+  // TODO PMREMGenerator should be fixed to not assume this
+  componentData.envMapTexture.flipY = true;
+  // Assume texture is always an equirect for now
+  componentData.envMapTexture.mapping = THREE.EquirectangularReflectionMapping;
+
+  el.setAttribute(componentName, componentData);
+});

--- a/src/systems/environment-system.js
+++ b/src/systems/environment-system.js
@@ -98,6 +98,13 @@ export class EnvironmentSystem {
       Object.assign(envSettings, envSettingsEl.components["environment-settings"].data);
     }
 
+    // TODO animated objects should not be static
+    envEl.object3D.traverse(o => {
+      if (o.isMesh) {
+        o.reflectionProbeMode = "static";
+      }
+    });
+
     this.applyEnvSettings(envSettings);
   }
 
@@ -192,5 +199,26 @@ AFRAME.registerComponent("environment-settings", {
     toneMapping: { default: defaultEnvSettings.toneMapping, oneOf: Object.values(toneMappingOptions) },
     toneMappingExposure: { default: defaultEnvSettings.toneMappingExposure },
     backgroundColor: { type: "color", default: defaultEnvSettings.background }
+  }
+});
+
+AFRAME.registerComponent("reflection-probe", {
+  schema: {
+    size: { default: 1 },
+    envMapTexture: { type: "map" }
+  },
+
+  init: function() {
+    this.el.object3D.updateMatrices();
+
+    const box = new THREE.Box3()
+      .setFromCenterAndSize(new THREE.Vector3(), new THREE.Vector3().setScalar(this.data.size * 2))
+      .applyMatrix4(this.el.object3D.matrixWorld);
+
+    this.el.setObject3D("probe", new THREE.ReflectionProbe(box, this.data.envMapTexture));
+
+    this.el.sceneEl.object3D.add(
+      new THREE.Box3Helper(box, new THREE.Color(Math.random(), Math.random(), Math.random()))
+    );
   }
 });

--- a/src/systems/environment-system.js
+++ b/src/systems/environment-system.js
@@ -217,8 +217,15 @@ AFRAME.registerComponent("reflection-probe", {
 
     this.el.setObject3D("probe", new THREE.ReflectionProbe(box, this.data.envMapTexture));
 
-    this.el.sceneEl.object3D.add(
-      new THREE.Box3Helper(box, new THREE.Color(Math.random(), Math.random(), Math.random()))
-    );
+    if (this.el.sceneEl.systems["hubs-systems"].environmentSystem.debugMode) {
+      const debugBox = new THREE.Box3().setFromCenterAndSize(
+        new THREE.Vector3(),
+        new THREE.Vector3().setScalar(this.data.size * 2)
+      );
+      this.el.setObject3D(
+        "helper",
+        new THREE.Box3Helper(debugBox, new THREE.Color(Math.random(), Math.random(), Math.random()))
+      );
+    }
   }
 });

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -267,6 +267,9 @@ export function injectCustomShaderChunks(obj) {
   obj.traverse(object => {
     if (!object.material) return;
 
+    // TODO this does not really belong here
+    object.reflectionProbeMode = "dynamic";
+
     updateMaterials(object, material => {
       if (material.hubs_InjectedCustomShaderChunks) return material;
       if (!validMaterials.includes(material.type)) {


### PR DESCRIPTION
You can now have multiple environment maps in your scenes using the new component `reflection-probe` component. Objects inside of the reflection probe's box will use the environment map configured for that probe rather than the one configured in environment-settings. When an object overlaps multiple probes, the object will use a mix of the 2 most overlapped probes' maps. This feature should be considered alpha and will likely be undergoing changes based on feedback.

![image](https://user-images.githubusercontent.com/130735/151902288-ab5c48ca-280e-4fc6-a9a7-a8a01250de02.png)

This is a first pass at this, and there will likely be more changes/features (possibly breaking) added, but the best way to find out what those changes/features are is to have people start trying to build actual scenes with it. I plan to limit the blast radius on breaking changes by not immediately merging the blender-exporter changes for this, to limit people using it ot people we have a good direct line of communication with.

before merging:
- [x] merge MozillaReality/three.js/pull/59
- [x] rebase and update build on `three-patches-133` branch in three repo
- [x] update package.json in this repo to point back at `three-patches-133`
- [x] update package-lock.json to point at the updated sha at the head of `three-patches-133`