### PR TITLE
Fix spawned chat messages on iOS Safari

### DIFF
--- a/src/assets/stylesheets/presence-log.scss
+++ b/src/assets/stylesheets/presence-log.scss
@@ -173,7 +173,7 @@
 
 :local(.presence-log-spawn) {
   position: absolute;
-  top: 0;
+  bottom: 0;
   z-index: -10;
   width: auto;
   margin: 0;


### PR DESCRIPTION
This fixes an issue where chat messages would not appear in a room when spawned from the chat on iOS Safari. If you had the chat input focused when you spawned the message, it would spawn an empty transparent image instead.

When we want to spawn a chat message in the room, we first create a temporary element that contains the content we want to render. That element is then rasterized to a canvas using `html2canvas`, then converted to a blob, which we upload as a file, and spawn into the room.

The temporary element is rendered at the top of the page using CSS that positions it there. However, when you've got the chat input focused on iOS, the iOS keyboard pushes the top of the page off the screen. I suspect this causes Safari to avoid rendering the element as an optimization, which means `html2canvas` ends up rendering a transparent image instead.

This fix moves the temporary element to the bottom of the screen, instead of the top, so that it is still within the bounds of the display when the iOS keyboard is open.

Fixes #3885