### PR TITLE
Turn off scene.autoUpdate in camera-tool.tock()

### DIFF
--- a/src/components/bone-visibility.js
+++ b/src/components/bone-visibility.js
@@ -31,6 +31,18 @@ export class BoneVisibilitySystem {
       cmp.lastVisible = visible;
     }
   }
+
+  // Called only from camera-tool.tock() to update the matrices
+  // of objects and their children whose are updated in tick().
+  updateMatrices() {
+    for (let i = 0; i < components.length; i++) {
+      const cmp = components[i];
+      const obj = cmp.el.object3D;
+      if (obj.matrixNeedsUpdate) {
+        obj.updateMatrixWorld();
+      }
+    }
+  }
 }
 
 AFRAME.registerComponent("bone-visibility", {

--- a/src/components/camera-tool.js
+++ b/src/components/camera-tool.js
@@ -584,6 +584,8 @@ AFRAME.registerComponent("camera-tool", {
       if (this.trackTarget) {
         if (this.trackTarget.parentNode) {
           this.lookAt(this.trackTarget);
+          // scene.autoUpdate will be false so explicitly update the world matrices
+          this.object3D.updateMatrixWorld();
         } else {
           this.trackTarget = null; // Target removed
         }
@@ -620,12 +622,19 @@ AFRAME.registerComponent("camera-tool", {
           // HACK, bone visibility typically takes a tick to update, but since we want to be able
           // to have enable() and disable() be reflected this frame, we need to do it immediately.
           boneVisibilitySystem.tick();
+          // scene.autoUpdate will be false so explicitly update the world matrices
+          boneVisibilitySystem.updateMatrices();
         }
 
         const tmpVRFlag = renderer.xr.enabled;
         const tmpOnAfterRender = sceneEl.object3D.onAfterRender;
+        const tmpAutoUpdate = sceneEl.object3D.autoUpdate;
         delete sceneEl.object3D.onAfterRender;
         renderer.xr.enabled = false;
+
+        // The entire scene graph matrices should already be updated
+        // in tick(). They don't need to be recomputed again in tock().
+        sceneEl.object3D.autoUpdate = false;
 
         if (allowVideo && this.videoRecorder && !this.videoRenderTarget) {
           // Create a separate render target for video because we need to flip and (sometimes) downscale it before
@@ -649,6 +658,7 @@ AFRAME.registerComponent("camera-tool", {
 
         renderer.xr.enabled = tmpVRFlag;
         sceneEl.object3D.onAfterRender = tmpOnAfterRender;
+        sceneEl.object3D.autoUpdate = tmpAutoUpdate;
 
         if (this.playerHud) {
           this.playerHud.visible = playerHudWasVisible;
@@ -666,6 +676,7 @@ AFRAME.registerComponent("camera-tool", {
           // HACK, bone visibility typically takes a tick to update, but since we want to be able
           // to have enable() and disable() be reflected this frame, we need to do it immediately.
           boneVisibilitySystem.tick();
+          boneVisibilitySystem.updateMatrices();
         }
 
         this.lastUpdate = now;


### PR DESCRIPTION
From: #5388

The entire scene graph matrices should already be updated in `tick()` and traversing/recomputing them again in `tock()` is not necessary.

This commit turns it off and updates only needed matrices in `camera-tool.tock()`.