### PR TITLE
Theme variables for spawned messages and button presets "landing", "signin"

### DIFF
--- a/src/assets/stylesheets/presence-log.scss
+++ b/src/assets/stylesheets/presence-log.scss
@@ -179,8 +179,8 @@
   margin: 0;
 
   :local(.presence-log-entry) {
-    background-color: black;
-    color: white;
+    background-color: theme.$spawned-chat-bubble-bg-color;
+    color: theme.$spawned-chat-bubble-text-color;
     min-height: 18px;
     padding: 8px 16px;
     border-radius: 16px;

--- a/src/react-components/input/Button.scss
+++ b/src/react-components/input/Button.scss
@@ -334,23 +334,23 @@
 }
 
 :local(.signin) {
-  border: 2px solid #007AB8;
+  border: 2px solid theme.$signin-border-color;
   background-color: transparent;
-  color: #007AB8;
+  color: theme.$signin-color;
   box-sizing: border-box;
   border-radius: 13px;
 }
 
 :local(.landing) {
-  border: 2px solid #007AB8;
-  background-color: #007AB8; 
+  border: 2px solid theme.$landing-border-color;
+  background-color: theme.$landing-color; 
   color: theme.$text5-color;
   box-sizing: border-box;
   border-radius: 13px;
   &:hover {
-    background-color: #008bd1;
+    background-color: theme.$landing-color-hover;
   }
   &:active {
-    background-color: #00699E;
+    background-color: theme.$landing-color-pressed;
   }
 }

--- a/src/react-components/styles/global.scss
+++ b/src/react-components/styles/global.scss
@@ -100,6 +100,14 @@
   --disabled-bg-color:  var(--background3-color);
   --disabled-icon-color: var(--text3-color);
 
+  --signin-color: #{theme.$blue};
+  --signin-border-color: var(--signin-color);
+
+  --landing-color: #{theme.$blue};
+  --landing-color-hover: #{theme.$blue-hover};
+  --landing-color-pressed: #{theme.$blue-pressed};
+  --landing-border-color: var(--landing-border-color);
+
   --radio-border-color: var(--border1-color);
   --radio-bg-color: var(--basic-color);
   --radio-bg-color-hover: var(--basic-color-hover);
@@ -136,6 +144,9 @@
   --chat-bubble-link-color-sent-hover: var(--basic-color-hover);
   --chat-bubble-link-color-sent-pressed: var(--basic-color-pressed);
   --chat-bubble-bg-color-received: var(--background3-color);
+
+  --spawned-chat-bubble-bg-color: #{theme.$black};
+  --spawned-chat-bubble-text-color: #{theme.$white};
 
   --tip-text-color: var(--text5-color);
   --tip-bg-color: var(--accent4-color);

--- a/src/react-components/styles/theme.scss
+++ b/src/react-components/styles/theme.scss
@@ -187,6 +187,14 @@ $disabled-text-color: var(--disabled-text-color);
 $disabled-bg-color: var(--disabled-bg-color);
 $disabled-icon-color: var(--disabled-icon-color);
 
+$signin-color: var(--signin-color);
+$signin-border-color: var(--signin-border-color);
+
+$landing-color: var(--landing-color);
+$landing-color-hover: var(--landing-color-hover);
+$landing-color-pressed: var(--landing-color-pressed);
+$landing-border-color: var(--landing-border-color);
+
 $radio-border-color: var(--radio-border-color);
 $radio-bg-color: var(--radio-bg-color);
 $radio-bg-color-hover: var(--radio-bg-color-hover);
@@ -223,6 +231,9 @@ $chat-bubble-text-color-sent: var(--chat-bubble-text-color-sent);
 $chat-bubble-link-color-sent-hover: var(--chat-bubble-link-color-sent-hover);
 $chat-bubble-link-color-sent-pressed: var(--chat-bubble-link-color-sent-pressed);
 $chat-bubble-bg-color-received: var(--chat-bubble-bg-color-received);
+
+$spawned-chat-bubble-bg-color: var(--spawned-chat-bubble-bg-color);
+$spawned-chat-bubble-text-color: var(--spawned-chat-bubble-text-color);
 
 $tip-text-color: var(--tip-text-color);
 $tip-bg-color: var(--tip-bg-color);


### PR DESCRIPTION
Added some theme variables for spawned chat messages and the new button presets "landing" and "signin". All previously hard-coded defaults have been preserved.

The following variables have been introduced with this PR:
- spawned-chat-bubble-bg-color
- spawned-chat-bubble-text-color
- signin-color
- signin-border-color
- landing-color
- landing-color-hover
- landing-color-pressed
- landing-border-color


Here an example for a spawned chat message with white background and black font:

![Bildschirmfoto 2022-03-04 um 12 12 35](https://user-images.githubusercontent.com/12909076/156772320-186b9ba6-fb7f-4b38-ba6e-dbbab29cadc5.png)


Here an example where the variables for the signin and landing button presets have been used:

![Bildschirmfoto 2022-03-04 um 12 52 29](https://user-images.githubusercontent.com/12909076/156772506-706d8f0a-890a-422a-9d42-a2fb2029e5c1.png)