### PR TITLE
Restore focusChat and focusChatCommand hotkeys

### DIFF
--- a/src/react-components/room/ChatSidebar.js
+++ b/src/react-components/room/ChatSidebar.js
@@ -92,12 +92,13 @@ ChatLengthWarning.propTypes = {
   maxLength: PropTypes.number
 };
 
-export function ChatInput({ warning, isOverMaxLength, ...props }) {
+export const ChatInput = forwardRef(({ warning, isOverMaxLength, ...props }, ref) => {
   const intl = useIntl();
 
   return (
     <div className={styles.chatInputContainer}>
       <TextAreaInput
+        ref={ref}
         textInputStyles={styles.chatInputTextAreaStyles}
         className={classNames({ [styles.warningBorder]: isOverMaxLength })}
         placeholder={intl.formatMessage({ id: "chat-sidebar.input.placeholder", defaultMessage: "Message..." })}
@@ -106,7 +107,7 @@ export function ChatInput({ warning, isOverMaxLength, ...props }) {
       {warning}
     </div>
   );
-}
+});
 
 ChatInput.propTypes = {
   onSpawn: PropTypes.func,

--- a/src/react-components/room/ChatSidebarContainer.js
+++ b/src/react-components/room/ChatSidebarContainer.js
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import {
   ChatSidebar,
@@ -160,11 +160,12 @@ ChatContextProvider.propTypes = {
   messageDispatch: PropTypes.object
 };
 
-export function ChatSidebarContainer({ scene, canSpawnMessages, presences, occupantCount, onClose }) {
+export function ChatSidebarContainer({ scene, canSpawnMessages, presences, occupantCount, inputEffect, onClose }) {
   const { messageGroups, sendMessage, setMessagesRead } = useContext(ChatContext);
   const [onScrollList, listRef, scrolledToBottom] = useMaintainScrollPosition(messageGroups);
   const [message, setMessage] = useState("");
   const intl = useIntl();
+  const inputRef = useRef();
 
   const onKeyDown = useCallback(
     e => {
@@ -203,6 +204,8 @@ export function ChatSidebarContainer({ scene, canSpawnMessages, presences, occup
     },
     [scene]
   );
+
+  useEffect(() => inputEffect(inputRef.current), [inputEffect, inputRef]);
 
   useEffect(
     () => {
@@ -269,6 +272,7 @@ export function ChatSidebarContainer({ scene, canSpawnMessages, presences, occup
       </ChatMessageList>
       <ChatInput
         id="chat-input"
+        ref={inputRef}
         onKeyDown={onKeyDown}
         onChange={e => setMessage(e.target.value)}
         placeholder={placeholder}
@@ -306,7 +310,8 @@ ChatSidebarContainer.propTypes = {
   presences: PropTypes.object.isRequired,
   occupantCount: PropTypes.number.isRequired,
   scene: PropTypes.object.isRequired,
-  onClose: PropTypes.func.isRequired
+  onClose: PropTypes.func.isRequired,
+  inputEffect: PropTypes.func.isRequired
 };
 
 export function ChatToolbarButtonContainer(props) {

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -301,7 +301,7 @@ class UIRoot extends Component {
     window.addEventListener("concurrentload", this.onConcurrentLoad);
     window.addEventListener("idle_detected", this.onIdleDetected);
     window.addEventListener("activity_detected", this.onActivityDetected);
-    window.addEventListener("focus_chat", this.focusChat);
+    window.addEventListener("focus_chat", this.onFocusChat);
     document.querySelector(".a-canvas").addEventListener("mouseup", () => {
       if (this.state.showShareDialog) {
         this.setState({ showShareDialog: false });
@@ -394,7 +394,7 @@ class UIRoot extends Component {
     window.removeEventListener("concurrentload", this.onConcurrentLoad);
     window.removeEventListener("idle_detected", this.onIdleDetected);
     window.removeEventListener("activity_detected", this.onActivityDetected);
-    window.removeEventListener("focus_chat", this.focusChat);
+    window.removeEventListener("focus_chat", this.onFocusChat);
   }
 
   storeUpdated = () => {
@@ -780,7 +780,7 @@ class UIRoot extends Component {
     });
   }
 
-  focusChat = e => {
+  onFocusChat = e => {
     this.setSidebar("chat", {
       chatInputEffect: input => {
         input.focus();

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -197,7 +197,8 @@ class UIRoot extends Component {
     objectInfo: null,
     objectSrc: "",
     sidebarId: null,
-    presenceCount: 0
+    presenceCount: 0,
+    chatInputEffect: () => {}
   };
 
   constructor(props) {
@@ -300,6 +301,7 @@ class UIRoot extends Component {
     window.addEventListener("concurrentload", this.onConcurrentLoad);
     window.addEventListener("idle_detected", this.onIdleDetected);
     window.addEventListener("activity_detected", this.onActivityDetected);
+    window.addEventListener("focus_chat", this.focusChat);
     document.querySelector(".a-canvas").addEventListener("mouseup", () => {
       if (this.state.showShareDialog) {
         this.setState({ showShareDialog: false });
@@ -392,6 +394,7 @@ class UIRoot extends Component {
     window.removeEventListener("concurrentload", this.onConcurrentLoad);
     window.removeEventListener("idle_detected", this.onIdleDetected);
     window.removeEventListener("activity_detected", this.onActivityDetected);
+    window.removeEventListener("focus_chat", this.focusChat);
   }
 
   storeUpdated = () => {
@@ -762,7 +765,7 @@ class UIRoot extends Component {
   pushHistoryState = (k, v) => pushHistoryState(this.props.history, k, v);
 
   setSidebar(sidebarId, otherState) {
-    this.setState({ sidebarId, selectedUserId: null, ...otherState });
+    this.setState({ sidebarId, chatInputEffect: () => {}, selectedUserId: null, ...otherState });
   }
 
   toggleSidebar(sidebarId, otherState) {
@@ -776,6 +779,15 @@ class UIRoot extends Component {
       };
     });
   }
+
+  focusChat = e => {
+    this.setSidebar("chat", {
+      chatInputEffect: input => {
+        input.focus();
+        input.value = e.detail.prefix;
+      }
+    });
+  };
 
   renderInterstitialPrompt = () => {
     return (
@@ -1444,6 +1456,7 @@ class UIRoot extends Component {
                           canSpawnMessages={entered && this.props.hubChannel.can("spawn_and_move_media")}
                           scene={this.props.scene}
                           onClose={() => this.setSidebar(null)}
+                          inputEffect={this.state.chatInputEffect}
                         />
                       )}
                       {this.state.sidebarId === "objects" && (

--- a/src/systems/ui-hotkeys.js
+++ b/src/systems/ui-hotkeys.js
@@ -24,11 +24,11 @@ AFRAME.registerSystem("ui-hotkeys", {
     }
 
     if (this.userinput.get(paths.actions.focusChat)) {
-      this.focusChat();
+      window.dispatchEvent(new CustomEvent("focus_chat", { detail: { prefix: "" } }));
     }
 
     if (this.userinput.get(paths.actions.focusChatCommand)) {
-      this.focusChat("/");
+      window.dispatchEvent(new CustomEvent("focus_chat", { detail: { prefix: "/" } }));
     }
 
     if (this.userinput.get(paths.actions.mediaExit)) {
@@ -61,17 +61,6 @@ AFRAME.registerSystem("ui-hotkeys", {
 
     if (this.userinput.get(paths.actions.toggleUI)) {
       this.el.emit("action_toggle_ui");
-    }
-  },
-
-  focusChat: function(prefix) {
-    const target = document.querySelector(".chat-focus-target");
-    if (!target) return;
-
-    target.focus();
-
-    if (prefix) {
-      target.value = prefix;
     }
   }
 });


### PR DESCRIPTION
Resolves #5082

I used a `focus_chat` custom event to talk with React from the hotkeys system, and added a `chatInputEffect` to the `UIRoot` state to provide imperative access to the chat text area.