### PR TITLE
Don't tonemap 2d media and camera tool preview

### DIFF
--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -120,6 +120,7 @@ AFRAME.registerComponent("camera-tool", {
     const material = new THREE.MeshBasicMaterial({
       map: this.renderTarget.texture
     });
+    material.toneMapped = false;
 
     // Bit of a hack here to only update the renderTarget when the screens are in view
     material.map.isVideoTexture = true;

--- a/src/components/media-image.js
+++ b/src/components/media-image.js
@@ -118,6 +118,7 @@ AFRAME.registerComponent("media-image", {
 
     if (!this.mesh || projection !== oldData.projection) {
       const material = new THREE.MeshBasicMaterial();
+      material.toneMapped = false;
 
       let geometry;
 

--- a/src/components/media-video.js
+++ b/src/components/media-video.js
@@ -456,6 +456,7 @@ AFRAME.registerComponent("media-video", {
 
     if (!this.mesh || projection !== oldData.projection) {
       const material = new THREE.MeshBasicMaterial();
+      material.toneMapped = false;
 
       let geometry;
 


### PR DESCRIPTION
For now, disable tonemapping on 2d media (images, videos, PDFs) and the camera tool preview window. May not be able to support this easily once post processing is implemented but it will be good to see how this feels in practice.