### PR TITLE
Fix `for-of` in deploy script

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -48,7 +48,7 @@ const getTs = (() => {
 
   const env = Object.assign(process.env, buildEnv);
 
-  for (const d in ["./dist", "./admin/dist"]) {
+  for (const d of ["./dist", "./admin/dist"]) {
     rmdir(d, err => {
       if (err) {
         console.error(err);


### PR DESCRIPTION
# Doing

- Line 51 `in` to `of`

# Why

I think this code is intended to delete `./dist` and `./admin/dist`
But, code is doing `rmdir 0` and `rmdir 1`
So, I fix code doing `rmdir ./dist` and `rmdir ./dist/admin`

<img width="333" alt="image" src="https://user-images.githubusercontent.com/41536271/152811632-aef73f64-4e55-4ff7-819f-5a710e0788d7.png">

## Before

<img width="536" alt="image" src="https://user-images.githubusercontent.com/41536271/152811729-241727d0-51b6-4204-b7a6-5845eddae3a8.png">

## After

<img width="521" alt="image" src="https://user-images.githubusercontent.com/41536271/152811775-a659c6fa-a11f-4a06-adc2-0d88cb998bb9.png">
