### PR TITLE
revert to dialog enable mic

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -1398,7 +1398,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   hubPhxChannel.on("mute", ({ session_id }) => {
     if (session_id === NAF.clientId) {
-      APP.mediaDevicesManager.enableMic(false);
+      APP.dialog.enableMicrophone(false);
     }
   });
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -1398,7 +1398,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   hubPhxChannel.on("mute", ({ session_id }) => {
     if (session_id === NAF.clientId) {
-      APP.dialog.enableMicrophone(false);
+      APP.mediaDevicesManager.micEnabled = false;
     }
   });
 


### PR DESCRIPTION
reverting to `APP.dialog.enableMicrophone(false)` seems to fix the issue #5062. Disregard this PR if there is a reason for keeping this on `mediaDevicesManager`

https://user-images.githubusercontent.com/4493657/156936402-591a5803-cf2d-4d31-893d-bfd4af76cc6d.mp4


