### PR TITLE
Fetch whats-new info from new reticulum API instead of github

### DIFF
--- a/src/assets/stylesheets/whats-new.scss
+++ b/src/assets/stylesheets/whats-new.scss
@@ -8,7 +8,7 @@
   h1 {
     font-size: theme.$font-size-xl;
     text-align: center;
-    margin-bottom: 20px;
+    margin: 15px 0;
   }
 }
 
@@ -26,6 +26,15 @@
     flex-direction: column;
   }
 }
+.note {
+  margin: 20px 0;
+  @media (max-width: 768px) {
+    margin: 10px 0;
+  }
+  strong {
+    font-size: 100%;
+  }
+}
 .date, .date-blank, .title {
   margin: 0;
 }
@@ -34,7 +43,7 @@
 }
 .title {
   flex: 1;
-  margin-bottom: 16px;
+  margin-bottom: 10px;
   @media (max-width: 768px) {
     align-self: flex-start;
   }
@@ -45,7 +54,7 @@
   width: 120px;
 }
 .date {
-  margin-top: 0.2em;
+  margin: 0.2em 0;
 }
 
 .body {
@@ -60,4 +69,14 @@
   }
 
   img { width: 100%; }
+
+  pre {
+    overflow-x: auto;
+  }
+}
+
+.loader {
+  display: flex;
+  justify-content: center;
+  margin: 2em 0;
 }

--- a/src/whats-new.js
+++ b/src/whats-new.js
@@ -15,7 +15,6 @@ import "./react-components/styles/global.scss";
 import "./assets/stylesheets/whats-new.scss";
 import { PageContainer } from "./react-components/layout/PageContainer";
 import { Spinner } from "./react-components/misc/Spinner";
-import { Center } from "./react-components/layout/Center";
 import { ThemeProvider } from "./react-components/styles/theme";
 
 registerTelemetry("/whats-new", "Hubs What's New");
@@ -25,84 +24,60 @@ function formatDate(value) {
 }
 
 const md = markdownit();
