### PR TITLE
Minor refactor for local dev host. dotenv cleanup.

### DIFF
--- a/.defaults.env
+++ b/.defaults.env
@@ -23,9 +23,6 @@ NON_CORS_PROXY_DOMAINS="hubs.local,dev.reticulum.io"
 # The root URL under which Hubs expects static assets to be served.
 BASE_ASSETS_PATH=/
 
-# The default scene to use. Note the example scene id is only available on dev.reticulum.io
-DEFAULT_SCENE_SID="JGLt8DP"
-
 # Uncomment to load the app config from the reticulum server in development.
 # Useful when testing the admin panel.
 # LOAD_APP_CONFIG=true

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -220,17 +220,18 @@ module.exports = async (env, argv) => {
     }
 
     if (env.localDev) {
+      const localDevHost = "hubs.local";
       // Local Dev Environment (npm run local)
       Object.assign(process.env, {
-        HOST: "hubs.local",
-        RETICULUM_SOCKET_SERVER: "hubs.local",
+        HOST: localDevHost,
+        RETICULUM_SOCKET_SERVER: localDevHost,
         CORS_PROXY_SERVER: "hubs-proxy.local:4000",
-        NON_CORS_PROXY_DOMAINS: "hubs.local,dev.reticulum.io",
-        BASE_ASSETS_PATH: "https://hubs.local:8080/",
-        RETICULUM_SERVER: "hubs.local:4000",
+        NON_CORS_PROXY_DOMAINS: `${localDevHost},dev.reticulum.io`,
+        BASE_ASSETS_PATH: `https://${localDevHost}:8080/`,
+        RETICULUM_SERVER: `${localDevHost}:4000`,
         POSTGREST_SERVER: "",
         ITA_SERVER: "",
-        UPLOADS_HOST: "https://hubs.local:4000"
+        UPLOADS_HOST: `https://${localDevHost}:4000`
       });
     }
   }


### PR DESCRIPTION
This PR is a minor change for local development that reduces repetition of `"hubs.local"` in the webpack config. This just makes it a bit easier to change the local dev host in certain cases, like when you want to use an IP address for testing mobile devices.

I've also removed `DEFAULT_SCENE_SID` from `.defaults.env`, since we stopped using that variable a long while ago.