### PR TITLE
Korean localize

### DIFF
--- a/src/components/troika-text.js
+++ b/src/components/troika-text.js
@@ -53,7 +53,11 @@ AFRAME.registerComponent("text", {
     direction: { type: "string", default: "auto", oneOf: ["auto", "ltr", "rtl"] },
     fillOpacity: { type: "number", default: 1 },
     // This is different from the Troika preoperty name, Using "fontUrl" to prevent conflict with previous "font" p=roperty and to allow us to make named fonts later
-    fontUrl: { type: "string" },
+    fontUrl: {
+      type: "string",
+      default:
+        "https://cdn.jsdelivr.net/gh/spoqa/spoqa-han-sans@latest/Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Regular.woff"
+    },
     // This default value differs from the Troika default of 0.1, it most closely matches the size of our previous text component.
     fontSize: { type: "number", default: 0.075 },
     letterSpacing: { type: "number", default: 0 },

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -48,7 +48,7 @@ export const SCHEMA = {
       type: "object",
       additionalProperties: false,
       properties: {
-        displayName: { type: "string", pattern: "^[가-힣A-Za-z0-9_~ -]{3,32}$" },
+        displayName: { type: "string", pattern: "^[가-힣A-Za-z0-9_~ -]{1,32}$" },
         avatarId: { type: "string" },
         // personalAvatarId is obsolete, but we need it here for backwards compatibility.
         personalAvatarId: { type: "string" }

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -48,7 +48,7 @@ export const SCHEMA = {
       type: "object",
       additionalProperties: false,
       properties: {
-        displayName: { type: "string", pattern: "^[A-Za-z0-9_~ -]{3,32}$" },
+        displayName: { type: "string", pattern: "^[가-힣A-Za-z0-9_~ -]{3,32}$" },
         avatarId: { type: "string" },
         // personalAvatarId is obsolete, but we need it here for backwards compatibility.
         personalAvatarId: { type: "string" }


### PR DESCRIPTION
# Doing

- troika-text의 기본 폰트를 spoqa han sans neo 로 변경
- 닉네임 정규식에 한글 추가 (가-힣)
- 1글자 닉네임도 가능하도록 수정