### PR TITLE
add a link to creator labs in nav and mobile nav

### DIFF
--- a/src/react-components/layout/Header.js
+++ b/src/react-components/layout/Header.js
@@ -71,6 +71,13 @@ export function Header({
                 </a>
               </li>
             )}
+            {isHmc && (
+              <li>
+                <a href="/labs">
+                  <FormattedMessage id="header.labs" defaultMessage="Labs" />
+                </a>
+              </li>
+            )}
             {isAdmin && (
               <li>
                 <a href="/admin" rel="noreferrer noopener">

--- a/src/react-components/layout/MobileNav.js
+++ b/src/react-components/layout/MobileNav.js
@@ -55,6 +55,13 @@ export function MobileNav({ isHmc, showDocsLink, docsUrl, showSourceLink, showCo
                     </a>
                   </li>
                 )}
+                {isHmc && (
+                  <li>
+                    <a href="/labs">
+                      <FormattedMessage id="header.labs" defaultMessage="Labs" />
+                    </a>
+                  </li>
+                )}
                 {isAdmin && (
                   <li>
                     <a style={{ marginLeft: 0 }} href="/admin" rel="noreferrer noopener">


### PR DESCRIPTION
Adds a link in the nav to access the new creator labs content. Creator Labs is a blog that helps showcase the amazing work our community is doing, tutorials, tools and resources for making great content in Mozilla Hubs. 

![Screen Shot 2022-03-18 at 11 07 13 AM](https://user-images.githubusercontent.com/4493657/159059892-05ab1f50-b84a-4ec1-9640-c7bf8087ee1d.png)
![Screen Shot 2022-03-18 at 11 07 39 AM](https://user-images.githubusercontent.com/4493657/159059898-cb843cbd-5fb7-48cc-a73e-76c56fcd0992.png)


