### PR TITLE
Fix mute user visibility

### DIFF
--- a/src/components/avatar-volume-controls.js
+++ b/src/components/avatar-volume-controls.js
@@ -94,6 +94,9 @@ AFRAME.registerComponent("avatar-volume-controls", {
   },
 
   onRemoteMuteUpdated({ detail: { muted } }) {
-    this.muteButton.object3D.visible = !muted;
+    if (!this.el.sceneEl.systems.permissions.canOrWillIfCreator("mute_users")) return;
+    this.muteButton.object3D.traverse(obj => {
+      obj.visible = !muted;
+    });
   }
 });


### PR DESCRIPTION
When the user doesn't have "mute_users" permissions the freeze-menu mute button visibility is not correct.