### PR TITLE
Restore microphone icon volume meter

### DIFF
--- a/src/react-components/room/AudioPopoverButton.js
+++ b/src/react-components/room/AudioPopoverButton.js
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import styles from "./AudioPopover.scss";
 import { Popover } from "../popover/Popover";
@@ -18,12 +18,30 @@ export const AudioPopoverButton = ({
   content,
   isMicrophoneMuted,
   isMicrophoneEnabled,
+  micLevel,
   onChangeMicrophoneMuted
 }) => {
   const ref = useRef();
   const intl = useIntl();
   const title = intl.formatMessage(invitePopoverTitle);
   const popoverApiRef = useRef();
+
+  useEffect(
+    () => {
+      const rect = ref.current.querySelector("rect");
+
+      if (micLevel <= 0.1) {
+        rect.setAttribute("height", 0);
+      } else if (micLevel < 0.3) {
+        rect.setAttribute("y", 8);
+        rect.setAttribute("height", 4);
+      } else {
+        rect.setAttribute("y", 4);
+        rect.setAttribute("height", 8);
+      }
+    },
+    [micLevel]
+  );
 
   return (
     <Popover
@@ -65,6 +83,7 @@ AudioPopoverButton.propTypes = {
   initiallyVisible: PropTypes.bool,
   isMicrophoneMuted: PropTypes.bool,
   isMicrophoneEnabled: PropTypes.bool,
+  micLevel: PropTypes.number,
   onChangeMicrophoneMuted: PropTypes.func,
   content: PropTypes.element
 };

--- a/src/react-components/room/AudioPopoverButton.js
+++ b/src/react-components/room/AudioPopoverButton.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useCallback, useRef } from "react";
 import PropTypes from "prop-types";
 import styles from "./AudioPopover.scss";
 import { Popover } from "../popover/Popover";
@@ -21,23 +21,22 @@ export const AudioPopoverButton = ({
   micLevel,
   onChangeMicrophoneMuted
 }) => {
-  const ref = useRef();
   const intl = useIntl();
   const title = intl.formatMessage(invitePopoverTitle);
   const popoverApiRef = useRef();
-
-  useEffect(
-    () => {
-      const rect = ref.current.querySelector("rect");
-
-      if (micLevel <= 0.1) {
-        rect.setAttribute("height", 0);
-      } else if (micLevel < 0.3) {
-        rect.setAttribute("y", 8);
-        rect.setAttribute("height", 4);
-      } else {
-        rect.setAttribute("y", 4);
-        rect.setAttribute("height", 8);
+  const micButtonRef = useCallback(
+    node => {
+      if (node !== null) {
+        const rect = node.querySelector("rect");
+        if (micLevel <= 0.1) {
+          rect.setAttribute("height", 0);
+        } else if (micLevel < 0.3) {
+          rect.setAttribute("y", 8);
+          rect.setAttribute("height", 4);
+        } else {
+          rect.setAttribute("y", 4);
+          rect.setAttribute("height", 8);
+        }
       }
     },
     [micLevel]
@@ -65,7 +64,7 @@ export const AudioPopoverButton = ({
             title={"Audio Settings"}
           />
           <ToolbarButton
-            ref={ref}
+            ref={micButtonRef}
             icon={isMicrophoneMuted || !isMicrophoneEnabled ? <MicrophoneMutedIcon /> : <MicrophoneIcon />}
             label={<FormattedMessage id="voice-button-container.label" defaultMessage="Voice" />}
             preset="basic"

--- a/src/react-components/room/AudioPopoverButtonContainer.js
+++ b/src/react-components/room/AudioPopoverButtonContainer.js
@@ -2,15 +2,20 @@ import React from "react";
 import PropTypes from "prop-types";
 import { AudioPopoverButton } from "./AudioPopoverButton";
 import { useMicrophoneStatus } from "./useMicrophoneStatus";
+import { useVolumeMeter } from "../misc/useVolumeMeter";
 
 export const AudioPopoverButtonContainer = ({ scene, initiallyVisible, content }) => {
   const { isMicMuted, toggleMute, isMicEnabled } = useMicrophoneStatus(scene);
+  const { volume } = useVolumeMeter({
+    analyser: scene.systems["hubs-systems"].audioSystem.outboundAnalyser
+  });
   return (
     <AudioPopoverButton
       initiallyVisible={initiallyVisible}
       content={content}
       isMicrophoneMuted={isMicMuted}
       isMicrophoneEnabled={isMicEnabled}
+      micLevel={volume}
       onChangeMicrophoneMuted={toggleMute}
     />
   );


### PR DESCRIPTION
After #5014, the microphone icon in the mute button no longer displays the microphone volume, making it hard to tell if the microphone is working at a glance.

I copied the [old behavior](https://github.com/mozilla/hubs/blob/8adfe267f8350ed62be2c1c65a00f70d51aa95cd/src/react-components/room/VoiceButtonContainer.js) and changed the cutoff to 0.1 due to b66bfed18c606256d41e460baf7669744395fdc6.

If desired, this could be an opportunity to revisit https://github.com/mozilla/hubs/pull/5014#discussion_r788427276 to reduce re-renders.
