### PR TITLE
Catch DOM security exception when accessing properites of window.opener

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -264,10 +264,14 @@ let isOAuthModal = false;
 
 // OAuth popup handler
 // TODO: Replace with a new oauth callback route that has this postMessage script.
-if (window.opener && window.opener.doingTwitterOAuth) {
-  window.opener.postMessage("oauth-successful");
-  isOAuthModal = true;
-  window.close();
+try {
+  if (window.opener && window.opener.doingTwitterOAuth) {
+    window.opener.postMessage("oauth-successful");
+    isOAuthModal = true;
+    window.close();
+  }
+} catch(e) {
+  console.error("Exception in oauth processing code", e);  
 }
 
 const isBotMode = qsTruthy("bot");


### PR DESCRIPTION
Addresses https://github.com/mozilla/hubs/issues/4173

In the unusual case that a window is opened from an anchor as a named target, accessing properties on the `window.opener` object will throw a security exception if they are cross-origin, which is often going to be the case.

There may be more elegant ways to address this, but the code being wrapped is likely to be replaced once OAuth is fully implemented anyway.