### PR TITLE
Hack for unexpected ncp behaviour

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -101,6 +101,9 @@ const getTs = (() => {
   });
   step.text = "Preparing Deploy.";
 
+  // Tempoary hack because the ncp function returns before it finishes
+  await new Promise(res => setTimeout(res, 5000));
+
   step.text = "Packaging Build.";
   tar.c({ sync: true, gzip: true, C: path.join(__dirname, "..", "dist"), file: "_build.tar.gz" }, ["."]);
   step.text = `Uploading Build ${buildEnv.BUILD_VERSION}.`;


### PR DESCRIPTION
The is a temporary workaround to prevent deployment failures as discussed here https://github.com/mozilla/hubs/issues/4208#issuecomment-1006448926

The ncp command issues multiple callbacks during operation, which is unexpected and compromises the promise-based flow control.

Obviously this is only supposed to be a temporary solution. The full solution will probably require the selection of a new library to replace ncp and this more suitably tackled by the core dev team.