### PR TITLE
Set scene.autoUpdate false in video-texture-source.tock()

### DIFF
--- a/src/components/video-texture-target.js
+++ b/src/components/video-texture-target.js
@@ -72,9 +72,16 @@ AFRAME.registerComponent("video-texture-source", {
     delete sceneEl.object3D.onAfterRender;
     renderer.xr.enabled = false;
 
+    // The entire scene graph matrices should already be updated
+    // in tick(). They don't need to be recomputed again in tock().
+    const tmpAutoUpdate = sceneEl.object3D.autoUpdate;
+    sceneEl.object3D.autoUpdate = false;
+
     renderer.setRenderTarget(this.renderTarget);
     renderer.render(sceneEl.object3D, this.camera);
     renderer.setRenderTarget(null);
+
+    sceneEl.object3D.autoUpdate = tmpAutoUpdate;
 
     renderer.xr.enabled = tmpXRFlag;
     sceneEl.object3D.onAfterRender = tmpOnAfterRender;


### PR DESCRIPTION
From: #5388

`video-texture-source.tick()` calls `renderer.render(scene, camera)`. The renderer attempts to update entire scene graph matrices due to `scene.autoUpdate = true`.

But the matrices should already be updated in `tick()`. Attempting to update the matrices again in `tock()` is unnecessary and costly.

`scene.autoUpdate` should be `false` in `tock()`.

I want to make another PR for `camera-tool.tock()` because it seems to update a matrix. I want to carefully review it.