### PR TITLE
Fix menu placement regression from text update

### DIFF
--- a/src/utils/auto-box-collider.js
+++ b/src/utils/auto-box-collider.js
@@ -23,7 +23,9 @@ export const computeLocalBoundingBox = (function() {
       }
       node.updateMatrices();
       toRootSpace.multiplyMatrices(rootInverse, node.matrixWorld);
-      if (node.geometry) {
+      // TODO Troika Text GlyphGeometry has issues with this code, but we don't
+      // actually want to include it's bounds anyway so just ignore it for now.
+      if (node.geometry && !node.isTroikaText) {
         if (node.geometry.isGeometry) {
           for (let i = 0; i < node.geometry.vertices; i++) {
             vertex.copy(node.geometry.vertices[i]).applyMatrix4(toRootSpace);


### PR DESCRIPTION
The object menus were incorrectly being positioned after the switch to Troika text. This is because **GlyphGeometry** is not correctly handled by our code that computes object bounding boxes. I don't really recall why we are using custom code for this bounding box stuff... But just ignoring troika text meshes in this code since we actually don't care about including it in bounds for menu positioning.

![image](https://user-images.githubusercontent.com/130735/154604286-e304e9e3-8729-48d6-aeb6-638ada7a384c.png)
