### PR TITLE
[Hubs Cloud] Fix local assets path and upload proxy for localhost

### DIFF
--- a/src/utils/configs.js
+++ b/src/utils/configs.js
@@ -22,9 +22,16 @@ let isAdmin = false;
   const el = document.querySelector(`meta[name='env:${x.toLowerCase()}']`);
   configs[x] = el ? el.getAttribute("content") : process.env[x];
 
-  if (x === "BASE_ASSETS_PATH" && configs[x]) {
+  if (x === "BASE_ASSETS_PATH" && configs["BASE_ASSETS_PATH"]) {
     // eslint-disable-next-line no-undef
-    __webpack_public_path__ = configs[x];
+    __webpack_public_path__ = configs["BASE_ASSETS_PATH"];
+
+    // BASE_ASSETS_PATH might be a relative URL like "/" when it is set in
+    // .env or .defaults.env when running locally. We need to convert that
+    // to an absolute URL.
+    if (configs["BASE_ASSETS_PATH"] && !configs["BASE_ASSETS_PATH"].startsWith("http")) {
+      configs["BASE_ASSETS_PATH"] = new URL(configs["BASE_ASSETS_PATH"], window.location);
+    }
   }
 });
 

--- a/src/utils/configs.js
+++ b/src/utils/configs.js
@@ -22,16 +22,17 @@ let isAdmin = false;
   const el = document.querySelector(`meta[name='env:${x.toLowerCase()}']`);
   configs[x] = el ? el.getAttribute("content") : process.env[x];
 
-  if (x === "BASE_ASSETS_PATH" && configs["BASE_ASSETS_PATH"]) {
-    // eslint-disable-next-line no-undef
-    __webpack_public_path__ = configs["BASE_ASSETS_PATH"];
-
+  const BASE_ASSETS_PATH_KEY = "BASE_ASSETS_PATH";
+  if (x === BASE_ASSETS_PATH_KEY && configs[BASE_ASSETS_PATH_KEY]) {
     // BASE_ASSETS_PATH might be a relative URL like "/" when it is set in
     // .env or .defaults.env when running locally. We need to convert that
     // to an absolute URL.
-    if (configs["BASE_ASSETS_PATH"] && !configs["BASE_ASSETS_PATH"].startsWith("http")) {
-      configs["BASE_ASSETS_PATH"] = new URL(configs["BASE_ASSETS_PATH"], window.location);
+    if (!configs[BASE_ASSETS_PATH_KEY].startsWith("http")) {
+      configs[BASE_ASSETS_PATH_KEY] = new URL(configs[BASE_ASSETS_PATH_KEY], window.location).toString();
     }
+
+    // eslint-disable-next-line no-undef
+    __webpack_public_path__ = configs[BASE_ASSETS_PATH_KEY];
   }
 });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -322,7 +322,7 @@ module.exports = async (env, argv) => {
           if (req.method === "OPTIONS") {
             res.send();
           } else {
-            const url = req.path.replace("/cors-proxy/", "");
+            const url = req.originalUrl.replace("/cors-proxy/", "");
             request({ url, method: req.method }, error => {
               if (error) {
                 console.error(`cors-proxy: error fetching "${url}"\n`, error);


### PR DESCRIPTION
This PR fixes a couple of issues that occur when running a local client against a Hubs Cloud stack.

1. It converts the BASE_ASSETS_PATH config from a relative URL to and absolute URL. This fixes an error in the physics system, where we use BASE_ASSETS_PATH to load the Ammo.js WASM bundle.
2. It fixes the path used by the local cors-proxy, so that it includes the query string token for uploaded files. Previously, uploads would fail to render correctly in a room.

The change to BASE_ASSETS_PATH ought to be explained further, so I will do that here. 

In https://github.com/mozilla/reticulum/pull/508 we introduced a security fix that prevents uploaded files from being served from the primary domain. Uploads must now be served from secondary domains in order to keep them isolated. 

This security change worked well with the frontend hubs client, but it broke some aspects of the admin panel. The admin panel issues were fixed by introducing an UPLOADS_HOST environment variable (https://github.com/mozilla/hubs/pull/4565) which contained the secondary domain that uploads are typically served from. 

However, the UPLOADS_HOST variable did not work in scenarios where Hubs Cloud stacks used Cloudflare as a CDN, since uploads were being served via the CDN, which is a separate domain. We fixed the issue with Cloudflare in https://github.com/mozilla/hubs/pull/5100 by using the BASE_ASSETS_PATH configuration variable, which did include the correct Cloudflare domain. 

Unfortunately, that fix also broke another scenario, when users were running local clients against a Hubs Cloud stack. BASE_ASSETS_PATH was previously never used locally, so it was undefined, which causes a null reference error in `getUploadsUrl`. We then fixed this in https://github.com/mozilla/hubs/pull/5125 by defining BASE_ASSETS_PATH locally. 

This caused yet another problem. When running locally, BASE_ASSETS_PATH is set to "/" by default in `.defaults.env`. This breaks the physics system, since it relies on BASE_ASSETS_PATH to load the Ammo.js WASM bundle, and expects BASE_ASSETS_PATH to be an absolute URL, not a relative one. This PR fixes that issue.

Arguably, we could have fixed the null reference error in `getUploadsUrl` by doing a null check instead of defining BASE_ASSETS_PATH, but it might be better to move forward at this point, instead of reverting the change.