### PR TITLE
Cache the result of isSafari()

### DIFF
--- a/src/utils/detect-safari.js
+++ b/src/utils/detect-safari.js
@@ -1,6 +1,8 @@
 import { detect } from "detect-browser";
 
+const browser = detect();
+const browserIsSafari = ["iOS", "Mac OS"].includes(browser.os) && ["safari", "ios"].includes(browser.name);
+
 export function isSafari() {
-  const browser = detect();
-  return ["iOS", "Mac OS"].includes(browser.os) && ["safari", "ios"].includes(browser.name);
+  return browserIsSafari;
 }


### PR DESCRIPTION
`detect-browser` seems to be slow. If panner audio is disabled it is called every frame via `isSafari()`.

![image](https://user-images.githubusercontent.com/7637832/165403605-d242d1dc-955d-4fd8-bb67-9a4799974a3c.png)

Caching the result of `isSafari()` improves the Hubs Client performance.