### PR TITLE
Allow testing CSP with webpack-dev-server

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -252,6 +252,18 @@ module.exports = async (env, argv) => {
     ]
   };
 
+  const devServerHeaders = {
+    "Access-Control-Allow-Origin": "*"
+  };
+
+  // Behind and environment var for now pending further testing
+  if (process.env.CSP_HOST) {
+    const CSPResp = await fetch(`https://${process.env.CSP_HOST}/`);
+    const remoteCSP = CSPResp.headers.get("content-security-policy");
+    devServerHeaders["content-security-policy"] = remoteCSP;
+    // .replaceAll("connect-src", "connect-src https://example.com");
+  }
+
   return {
     node: {
       // need to specify this manually because some random lodash code will try to access
@@ -285,9 +297,7 @@ module.exports = async (env, argv) => {
       public: `${host}:8080`,
       useLocalIp: true,
       allowedHosts: [host, "hubs.local"],
-      headers: {
-        "Access-Control-Allow-Origin": "*"
-      },
+      headers: devServerHeaders,
       hot: liveReload,
       inline: liveReload,
       historyApiFallback: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -257,8 +257,8 @@ module.exports = async (env, argv) => {
   };
 
   // Behind and environment var for now pending further testing
-  if (process.env.CSP_HOST) {
-    const CSPResp = await fetch(`https://${process.env.CSP_HOST}/`);
+  if (process.env.DEV_CSP_SOURCE) {
+    const CSPResp = await fetch(`https://${process.env.DEV_CSP_SOURCE}/`);
     const remoteCSP = CSPResp.headers.get("content-security-policy");
     devServerHeaders["content-security-policy"] = remoteCSP;
     // .replaceAll("connect-src", "connect-src https://example.com");


### PR DESCRIPTION
CSP issues often only surface when deploying. This PR adds the `DEV_CSP_SOURCE` environment variable which will have webpack-dev-server serve the same CSP as the destination host. 

Typically you might want to test things like this `DEV_CSP_SOURCE="dev.reticulum.io" npm run dev`

Keeping this as an environment variable to start as I want people to be able to test this a bit more and also we need to figure out how this should work with Hubs Cloud.