### PR TITLE
Refactor aframe startup and RAF loop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15795,7 +15795,7 @@
       "dev": true
     },
     "aframe": {
-      "version": "github:mozillareality/aframe#9c5c2e6280aebe3f95a96c761454331bb9a6961a",
+      "version": "github:mozillareality/aframe#0cd5cac593a1000d59895aedfac38068060be04b",
       "from": "github:mozillareality/aframe#refactor-init",
       "requires": {
         "custom-event-polyfill": "^1.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15795,8 +15795,8 @@
       "dev": true
     },
     "aframe": {
-      "version": "github:mozillareality/aframe#0cd5cac593a1000d59895aedfac38068060be04b",
-      "from": "github:mozillareality/aframe#refactor-init",
+      "version": "github:mozillareality/aframe#033ec6571ff6ec2c9162e26ff4e23ee2e65afc12",
+      "from": "github:mozillareality/aframe#hubs/master",
       "requires": {
         "custom-event-polyfill": "^1.0.6",
         "debug": "github:ngokevin/debug#noTimestamp",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15795,8 +15795,8 @@
       "dev": true
     },
     "aframe": {
-      "version": "github:mozillareality/aframe#1f77f3d9328f00faff76e94dcc190d4278ddb3c6",
-      "from": "github:mozillareality/aframe#hubs/master",
+      "version": "github:mozillareality/aframe#9c5c2e6280aebe3f95a96c761454331bb9a6961a",
+      "from": "github:mozillareality/aframe#refactor-init",
       "requires": {
         "custom-event-polyfill": "^1.0.6",
         "debug": "github:ngokevin/debug#noTimestamp",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@mozillareality/easing-functions": "^0.1.1",
     "@mozillareality/three-batch-manager": "github:mozillareality/three-batch-manager#master",
     "@popperjs/core": "^2.4.4",
-    "aframe": "github:mozillareality/aframe#refactor-init",
+    "aframe": "github:mozillareality/aframe#hubs/master",
     "aframe-rounded": "^1.0.3",
     "aframe-slice9-component": "github:takahirox/aframe-slice9-component#AlphaTest",
     "ammo-debug-drawer": "github:infinitelee/ammo-debug-drawer",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@mozillareality/easing-functions": "^0.1.1",
     "@mozillareality/three-batch-manager": "github:mozillareality/three-batch-manager#master",
     "@popperjs/core": "^2.4.4",
-    "aframe": "github:mozillareality/aframe#hubs/master",
+    "aframe": "github:mozillareality/aframe#refactor-init",
     "aframe-rounded": "^1.0.3",
     "aframe-slice9-component": "github:takahirox/aframe-slice9-component#AlphaTest",
     "ammo-debug-drawer": "github:infinitelee/ammo-debug-drawer",

--- a/src/App.js
+++ b/src/App.js
@@ -33,6 +33,7 @@ export class App {
     canvas.dataset.aframeCanvas = true;
 
     const renderer = new THREE.WebGLRenderer({
+      // TODO we should not be using alpha: false https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#avoid_alphafalse_which_can_be_expensive
       alpha: false,
       antialias: true,
       depth: true,
@@ -40,16 +41,17 @@ export class App {
       premultipliedAlpha: true,
       preserveDrawingBuffer: false,
       logarithmicDepthBuffer: false,
+      // TODO we probably want high-performance
       powerPreference: "default",
       canvas
     });
 
     renderer.setPixelRatio(window.devicePixelRatio);
-    renderer.sortObjects = false;
+
+    // These get overridden by environment-system but setting to the highly expected defaults to avoid any extra work
     renderer.physicallyCorrectLights = true;
     renderer.outputEncoding = THREE.sRGBEncoding;
 
-    sceneEl.maxCanvasSize = { height: 1920, width: 1920 };
     sceneEl.appendChild(renderer.domElement);
 
     const camera = new THREE.PerspectiveCamera(80, window.innerWidth / window.innerHeight, 0.05, 10000);
@@ -74,17 +76,6 @@ export class App {
 
     // This gets called after all system and component init functions
     sceneEl.addEventListener("loaded", () => {
-      console.log("scene loaded");
-
-      // Kick off render loop.
-      // if (sceneEl.renderer) {
-      //   if (window.performance) { window.performance.mark('render-started'); }
-      //   vrDisplay = utils.device.getVRDisplay();
-      //   if (vrDisplay && vrDisplay.isPresenting) {
-      //     vrManager.setDevice(vrDisplay);
-      //     vrManager.enabled = true;
-      //     sceneEl.enterVR();
-      //   }
       renderer.setAnimationLoop(mainTick);
       sceneEl.renderStarted = true;
     });

--- a/src/App.js
+++ b/src/App.js
@@ -61,6 +61,9 @@ export class App {
 
     const renderClock = new THREE.Clock();
 
+    // TODO NAF currently depends on this, it should not
+    sceneEl.clock = renderClock;
+
     // Main RAF loop
     function mainTick(_rafTime, xrFrame) {
       // TODO we should probably be using time from the raf loop itself

--- a/src/App.js
+++ b/src/App.js
@@ -62,7 +62,8 @@ export class App {
     const renderClock = new THREE.Clock();
 
     // Main RAF loop
-    function mainTick(_rafTime, _xrFrame) {
+    function mainTick(/*rafTime, _xrFrame*/) {
+      // TODO we should probably be using time from the raf loop itself
       const delta = renderClock.getDelta() * 1000;
       const time = renderClock.elapsedTime * 1000;
 

--- a/src/App.js
+++ b/src/App.js
@@ -32,6 +32,12 @@ export class App {
     canvas.classList.add("a-canvas");
     canvas.dataset.aframeCanvas = true;
 
+    // TODO this comes from aframe and prevents zoom on ipad.
+    // This should alreeady be handleed by disable-ios-zoom but it does not appear to work
+    canvas.addEventListener("touchmove", function(event) {
+      event.preventDefault();
+    });
+
     const renderer = new THREE.WebGLRenderer({
       // TODO we should not be using alpha: false https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#avoid_alphafalse_which_can_be_expensive
       alpha: false,

--- a/src/App.js
+++ b/src/App.js
@@ -62,10 +62,13 @@ export class App {
     const renderClock = new THREE.Clock();
 
     // Main RAF loop
-    function mainTick(/*rafTime, _xrFrame*/) {
+    function mainTick(_rafTime, xrFrame) {
       // TODO we should probably be using time from the raf loop itself
       const delta = renderClock.getDelta() * 1000;
       const time = renderClock.elapsedTime * 1000;
+
+      // TODO pass this into systems that care about it (like input) once they are moved into this loop
+      sceneEl.frame = xrFrame;
 
       // Tick AFrame systems and components
       if (sceneEl.isPlaying) {

--- a/src/App.js
+++ b/src/App.js
@@ -23,4 +23,76 @@ export class App {
     this.mutedState = new Set();
     this.isAudioPaused = new Set();
   }
+
+  // This gets called by a-scene to setup the renderer, camera, and audio listener
+  // TODO ideally the contorl flow here would be inverted, and we would setup this stuff,
+  // initialize aframe, and then run our own RAF loop
+  setupRenderer(sceneEl) {
+    const canvas = document.createElement("canvas");
+    canvas.classList.add("a-canvas");
+    canvas.dataset.aframeCanvas = true;
+
+    const renderer = new THREE.WebGLRenderer({
+      alpha: false,
+      antialias: true,
+      depth: true,
+      stencil: true,
+      premultipliedAlpha: true,
+      preserveDrawingBuffer: false,
+      logarithmicDepthBuffer: false,
+      powerPreference: "default",
+      canvas
+    });
+
+    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.sortObjects = false;
+    renderer.physicallyCorrectLights = true;
+    renderer.outputEncoding = THREE.sRGBEncoding;
+
+    sceneEl.maxCanvasSize = { height: 1920, width: 1920 };
+    sceneEl.appendChild(renderer.domElement);
+
+    const camera = new THREE.PerspectiveCamera(80, window.innerWidth / window.innerHeight, 0.05, 10000);
+
+    const audioListener = new THREE.AudioListener();
+    camera.add(audioListener);
+
+    const renderClock = new THREE.Clock();
+
+    // Main RAF loop
+    function mainTick(_rafTime, _xrFrame) {
+      const delta = renderClock.getDelta() * 1000;
+      const time = renderClock.elapsedTime * 1000;
+
+      // Tick AFrame systems and components
+      if (sceneEl.isPlaying) {
+        sceneEl.tick(time, delta);
+      }
+
+      renderer.render(sceneEl.object3D, camera);
+    }
+
+    // This gets called after all system and component init functions
+    sceneEl.addEventListener("loaded", () => {
+      console.log("scene loaded");
+
+      // Kick off render loop.
+      // if (sceneEl.renderer) {
+      //   if (window.performance) { window.performance.mark('render-started'); }
+      //   vrDisplay = utils.device.getVRDisplay();
+      //   if (vrDisplay && vrDisplay.isPresenting) {
+      //     vrManager.setDevice(vrDisplay);
+      //     vrManager.enabled = true;
+      //     sceneEl.enterVR();
+      //   }
+      renderer.setAnimationLoop(mainTick);
+      sceneEl.renderStarted = true;
+    });
+
+    return {
+      renderer,
+      camera,
+      audioListener
+    };
+  }
 }

--- a/src/components/ambient-light.js
+++ b/src/components/ambient-light.js
@@ -8,7 +8,6 @@ AFRAME.registerComponent("ambient-light", {
     const el = this.el;
     this.light = new THREE.AmbientLight();
     this.el.setObject3D("ambient-light", this.light);
-    this.el.sceneEl.systems.light.registerLight(el);
     this.rendererSystem = this.el.sceneEl.systems.renderer;
   },
 

--- a/src/components/ambient-light.js
+++ b/src/components/ambient-light.js
@@ -5,7 +5,6 @@ AFRAME.registerComponent("ambient-light", {
   },
 
   init() {
-    const el = this.el;
     this.light = new THREE.AmbientLight();
     this.el.setObject3D("ambient-light", this.light);
     this.rendererSystem = this.el.sceneEl.systems.renderer;

--- a/src/components/billboard.js
+++ b/src/components/billboard.js
@@ -43,7 +43,7 @@ AFRAME.registerComponent("billboard", {
 
     const isInViewOfCamera = (obj, screenCamera) => {
       frustumMatrix.multiplyMatrices(screenCamera.projectionMatrix, screenCamera.matrixWorldInverse);
-      frustum.setFromMatrix(frustumMatrix);
+      frustum.setFromProjectionMatrix(frustumMatrix);
       box.makeEmpty();
       obj.traverse(expandBox);
 

--- a/src/components/directional-light.js
+++ b/src/components/directional-light.js
@@ -15,7 +15,6 @@ AFRAME.registerComponent("directional-light", {
     this.light.target.position.set(0, 0, 1);
     this.light.add(this.light.target);
     this.el.setObject3D("directional-light", this.light);
-    this.el.sceneEl.systems.light.registerLight(el);
     this.rendererSystem = this.el.sceneEl.systems.renderer;
   },
 

--- a/src/components/directional-light.js
+++ b/src/components/directional-light.js
@@ -9,7 +9,6 @@ AFRAME.registerComponent("directional-light", {
   },
 
   init() {
-    const el = this.el;
     this.light = new THREE.DirectionalLight();
     this.light.position.set(0, 0, 0);
     this.light.target.position.set(0, 0, 1);

--- a/src/components/hemisphere-light.js
+++ b/src/components/hemisphere-light.js
@@ -6,7 +6,6 @@ AFRAME.registerComponent("hemisphere-light", {
   },
 
   init() {
-    const el = this.el;
     this.light = new THREE.HemisphereLight();
     this.light.position.set(0, 0, 0);
     this.light.matrixNeedsUpdate = true;

--- a/src/components/hemisphere-light.js
+++ b/src/components/hemisphere-light.js
@@ -11,7 +11,6 @@ AFRAME.registerComponent("hemisphere-light", {
     this.light.position.set(0, 0, 0);
     this.light.matrixNeedsUpdate = true;
     this.el.setObject3D("hemisphere-light", this.light);
-    this.el.sceneEl.systems.light.registerLight(el);
   },
 
   update(prevData) {

--- a/src/components/inject-main-camera-here.js
+++ b/src/components/inject-main-camera-here.js
@@ -1,4 +1,4 @@
-AFRAME.registerComponent("set-active-camera", {
+AFRAME.registerComponent("inject-main-camera-here", {
   init() {
     // This is what actually puts the camera into the scene graph.
     // Ideally we would just be doing this ourselves, but we have to do it after the entity we want to parent it to is created

--- a/src/components/media-video.js
+++ b/src/components/media-video.js
@@ -157,16 +157,6 @@ AFRAME.registerComponent("media-video", {
         this.updatePlaybackState();
       });
 
-    // from a-sound
-    const sceneEl = this.el.sceneEl;
-    sceneEl.audioListener = sceneEl.audioListener || new THREE.AudioListener();
-    if (sceneEl.camera) {
-      sceneEl.camera.add(sceneEl.audioListener);
-    }
-    sceneEl.addEventListener("camera-set-active", function(evt) {
-      evt.detail.cameraEl.getObject3D("camera").add(sceneEl.audioListener);
-    });
-
     let disableLeftRightPanningPref = APP.store.state.preferences.disableLeftRightPanning;
     this.onPreferenceChanged = () => {
       const newPref = APP.store.state.preferences.disableLeftRightPanning;

--- a/src/components/point-light.js
+++ b/src/components/point-light.js
@@ -11,7 +11,6 @@ AFRAME.registerComponent("point-light", {
   },
 
   init() {
-    const el = this.el;
     this.light = new THREE.PointLight();
     this.light.shadow.camera.matrixAutoUpdate = true;
     this.el.setObject3D("point-light", this.light);

--- a/src/components/point-light.js
+++ b/src/components/point-light.js
@@ -15,7 +15,6 @@ AFRAME.registerComponent("point-light", {
     this.light = new THREE.PointLight();
     this.light.shadow.camera.matrixAutoUpdate = true;
     this.el.setObject3D("point-light", this.light);
-    this.el.sceneEl.systems.light.registerLight(el);
     this.rendererSystem = this.el.sceneEl.systems.renderer;
   },
 

--- a/src/components/scene-components.js
+++ b/src/components/scene-components.js
@@ -31,4 +31,4 @@ import "./audio-zone";
 import "./audio-zone-source";
 import "./troika-text";
 import "./frustrum";
-import "./set-active-camera";
+import "./inject-main-camera-here";

--- a/src/components/scene-components.js
+++ b/src/components/scene-components.js
@@ -31,3 +31,4 @@ import "./audio-zone";
 import "./audio-zone-source";
 import "./troika-text";
 import "./frustrum";
+import "./set-active-camera";

--- a/src/components/set-active-camera.js
+++ b/src/components/set-active-camera.js
@@ -1,18 +1,8 @@
 AFRAME.registerComponent("set-active-camera", {
   init() {
-    // This is a hack needed to set the active camera because sometimes A-Frame will create the default camera and set it to the active camera on startup because the query selector to find an existing camera in the scene fails.
-
-    const cameraSystem = this.el.sceneEl.systems.camera;
-    const currentActiveCamera = cameraSystem.activeCameraEl;
-
-    if (currentActiveCamera !== this.el) {
-      cameraSystem.setActiveCamera(this.el);
-
-      // Also A-Frame fails to delete the default camera :P
-      currentActiveCamera.parentNode.removeChild(currentActiveCamera);
-
-      // Look controls leaves behind this CSS class.
-      this.el.sceneEl.canvas.classList.remove("a-grab-cursor");
-    }
+    // This is what actually puts the camera into the scene graph.
+    // Ideally we would just be doing this ourselves, but we have to do it after the entity we want to parent it to is created
+    // TODO any references to this entity should instead get the camera reference from the camera system
+    this.el.setObject3D("camera", this.el.sceneEl.camera);
   }
 });

--- a/src/components/spot-light.js
+++ b/src/components/spot-light.js
@@ -21,7 +21,6 @@ AFRAME.registerComponent("spot-light", {
     this.light.matrixNeedsUpdate = true;
     this.light.target.matrixNeedsUpdate = true;
     this.el.setObject3D("spot-light", this.light);
-    this.el.sceneEl.systems.light.registerLight(el);
   },
 
   update(prevData) {

--- a/src/components/spot-light.js
+++ b/src/components/spot-light.js
@@ -13,7 +13,6 @@ AFRAME.registerComponent("spot-light", {
   },
 
   init() {
-    const el = this.el;
     this.light = new THREE.SpotLight();
     this.light.position.set(0, 0, 0);
     this.light.target.position.set(0, 0, 1);

--- a/src/hub.html
+++ b/src/hub.html
@@ -55,8 +55,6 @@
     <div id="support-root"></div>
 
     <a-scene
-        disable-resize
-        embedded
         vr-mode-ui="enabled: false"
         loading-screen="enabled: false"
         hubs-systems
@@ -64,14 +62,6 @@
         listed-media
         local-audio-analyser
         class="grab-cursor"
-        renderer="
-            antialias: true;
-            colorManagement: true;
-            sortObjects: true;
-            physicallyCorrectLights: true;
-            alpha: false;
-            webgl2: true;
-            multiview: false;"
         shadow="type: pcfsoft;autoUpdate: false"
         networked-scene="audio: true; debug: true; connectOnLoad: false;"
         mute-mic="eventSrc: a-scene; toggleEvents: action_mute"
@@ -79,7 +69,6 @@
         freeze-controller
         personal-space-bubble="debug: false;"
         rotate-selected-object
-        light="defaultLightsEnabled: false"
     >
         <a-assets>
             <img id="presence-count" crossorigin="anonymous" src="./assets/hud/presence-count.png">
@@ -1370,7 +1359,6 @@
         <a-entity id="viewing-rig" set-yxz-order matrix-auto-update>
             <a-entity
                 id="viewing-camera"
-                camera="near: 0.05"
                 set-active-camera
                 rotation
                 fader

--- a/src/hub.html
+++ b/src/hub.html
@@ -1359,7 +1359,7 @@
         <a-entity id="viewing-rig" set-yxz-order matrix-auto-update>
             <a-entity
                 id="viewing-camera"
-                set-active-camera
+                inject-main-camera-here
                 rotation
                 fader
                 set-yxz-order

--- a/src/hub.js
+++ b/src/hub.js
@@ -133,7 +133,6 @@ import "./components/scale-button";
 import "./components/hover-menu";
 import "./components/disable-frustum-culling";
 import "./components/teleporter";
-import "./components/set-active-camera";
 import "./components/track-pose";
 import "./components/replay";
 import "./components/visibility-by-path";

--- a/src/react-components/scene-ui.js
+++ b/src/react-components/scene-ui.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { Component, useRef } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import { FormattedMessage, injectIntl } from "react-intl";
@@ -11,10 +11,18 @@ import { ReactComponent as Twitter } from "./icons/Twitter.svg";
 import { ReactComponent as CodeBranch } from "./icons/CodeBranch.svg";
 import { ReactComponent as Pen } from "./icons/Pen.svg";
 
+import { useResizeViewport } from "./room/useResizeViewport";
+function ResizeHookWrapper({ store, scene }) {
+  const viewportRef = useRef(document.body);
+  useResizeViewport(viewportRef, store, scene);
+  return <></>;
+}
+
 class SceneUI extends Component {
   static propTypes = {
     intl: PropTypes.object,
     scene: PropTypes.object,
+    store: PropTypes.object,
     sceneLoaded: PropTypes.bool,
     sceneId: PropTypes.string,
     sceneName: PropTypes.string,
@@ -277,6 +285,7 @@ class SceneUI extends Component {
             <div className={styles.attribution}>{attributions}</div>
           </div>
         </div>
+        <ResizeHookWrapper store={this.props.store} scene={this.props.scene} />
       </div>
     );
   }

--- a/src/scene.html
+++ b/src/scene.html
@@ -36,7 +36,7 @@
             static-body="shape: none;"
         ></a-entity>
 
-        <a-entity id="camera" set-active-camera></a-entity>
+        <a-entity id="camera" inject-main-camera-here></a-entity>
     </a-scene>
 
     <div id="ui-root"></div>

--- a/src/scene.html
+++ b/src/scene.html
@@ -28,13 +28,6 @@
 
     <a-scene
         loading-screen="enabled: false"
-        renderer="
-            antialias: true;
-            gammaOutput: true;
-            sortObjects: true;
-            physicallyCorrectLights: true;
-            colorManagement: true;
-            alpha: false;"
         shadow="type: pcfsoft;autoUpdate: false"
         light="defaultLightsEnabled: false"
     >
@@ -43,7 +36,7 @@
             static-body="shape: none;"
         ></a-entity>
 
-        <a-camera id="camera" fov="80" near="0.05" look-controls="enabled: false" wasd-controls="enabled: false"></a-camera>
+        <a-entity id="camera" set-active-camera></a-entity>
     </a-scene>
 
     <div id="ui-root"></div>

--- a/src/scene.js
+++ b/src/scene.js
@@ -53,6 +53,7 @@ function mountUI(scene, props = {}) {
         <SceneUI
           {...{
             scene,
+            store: window.APP.store,
             ...props
           }}
         />

--- a/src/systems/audio-system.js
+++ b/src/systems/audio-system.js
@@ -124,13 +124,6 @@ async function enableChromeAEC(gainNode) {
 export class AudioSystem {
   constructor(sceneEl) {
     this._sceneEl = sceneEl;
-    this._sceneEl.audioListener = this._sceneEl.audioListener || new THREE.AudioListener();
-    if (this._sceneEl.camera) {
-      this._sceneEl.camera.add(this._sceneEl.audioListener);
-    }
-    this._sceneEl.addEventListener("camera-set-active", evt => {
-      evt.detail.cameraEl.getObject3D("camera").add(this._sceneEl.audioListener);
-    });
 
     this.audioContext = THREE.AudioContext.getContext();
     this.audioNodes = new Map();

--- a/src/systems/camera-system.js
+++ b/src/systems/camera-system.js
@@ -215,6 +215,9 @@ export class CameraSystem {
     this.snapshot = { audioTransform: new THREE.Matrix4(), matrixWorld: new THREE.Matrix4() };
     this.audioSourceTargetTransform = new THREE.Matrix4();
 
+    if (customFOV) {
+      this.viewingCamera.fov = customFOV;
+    }
     this.viewingCamera.layers.enable(Layers.CAMERA_LAYER_VIDEO_TEXTURE_TARGET);
     this.viewingCamera.layers.enable(Layers.CAMERA_LAYER_FIRST_PERSON_ONLY);
 

--- a/src/systems/camera-system.js
+++ b/src/systems/camera-system.js
@@ -205,7 +205,8 @@ function getAudio(o) {
 
 const FALLOFF = 0.9;
 export class CameraSystem {
-  constructor(scene) {
+  constructor(camera, renderer) {
+    this.viewingCamera = camera;
     this.lightsEnabled = localStorage.getItem("show-background-while-inspecting") === "true";
     this.verticalDelta = 0;
     this.horizontalDelta = 0;
@@ -213,10 +214,29 @@ export class CameraSystem {
     this.mode = CAMERA_MODE_SCENE_PREVIEW;
     this.snapshot = { audioTransform: new THREE.Matrix4(), matrixWorld: new THREE.Matrix4() };
     this.audioSourceTargetTransform = new THREE.Matrix4();
+
+    this.viewingCamera.layers.enable(Layers.CAMERA_LAYER_VIDEO_TEXTURE_TARGET);
+    this.viewingCamera.layers.enable(Layers.CAMERA_LAYER_FIRST_PERSON_ONLY);
+
+    // xr.updateCamera gets called every render to copy the active cameras properties to the XR cameras. We also want to copy layers.
+    // TODO this logic should either be moved into THREE or removed when we ditch aframe camera system
+    const xrManager = renderer.xr;
+    const updateXRCamera = xrManager.updateCamera;
+    xrManager.updateCamera = function(camera) {
+      updateXRCamera(camera);
+      const xrCamera = xrManager.getCamera();
+      xrCamera.layers.mask = camera.layers.mask;
+      if (xrCamera.cameras.length) {
+        xrCamera.cameras[0].layers.set(Layers.CAMERA_LAYER_XR_LEFT_EYE);
+        xrCamera.cameras[0].layers.mask |= camera.layers.mask;
+        xrCamera.cameras[1].layers.set(Layers.CAMERA_LAYER_XR_RIGHT_EYE);
+        xrCamera.cameras[1].layers.mask |= camera.layers.mask;
+      }
+    };
+
     waitForDOMContentLoaded().then(() => {
       this.avatarPOV = document.getElementById("avatar-pov-node");
       this.avatarRig = document.getElementById("avatar-rig");
-      this.viewingCamera = document.getElementById("viewing-camera");
       this.viewingRig = document.getElementById("viewing-rig");
 
       const bg = new THREE.Mesh(
@@ -225,38 +245,6 @@ export class CameraSystem {
       );
       bg.layers.set(Layers.CAMERA_LAYER_INSPECT);
       this.viewingRig.object3D.add(bg);
-
-      // TODO get rid of built in aframe camera system, we just keep having to fight it
-      const setupCamera = ({ detail: { cameraEl } }) => {
-        if (customFOV) {
-          cameraEl.setAttribute("camera", { fov: customFOV });
-        }
-        const camera = cameraEl.getObject3D("camera");
-        camera.layers.enable(Layers.CAMERA_LAYER_VIDEO_TEXTURE_TARGET);
-        camera.layers.enable(Layers.CAMERA_LAYER_FIRST_PERSON_ONLY);
-      };
-
-      if (this.viewingCamera.components.camera) {
-        setupCamera({ detail: { cameraEl: this.viewingCamera } });
-      } else {
-        scene.addEventListener("camera-set-active", setupCamera);
-      }
-
-      // xr.updateCamera gets called every render to copy the active cameras properties to the XR cameras. We also want to copy layers.
-      // TODO this logic should either be moved into THREE or removed when we ditch aframe camera system
-      const xrManager = scene.renderer.xr;
-      const updateXRCamera = xrManager.updateCamera;
-      xrManager.updateCamera = function(camera) {
-        updateXRCamera(camera);
-        const xrCamera = xrManager.getCamera();
-        xrCamera.layers.mask = camera.layers.mask;
-        if (xrCamera.cameras.length) {
-          xrCamera.cameras[0].layers.set(Layers.CAMERA_LAYER_XR_LEFT_EYE);
-          xrCamera.cameras[0].layers.mask |= camera.layers.mask;
-          xrCamera.cameras[1].layers.set(Layers.CAMERA_LAYER_XR_RIGHT_EYE);
-          xrCamera.cameras[1].layers.mask |= camera.layers.mask;
-        }
-      };
     });
   }
 
@@ -299,7 +287,7 @@ export class CameraSystem {
       camera.layers.enable(Layers.CAMERA_LAYER_THIRD_PERSON_ONLY);
     }
 
-    this.viewingCamera.object3DMap.camera.updateMatrices();
+    this.viewingCamera.updateMatrices();
     this.snapshot.matrixWorld.copy(this.viewingRig.object3D.matrixWorld);
 
     this.snapshot.audio = !(inspectable.el && isTagged(inspectable.el, "preventAudioBoost")) && getAudio(inspectable);
@@ -315,7 +303,7 @@ export class CameraSystem {
 
     moveRigSoCameraLooksAtPivot(
       this.viewingRig.object3D,
-      this.viewingCamera.object3DMap.camera,
+      this.viewingCamera,
       this.inspectable,
       this.pivot,
       distanceMod || 1
@@ -380,9 +368,9 @@ export class CameraSystem {
         (this.mode === CAMERA_MODE_FIRST_PERSON ||
           this.mode === CAMERA_MODE_THIRD_PERSON_NEAR ||
           this.mode === CAMERA_MODE_THIRD_PERSON_FAR) &&
-        scene.audioListener.parent !== this.viewingCamera.object3DMap.camera
+        scene.audioListener.parent !== this.viewingCamera
       ) {
-        this.viewingCamera.object3DMap.camera.add(scene.audioListener);
+        this.viewingCamera.add(scene.audioListener);
       }
     }
   }
@@ -410,9 +398,9 @@ export class CameraSystem {
     const translation = new THREE.Matrix4();
     let uiRoot;
     return function tick(scene, dt) {
-      this.viewingCamera.object3DMap.camera.matrixNeedsUpdate = true;
-      this.viewingCamera.object3DMap.camera.updateMatrix();
-      this.viewingCamera.object3DMap.camera.updateMatrixWorld();
+      this.viewingCamera.matrixNeedsUpdate = true;
+      this.viewingCamera.updateMatrix();
+      this.viewingCamera.updateMatrixWorld();
 
       const entered = scene.is("entered");
       uiRoot = uiRoot || document.getElementById("ui-root");
@@ -424,7 +412,7 @@ export class CameraSystem {
         const scale = new THREE.Vector3();
         this.viewingRig.object3D.updateMatrices();
         this.viewingRig.object3D.matrixWorld.decompose(position, quat, scale);
-        position.setFromMatrixPosition(this.viewingCamera.object3DMap.camera.matrixWorld);
+        position.setFromMatrixPosition(this.viewingCamera.matrixWorld);
         position.y = position.y - 1.6;
         setMatrixWorld(
           this.avatarRig.object3D,
@@ -436,14 +424,14 @@ export class CameraSystem {
         );
         scene.systems["hubs-systems"].characterController.fly = true;
         this.avatarPOV.object3D.updateMatrices();
-        setMatrixWorld(this.avatarPOV.object3D, this.viewingCamera.object3DMap.camera.matrixWorld);
+        setMatrixWorld(this.avatarPOV.object3D, this.viewingCamera.matrixWorld);
       }
       if (!this.enteredScene && entered) {
         this.enteredScene = true;
         this.mode = CAMERA_MODE_FIRST_PERSON;
       }
       this.avatarPOVRotator = this.avatarPOVRotator || this.avatarPOV.components["pitch-yaw-rotator"];
-      this.viewingCameraRotator = this.viewingCameraRotator || this.viewingCamera.components["pitch-yaw-rotator"];
+      this.viewingCameraRotator = this.viewingCameraRotator || this.viewingCamera.el.components["pitch-yaw-rotator"];
       this.avatarPOVRotator.on = true;
       this.viewingCameraRotator.on = true;
 
@@ -472,11 +460,11 @@ export class CameraSystem {
         this.avatarRig.object3D.updateMatrices();
         setMatrixWorld(this.viewingRig.object3D, this.avatarRig.object3D.matrixWorld);
         if (scene.is("vr-mode")) {
-          this.viewingCamera.object3DMap.camera.updateMatrices();
-          setMatrixWorld(this.avatarPOV.object3D, this.viewingCamera.object3DMap.camera.matrixWorld);
+          this.viewingCamera.updateMatrices();
+          setMatrixWorld(this.avatarPOV.object3D, this.viewingCamera.matrixWorld);
         } else {
           this.avatarPOV.object3D.updateMatrices();
-          setMatrixWorld(this.viewingCamera.object3DMap.camera, this.avatarPOV.object3D.matrixWorld);
+          setMatrixWorld(this.viewingCamera, this.avatarPOV.object3D.matrixWorld);
         }
       } else if (this.mode === CAMERA_MODE_THIRD_PERSON_NEAR || this.mode === CAMERA_MODE_THIRD_PERSON_FAR) {
         if (this.mode === CAMERA_MODE_THIRD_PERSON_NEAR) {
@@ -487,7 +475,7 @@ export class CameraSystem {
         this.avatarRig.object3D.updateMatrices();
         this.viewingRig.object3D.matrixWorld.copy(this.avatarRig.object3D.matrixWorld).multiply(translation);
         setMatrixWorld(this.viewingRig.object3D, this.viewingRig.object3D.matrixWorld);
-        this.avatarPOV.object3D.quaternion.copy(this.viewingCamera.object3DMap.camera.quaternion);
+        this.avatarPOV.object3D.quaternion.copy(this.viewingCamera.quaternion);
         this.avatarPOV.object3D.matrixNeedsUpdate = true;
       } else if (this.mode === CAMERA_MODE_INSPECT) {
         this.avatarPOVRotator.on = false;
@@ -515,13 +503,7 @@ export class CameraSystem {
         }
         const panY = this.userinput.get(paths.actions.inspectPanY) || 0;
         if (this.userinput.get(paths.actions.resetInspectView)) {
-          moveRigSoCameraLooksAtPivot(
-            this.viewingRig.object3D,
-            this.viewingCamera.object3DMap.camera,
-            this.inspectable,
-            this.pivot,
-            1
-          );
+          moveRigSoCameraLooksAtPivot(this.viewingRig.object3D, this.viewingCamera, this.inspectable, this.pivot, 1);
         }
         if (this.snapshot.audio) {
           setMatrixWorld(this.snapshot.audio, this.audioSourceTargetTransform);
@@ -536,7 +518,7 @@ export class CameraSystem {
           orbit(
             this.pivot,
             this.viewingRig.object3D,
-            this.viewingCamera.object3DMap.camera,
+            this.viewingCamera,
             this.horizontalDelta,
             this.verticalDelta,
             this.inspectZoom,

--- a/src/systems/hubs-systems.js
+++ b/src/systems/hubs-systems.js
@@ -58,7 +58,7 @@ AFRAME.registerSystem("hubs-systems", {
     this.scenePreviewCameraSystem = new ScenePreviewCameraSystem();
     this.spriteSystem = new SpriteSystem(this.el);
     this.batchManagerSystem = new BatchManagerSystem(this.el.object3D, this.el.renderer);
-    this.cameraSystem = new CameraSystem(this.el);
+    this.cameraSystem = new CameraSystem(this.el.camera, this.el.renderer);
     this.drawingMenuSystem = new DrawingMenuSystem(this.el);
     this.characterController = new CharacterControllerSystem(this.el);
     this.waypointSystem = new WaypointSystem(this.el, this.characterController);

--- a/src/systems/userinput/bindings/xforms.js
+++ b/src/systems/userinput/bindings/xforms.js
@@ -84,12 +84,9 @@ export const xforms = {
     frame.setVector2(dest.value, 0, 0);
   },
   poseFromCameraProjection: function() {
-    let camera;
     const pose = new Pose();
     return function poseFromCameraProjection(frame, src, dest) {
-      if (!camera) {
-        camera = document.getElementById("viewing-camera").components.camera.camera;
-      }
+      const camera = AFRAME.scenes[0].systems["hubs-systems"].cameraSystem.viewingCamera;
       const value = frame.get(src.value);
       frame.setPose(dest.value, pose.fromCameraProjection(camera, value[0], value[1]));
     };

--- a/src/systems/userinput/devices/app-aware-mouse.js
+++ b/src/systems/userinput/devices/app-aware-mouse.js
@@ -41,11 +41,7 @@ export class AppAwareMouseDevice {
     }
 
     if (!this.camera) {
-      const viewingCamera = document.getElementById("viewing-camera");
-
-      if (viewingCamera && viewingCamera.components) {
-        this.camera = viewingCamera.components.camera.camera;
-      }
+      this.camera = AFRAME.scenes[0].systems["hubs-systems"].cameraSystem.viewingCamera;
     }
 
     const buttonLeft = frame.get(paths.device.mouse.buttonLeft);

--- a/src/systems/userinput/devices/app-aware-touchscreen.js
+++ b/src/systems/userinput/devices/app-aware-touchscreen.js
@@ -24,17 +24,9 @@ function distance(x1, y1, x2, y2) {
   return Math.sqrt(dx * dx + dy * dy);
 }
 
-const getPlayerCamera = (() => {
-  let playerCamera;
-
-  return function() {
-    if (!playerCamera) {
-      playerCamera = document.getElementById("viewing-camera").components.camera.camera;
-    }
-
-    return playerCamera;
-  };
-})();
+const getPlayerCamera = function() {
+  return AFRAME.scenes[0].systems["hubs-systems"].cameraSystem.viewingCamera;
+};
 
 function isSingleActionButton(el) {
   return el.components.tags && el.components.tags.data.singleActionButton;

--- a/src/utils/disable-ios-zoom.js
+++ b/src/utils/disable-ios-zoom.js
@@ -1,7 +1,9 @@
-import { detectOS } from "detect-browser";
+import { isIOS as detectIOS } from "./is-mobile";
+const isIOS = detectIOS();
 
+// TODO should we be using touch-action CSS for this?
 export function disableiOSZoom() {
-  if (detectOS(navigator.userAgent) !== "iOS") return;
+  if (!isIOS) return;
 
   let lastTouchAtMs = 0;
 

--- a/src/utils/is-mobile.js
+++ b/src/utils/is-mobile.js
@@ -15,7 +15,7 @@ export function isIOS() {
 
 function isTablet(mockUserAgent) {
   const userAgent = mockUserAgent || window.navigator.userAgent;
-  return /ipad|Nexus (7|9)|xoom|sch-i800|playbook|tablet|kindle/i.test(userAgent);
+  return isIpadOS() || /ipad|Nexus (7|9)|xoom|sch-i800|playbook|tablet|kindle/i.test(userAgent);
 }
 
 function isR7() {


### PR DESCRIPTION
This PR attempts to rework the way some of the early initialization happens in aframe. The main goal is to begin taking more direct control over the main RAF loop and start to untangle some incidental complexity around overriding many of the built in aframe systems. This first PR attempts not to change the code flow too much, but some of the async behavior around camera initialization was easier to simplify than temporarily maintain the old complexity.

Most of the interesting changes are in https://github.com/MozillaReality/aframe/pull/33, and comparing that to the changes in app.js here.

todo:
- [x] merge MozillaReality/aframe/pull/33
- [x] update package.json and package-lock.json to point at merged branch/commit