### PR TITLE
Simplify the behavior of real-time shadows

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -62,7 +62,7 @@
         listed-media
         local-audio-analyser
         class="grab-cursor"
-        shadow="type: pcfsoft;autoUpdate: false"
+        shadow="enabled: false; type: pcfsoft; autoUpdate: true"
         networked-scene="audio: true; debug: true; connectOnLoad: false;"
         mute-mic="eventSrc: a-scene; toggleEvents: action_mute"
         action-to-event__mute="path: /actions/muteMic; event: action_mute;"

--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -425,7 +425,7 @@ const preferenceLabels = defineMessages({
   },
   enableDynamicShadows: {
     id: "preferences-screen.preference.enable-dynamic-shadows",
-    defaultMessage: "Enable Dynamic Shadows"
+    defaultMessage: "Enable Real-time Shadows"
   },
   disableAutoPixelRatio: {
     id: "preferences-screen.preference.disable-auto-pixel-ratio",
@@ -1143,7 +1143,7 @@ class PreferencesScreen extends Component {
           {
             key: "enableDynamicShadows",
             prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX,
-            promptForRefresh: true
+            defaultBool: false
           },
           {
             key: "disableAutoPixelRatio",

--- a/src/utils/three-utils.js
+++ b/src/utils/three-utils.js
@@ -345,25 +345,6 @@ export const childMatch = (function() {
   };
 })();
 
-export function traverseAnimationTargets(rootObject, animations, callback) {
-  if (animations && animations.length > 0) {
-    for (const animation of animations) {
-      for (const track of animation.tracks) {
-        const { nodeName } = THREE.PropertyBinding.parseTrackName(track.name);
-        let animatedNode = rootObject.getObjectByProperty("uuid", nodeName);
-
-        if (!animatedNode) {
-          animatedNode = rootObject.getObjectByName(nodeName);
-        }
-
-        if (animatedNode) {
-          callback(animatedNode);
-        }
-      }
-    }
-  }
-}
-
 export function createPlaneBufferGeometry(width, height, widthSegments, heightSegments, flipY = true) {
   const geometry = new THREE.PlaneBufferGeometry(width, height, widthSegments, heightSegments);
   // Three.js seems to assume texture flipY is true for all its built in geometry


### PR DESCRIPTION
Fixes #5212

This PR simplifies the behavior of real-time shadows preference.

Changes
* Rename "Dynamic shadows" to "Real-time shadows" in the label in the preference as suggested in https://github.com/mozilla/hubs/issues/5212#issuecomment-1064695862
* Simply enable real-time shadow (`renderer.shadowMap.enabled = true`) if "Enable Real-time shadows" checkbox is checked and disable it (`renderer.shadowMap.enabled = false`) if unchecked
* No longer page refresh is needed when checking/unchecking the checkbox

Benefits
* Probably the new behavior will be fit to uesrs' expectation
* Performance optimization. In the current behavior shadow map texture is fetched for rendering objects which can receive shadows every frame even if "Dynamic shadows" is disabled. In the new behavior, shadow map texture won't be fetched/used if "Real-time shadows" is disabled

Additional contexts
* This PR changes the behavior of disabled dynamic (real-time) shadows from updating shadow map only once when environment is loaded to simply disable shadows. We may be able to encourage to use light map instead.
* Most of assets don't support shadows (don't have Hubs shadow components) so that enabling real-time shadow doesn't have an effect in most of cases. It may be confusing to users. We may be able to consider to change the preference from "Enable real-time shadows" to "Force to disable real-time shadows" (later in another PR), it may be clearer.