### PR TITLE
Fix error on entry modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32183,17 +32183,6 @@
         "refractor": "^3.1.0"
       }
     },
-    "react-test-renderer": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
-      "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
-      "requires": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.8.6",
-        "scheduler": "^0.19.1"
-      }
-    },
     "react-textarea-autosize": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.0.tgz",
@@ -32220,13 +32209,9 @@
       }
     },
     "react-use-css-breakpoints": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/react-use-css-breakpoints/-/react-use-css-breakpoints-1.0.3.tgz",
-      "integrity": "sha512-l1rg/gknC8bDELa3lW3Ph0tTTbn1J31gUx+pskbS1OxSEh/7aEQeT37ZB5IPfmDediriROSPERx0XKq7UEfC0w==",
-      "requires": {
-        "react": "^16.10.2",
-        "react-test-renderer": "^16.10.2"
-      }
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/react-use-css-breakpoints/-/react-use-css-breakpoints-1.0.4.tgz",
+      "integrity": "sha512-1IpfjgGv7l0A8MwGIIXQiXgbDyi64qNVtcrj9E19Dt3cOIbIJvyDorbRzwY4hqCj/OUXcntGDwrptBxeA7CIyw=="
     },
     "reactcss": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",
     "react-textarea-autosize": "^8.2.0",
-    "react-use-css-breakpoints": "^1.0.3",
+    "react-use-css-breakpoints": "^1.0.4",
     "resize-observer-polyfill": "^1.5.1",
     "screenfull": "^4.0.1",
     "sdp-transform": "^2.14.1",


### PR DESCRIPTION
Sometimes the `react-use-css-breakpoint` hook tries to perform an update when the entry modal component has already been unmounted.

This has been fixed in the original library: https://github.com/matthewhall/react-use-css-breakpoints/pull/13
This PR just update the upstream version to use the fixed one