### PR TITLE
Disable panner node for Android

### DIFF
--- a/src/update-audio-settings.js
+++ b/src/update-audio-settings.js
@@ -5,6 +5,8 @@ import {
   AvatarAudioDefaults,
   TargetAudioDefaults
 } from "./components/audio-params";
+import isMobile from "./utils/is-mobile";
+import { isAndroid } from "./utils/detect-android";
 import { isSafari } from "./utils/detect-safari";
 
 const defaultSettingsForSourceType = Object.freeze(
@@ -38,6 +40,12 @@ export function getCurrentAudioSettings(el) {
   const preferencesOverrides = APP.store.state.preferences.disableLeftRightPanning
     ? { audioType: AudioType.Stereo }
     : {};
+  // Android has PannerNode audio problem. We already reported it.
+  // Until it will be fixed, we force to disable panner audio
+  // as short-term workaround. Disable only for Android phone
+  // because we haven't heard the problem on VR device so far.
+  // See #5057
+  const androidOverrides = isAndroid() && isMobile() ? { audioType: AudioType.Stereo } : {};
   const safariOverrides = isSafari() ? { audioType: AudioType.Stereo } : {};
   const settings = Object.assign(
     {},
@@ -47,6 +55,7 @@ export function getCurrentAudioSettings(el) {
     audioDebugPanelOverrides,
     zoneSettings,
     preferencesOverrides,
+    androidOverrides,
     safariOverrides
   );
 

--- a/src/utils/detect-android.js
+++ b/src/utils/detect-android.js
@@ -1,0 +1,6 @@
+import { detect } from "detect-browser";
+
+export function isAndroid() {
+  const browser = detect();
+  return ["Android OS"].includes(browser.os);
+}


### PR DESCRIPTION
Currently Android seems to have a panner node audio problem. With 10 or many Panner nodes (the number depends on Android OS version or device. The problem seems to happen more easily on older or lower-end devices) the audio can be crackled or broken. See #5057

We already reported it. Until it will be resolved on Android end, I would like to suggest to force to disable it as short-term workaround. The change is small. It may not be a perfect solution but it is a short-term workaround. I hope we can accept.
