### PR TITLE
Fix handling of layers for VR cameras

### DIFF
--- a/src/components/layers.js
+++ b/src/components/layers.js
@@ -1,9 +1,8 @@
 export const Layers = {
   // These 3 layers are hardcoded in THREE
   CAMERA_LAYER_DEFAULT: 0,
-  // We disable support for these in camera-system to simplify dealing with layers
-  // CAMERA_LAYER_XR_LEFT_EYE: 1,
-  // CAMERA_LAYER_XR_RIGHT_EYE: 2,
+  CAMERA_LAYER_XR_LEFT_EYE: 1,
+  CAMERA_LAYER_XR_RIGHT_EYE: 2,
 
   CAMERA_LAYER_REFLECTION: 3,
   CAMERA_LAYER_INSPECT: 4,


### PR DESCRIPTION
This fixes a regression caused in #5260 where VR users could not see their own avatar. It also incidentally fixes #4553 and actually simplifies the code a bit, without losing support for single eye layers (useful if we want to do any stereoscopic effects).

This change should probably land in THREE instead, but putting it here for now since it hotfixes an issue and I am already actively refactoring this code in another branch.