### PR TITLE
Pared down unsupported browser message

### DIFF
--- a/src/assets/stylesheets/support.scss
+++ b/src/assets/stylesheets/support.scss
@@ -18,12 +18,15 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
+  margin: 1em;
   a {
     font-size: smaller;
     color: white;
   }
   input {
     width: 15em;
+    background: white;
+    color: black;
     font-size: 12pt;
     padding: 0.4em;
     border-radius: 10px;
@@ -33,11 +36,12 @@
     margin-left: 0.5em;
     font-size: 12pt;
   }
-}
 
-:local(.logo) {
-  max-width: 250px;
-  filter: drop-shadow(0 0 4px #888);
+  :local(.unsupported-langs) {
+    span {
+      white-space: nowrap;
+    }
+  }
 }
 
 :local(.details) {

--- a/src/assets/stylesheets/support.scss
+++ b/src/assets/stylesheets/support.scss
@@ -14,9 +14,6 @@
 }
 
 :local(.support-content) {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
   text-align: center;
   margin: 1em;
   a {
@@ -36,11 +33,13 @@
     margin-left: 0.5em;
     font-size: 12pt;
   }
-
   :local(.unsupported-langs) {
     span {
       white-space: nowrap;
     }
+  }
+  table {
+    margin: auto;
   }
 }
 

--- a/src/support.js
+++ b/src/support.js
@@ -1,19 +1,18 @@
+/* eslint-disable @calm/react-intl/missing-formatted-message */
+
 /*
 NOTE: support.js needs to be as self-contained as possible, since it needs to work in legacy browers
 that we do not support. Avoid adding imports to libraries or other modules from our own codebase
 that might break the support UI in legacy browsers.
+We also do not support localization in this file.
 */
 
 import React from "react";
 import ReactDOM from "react-dom";
 import copy from "copy-to-clipboard";
 import { detectOS } from "detect-browser";
-import { FormattedMessage } from "react-intl";
-import { WrappedIntlProvider } from "./react-components/wrapped-intl-provider";
 import "./react-components/styles/global.scss";
 import styles from "./assets/stylesheets/support.scss";
-import configs from "./utils/configs";
-import { ThemeProvider } from "./react-components/styles/theme";
 
 const SHORTHAND_INITIALIZER = "var foo = 'bar'; var baz = { foo };";
 const SPREAD_SYNTAX = "var foo = {}; var baz = { ...foo };";
@@ -82,75 +81,56 @@ class Support extends React.Component {
     const detectedOS = detectOS(navigator.userAgent);
 
     return (
-      <WrappedIntlProvider>
-        <ThemeProvider>
-          <div className={styles.supportMain}>
-            <div className={styles.supportContent}>
-              <div>
-                <img className={styles.logo} src={configs.image("logo")} />
-              </div>
-              <p>
-                <FormattedMessage
-                  id="support.missing-features"
-                  defaultMessage="Your browser is missing required features."
-                />
-                <br />
-                {inAppBrowser ? (
-                  detectedOS === "iOS" ? (
-                    <FormattedMessage
-                      id="support.in-app-browser-ios"
-                      defaultMessage="Copy and paste this link directly into Safari"
-                    />
-                  ) : (
-                    <FormattedMessage
-                      id="support.in-app-browser-android"
-                      defaultMessage="Copy and paste this link directly into Chrome or Firefox"
-                    />
-                  )
-                ) : (
-                  <FormattedMessage
-                    id="support.update-browser"
-                    defaultMessage="Please try switching or updating to a newer browser"
-                  />
-                )}
-                <br />
-                <br />
-                <input type="text" readOnly onFocus={e => e.target.select()} value={document.location} />
-                <a className="copy-link" href="#" onClick={this.onCopyClicked}>
-                  {this.state.hasCopied ? (
-                    <FormattedMessage id="support.copied" defaultMessage="copied!" />
-                  ) : (
-                    <FormattedMessage id="support.copy" defaultMessage="copy" />
-                  )}
-                </a>
-                <br />
-                <br />
-                <a className={styles.detailsLink} href="#" onClick={this.toggleDetails}>
-                  <FormattedMessage id="support.details" defaultMessage="details" />
-                </a>
-              </p>
-              {this.state.showDetails && (
-                <table className={styles.details}>
-                  <tbody>
-                    {platformSupport.sort((a, b) => (a.supported && !b.supported ? 1 : -1)).map(s => (
-                      <tr key={s.name}>
-                        <td>{s.name}</td>
-                        <td>
-                          {s.supported ? (
-                            <FormattedMessage id="support.supported" defaultMessage="supported" />
-                          ) : (
-                            <FormattedMessage id="support.unsupported" defaultMessage="unsupported" />
-                          )}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              )}
-            </div>
-          </div>
-        </ThemeProvider>
-      </WrappedIntlProvider>
+      <div className={styles.supportMain}>
+        <div className={styles.supportContent}>
+          <h1>Mozilla Hubs</h1>
+          <br />
+          <p className={styles.unsupportedLangs}>
+            · <span>Unsupported</span> · <span>No Soportado</span> · <span>Nicht Unterstützt</span>
+            {" · "}
+            <span>Sem Suporte</span> · <span>Non Compatible</span> · <span>не поддерживается</span>
+            {" · "}
+            <span>サポートされていません</span> ·
+          </p>
+          <br />
+          <p>
+            <span>Your browser is missing required features.</span>
+            <br />
+            {inAppBrowser ? (
+              detectedOS === "iOS" ? (
+                <span>Copy and paste this link directly into Safari</span>
+              ) : (
+                <span>Copy and paste this link directly into Chrome or Firefox</span>
+              )
+            ) : (
+              <span>Please try switching or updating to a newer browser</span>
+            )}
+            <br />
+            <br />
+            <input type="text" readOnly onFocus={e => e.target.select()} value={document.location} />
+            <a className="copy-link" href="#" onClick={this.onCopyClicked}>
+              {this.state.hasCopied ? "copied!" : "copy"}
+            </a>
+            <br />
+            <br />
+            <a className={styles.detailsLink} href="#" onClick={this.toggleDetails}>
+              <span>details</span>
+            </a>
+          </p>
+          {this.state.showDetails && (
+            <table className={styles.details}>
+              <tbody>
+                {platformSupport.sort((a, b) => (a.supported && !b.supported ? 1 : -1)).map(s => (
+                  <tr key={s.name}>
+                    <td>{s.name}</td>
+                    <td>{s.supported ? "supported" : "unsupported"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
     );
   }
 }

--- a/src/support.js
+++ b/src/support.js
@@ -4,7 +4,8 @@
 NOTE: support.js needs to be as self-contained as possible, since it needs to work in legacy browers
 that we do not support. Avoid adding imports to libraries or other modules from our own codebase
 that might break the support UI in legacy browsers.
-We also do not support localization in this file.
+We also do not support localization in this file, since it would require additional transpiliation
+and polyfilling.
 */
 
 import React from "react";
@@ -31,9 +32,11 @@ function getPlatformSupport() {
   return [
     { name: "Web Assembly", supported: !!window.WebAssembly },
     { name: "Media Devices", supported: !!navigator.mediaDevices },
-    { name: "Shorthand initializer syntax", supported: syntaxSupported(SHORTHAND_INITIALIZER) },
-    { name: "Spread syntax", supported: syntaxSupported(SPREAD_SYNTAX) },
-    { name: "Optional catch syntax", supported: syntaxSupported(CATCH_SYNTAX) }
+    {
+      name: "Modern JavaScript Syntax",
+      supported:
+        syntaxSupported(CATCH_SYNTAX) && syntaxSupported(SPREAD_SYNTAX) && syntaxSupported(SHORTHAND_INITIALIZER)
+    }
   ];
 }
 
@@ -88,9 +91,9 @@ class Support extends React.Component {
           <p className={styles.unsupportedLangs}>
             · <span>Unsupported</span> · <span>No Soportado</span> · <span>Nicht Unterstützt</span>
             {" · "}
-            <span>Sem Suporte</span> · <span>Non Compatible</span> · <span>не поддерживается</span>
+            <span>Sem Suporte</span> · <span>Non Compatible</span> · <span>不支援</span>
             {" · "}
-            <span>サポートされていません</span> ·
+            <span>не поддерживается</span> · <span>サポートされていません</span> ·
           </p>
           <br />
           <p>


### PR DESCRIPTION
Currently if you visit hubs.mozilla.com in IE 11, the app doesn't display anything at all. We'd like to at least display an unsupported message in legacy browsers. This PR pares down the unsupported message UI so that we don't have to spend the effort to target and polyfill old browsers. Unfortunately it means we can't support localization in this UI, but it's better than display nothing at all.

![image](https://user-images.githubusercontent.com/79419/162650250-1212344e-4e09-4759-8acb-f20f19cb2fde.png)
