### PR TITLE
Fix localization typo

### DIFF
--- a/src/assets/locales/fr.json
+++ b/src/assets/locales/fr.json
@@ -54,7 +54,7 @@
   "avatar-editor.submit-button.uploading": "Envoi...",
   "avatar-editor.upload-custom-avatar-button": "{icon} GLB personnalisé",
   "avatar-page.copy-button": "Copier vers mes avatars",
-  "avatar-page.copyied-avatar": "Copié",
+  "avatar-page.copied-avatar": "Copié",
   "avatar-page.copying-avatar": "Copie...",
   "avatar-page.loading": "Chargement",
   "avatar-page.logo": "Logo",

--- a/src/assets/locales/fr.json
+++ b/src/assets/locales/fr.json
@@ -32,7 +32,7 @@
   "avatar-editor.delist-avatar-button": "Retirer l'avatar de la liste",
   "avatar-editor.delist-avatar-info": "Cet avatar sera toujours disponible pour les autres utilisateurs qui l'ont déjà choisi, mais il sera supprimé du menu Mes avatars ainsi que des résultats de recherche.",
   "avatar-editor.external-editor-info": "Créer un costume personnalisé pour cet avatar:",
-  "avatar-editor.field.alllow-remixing": "Autoriser les autres utilisateurs à éditer et re-publier votre avatar à condition de vous mentionner en crédits.",
+  "avatar-editor.field.allow-remixing": "Autoriser les autres utilisateurs à éditer et re-publier votre avatar à condition de vous mentionner en crédits.",
   "avatar-editor.field.allow-promotion": "Autoriser {companyName} à promouvoir votre avatar et le montrer dans les résultats de recherche.",
   "avatar-editor.field.allow-promotion-checkbox": "Autoriser <a>Promotion</a>",
   "avatar-editor.field.allow-remixing-checkbox": "Autoriser le <a>Remixing</a> <license>(sous <licenselink>CC-BY 3.0</licenselink>)</license>",

--- a/src/avatar.js
+++ b/src/avatar.js
@@ -108,7 +108,7 @@ class AvatarPage extends React.Component {
                 {copyState === "copying" ? (
                   <FormattedMessage id="avatar-page.copying-avatar" defaultMessage="Copying..." />
                 ) : (
-                  <FormattedMessage id="avatar-page.copyied-avatar" defaultMessage="Copied" />
+                  <FormattedMessage id="avatar-page.copied-avatar" defaultMessage="Copied" />
                 )}
               </div>
             ) : (

--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -602,7 +602,7 @@ class AvatarEditor extends Component {
                 {this.checkbox(
                   "allow_remixing",
                   intl.formatMessage({
-                    id: "avatar-editor.field.alllow-remixing",
+                    id: "avatar-editor.field.allow-remixing",
                     defaultMessage: "Allow others to edit and re-publish your avatar as long as they give you credit."
                   }),
                   <span>


### PR DESCRIPTION
# Doing

- `src/avatar.js`: `"avatar-editor.field.alllow-remixing"` to `"avatar-editor.field.allow-remixing"`
- `src/react-components/avatar-editor.js`: `"avatar-page.copyied-avatar"` to `"avatar-page.copied-avatar"`

# Why

I found this typos when doing korean localization.
I'll be soon upload pull request korean localization.