### PR TITLE
Flip mute state on entry 

### DIFF
--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -900,7 +900,7 @@ class UIRoot extends Component {
   };
 
   renderAudioSetupPanel = () => {
-    this.mediaDevicesManager.micShouldBeEnabled = !!this.props.store.state.preferences["muteMicOnEntry"];
+    this.mediaDevicesManager.micShouldBeEnabled = !this.props.store.state.preferences["muteMicOnEntry"];
     // TODO: Show HMD mic not chosen warning
     return (
       <MicSetupModalContainer
@@ -908,7 +908,7 @@ class UIRoot extends Component {
         onEnterRoom={this.onAudioReadyButton}
         onMicMuted={() =>
           this.props.store.update({
-            preferences: { muteMicOnEntry: !!this.props.store.state.preferences["muteMicOnEntry"] }
+            preferences: { muteMicOnEntry: !this.props.store.state.preferences["muteMicOnEntry"] }
           })
         }
         onBack={() => this.props.history.goBack()}


### PR DESCRIPTION
This flips a boolean that seems to be incorrect. It's easy to confused variables named `muted` and `enabled`.

The entry flow seems to have a bug where if the user changes their `muteMicOnEntry` preference, the change is not reflected in the `MicSetupModal`. This PR does not address that problem.  