### PR TITLE
Add public rooms back to the home page

### DIFF
--- a/src/react-components/home/HomePage.js
+++ b/src/react-components/home/HomePage.js
@@ -6,7 +6,7 @@ import { getAppLogo } from "../../utils/get-app-logo";
 import { CreateRoomButton } from "./CreateRoomButton";
 import { PWAButton } from "./PWAButton";
 import { useFavoriteRooms } from "./useFavoriteRooms";
-//import { usePublicRooms } from "./usePublicRooms";
+import { usePublicRooms } from "./usePublicRooms";
 import styles from "./HomePage.scss";
 import { AuthContext } from "../auth/AuthContext";
 import { createAndRedirectToNewHub } from "../../utils/phoenix-utils";
@@ -27,10 +27,10 @@ export function HomePage() {
   const intl = useIntl();
 
   const { results: favoriteRooms } = useFavoriteRooms();
-  //const { results: publicRooms } = usePublicRooms();
+  const { results: publicRooms } = usePublicRooms();
 
   const sortedFavoriteRooms = Array.from(favoriteRooms).sort((a, b) => b.member_count - a.member_count);
-  const sortedPublicRooms = []; //Array.from(publicRooms).sort((a, b) => b.member_count - a.member_count);
+  const sortedPublicRooms = Array.from(publicRooms).sort((a, b) => b.member_count - a.member_count);
   const wrapInBold = chunk => <b>{chunk}</b>;
   const isHmc = configs.feature("show_cloud");
   useEffect(() => {


### PR DESCRIPTION
We removed public rooms from the home page in a quick hot fix (https://github.com/mozilla/hubs/commit/3060b758fcdac4d1f0da09396ea2015715227372). This re-enables them, but it shouldn't be merged before the corresponding DB optimization in https://github.com/mozilla/reticulum/pull/568