### PR TITLE
Do not update the avatar preview component when unmounted

### DIFF
--- a/src/react-components/avatar-preview.js
+++ b/src/react-components/avatar-preview.js
@@ -83,6 +83,7 @@ class AvatarPreview extends Component {
     this.state = { loading: true, error: null };
     this.avatar = null;
     this.imageBitmaps = {};
+    this.mounted = false;
   }
 
   componentDidMount = () => {
@@ -129,6 +130,8 @@ class AvatarPreview extends Component {
     });
     window.addEventListener("resize", this.resize);
     this.resize();
+
+    this.mounted = true;
   };
 
   resize = () => {
@@ -166,6 +169,8 @@ class AvatarPreview extends Component {
   })();
 
   componentWillUnmount = () => {
+    this.mounted = false;
+
     // Gotta be particularly careful about disposing things here since we will likely create many avatar
     // previews during a session and Chrome will eventually discard the oldest webgl context if we leak
     // contexts by holding on to them directly or indirectly.
@@ -205,7 +210,7 @@ class AvatarPreview extends Component {
     const url = proxiedUrlFor(this.props.avatarGltfUrl);
     const gltf = await this.loadPreviewAvatar(url);
     // If we had started loading another avatar while we were loading this one, throw this one away
-    if (newLoadId !== this.loadId) return;
+    if (!this.mounted || newLoadId !== this.loadId) return;
     if (gltf && this.props.onGltfLoaded) this.props.onGltfLoaded(gltf);
     this.setAvatar(gltf.scene);
   }
@@ -236,6 +241,8 @@ class AvatarPreview extends Component {
       this.setState({ loading: false, error: true });
       return;
     }
+
+    if (!this.mounted) return;
 
     // TODO Check for "Bot_Skinned" here is a hack for legacy avatars which only has a name one of the MOZ_alt_material nodes
     this.previewMesh = findNode(


### PR DESCRIPTION
When the Preview component is unmounted there might still be async operations ongoing and that's going to alter the component state after the operation resolves throwing a console error. This PR makes sure that we don't update the state after the component has been unmounted.

<img width="714" alt="Screen Shot 2022-03-17 at 17 41 38" src="https://user-images.githubusercontent.com/837184/158850807-8cc785e6-af90-49b5-8128-30d339c9527c.png">