-function formatBody(pull) {
-  const paragraphs = pull.body.split("\r\n\r\n").filter(l => l.trim());
-  const paraAndImage = [paragraphs[0]];
-  if (paragraphs[1] && paragraphs[1].includes("![")) {
-    paraAndImage.push(paragraphs[1]);
-  }
-  pull.body = md.render(paraAndImage.join("\r\n\r\n"));
-}
 
 class WhatsNew extends Component {
   state = {
-    notes: [],
+    pullRequests: [],
+    moreCursor: null,
     hasMore: true,
     currentDate: null
   };
-  async getNotes(page) {
-    // TODO Move this request to reticulum and return the results to the client
-    const endpoint = "https://api.github.com/repos/mozilla/hubs/pulls";
-    // Read-only, public access token.
-    // HACK - break the token in two so that it is not automatically revoked
-    // See https://github.com/mozilla/hubs/pull/3729
-    const token_start = "8247efa60";
-    const token_end = "655f4dd312b3d8085f78abadf845429";
-    const token = `${token_start}${token_end}`;
-    const params = [
-      "sort=created",
-      "direction=desc",
-      "state=closed",
-      "base=master",
-      "per_page=30",
-      `page=${page}`
-    ].join("&");
-    const resp = await fetch(`${endpoint}?${params}`, {
-      headers: { authorization: `token ${token}` }
-    });
-    const pulls = await resp.json();
+  async getWhatsNew() {
+    const endpoint = "/api/v1/whats-new";
+    const params = ["source=hubs", this.state.moreCursor ? `cursor=${this.state.moreCursor}` : ""].join("&");
 
-    if (!pulls.length) {
-      this.setState({ hasMore: false });
-      return;
+    let moreCursor;
+    let pullRequests = [];
+    try {
+      const respJson = await fetch(`${endpoint}?${params}`).then(r => r.json());
+      moreCursor = respJson.moreCursor;
+      pullRequests = respJson.pullRequests;
+    } catch (e) {
+      console.error("Error fetching whats-new", e);
     }
-
-    const merged = pulls.filter(x => x.merged_at && !!x.labels.find(l => l.name === "whats new"));
-
-    if (!merged.length) {
-      // Just trigger a render again so that InfiniteScroll will load the next page.
-      this.setState({});
-      return;
-    }
-
-    merged.sort((a, b) => a.merged_at < b.merged_at);
 
     let currentDate = this.state.currentDate;
 
-    for (let i = 0; i < merged.length; i++) {
-      const pull = merged[i];
-      if (formatDate(pull.merged_at) === currentDate) {
-        pull.merged_at = null;
+    for (let i = 0; i < pullRequests.length; i++) {
+      const pullRequest = pullRequests[i];
+      if (formatDate(pullRequest.mergedAt) === currentDate) {
+        pullRequest.mergedAt = null;
       } else {
-        currentDate = formatDate(pull.merged_at);
+        currentDate = formatDate(pullRequest.mergedAt);
       }
-      formatBody(pull);
+      pullRequest.body = md.render(pullRequest.body);
     }
 
-    this.setState({ currentDate, notes: [...this.state.notes, ...merged] });
+    this.setState({
+      hasMore: !!moreCursor,
+      moreCursor,
+      currentDate,
+      pullRequests: [...this.state.pullRequests, ...pullRequests]
+    });
   }
   render() {
     return (
       <PageContainer>
         <InfiniteScroll
-          pageStart={0}
-          loadMore={this.getNotes.bind(this)}
+          loadMore={this.getWhatsNew.bind(this)}
           hasMore={this.state.hasMore}
           loader={
-            <Center>
+            <div key="loader" className="loader">
               <Spinner />
-            </Center>
+            </div>
           }
+          useWindow={false}
+          getScrollParent={() => document.body}
         >
           <div className="container">
             <div className="main">
@@ -110,18 +85,20 @@ class WhatsNew extends Component {
                 <h1>
                   <FormattedMessage id="whats-new-page.title" defaultMessage="What's New" />
                 </h1>
-                {this.state.notes.map((note, i) => {
+                {this.state.pullRequests.map((pullRequest, i) => {
                   return (
                     <div key={i} className="note">
                       <div className="note-header">
-                        <h2 className={note.merged_at ? "date" : "date-blank"}>{formatDate(note.merged_at)}</h2>
+                        <h2 className={pullRequest.mergedAt ? "date" : "date-blank"}>
+                          {formatDate(pullRequest.mergedAt)}
+                        </h2>
                         <h2 className="title">
-                          <a href={note.html_url}>{note.title}</a>
+                          <a href={pullRequest.url}>{pullRequest.title}</a>
                         </h2>
                       </div>
                       {/* Setting HTML generated directly by markdownit, which is safe by default:
                       https://github.com/markdown-it/markdown-it/blob/master/docs/security.md */}
-                      <p className="body" dangerouslySetInnerHTML={{ __html: note.body }} />
+                      <p className="body" dangerouslySetInnerHTML={{ __html: pullRequest.body }} />
                     </div>
                   );
                 })}

--- a/src/whats-new.js
+++ b/src/whats-new.js
@@ -36,7 +36,7 @@ class WhatsNew extends Component {
     const endpoint = "/api/v1/whats-new";
     const params = ["source=hubs", this.state.moreCursor ? `cursor=${this.state.moreCursor}` : ""].join("&");
 
-    let moreCursor;
+    let moreCursor = null;
     let pullRequests = [];
     try {
       const respJson = await fetch(`${endpoint}?${params}`).then(r => r.json());


### PR DESCRIPTION
Uses a new whats-new API in reticulum instead of directly fetching from the GitHub API. Also fixes infinite scrolling behavior on the whats-new page, and tweaks the styling a bit.

Goes with https://github.com/mozilla/reticulum/pull/559