### PR TITLE
Fix default devices id not working on FF

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -778,7 +778,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   });
 
   const audioSystem = scene.systems["hubs-systems"].audioSystem;
-  window.APP.mediaDevicesManager = new MediaDevicesManager(scene, store, audioSystem);
+  APP.mediaDevicesManager = new MediaDevicesManager(scene, store, audioSystem);
 
   const performConditionalSignIn = async (predicate, action, signInMessage, onFailure) => {
     if (predicate()) return action();

--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -814,7 +814,7 @@ class PreferencesScreen extends Component {
     const preferredMic = { ...this.state.preferredMic };
     preferredMic.options = micOptions;
 
-    const speakersOptions = this.mediaDevicesManager.outputDevices.map(device => ({
+    const speakersOptions = this.mediaDevicesManager.outputDevicesOptions.map(device => ({
       value: device.value,
       text: device.label
     }));
@@ -822,7 +822,7 @@ class PreferencesScreen extends Component {
     preferredSpeakers.options = speakersOptions?.length > 0 ? speakersOptions : [{ value: "none", text: "None" }];
 
     // Video devices update
-    const videoOptions = this.mediaDevicesManager.videoDevices.map(device => ({
+    const videoOptions = this.mediaDevicesManager.videoDevicesOptions.map(device => ({
       value: device.value,
       text: device.label
     }));

--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -802,6 +802,12 @@ class PreferencesScreen extends Component {
   }
 
   onMediaDevicesUpdated = () => {
+    const currentSpeakers = this.mediaDevicesManager.selectedSpeakersDeviceId;
+    if (this.props.store.state.preferences.preferredSpeakers !== currentSpeakers) {
+      this.props.store.update({
+        preferences: { preferredSpeakers: currentSpeakers }
+      });
+    }
     this.updateMediaDevices();
   };
 

--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -807,7 +807,7 @@ class PreferencesScreen extends Component {
 
   updateMediaDevices = () => {
     // Audio devices update
-    const micOptions = this.mediaDevicesManager.micDevices.map(device => ({
+    const micOptions = this.mediaDevicesManager.micDevicesOptions.map(device => ({
       value: device.value,
       text: device.label
     }));

--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -918,7 +918,6 @@ class PreferencesScreen extends Component {
       });
     }
 
-    const prefSchema = this.props.store.schema.definitions.preferences.properties;
     const DEFINITIONS = new Map([
       [
         CATEGORY_TOUCHSCREEN,

--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -776,7 +776,7 @@ class PreferencesScreen extends Component {
 
     this.storeUpdated = this.storeUpdated.bind(this);
 
-    this.mediaDevicesManager = window.APP.mediaDevicesManager;
+    this.mediaDevicesManager = APP.mediaDevicesManager;
 
     this.state = {
       category: CATEGORY_AUDIO,

--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -875,9 +875,7 @@ class PreferencesScreen extends Component {
   storeUpdated() {
     const { preferredMic } = this.props.store.state.preferences;
     if (preferredMic !== this.mediaDevicesManager.selectedMicDeviceId) {
-      this.mediaDevicesManager
-        .startMicShare({ deviceId: preferredMic, updatePrefs: false })
-        .then(this.updateMediaDevices);
+      this.mediaDevicesManager.startMicShare({ updatePrefs: false }).then(this.updateMediaDevices);
     }
   }
 

--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -977,7 +977,7 @@ class PreferencesScreen extends Component {
       [
         CATEGORY_AUDIO,
         [
-          this.state.preferredMic,
+          ...(MediaDevicesManager.isAudioInputSelectEnabled ? [this.state.preferredMic] : []),
           ...(MediaDevicesManager.isAudioOutputSelectEnabled ? [this.state.preferredSpeakers] : []),
           {
             key: "muteMicOnEntry",

--- a/src/react-components/room/AudioPopoverContent.js
+++ b/src/react-components/room/AudioPopoverContent.js
@@ -16,12 +16,10 @@ import { Button } from "../input/Button";
 export const AudioPopoverContent = ({
   micLevel,
   microphoneOptions,
-  selectedMicrophone,
   onChangeMicrophone,
   isMicrophoneEnabled,
   isMicrophoneMuted,
   onChangeMicrophoneMuted,
-  selectedSpeaker,
   speakerOptions,
   onChangeSpeaker,
   speakerLevel,
@@ -36,9 +34,8 @@ export const AudioPopoverContent = ({
       <SelectInputField
         className={styles.selectionInput}
         buttonClassName={styles.selectionInput}
-        value={selectedMicrophone}
-        options={microphoneOptions}
         onChange={onChangeMicrophone}
+        {...microphoneOptions}
       />
       <Row noWrap>
         {isMicrophoneEnabled && !isMicrophoneMuted ? (
@@ -59,13 +56,12 @@ export const AudioPopoverContent = ({
       <p style={{ alignSelf: "start" }}>
         <FormattedMessage id="mic-setup-modal.speakers-text" defaultMessage="Speakers" />
       </p>
-      {speakerOptions?.length > 0 && (
+      {speakerOptions?.options?.length > 0 && (
         <SelectInputField
           className={styles.selectionInput}
           buttonClassName={styles.selectionInput}
-          value={selectedSpeaker}
-          options={speakerOptions}
           onChange={onChangeSpeaker}
+          {...speakerOptions}
         />
       )}
       <Row noWrap>
@@ -87,10 +83,8 @@ AudioPopoverContent.propTypes = {
   isMicrophoneEnabled: PropTypes.bool,
   isMicrophoneMuted: PropTypes.bool,
   onChangeMicrophoneMuted: PropTypes.func,
-  selectedMicrophone: PropTypes.string,
-  microphoneOptions: PropTypes.array,
+  microphoneOptions: PropTypes.object,
   onChangeMicrophone: PropTypes.func,
-  selectedSpeaker: PropTypes.string,
-  speakerOptions: PropTypes.array,
+  speakerOptions: PropTypes.object,
   onChangeSpeaker: PropTypes.func
 };

--- a/src/react-components/room/AudioPopoverContent.js
+++ b/src/react-components/room/AudioPopoverContent.js
@@ -12,6 +12,7 @@ import { LevelBar } from "../misc/LevelBar";
 import { ToggleInput } from "../input/ToggleInput";
 import { Divider } from "../layout/Divider";
 import { Button } from "../input/Button";
+import MediaDevicesManager from "../../utils/media-devices-manager";
 
 export const AudioPopoverContent = ({
   micLevel,
@@ -31,12 +32,14 @@ export const AudioPopoverContent = ({
       <p style={{ alignSelf: "start" }}>
         <FormattedMessage id="mic-setup-modal.microphone-text" defaultMessage="Microphone" />
       </p>
-      <SelectInputField
-        className={styles.selectionInput}
-        buttonClassName={styles.selectionInput}
-        onChange={onChangeMicrophone}
-        {...microphoneOptions}
-      />
+      {MediaDevicesManager.isAudioInputSelectEnabled && (
+        <SelectInputField
+          className={styles.selectionInput}
+          buttonClassName={styles.selectionInput}
+          onChange={onChangeMicrophone}
+          {...microphoneOptions}
+        />
+      )}
       <Row noWrap>
         {isMicrophoneEnabled && !isMicrophoneMuted ? (
           <MicrophoneIcon className={iconStyle} style={{ marginRight: "12px" }} />
@@ -56,7 +59,7 @@ export const AudioPopoverContent = ({
       <p style={{ alignSelf: "start" }}>
         <FormattedMessage id="mic-setup-modal.speakers-text" defaultMessage="Speakers" />
       </p>
-      {speakerOptions?.options?.length > 0 && (
+      {MediaDevicesManager.isAudioOutputSelectEnabled && (
         <SelectInputField
           className={styles.selectionInput}
           buttonClassName={styles.selectionInput}

--- a/src/react-components/room/AudioPopoverContentContainer.js
+++ b/src/react-components/room/AudioPopoverContentContainer.js
@@ -10,11 +10,11 @@ import { useMicrophoneStatus } from "./useMicrophoneStatus";
 
 export const AudioPopoverContentContainer = ({ scene }) => {
   const { isMicMuted, toggleMute, isMicEnabled } = useMicrophoneStatus(scene);
-  const { micDeviceChanged, selectedMicDeviceId, micDevices } = useMicrophone(scene);
+  const { micDeviceChanged, micDevices } = useMicrophone(scene);
   const { volume: micVolume } = useVolumeMeter({
     analyser: scene.systems["hubs-systems"].audioSystem.outboundAnalyser
   });
-  const { speakerDeviceChanged, selectedSpeakersDeviceId, speakerDevices } = useSpeakers(scene);
+  const { speakerDeviceChanged, speakerDevices } = useSpeakers();
   const { playSound, soundVolume } = useSound({
     scene,
     sound: SOUND_SPEAKER_TONE
@@ -23,12 +23,10 @@ export const AudioPopoverContentContainer = ({ scene }) => {
     <AudioPopoverContent
       micLevel={micVolume}
       microphoneOptions={micDevices}
-      selectedMicrophone={selectedMicDeviceId}
       onChangeMicrophone={micDeviceChanged}
       isMicrophoneEnabled={isMicEnabled}
       isMicrophoneMuted={isMicMuted}
       onChangeMicrophoneMuted={toggleMute}
-      selectedSpeaker={selectedSpeakersDeviceId}
       speakerOptions={speakerDevices}
       onChangeSpeaker={speakerDeviceChanged}
       speakerLevel={soundVolume}

--- a/src/react-components/room/ChatSidebarContainer.js
+++ b/src/react-components/room/ChatSidebarContainer.js
@@ -187,7 +187,7 @@ export function ChatSidebarContainer({ scene, canSpawnMessages, presences, occup
       typingTimeoutRef.current = setTimeout(() => window.APP.hubChannel.endTyping(), 500);
       window.APP.hubChannel.beginTyping();
     },
-    [scene, sendMessage, setMessage, onClose]
+    [sendMessage, setMessage, onClose]
   );
 
   const onSendMessage = useCallback(

--- a/src/react-components/room/MicSetupModal.js
+++ b/src/react-components/room/MicSetupModal.js
@@ -16,6 +16,7 @@ import { LevelBar } from "../misc/LevelBar";
 import { Popover } from "../popover/Popover";
 import { PermissionStatus } from "../../utils/media-devices-utils";
 import { Spinner } from "../misc/Spinner";
+import MediaDevicesManager from "../../utils/media-devices-manager";
 
 export function MicSetupModal({
   className,
@@ -131,6 +132,7 @@ export function MicSetupModal({
               )}
             </div>
             {permissionStatus === PermissionStatus.GRANTED &&
+              MediaDevicesManager.isAudioInputSelectEnabled &&
               isMicrophoneEnabled &&
               microphoneOptions?.length > 0 && (
                 <div className={styles.selectionContainer}>

--- a/src/react-components/room/MicSetupModal.js
+++ b/src/react-components/room/MicSetupModal.js
@@ -20,10 +20,8 @@ import MediaDevicesManager from "../../utils/media-devices-manager";
 
 export function MicSetupModal({
   className,
-  selectedMicrophone,
   microphoneOptions,
   onChangeMicrophone,
-  selectedSpeaker,
   speakerOptions,
   onChangeSpeaker,
   isMicrophoneEnabled,
@@ -133,8 +131,8 @@ export function MicSetupModal({
             </div>
             {permissionStatus === PermissionStatus.GRANTED &&
               MediaDevicesManager.isAudioInputSelectEnabled &&
-              isMicrophoneEnabled &&
-              microphoneOptions?.length > 0 && (
+              microphoneOptions?.options?.length > 0 &&
+              isMicrophoneEnabled && (
                 <div className={styles.selectionContainer}>
                   <p style={{ alignSelf: "start" }}>
                     <FormattedMessage id="mic-setup-modal.microphone-text" defaultMessage="Microphone" />
@@ -142,9 +140,8 @@ export function MicSetupModal({
                   <SelectInputField
                     className={styles.selectionInput}
                     buttonClassName={styles.selectionInput}
-                    value={selectedMicrophone}
-                    options={microphoneOptions}
                     onChange={onChangeMicrophone}
+                    {...microphoneOptions}
                   />
                 </div>
               )}
@@ -160,17 +157,16 @@ export function MicSetupModal({
               </Button>
             </div>
             {permissionStatus === PermissionStatus.GRANTED &&
-              speakerOptions?.length > 0 && (
+              speakerOptions?.options?.length > 0 && (
                 <div className={styles.selectionContainer}>
                   <p style={{ alignSelf: "start" }}>
                     <FormattedMessage id="mic-setup-modal.speakers-text" defaultMessage="Speakers" />
                   </p>
                   <SelectInputField
-                    value={selectedSpeaker}
-                    options={speakerOptions}
                     onChange={onChangeSpeaker}
                     className={styles.selectionInput}
                     buttonClassName={styles.selectionInput}
+                    {...speakerOptions}
                   />
                 </div>
               )}
@@ -192,11 +188,9 @@ MicSetupModal.propTypes = {
   isMicrophoneEnabled: PropTypes.bool,
   isMicrophoneMuted: PropTypes.bool,
   onChangeMicrophoneMuted: PropTypes.func,
-  selectedMicrophone: PropTypes.string,
-  microphoneOptions: PropTypes.array,
+  microphoneOptions: PropTypes.object,
   onChangeMicrophone: PropTypes.func,
-  selectedSpeaker: PropTypes.string,
-  speakerOptions: PropTypes.array,
+  speakerOptions: PropTypes.object,
   onChangeSpeaker: PropTypes.func,
   onEnterRoom: PropTypes.func,
   onBack: PropTypes.func,

--- a/src/react-components/room/MicSetupModal.js
+++ b/src/react-components/room/MicSetupModal.js
@@ -59,7 +59,7 @@ export function MicSetupModal({
                     <Spinner />
                   </div>
                 )}
-                {permissionStatus === PermissionStatus.GRANTED && isMicrophoneEnabled && !isMicrophoneMuted ? (
+                {permissionStatus === PermissionStatus.GRANTED && !isMicrophoneMuted ? (
                   <MicrophoneIcon className={iconStyle} />
                 ) : (
                   <MicrophoneMutedIcon className={iconStyle} />
@@ -73,7 +73,7 @@ export function MicSetupModal({
               )}
             </div>
             <div className={styles.actionContainer}>
-              {permissionStatus === PermissionStatus.GRANTED && isMicrophoneEnabled ? (
+              {permissionStatus === PermissionStatus.GRANTED ? (
                 <>
                   <ToggleInput
                     label={<FormattedMessage id="mic-setup-modal.mute-mic-toggle-v2" defaultMessage="Mute" />}
@@ -130,9 +130,7 @@ export function MicSetupModal({
               )}
             </div>
             {permissionStatus === PermissionStatus.GRANTED &&
-              MediaDevicesManager.isAudioInputSelectEnabled &&
-              microphoneOptions?.options?.length > 0 &&
-              isMicrophoneEnabled && (
+              MediaDevicesManager.isAudioInputSelectEnabled && (
                 <div className={styles.selectionContainer}>
                   <p style={{ alignSelf: "start" }}>
                     <FormattedMessage id="mic-setup-modal.microphone-text" defaultMessage="Microphone" />
@@ -157,7 +155,7 @@ export function MicSetupModal({
               </Button>
             </div>
             {permissionStatus === PermissionStatus.GRANTED &&
-              speakerOptions?.options?.length > 0 && (
+              MediaDevicesManager.isAudioOutputSelectEnabled && (
                 <div className={styles.selectionContainer}>
                   <p style={{ alignSelf: "start" }}>
                     <FormattedMessage id="mic-setup-modal.speakers-text" defaultMessage="Speakers" />

--- a/src/react-components/room/MicSetupModal.scss
+++ b/src/react-components/room/MicSetupModal.scss
@@ -44,8 +44,8 @@ $mobile-breakpoint-width: 450px;
     stroke-width: 1;
   }
 
-  width: 42px;
-  height: 42px;
+  width: 48px;
+  height: 48px;
 
   *[stroke=\#000] {
     stroke: theme.$text1-color;

--- a/src/react-components/room/MicSetupModalContainer.js
+++ b/src/react-components/room/MicSetupModalContainer.js
@@ -15,8 +15,8 @@ export function MicSetupModalContainer({ scene, ...rest }) {
   });
   const { onMicMuted } = rest;
   const { isMicEnabled, isMicMuted, toggleMute, permissionStatus } = useMicrophoneStatus(scene);
-  const { micDeviceChanged, selectedMicDeviceId, micDevices } = useMicrophone(scene);
-  const { speakerDeviceChanged, selectedSpeakersDeviceId, speakerDevices } = useSpeakers(scene);
+  const { micDeviceChanged, micDevices } = useMicrophone(scene);
+  const { speakerDeviceChanged, speakerDevices } = useSpeakers();
   const { playSound, soundVolume } = useSound({
     scene,
     sound: SOUND_SPEAKER_TONE
@@ -37,8 +37,6 @@ export function MicSetupModalContainer({ scene, ...rest }) {
       isMicrophoneEnabled={isMicEnabled}
       isMicrophoneMuted={isMicMuted}
       permissionStatus={permissionStatus}
-      selectedMicrophone={selectedMicDeviceId}
-      selectedSpeaker={selectedSpeakersDeviceId}
       microphoneOptions={micDevices}
       speakerOptions={speakerDevices}
       onChangeMicrophone={micDeviceChanged}

--- a/src/react-components/room/SharePopoverContainer.js
+++ b/src/react-components/room/SharePopoverContainer.js
@@ -9,7 +9,7 @@ import useAvatar from "./useAvatar";
 import { MediaDevicesEvents, MediaDevices } from "../../utils/media-devices-utils";
 
 function useShare(scene, hubChannel) {
-  const mediaDevicesManager = window.APP.mediaDevicesManager;
+  const mediaDevicesManager = APP.mediaDevicesManager;
   const [sharingSource, setSharingSource] = useState(null);
   const [canShareCamera, setCanShareCamera] = useState(false);
   const [canShareScreen, setCanShareScreen] = useState(false);

--- a/src/react-components/room/useMicrophone.js
+++ b/src/react-components/room/useMicrophone.js
@@ -4,17 +4,17 @@ import { MediaDevices, MediaDevicesEvents } from "../../utils/media-devices-util
 export function useMicrophone(scene) {
   const mediaDevicesManager = window.APP.mediaDevicesManager;
   const [selectedMicDeviceId, setSelectedMicDeviceId] = useState(mediaDevicesManager.selectedMicDeviceId);
-  const [micDevices, setMicDevices] = useState(mediaDevicesManager.micDevices);
+  const [micDevices, setMicDevices] = useState(mediaDevicesManager.micDevicesOptions);
 
   useEffect(
     () => {
       const onMicEnabled = () => {
         setSelectedMicDeviceId(mediaDevicesManager.selectedMicDeviceId);
-        setMicDevices(mediaDevicesManager.micDevices);
+        setMicDevices(mediaDevicesManager.micDevicesOptions);
       };
       const onMicDisabled = () => {
         setSelectedMicDeviceId(mediaDevicesManager.selectedMicDeviceId);
-        setMicDevices(mediaDevicesManager.micDevices);
+        setMicDevices(mediaDevicesManager.micDevicesOptions);
       };
       scene.addEventListener(MediaDevicesEvents.MIC_SHARE_ENDED, onMicDisabled);
       scene.addEventListener(MediaDevicesEvents.MIC_SHARE_STARTED, onMicEnabled);
@@ -22,19 +22,19 @@ export function useMicrophone(scene) {
       const onPermissionsChanged = ({ mediaDevice }) => {
         if (mediaDevice === MediaDevices.MICROPHONE) {
           setSelectedMicDeviceId(mediaDevicesManager.selectedMicDeviceId);
-          setMicDevices(mediaDevicesManager.micDevices);
+          setMicDevices(mediaDevicesManager.micDevicesOptions);
         }
       };
       mediaDevicesManager.on(MediaDevicesEvents.PERMISSIONS_STATUS_CHANGED, onPermissionsChanged);
 
       const onDeviceChange = () => {
         setSelectedMicDeviceId(mediaDevicesManager.selectedMicDeviceId);
-        setMicDevices(mediaDevicesManager.micDevices);
+        setMicDevices(mediaDevicesManager.micDevicesOptions);
       };
       mediaDevicesManager.on(MediaDevicesEvents.DEVICE_CHANGE, onDeviceChange);
 
       setSelectedMicDeviceId(mediaDevicesManager.selectedMicDeviceId);
-      setMicDevices(mediaDevicesManager.micDevices);
+      setMicDevices(mediaDevicesManager.micDevicesOptions);
 
       return () => {
         scene.removeEventListener(MediaDevicesEvents.MIC_SHARE_ENDED, onMicDisabled);
@@ -49,7 +49,7 @@ export function useMicrophone(scene) {
   const micDeviceChanged = useCallback(
     deviceId => {
       setSelectedMicDeviceId(deviceId);
-      setMicDevices(mediaDevicesManager.micDevices);
+      setMicDevices(mediaDevicesManager.micDevicesOptions);
       mediaDevicesManager.startMicShare({ deviceId });
     },
     [mediaDevicesManager]

--- a/src/react-components/room/useMicrophone.js
+++ b/src/react-components/room/useMicrophone.js
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { MediaDevices, MediaDevicesEvents } from "../../utils/media-devices-utils";
 
 export function useMicrophone(scene) {
-  const mediaDevicesManager = window.APP.mediaDevicesManager;
+  const mediaDevicesManager = APP.mediaDevicesManager;
   const [micDevices, setMicDevices] = useState({
     value: mediaDevicesManager.selectedMicDeviceId,
     options: mediaDevicesManager.micDevicesOptions

--- a/src/react-components/room/useMicrophone.js
+++ b/src/react-components/room/useMicrophone.js
@@ -3,38 +3,50 @@ import { MediaDevices, MediaDevicesEvents } from "../../utils/media-devices-util
 
 export function useMicrophone(scene) {
   const mediaDevicesManager = window.APP.mediaDevicesManager;
-  const [selectedMicDeviceId, setSelectedMicDeviceId] = useState(mediaDevicesManager.selectedMicDeviceId);
-  const [micDevices, setMicDevices] = useState(mediaDevicesManager.micDevicesOptions);
+  const [micDevices, setMicDevices] = useState({
+    value: mediaDevicesManager.selectedMicDeviceId,
+    options: mediaDevicesManager.micDevicesOptions
+  });
 
   useEffect(
     () => {
       const onMicEnabled = () => {
-        setSelectedMicDeviceId(mediaDevicesManager.selectedMicDeviceId);
-        setMicDevices(mediaDevicesManager.micDevicesOptions);
+        setMicDevices({
+          value: mediaDevicesManager.selectedMicDeviceId,
+          options: mediaDevicesManager.micDevicesOptions
+        });
       };
       const onMicDisabled = () => {
-        setSelectedMicDeviceId(mediaDevicesManager.selectedMicDeviceId);
-        setMicDevices(mediaDevicesManager.micDevicesOptions);
+        setMicDevices({
+          value: mediaDevicesManager.selectedMicDeviceId,
+          options: mediaDevicesManager.micDevicesOptions
+        });
       };
       scene.addEventListener(MediaDevicesEvents.MIC_SHARE_ENDED, onMicDisabled);
       scene.addEventListener(MediaDevicesEvents.MIC_SHARE_STARTED, onMicEnabled);
 
       const onPermissionsChanged = ({ mediaDevice }) => {
         if (mediaDevice === MediaDevices.MICROPHONE) {
-          setSelectedMicDeviceId(mediaDevicesManager.selectedMicDeviceId);
-          setMicDevices(mediaDevicesManager.micDevicesOptions);
+          setMicDevices({
+            value: mediaDevicesManager.selectedMicDeviceId,
+            options: mediaDevicesManager.micDevicesOptions
+          });
         }
       };
       mediaDevicesManager.on(MediaDevicesEvents.PERMISSIONS_STATUS_CHANGED, onPermissionsChanged);
 
       const onDeviceChange = () => {
-        setSelectedMicDeviceId(mediaDevicesManager.selectedMicDeviceId);
-        setMicDevices(mediaDevicesManager.micDevicesOptions);
+        setMicDevices({
+          value: mediaDevicesManager.selectedMicDeviceId,
+          options: mediaDevicesManager.micDevicesOptions
+        });
       };
       mediaDevicesManager.on(MediaDevicesEvents.DEVICE_CHANGE, onDeviceChange);
 
-      setSelectedMicDeviceId(mediaDevicesManager.selectedMicDeviceId);
-      setMicDevices(mediaDevicesManager.micDevicesOptions);
+      setMicDevices({
+        value: mediaDevicesManager.selectedMicDeviceId,
+        options: mediaDevicesManager.micDevicesOptions
+      });
 
       return () => {
         scene.removeEventListener(MediaDevicesEvents.MIC_SHARE_ENDED, onMicDisabled);
@@ -43,13 +55,15 @@ export function useMicrophone(scene) {
         mediaDevicesManager.off(MediaDevicesEvents.DEVICE_CHANGE, onDeviceChange);
       };
     },
-    [setSelectedMicDeviceId, setMicDevices, scene, mediaDevicesManager]
+    [setMicDevices, scene, mediaDevicesManager]
   );
 
   const micDeviceChanged = useCallback(
     deviceId => {
-      setSelectedMicDeviceId(deviceId);
-      setMicDevices(mediaDevicesManager.micDevicesOptions);
+      setMicDevices({
+        value: mediaDevicesManager.selectedMicDeviceId,
+        options: mediaDevicesManager.micDevicesOptions
+      });
       mediaDevicesManager.startMicShare({ deviceId });
     },
     [mediaDevicesManager]
@@ -57,7 +71,6 @@ export function useMicrophone(scene) {
 
   return {
     micDeviceChanged,
-    selectedMicDeviceId,
     micDevices
   };
 }

--- a/src/react-components/room/useMicrophoneStatus.js
+++ b/src/react-components/room/useMicrophoneStatus.js
@@ -2,9 +2,9 @@ import { useState, useEffect, useCallback } from "react";
 import { MediaDevices, MediaDevicesEvents } from "../../utils/media-devices-utils";
 
 export function useMicrophoneStatus(scene) {
-  const mediaDevicesManager = window.APP.mediaDevicesManager;
+  const mediaDevicesManager = APP.mediaDevicesManager;
   const [isMicMuted, setIsMicMuted] = useState(!mediaDevicesManager.isMicEnabled);
-  const [isMicEnabled, setIsMicEnabled] = useState(window.APP.mediaDevicesManager.isMicShared);
+  const [isMicEnabled, setIsMicEnabled] = useState(APP.mediaDevicesManager.isMicShared);
   const [permissionStatus, setPermissionsStatus] = useState(
     mediaDevicesManager.getPermissionsStatus(MediaDevices.MICROPHONE)
   );

--- a/src/react-components/room/useSpeakers.js
+++ b/src/react-components/room/useSpeakers.js
@@ -6,26 +6,26 @@ export function useSpeakers() {
   const [selectedSpeakersDeviceId, setSelectedSpeakersDeviceId] = useState(
     mediaDevicesManager.selectedSpeakersDeviceId
   );
-  const [speakerDevices, setSpeakerDevices] = useState(mediaDevicesManager.outputDevices);
+  const [speakerDevices, setSpeakerDevices] = useState(mediaDevicesManager.outputDevicesOptions);
 
   useEffect(
     () => {
       const onPermissionsChanged = ({ mediaDevice }) => {
         if (mediaDevice === MediaDevices.MICROPHONE) {
           setSelectedSpeakersDeviceId(mediaDevicesManager.selectedSpeakersDeviceId);
-          setSpeakerDevices(mediaDevicesManager.outputDevices);
+          setSpeakerDevices(mediaDevicesManager.outputDevicesOptions);
         }
       };
       mediaDevicesManager.on(MediaDevicesEvents.PERMISSIONS_STATUS_CHANGED, onPermissionsChanged);
 
       const onDeviceChange = () => {
         setSelectedSpeakersDeviceId(mediaDevicesManager.selectedSpeakersDeviceId);
-        setSpeakerDevices(mediaDevicesManager.outputDevices);
+        setSpeakerDevices(mediaDevicesManager.outputDevicesOptions);
       };
       mediaDevicesManager.on(MediaDevicesEvents.DEVICE_CHANGE, onDeviceChange);
 
       setSelectedSpeakersDeviceId(mediaDevicesManager.selectedSpeakersDeviceId);
-      setSpeakerDevices(mediaDevicesManager.outputDevices);
+      setSpeakerDevices(mediaDevicesManager.outputDevicesOptions);
 
       return () => {
         mediaDevicesManager.off(MediaDevicesEvents.PERMISSIONS_STATUS_CHANGED, onPermissionsChanged);
@@ -38,7 +38,7 @@ export function useSpeakers() {
   const speakerDeviceChanged = useCallback(
     deviceId => {
       mediaDevicesManager.changeAudioOutput(deviceId);
-      setSpeakerDevices(mediaDevicesManager.outputDevices);
+      setSpeakerDevices(mediaDevicesManager.outputDevicesOptions);
       setSelectedSpeakersDeviceId(deviceId);
     },
     [mediaDevicesManager]

--- a/src/react-components/room/useSpeakers.js
+++ b/src/react-components/room/useSpeakers.js
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { MediaDevices, MediaDevicesEvents } from "../../utils/media-devices-utils";
 
 export function useSpeakers() {
-  const mediaDevicesManager = window.APP.mediaDevicesManager;
+  const mediaDevicesManager = APP.mediaDevicesManager;
   const [speakerDevices, setSpeakerDevices] = useState({
     value: mediaDevicesManager.selectedSpeakersDeviceId,
     options: mediaDevicesManager.outputDevicesOptions

--- a/src/react-components/room/useSpeakers.js
+++ b/src/react-components/room/useSpeakers.js
@@ -3,50 +3,57 @@ import { MediaDevices, MediaDevicesEvents } from "../../utils/media-devices-util
 
 export function useSpeakers() {
   const mediaDevicesManager = window.APP.mediaDevicesManager;
-  const [selectedSpeakersDeviceId, setSelectedSpeakersDeviceId] = useState(
-    mediaDevicesManager.selectedSpeakersDeviceId
-  );
-  const [speakerDevices, setSpeakerDevices] = useState(mediaDevicesManager.outputDevicesOptions);
+  const [speakerDevices, setSpeakerDevices] = useState({
+    value: mediaDevicesManager.selectedSpeakersDeviceId,
+    options: mediaDevicesManager.outputDevicesOptions
+  });
 
   useEffect(
     () => {
       const onPermissionsChanged = ({ mediaDevice }) => {
         if (mediaDevice === MediaDevices.MICROPHONE) {
-          setSelectedSpeakersDeviceId(mediaDevicesManager.selectedSpeakersDeviceId);
-          setSpeakerDevices(mediaDevicesManager.outputDevicesOptions);
+          setSpeakerDevices({
+            value: mediaDevicesManager.selectedSpeakersDeviceId,
+            options: mediaDevicesManager.outputDevicesOptions
+          });
         }
       };
       mediaDevicesManager.on(MediaDevicesEvents.PERMISSIONS_STATUS_CHANGED, onPermissionsChanged);
 
       const onDeviceChange = () => {
-        setSelectedSpeakersDeviceId(mediaDevicesManager.selectedSpeakersDeviceId);
-        setSpeakerDevices(mediaDevicesManager.outputDevicesOptions);
+        setSpeakerDevices({
+          value: mediaDevicesManager.selectedSpeakersDeviceId,
+          options: mediaDevicesManager.outputDevicesOptions
+        });
       };
       mediaDevicesManager.on(MediaDevicesEvents.DEVICE_CHANGE, onDeviceChange);
 
-      setSelectedSpeakersDeviceId(mediaDevicesManager.selectedSpeakersDeviceId);
-      setSpeakerDevices(mediaDevicesManager.outputDevicesOptions);
+      setSpeakerDevices({
+        value: mediaDevicesManager.selectedSpeakersDeviceId,
+        options: mediaDevicesManager.outputDevicesOptions
+      });
 
       return () => {
         mediaDevicesManager.off(MediaDevicesEvents.PERMISSIONS_STATUS_CHANGED, onPermissionsChanged);
         mediaDevicesManager.off(MediaDevicesEvents.DEVICE_CHANGE, onDeviceChange);
       };
     },
-    [setSelectedSpeakersDeviceId, setSpeakerDevices, mediaDevicesManager]
+    [setSpeakerDevices, mediaDevicesManager]
   );
 
   const speakerDeviceChanged = useCallback(
     deviceId => {
       mediaDevicesManager.changeAudioOutput(deviceId);
-      setSpeakerDevices(mediaDevicesManager.outputDevicesOptions);
-      setSelectedSpeakersDeviceId(deviceId);
+      setSpeakerDevices({
+        value: mediaDevicesManager.selectedSpeakersDeviceId,
+        options: mediaDevicesManager.outputDevicesOptions
+      });
     },
     [mediaDevicesManager]
   );
 
   return {
     speakerDeviceChanged,
-    selectedSpeakersDeviceId,
     speakerDevices
   };
 }

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -327,8 +327,6 @@ class UIRoot extends Component {
       this.forceUpdate();
     });
 
-    this.updateMediaPermissions();
-
     const scene = this.props.scene;
 
     const unsubscribe = this.props.history.listen((location, action) => {
@@ -558,9 +556,7 @@ class UIRoot extends Component {
 
     if (hasGrantedMic) {
       if (!this.mediaDevicesManager.isMicShared) {
-        await this.mediaDevicesManager.startMicShare({
-          deviceId: this.mediaDevicesManager.preferredMicDeviceId
-        });
+        await this.mediaDevicesManager.startMicShare({});
       }
       this.beginOrSkipAudioSetup();
     } else {
@@ -591,13 +587,7 @@ class UIRoot extends Component {
   };
 
   onRequestMicPermission = async () => {
-    await this.mediaDevicesManager.startMicShare({
-      deviceId: this.mediaDevicesManager.preferredMicDeviceId
-    });
-  };
-
-  updateMediaPermissions = async () => {
-    await this.mediaDevicesManager.updatePermissions();
+    await this.mediaDevicesManager.startMicShare({});
   };
 
   beginOrSkipAudioSetup = () => {

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -208,7 +208,7 @@ class UIRoot extends Component {
 
     // An exit handler that discards event arguments and can be cleaned up.
     this.exitEventHandler = () => this.props.exitScene();
-    this.mediaDevicesManager = window.APP.mediaDevicesManager;
+    this.mediaDevicesManager = APP.mediaDevicesManager;
   }
 
   componentDidUpdate(prevProps) {

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -1,7 +1,6 @@
 import qsTruthy from "./utils/qs_truthy";
 import nextTick from "./utils/next-tick";
 import { hackyMobileSafariTest } from "./utils/detect-touchscreen";
-import { isIOS as detectIOS } from "./utils/is-mobile";
 import { SignInMessages } from "./react-components/auth/SignInModal";
 
 const isBotMode = qsTruthy("bot");
@@ -22,8 +21,6 @@ import { ObjectContentOrigins } from "./object-types";
 import { getAvatarSrc, getAvatarType } from "./utils/avatar-utils";
 import { SOUND_ENTER_SCENE } from "./systems/sound-effects-system";
 import { MediaDevices, MediaDevicesEvents } from "./utils/media-devices-utils";
-
-const isIOS = detectIOS();
 
 export default class SceneEntryManager {
   constructor(hubChannel, authChannel, history) {
@@ -354,57 +351,23 @@ export default class SceneEntryManager {
     this.scene.addEventListener("action_share_camera", event => {
       if (isHandlingVideoShare) return;
       isHandlingVideoShare = true;
-
-      const constraints = {
-        video: {
-          width: isIOS ? { max: 1280 } : { max: 1280, ideal: 720 },
-          frameRate: 30
-        }
-        //TODO: Capture audio from camera?
-      };
-
-      // check preferences
-      const preferredCamera = this.store.state.preferences.preferredCamera;
-      switch (preferredCamera) {
-        case "default":
-          constraints.video.mediaSource = MediaDevices.CAMERA;
-          break;
-        case "user":
-        case "environment":
-          constraints.video.facingMode = preferredCamera;
-          break;
-        default:
-          constraints.video.deviceId = preferredCamera;
-          break;
-      }
-
-      this.mediaDevicesManager.startVideoShare(constraints, false, event.detail?.target, shareSuccess, shareError);
+      this.mediaDevicesManager.startVideoShare({
+        isDisplayMedia: false,
+        target: event.detail?.target,
+        success: shareSuccess,
+        error: shareError
+      });
     });
 
     this.scene.addEventListener("action_share_screen", () => {
       if (isHandlingVideoShare) return;
       isHandlingVideoShare = true;
-
-      this.mediaDevicesManager.startVideoShare(
-        {
-          video: {
-            // Work around BMO 1449832 by calculating the width. This will break for multi monitors if you share anything
-            // other than your current monitor that has a different aspect ratio.
-            width: 720 * (screen.width / screen.height),
-            height: 720,
-            frameRate: 30
-          },
-          audio: {
-            echoCancellation: !this.store.state.preferences.disableEchoCancellation,
-            noiseSuppression: !this.store.state.preferences.disableNoiseSuppression,
-            autoGainControl: !this.store.state.preferences.disableAutoGainControl
-          }
-        },
-        true,
-        null,
-        shareSuccess,
-        shareError
-      );
+      this.mediaDevicesManager.startVideoShare({
+        isDisplayMedia: true,
+        target: null,
+        success: shareSuccess,
+        error: shareError
+      });
     });
 
     this.scene.addEventListener(MediaDevicesEvents.VIDEO_SHARE_ENDED, async () => {

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -42,7 +42,7 @@ export default class SceneEntryManager {
       console.log("Scene is loaded so setting up controllers");
       this.rightCursorController.components["cursor-controller"].enabled = false;
       this.leftCursorController.components["cursor-controller"].enabled = false;
-      this.mediaDevicesManager = window.APP.mediaDevicesManager;
+      this.mediaDevicesManager = APP.mediaDevicesManager;
       this._setupBlocking();
     });
   };

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -10,6 +10,7 @@ const OAUTH_FLOW_CREDENTIALS_KEY = "ret-oauth-flow-account-credentials";
 const validator = new Validator();
 import { EventTarget } from "event-target-shim";
 import { fetchRandomDefaultAvatarId, generateRandomName } from "../utils/identity.js";
+import { NO_DEVICE_ID } from "../utils/media-devices-utils.js";
 
 const defaultMaterialQuality = (function() {
   const MATERIAL_QUALITY_OPTIONS = ["low", "medium", "high"];
@@ -95,9 +96,10 @@ export const SCHEMA = {
       additionalProperties: false,
       properties: {
         shouldPromptForRefresh: { type: "bool", default: false },
-        preferredMic: { type: "string", default: "Default" },
-        preferredSpeakers: { type: "string", default: "Default" },
-        preferredCamera: { type: "string", default: "none" },
+        // Preferred media will be set dynamically
+        preferredMic: { type: "string", default: NO_DEVICE_ID },
+        preferredSpeakers: { type: "string", default: NO_DEVICE_ID },
+        preferredCamera: { type: "string", default: NO_DEVICE_ID },
         muteMicOnEntry: { type: "bool", default: false },
         disableLeftRightPanning: { type: "bool", default: false },
         audioNormalization: { type: "bool", default: 0.0 },

--- a/src/systems/audio-system.js
+++ b/src/systems/audio-system.js
@@ -20,7 +20,6 @@ function performDelayedReconnect(gainNode) {
 import * as sdpTransform from "sdp-transform";
 import MediaDevicesManager from "../utils/media-devices-manager";
 import { THREE } from "aframe";
-import { DEFAULT_DEVICE_ID } from "../utils/media-devices-utils";
 
 function isThreeAudio(node) {
   return node instanceof THREE.Audio || node instanceof THREE.PositionalAudio;
@@ -227,7 +226,7 @@ export class AudioSystem {
 
     if (MediaDevicesManager.isAudioOutputSelectEnabled && window.APP.mediaDevicesManager) {
       const sinkId = window.APP.mediaDevicesManager.selectedSpeakersDeviceId;
-      const isDefault = sinkId === DEFAULT_DEVICE_ID;
+      const isDefault = sinkId === window.APP.mediaDevicesManager.defaultOutputDeviceId;
       const sink = isDefault ? this._sceneEl.audioListener.getInput() : this.audioDestination;
       this.mixer[SourceType.AVATAR_AUDIO_SOURCE].disconnect();
       this.mixer[SourceType.AVATAR_AUDIO_SOURCE].connect(sink);

--- a/src/systems/audio-system.js
+++ b/src/systems/audio-system.js
@@ -227,6 +227,7 @@ export class AudioSystem {
     if (MediaDevicesManager.isAudioOutputSelectEnabled && window.APP.mediaDevicesManager) {
       const sinkId = window.APP.mediaDevicesManager.selectedSpeakersDeviceId;
       const isDefault = sinkId === window.APP.mediaDevicesManager.defaultOutputDeviceId;
+      if ((!this.outputMediaAudio && isDefault) || sinkId === this.outputMediaAudio?.sinkId) return;
       const sink = isDefault ? this._sceneEl.audioListener.getInput() : this.audioDestination;
       this.mixer[SourceType.AVATAR_AUDIO_SOURCE].disconnect();
       this.mixer[SourceType.AVATAR_AUDIO_SOURCE].connect(sink);

--- a/src/systems/audio-system.js
+++ b/src/systems/audio-system.js
@@ -224,9 +224,9 @@ export class AudioSystem {
       GAIN_TIME_CONST
     );
 
-    if (MediaDevicesManager.isAudioOutputSelectEnabled && window.APP.mediaDevicesManager) {
-      const sinkId = window.APP.mediaDevicesManager.selectedSpeakersDeviceId;
-      const isDefault = sinkId === window.APP.mediaDevicesManager.defaultOutputDeviceId;
+    if (MediaDevicesManager.isAudioOutputSelectEnabled && APP.mediaDevicesManager) {
+      const sinkId = APP.mediaDevicesManager.selectedSpeakersDeviceId;
+      const isDefault = sinkId === APP.mediaDevicesManager.defaultOutputDeviceId;
       if ((!this.outputMediaAudio && isDefault) || sinkId === this.outputMediaAudio?.sinkId) return;
       const sink = isDefault ? this._sceneEl.audioListener.getInput() : this.audioDestination;
       this.mixer[SourceType.AVATAR_AUDIO_SOURCE].disconnect();

--- a/src/utils/media-devices-manager.js
+++ b/src/utils/media-devices-manager.js
@@ -290,9 +290,7 @@ export default class MediaDevicesManager extends EventEmitter {
       this.audioTrack = newStream.getAudioTracks()[0];
       this.audioTrack.addEventListener("ended", async () => {
         this._scene.emit(MediaDevicesEvents.MIC_SHARE_ENDED);
-        if (this._permissionsStatus[MediaDevices.MICROPHONE] === PermissionStatus.GRANTED) {
-          this.startMicShare({ unmute: this.isMicEnabled });
-        }
+        this.startMicShare({ unmute: this.isMicEnabled });
       });
 
       if (/Oculus/.test(navigator.userAgent)) {

--- a/src/utils/media-devices-manager.js
+++ b/src/utils/media-devices-manager.js
@@ -265,15 +265,15 @@ export default class MediaDevicesManager extends EventEmitter {
     }
 
     if (result) {
-      this._scene.emit(MediaDevicesEvents.MIC_SHARE_STARTED);
       this._permissionsStatus[MediaDevices.MICROPHONE] = PermissionStatus.GRANTED;
+      this._scene.emit(MediaDevicesEvents.MIC_SHARE_STARTED);
       this.emit(MediaDevicesEvents.PERMISSIONS_STATUS_CHANGED, {
         mediaDevice: MediaDevices.MICROPHONE,
         status: PermissionStatus.GRANTED
       });
     } else {
-      this._scene.emit(MediaDevicesEvents.MIC_SHARE_ENDED);
       this._permissionsStatus[MediaDevices.MICROPHONE] = PermissionStatus.DENIED;
+      this._scene.emit(MediaDevicesEvents.MIC_SHARE_ENDED);
       this.emit(MediaDevicesEvents.PERMISSIONS_STATUS_CHANGED, {
         mediaDevice: MediaDevices.MICROPHONE,
         status: PermissionStatus.DENIED
@@ -386,18 +386,18 @@ export default class MediaDevicesManager extends EventEmitter {
 
         const mediaDevice = isDisplayMedia ? MediaDevices.SCREEN : MediaDevices.CAMERA;
         this._permissionsStatus[mediaDevice] = PermissionStatus.GRANTED;
+        this._scene.emit(MediaDevicesEvents.VIDEO_SHARE_STARTED);
         this.emit(MediaDevicesEvents.PERMISSIONS_STATUS_CHANGED, { mediaDevice, status: PermissionStatus.GRANTED });
       }
     } catch (e) {
       error(e);
-      this._scene.emit(MediaDevicesEvents.VIDEO_SHARE_ENDED);
       const mediaDevice = isDisplayMedia ? MediaDevices.SCREEN : MediaDevices.CAMERA;
       this._permissionsStatus[mediaDevice] = PermissionStatus.DENIED;
+      this._scene.emit(MediaDevicesEvents.VIDEO_SHARE_ENDED);
       this.emit(MediaDevicesEvents.PERMISSIONS_STATUS_CHANGED, { mediaDevice, status: PermissionStatus.DENIED });
       return;
     }
 
-    this._scene.emit(MediaDevicesEvents.VIDEO_SHARE_STARTED);
     success(isDisplayMedia, videoTrackAdded, target);
   }
 

--- a/src/utils/media-devices-manager.js
+++ b/src/utils/media-devices-manager.js
@@ -1,11 +1,5 @@
 import { EventEmitter } from "eventemitter3";
-import {
-  MediaDevicesEvents,
-  PermissionStatus,
-  MediaDevices,
-  DEFAULT_DEVICE_ID,
-  NO_DEVICE_ID
-} from "./media-devices-utils";
+import { MediaDevicesEvents, PermissionStatus, MediaDevices, NO_DEVICE_ID } from "./media-devices-utils";
 import { detectOS, detect } from "detect-browser";
 
 const isMobile = AFRAME.utils.device.isMobile();
@@ -76,6 +70,18 @@ export default class MediaDevicesManager extends EventEmitter {
     this._audioTrack = audioTrack;
   }
 
+  get defaultInputDeviceId() {
+    return this._micDevices && this._micDevices.length > 0 ? this._micDevices[0].value : NO_DEVICE_ID;
+  }
+
+  get defaultOutputDeviceId() {
+    return this._outputDevices && this._outputDevices.length > 0 ? this._micDevices[0].value : NO_DEVICE_ID;
+  }
+
+  get defaultVideoDeviceId() {
+    return this._videoDevices && this._videoDevices.length > 0 ? this._micDevices[0].value : NO_DEVICE_ID;
+  }
+
   get micDevices() {
     if (MediaDevicesManager.isAudioInputSelectEnabled) {
       if (this._permissionsStatus[MediaDevices.MICROPHONE] === PermissionStatus.DENIED) {
@@ -84,7 +90,7 @@ export default class MediaDevicesManager extends EventEmitter {
         return this._micDevices;
       }
     } else {
-      return [{ value: DEFAULT_DEVICE_ID, label: "Default" }];
+      return [{ value: this.defaultInputDeviceId, label: this.micLabelForDeviceId(this.defaultInputDeviceId) }];
     }
   }
 
@@ -125,10 +131,10 @@ export default class MediaDevicesManager extends EventEmitter {
       if (this._permissionsStatus[MediaDevices.MICROPHONE] === PermissionStatus.DENIED) {
         return NO_DEVICE_ID;
       } else {
-        return this.deviceIdForMicDeviceLabel(this.selectedMicLabel) || DEFAULT_DEVICE_ID;
+        return this.deviceIdForMicDeviceLabel(this.selectedMicLabel) || this.defaultInputDeviceId;
       }
     } else {
-      return DEFAULT_DEVICE_ID;
+      return this.defaultInputDeviceId;
     }
   }
 
@@ -138,10 +144,10 @@ export default class MediaDevicesManager extends EventEmitter {
         return NO_DEVICE_ID;
       } else {
         const { preferredMic } = this._store.state.preferences;
-        return preferredMic || DEFAULT_DEVICE_ID;
+        return preferredMic || this.defaultInputDeviceId;
       }
     } else {
-      return DEFAULT_DEVICE_ID;
+      return this.defaultInputDeviceId;
     }
   }
 
@@ -150,7 +156,7 @@ export default class MediaDevicesManager extends EventEmitter {
     const exists = this.outputDevices.some(device => {
       return device.value === preferredSpeakers;
     });
-    return exists ? preferredSpeakers : this.outputDevices[0]?.value || DEFAULT_DEVICE_ID;
+    return exists ? preferredSpeakers : this.outputDevices[0]?.value || this.defaultOutputDeviceId;
   }
 
   get isMicShared() {
@@ -253,7 +259,7 @@ export default class MediaDevicesManager extends EventEmitter {
     console.log("Starting microphone sharing");
 
     if (!deviceId) {
-      deviceId = DEFAULT_DEVICE_ID;
+      deviceId = this.defaultInputDeviceId;
     }
     let constraints = { audio: {} };
     if (deviceId) {

--- a/src/utils/media-devices-manager.js
+++ b/src/utils/media-devices-manager.js
@@ -115,11 +115,6 @@ export default class MediaDevicesManager extends EventEmitter {
       : this.deviceIdForMicDeviceLabel(this.selectedMicLabel);
   }
 
-  get preferredMicDeviceId() {
-    const { preferredMic } = this._store.state.preferences;
-    return preferredMic !== NO_DEVICE_ID ? preferredMic : undefined;
-  }
-
   get selectedSpeakersDeviceId() {
     const { preferredSpeakers } = this._store.state.preferences;
     const exists = this._outputDevices.some(device => {
@@ -227,7 +222,8 @@ export default class MediaDevicesManager extends EventEmitter {
     console.log("Starting microphone sharing");
 
     if (!deviceId) {
-      deviceId = this.preferredMicDeviceId;
+      const { preferredMic } = this._store.state.preferences;
+      deviceId = preferredMic !== NO_DEVICE_ID ? preferredMic : undefined;
     }
     let constraints = { audio: {} };
     if (deviceId) {

--- a/src/utils/media-devices-manager.js
+++ b/src/utils/media-devices-manager.js
@@ -4,6 +4,7 @@ import { detectOS, detect } from "detect-browser";
 import { isIOS as detectIOS } from "./is-mobile";
 
 const isMobile = AFRAME.utils.device.isMobile();
+const isIOS = detectIOS();
 
 // This is a list of regexes that match the microphone labels of HMDs.
 //
@@ -357,7 +358,7 @@ export default class MediaDevicesManager extends EventEmitter {
       } else {
         newStream = await navigator.mediaDevices.getUserMedia({
           video: {
-            width: detectIOS ? { max: 1280 } : { max: 1280, ideal: 720 },
+            width: isIOS ? { max: 1280 } : { max: 1280, ideal: 720 },
             frameRate: 30
           }
           //TODO: Capture audio from camera?

--- a/src/utils/media-devices-manager.js
+++ b/src/utils/media-devices-manager.js
@@ -203,18 +203,16 @@ export default class MediaDevicesManager extends EventEmitter {
     return new Promise(resolve => {
       navigator.mediaDevices.enumerateDevices().then(mediaDevices => {
         mediaDevices = mediaDevices.filter(d => d.label !== "");
-        if (MediaDevicesManager.isAudioInputSelectEnabled) {
-          this._micDevices = mediaDevices
-            .filter(d => d.kind === "audioinput")
-            .map(d => ({ value: d.deviceId, label: d.label || `Mic Device (${d.deviceId.substr(0, 9)})` }));
-        }
+        this._micDevices = mediaDevices
+          .filter(d => d.deviceId !== "default" && d.kind === "audioinput")
+          .map(d => ({ value: d.deviceId, label: d.label || `Mic Device (${d.deviceId.substring(0, 9)})` }));
         this._videoDevices = mediaDevices
-          .filter(d => d.kind === "videoinput")
-          .map(d => ({ value: d.deviceId, label: d.label || `Camera Device (${d.deviceId.substr(0, 9)})` }));
+          .filter(d => d.deviceId !== "default" && d.kind === "videoinput")
+          .map(d => ({ value: d.deviceId, label: d.label || `Camera Device (${d.deviceId.substring(0, 9)})` }));
         if (MediaDevicesManager.isAudioOutputSelectEnabled) {
           this._outputDevices = mediaDevices
-            .filter(d => d.kind === "audiooutput")
-            .map(d => ({ value: d.deviceId, label: d.label || `Audio Output (${d.deviceId.substr(0, 9)})` }));
+            .filter(d => d.deviceId !== "default" && d.kind === "audiooutput")
+            .map(d => ({ value: d.deviceId, label: d.label || `Audio Output (${d.deviceId.substring(0, 9)})` }));
         }
         resolve();
       });
@@ -436,7 +434,12 @@ export default class MediaDevicesManager extends EventEmitter {
   }
 
   micLabelForAudioTrack(audioTrack) {
-    return (audioTrack && audioTrack.label) || "";
+    const label = (audioTrack && audioTrack.label) || "";
+    if (label.indexOf("Default - ") < 0) {
+      return label;
+    } else {
+      return label.substring(10);
+    }
   }
 
   deviceIdForMicDeviceLabel(label) {

--- a/src/utils/media-devices-manager.js
+++ b/src/utils/media-devices-manager.js
@@ -171,6 +171,7 @@ export default class MediaDevicesManager extends EventEmitter {
 
   onDeviceChange = () => {
     this.fetchMediaDevices().then(() => {
+      this.changeAudioOutput(this.selectedSpeakersDeviceId);
       this.emit(MediaDevicesEvents.DEVICE_CHANGE, null);
     });
   };

--- a/src/utils/media-devices-manager.js
+++ b/src/utils/media-devices-manager.js
@@ -229,7 +229,7 @@ export default class MediaDevicesManager extends EventEmitter {
     console.log("Starting microphone sharing");
 
     if (!deviceId) {
-      deviceId = this.defaultInputDeviceId;
+      deviceId = this.preferredMicDeviceId;
     }
     let constraints = { audio: {} };
     if (deviceId) {

--- a/src/utils/media-devices-manager.js
+++ b/src/utils/media-devices-manager.js
@@ -357,7 +357,7 @@ export default class MediaDevicesManager extends EventEmitter {
       } else {
         newStream = await navigator.mediaDevices.getUserMedia({
           video: {
-            width: isIOS ? { max: 1280 } : { max: 1280, ideal: 720 },
+            width: detectIOS ? { max: 1280 } : { max: 1280, ideal: 720 },
             frameRate: 30
           }
           //TODO: Capture audio from camera?

--- a/src/utils/media-devices-manager.js
+++ b/src/utils/media-devices-manager.js
@@ -75,31 +75,23 @@ export default class MediaDevicesManager extends EventEmitter {
   }
 
   get defaultOutputDeviceId() {
-    return this._outputDevices.length > 0 ? this._micDevices[0].value : NO_DEVICE_ID;
+    return this._outputDevices.length > 0 ? this._outputDevices[0].value : NO_DEVICE_ID;
   }
 
   get defaultVideoDeviceId() {
-    return this._videoDevices.length > 0 ? this._micDevices[0].value : NO_DEVICE_ID;
+    return this._videoDevices.length > 0 ? this._videoDevices[0].value : NO_DEVICE_ID;
   }
 
   get micDevicesOptions() {
     return this._micDevices.length > 0 ? this._micDevices : [{ value: NO_DEVICE_ID, label: "None" }];
   }
 
-  get videoDevices() {
-    return this._videoDevices;
+  get videoDevicesOptions() {
+    return this._videoDevices.length > 0 ? this._videoDevices : [{ value: NO_DEVICE_ID, label: "None" }];
   }
 
-  set videoDevices(videoDevices) {
-    this._videoDevices = videoDevices;
-  }
-
-  set outputDevices(outputDevices) {
-    this._outputDevices = outputDevices;
-  }
-
-  get outputDevices() {
-    return this._outputDevices;
+  get outputDevicesOptions() {
+    return this._outputDevices.length > 0 ? this._outputDevices : [{ value: NO_DEVICE_ID, label: "None" }];
   }
 
   get mediaStream() {
@@ -130,10 +122,10 @@ export default class MediaDevicesManager extends EventEmitter {
 
   get selectedSpeakersDeviceId() {
     const { preferredSpeakers } = this._store.state.preferences;
-    const exists = this.outputDevices.some(device => {
+    const exists = this._outputDevices.some(device => {
       return device.value === preferredSpeakers;
     });
-    return exists ? preferredSpeakers : this.outputDevices[0]?.value || this.defaultOutputDeviceId;
+    return exists ? preferredSpeakers : this._outputDevices[0]?.value || this.defaultOutputDeviceId;
   }
 
   get isMicShared() {
@@ -190,7 +182,7 @@ export default class MediaDevicesManager extends EventEmitter {
       mediaDevice: MediaDevices.MICROPHONE,
       status: micStatus
     });
-    const videoStatus = this.videoDevices.length === 0 ? PermissionStatus.PROMPT : PermissionStatus.GRANTED;
+    const videoStatus = this._videoDevices.length === 0 ? PermissionStatus.PROMPT : PermissionStatus.GRANTED;
     this._permissionsStatus[MediaDevices.CAMERA] = videoStatus;
     this.emit(MediaDevicesEvents.PERMISSIONS_STATUS_CHANGED, {
       mediaDevice: MediaDevices.CAMERA,
@@ -214,11 +206,11 @@ export default class MediaDevicesManager extends EventEmitter {
             .filter(d => d.kind === "audioinput")
             .map(d => ({ value: d.deviceId, label: d.label || `Mic Device (${d.deviceId.substr(0, 9)})` }));
         }
-        this.videoDevices = mediaDevices
+        this._videoDevices = mediaDevices
           .filter(d => d.kind === "videoinput")
           .map(d => ({ value: d.deviceId, label: d.label || `Camera Device (${d.deviceId.substr(0, 9)})` }));
         if (MediaDevicesManager.isAudioOutputSelectEnabled) {
-          this.outputDevices = mediaDevices
+          this._outputDevices = mediaDevices
             .filter(d => d.kind === "audiooutput")
             .map(d => ({ value: d.deviceId, label: d.label || `Audio Output (${d.deviceId.substr(0, 9)})` }));
         }
@@ -431,7 +423,7 @@ export default class MediaDevicesManager extends EventEmitter {
   }
 
   deviceIdForSpeakersDeviceLabel(label) {
-    return this.outputDevices.filter(d => d.label === label).map(d => d.value)[0];
+    return this._outputDevices.filter(d => d.label === label).map(d => d.value)[0];
   }
 
   micLabelForDeviceId(deviceId) {
@@ -439,7 +431,7 @@ export default class MediaDevicesManager extends EventEmitter {
   }
 
   speakersLabelForDeviceId(deviceId) {
-    return this.outputDevices.filter(d => d.value === deviceId).map(d => d.label)[0];
+    return this._outputDevices.filter(d => d.value === deviceId).map(d => d.label)[0];
   }
 
   hasHmdMicrophone() {
@@ -447,10 +439,10 @@ export default class MediaDevicesManager extends EventEmitter {
   }
 
   videoDeviceIdForMicLabel(label) {
-    return this.videoDevices.filter(d => d.label === label).map(d => d.value)[0];
+    return this._videoDevices.filter(d => d.label === label).map(d => d.value)[0];
   }
 
   videoLabelForDeviceId(deviceId) {
-    return this.videoDevices.filter(d => d.value === deviceId).map(d => d.label)[0];
+    return this._videoDevices.filter(d => d.value === deviceId).map(d => d.label)[0];
   }
 }

--- a/src/utils/media-devices-manager.js
+++ b/src/utils/media-devices-manager.js
@@ -238,7 +238,14 @@ export default class MediaDevicesManager extends EventEmitter {
     if (this.audioTrack) {
       const micDeviceId = this.deviceIdForMicDeviceLabel(this.micLabelForAudioTrack(this.audioTrack));
       if (micDeviceId) {
-        updatePrefs && this._store.update({ preferences: { preferredMic: micDeviceId } });
+        if (updatePrefs) {
+          this._store.update({
+            preferences: {
+              preferredMic: micDeviceId,
+              preferredSpeakers: this.selectedSpeakersDeviceId
+            }
+          });
+        }
         console.log(`Selected input device: ${this.micLabelForDeviceId(micDeviceId)}`);
       }
     } else {

--- a/src/utils/media-devices-utils.js
+++ b/src/utils/media-devices-utils.js
@@ -20,5 +20,4 @@ export const MediaDevices = Object.freeze({
   SCREEN: "screen"
 });
 
-export const DEFAULT_DEVICE_ID = "default";
 export const NO_DEVICE_ID = "none";


### PR DESCRIPTION
FF doesn't tag the default device as default so when using the "default" tag it wasn't choosing the right device. Use the first device as the default for all platforms.