### PR TITLE
Fix manually setting matrixIsModified for hands

### DIFF
--- a/src/systems/cursor-pose-tracking.js
+++ b/src/systems/cursor-pose-tracking.js
@@ -1,8 +1,10 @@
+const IDENTITY = new THREE.Matrix4().identity();
 export class CursorPoseTrackingSystem {
   constructor() {
     this.pairs = [];
   }
   register(object3D, path) {
+    object3D.applyMatrix4(IDENTITY); // make sure target gets updated at least once for our matrix optimizations
     this.pairs.push({ object3D, path });
   }
   unregister(object3D) {
@@ -15,7 +17,6 @@ export class CursorPoseTrackingSystem {
         const o = this.pairs[i].object3D;
         o.matrix.copy(matrix);
         o.matrix.decompose(o.position, o.quaternion, o.scale);
-        o.matrixIsModified = true;
         o.matrixWorldNeedsUpdate = true;
       }
     }


### PR DESCRIPTION
This fixes #5373 , a regression caused by #5290. 

This bug already existed but was being masked by matrix-auto-update. The root cause is the breaking of this rule from  https://github.com/MozillaReality/three.js/commit/b7dd0a176f9a3e3895d253831abe09bb8aaceb32

> - Do not set matrixIsModified yourself; You could accidentally overwrite a shared parent matrixWorld.

The hand poses ended up being applied to the identity matrix which breaks all sorts of things. This fixes the `track-pose` system so that this flag gets flipped properly. We should probably add a function to Object3D to make this less hacky. The actual side effect we want from this `applyMatrix4` is to call `_handleMatrixModification` which handles flipping the `matrixIsModified` flag and correctly clearing the cached matrix. We could call this directly, but based on the name we sort of expect this to be an internal implementation detail. Will need to think more about what the right API is here.