### PR TITLE
Fix shadows for directinal lights

### DIFF
--- a/src/systems/shadow-system.js
+++ b/src/systems/shadow-system.js
@@ -1,7 +1,7 @@
 import { traverseAnimationTargets } from "../utils/three-utils";
 
 const frustumBox = new THREE.Box3();
-const inverseLightMatrixWorld = new THREE.Matrix4();
+const inverseShadowCameraMatrixWorld = new THREE.Matrix4();
 const tempBox = new THREE.Box3();
 const FRUSTUM_PADDING = 1;
 const NEAR_CLIPPING_PLANE = -500;
@@ -64,10 +64,12 @@ function resizeShadowCameraFrustum(light, boundingBox) {
   verts[7].set(max.x, max.y, max.z);
 
   light.updateMatrices();
-  inverseLightMatrixWorld.copy(light.matrixWorld).invert();
+  light.target.updateMatrices();
+  light.shadow.updateMatrices(light);
+  inverseShadowCameraMatrixWorld.copy(light.shadow.camera.matrixWorld).invert();
 
   for (let i = 0; i < verts.length; i++) {
-    verts[i].applyMatrix4(inverseLightMatrixWorld);
+    verts[i].applyMatrix4(inverseShadowCameraMatrixWorld);
     frustumBox.expandByPoint(verts[i]);
   }
 


### PR DESCRIPTION
Fixes #4164

This PR fixes a broken directional light shadow. (Other light types shadows seem to be fine.)

If I'm right, we should use `light.shadow.camera` instead of `light` for converting world matrix to shadow camera space matrix.

I haven't tested this change well other than with this scene https://hubs.mozilla.com/scenes/zfWqEaF I'm happy if anyone who has any scenes in which shadows are broken tests this change.