### PR TITLE
Dirty flag performance optimization in setMatrixWorld()

### DIFF
--- a/src/utils/three-utils.js
+++ b/src/utils/three-utils.js
@@ -52,10 +52,13 @@ export function disposeNode(node) {
 }
 
 const IDENTITY = new THREE.Matrix4().identity();
+const tempMatrix4 = new THREE.Matrix4();
+const EPSILON = 0.00000000001;
 export function setMatrixWorld(object3D, m) {
   if (!object3D.matrixIsModified) {
     object3D.applyMatrix4(IDENTITY); // hack around our matrix optimizations
   }
+  tempMatrix4.copy(object3D.matrixWorld);
   object3D.matrixWorld.copy(m);
   if (object3D.parent) {
     object3D.parent.updateMatrices();
@@ -67,7 +70,11 @@ export function setMatrixWorld(object3D, m) {
     object3D.matrix.copy(object3D.matrixWorld);
   }
   object3D.matrix.decompose(object3D.position, object3D.quaternion, object3D.scale);
-  object3D.childrenNeedMatrixWorldUpdate = true;
+  if (tempMatrix4.near(object3D.matrixWorld, EPSILON)) {
+    object3D.matrixWorld.copy(tempMatrix4);
+  } else {
+    object3D.childrenNeedMatrixWorldUpdate = true;
+  }
 }
 
 // Modified version of Don McCurdy's AnimationUtils.clone


### PR DESCRIPTION
Related: #5322
Requires: https://github.com/MozillaReality/three.js/pull/64

Similar to https://github.com/MozillaReality/three.js/pull/64, I would like to suggest to raise the `childrenNeedMatrixWorldUpdate` flag in `setMatrixWorld()` only if the new values have diff from the current values to avoid unnecessary matrices update.