### PR TITLE
Prevent multiple requests to reaction emoji images in Firefox

### DIFF
--- a/src/react-components/popover/ImageGridPopover.js
+++ b/src/react-components/popover/ImageGridPopover.js
@@ -10,6 +10,8 @@ export function ImageGridPopover({ fullscreen, items, closePopover }) {
         return (
           <img
             key={item.id}
+            // crossOrigin: "anonymous" is a workaround for CORS error on Chrome. See #4400
+            crossOrigin="anonymous"
             src={item.src}
             alt={item.label}
             onClick={() => {
@@ -19,8 +21,6 @@ export function ImageGridPopover({ fullscreen, items, closePopover }) {
 
               closePopover();
             }}
-            // crossOrigin: "anonymous" is a workaround for CORS error on Chrome. See #4400
-            crossOrigin="anonymous"
           />
         );
       })}


### PR DESCRIPTION
If an image element is created with the `crossOrigin` attribute set after the `src` attribute, Firefox will re-request the image every time it is added to the DOM. This PR just reorders the `img` attributes in ImageGridPopover so that the `crossOrigin` attribute is set before the `src` attribute.

Fixes #5265