### PR TITLE
Fix Share popover prop type

### DIFF
--- a/src/react-components/popover/ButtonGridPopover.js
+++ b/src/react-components/popover/ButtonGridPopover.js
@@ -37,7 +37,7 @@ ButtonGridPopover.propTypes = {
       id: PropTypes.string.isRequired,
       icon: PropTypes.elementType.isRequired,
       color: PropTypes.string,
-      name: PropTypes.string.isRequired,
+      label: PropTypes.element.isRequired,
       onSelect: PropTypes.func
     })
   ).isRequired,


### PR DESCRIPTION
There is an error in the prop type in the Button popover that throws an error every time is opened. This PR fixes the type.

<img width="719" alt="Screen Shot 2022-03-17 at 17 53 52" src="https://user-images.githubusercontent.com/837184/158853785-4a0dda56-e00e-450b-9e4a-9b4531127c38.png">