### PR TITLE
Fixes broken admin scene/avatar listings

### DIFF
--- a/admin/webpack.config.js
+++ b/admin/webpack.config.js
@@ -225,7 +225,8 @@ module.exports = (env, argv) => {
           RETICULUM_SERVER: process.env.RETICULUM_SERVER,
           CORS_PROXY_SERVER: process.env.CORS_PROXY_SERVER,
           POSTGREST_SERVER: process.env.POSTGREST_SERVER,
-          UPLOADS_HOST: process.env.UPLOADS_HOST
+          UPLOADS_HOST: process.env.UPLOADS_HOST,
+          BASE_ASSETS_PATH: process.env.BASE_ASSETS_PATH
         })
       })
     ]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -645,6 +645,7 @@ module.exports = async (env, argv) => {
           GA_TRACKING_ID: process.env.GA_TRACKING_ID,
           POSTGREST_SERVER: process.env.POSTGREST_SERVER,
           UPLOADS_HOST: process.env.UPLOADS_HOST,
+          BASE_ASSETS_PATH: process.env.BASE_ASSETS_PATH,
           APP_CONFIG: appConfig
         })
       })


### PR DESCRIPTION
BASE_ASSETS_PATH was not available in the `process.env` generated by webpack, so it was undefined when read by `config.js`

Got this after meting in latest hubs-cloud: 
![image](https://user-images.githubusercontent.com/10034859/153688311-1a5c0beb-3117-4c4d-9c8e-59b9323642ee.png)

After this fix:
![image](https://user-images.githubusercontent.com/10034859/153688334-2906998a-a0b3-49be-93a1-cd99654af726.png)

Others reporting this issue on Discord:
https://discord.com/channels/498741086295031808/819203046931693589/941487090942742548

This fix doesn't really explain what went wrong - as this isn't a new env var and wasn't in the webpack defines before, but it works :upside_down_face: 