### PR TITLE
Fix typo `availible` to `available`

### DIFF
--- a/.defaults.env
+++ b/.defaults.env
@@ -23,7 +23,7 @@ NON_CORS_PROXY_DOMAINS="hubs.local,dev.reticulum.io"
 # The root URL under which Hubs expects static assets to be served.
 BASE_ASSETS_PATH=/
 
-# The default scene to use. Note the example scene id is only availible on dev.reticulum.io
+# The default scene to use. Note the example scene id is only available on dev.reticulum.io
 DEFAULT_SCENE_SID="JGLt8DP"
 
 # Uncomment to load the app config from the reticulum server in development.

--- a/src/assets/locales/fr.json
+++ b/src/assets/locales/fr.json
@@ -149,7 +149,7 @@
   "exited-room-screen.contact-us": "Si vous avez des questions, contactez-nous via {contactEmail}.",
   "exited-room-screen.create-room": "Vous pouvez aussi <a>créer une nouvelle salle</a>.",
   "exited-room-screen.home-button": "Retour à l'accueil",
-  "exited-room-screen.no-longer-availible": "Désolé, cette salle n'est plus disponible.",
+  "exited-room-screen.no-longer-available": "Désolé, cette salle n'est plus disponible.",
   "exited-room-screen.reason.closed": "Cette salle n'est plus disponible.",
   "exited-room-screen.reason.connect-error": "Impossible de se connecter à cette salle, merci de réessayer plus tard.",
   "exited-room-screen.reason.denied": "Vous n'êtes pas autorisé(e) à rejoindre cette salle. Demandez une autorisation au créateur de cette salle.",

--- a/src/assets/locales/ko.json
+++ b/src/assets/locales/ko.json
@@ -52,7 +52,7 @@
   "exited-room-screen.reason.scene-error": "Scene을 불러오는데 실패했습니다.",
   "exited-room-screen.reason.connect-error": "Room에 연결할 수 없습니다. 나중에 다시 시도하십시오.",
   "exited-room-screen.reason.version-mismatch": "배포한 버전은 아직 사용할 수 없습니다. 5초 후에 페이지가 새로고침 됩니다.",
-  "exited-room-screen.no-longer-availible": "죄송합니다, 이 Room은 더 이상 이용할 수 없습니다.",
+  "exited-room-screen.no-longer-available": "죄송합니다, 이 Room은 더 이상 이용할 수 없습니다.",
   "exited-room-screen.closed-room-tos": "Room을 닫았거나, 또는 <toslink>이용 약관</toslink>을 위반한다는 신고가 접수 된 경우.",
   "exited-room-screen.contact-us": "문의 사항이 있으면 {contactEmail} 으로 문의하십시오.",
   "exited-room-screen.source-link": "자체 서버를 실행하려는 경우 <a>GitHub</a>에서 Hubs의 소스 코드를 사용할 수 있습니다.",

--- a/src/react-components/room/ExitedRoomScreen.js
+++ b/src/react-components/room/ExitedRoomScreen.js
@@ -66,7 +66,7 @@ export function ExitedRoomScreen({ reason, showTerms, termsUrl, logoSrc, showSou
       <>
         <b>
           <FormattedMessage
-            id="exited-room-screen.no-longer-availible"
+            id="exited-room-screen.no-longer-available"
             defaultMessage="Sorry, this room is no longer available."
           />
         </b>


### PR DESCRIPTION
# Doing

- `availible` to `available`
- `.defaults.env` line 26
- `src/assets/locales/fr.json` line 152
- `src/assets/locales/ko.json` line 55
- `src/react-components/room/ExitedRoomScreen.js` line 69