### PR TITLE
Improved the chat emoji picker 👀 

### DIFF
--- a/src/react-components/room/ChatSidebarContainer.js
+++ b/src/react-components/room/ChatSidebarContainer.js
@@ -215,6 +215,16 @@ export function ChatSidebarContainer({ scene, canSpawnMessages, presences, occup
     [scene]
   );
 
+  const onSelectEmoji = useCallback(
+    ({ emoji, pickerRemainedOpen }) => {
+      setMessage(message => message + emoji.native);
+      // If the picker remained open, avoid selecting the input so that the
+      // user can keep picking emojis.
+      if (!pickerRemainedOpen) inputRef.current.select();
+    },
+    [setMessage, inputRef]
+  );
+
   useEffect(() => inputEffect(inputRef.current), [inputEffect, inputRef]);
 
   useEffect(
@@ -297,9 +307,7 @@ export function ChatSidebarContainer({ scene, canSpawnMessages, presences, occup
         }
         afterInput={
           <>
-            {!isMobile && (
-              <EmojiPickerPopoverButton onSelectEmoji={emoji => setMessage(message => message + emoji.native)} />
-            )}
+            {!isMobile && <EmojiPickerPopoverButton onSelectEmoji={onSelectEmoji} />}
             {message.length === 0 && canSpawnMessages ? (
               <MessageAttachmentButton onChange={onUploadAttachments} />
             ) : (


### PR DESCRIPTION
The emoji picker is now a bit nicer to use! You can hold down the `Shift` key to keep inserting emojis. The chat input also gets focused after picking an emoji, so that you can keep typing, and we've fixed an annoying bug that caused the emoji picker to reset itself when you received new chat messages 😤

![hubs-chat-emoji](https://user-images.githubusercontent.com/79419/161569561-d43bde77-4f5e-4e09-9d4a-67ceabe527dd.gif)

---

The core issue in #4250 is that emoji-mart, the emoji picker we use, does not seem to support re-renders well. It looses it search and filter state. I believe it's also quite heavy to load and render. So I used [React.memo](https://reactjs.org/docs/react-api.html#reactmemo) on `EmojiPickerPopoverButton` to avoid a re-render unless its `onSelectEmoji` prop changed.

While I was at it, I decided to improve the picker a bit more. Now, when you pick a single emoji, the chat input will be selected, using the existing `inputRef`, so that you can continue typing. Additionally, if you hold `Shift` down while picking emojis, the picker will stay open so that you can keep picking emojis. This was done using a [`useRef`](https://reactjs.org/docs/hooks-reference.html#useref) and keydown/up even handlers to track the current state of the Shift key. I also removed the implicit prop spreading (`{...props}`) from `Popover` to `EmojiPicker`, since we weren't actually using any of those props.

Fixes #4250 