### PR TITLE
Fix invalid material.side parameter set in troika-text

### DIFF
--- a/src/components/troika-text.js
+++ b/src/components/troika-text.js
@@ -7,6 +7,12 @@ import { Text } from "troika-three-text";
 // Mark this type of object so we can filter in from our shader patching
 Text.prototype.isTroikaText = true;
 
+const THREE_SIDES = {
+  front: THREE.FrontSide,
+  back: THREE.BackSide,
+  double: THREE.DoubleSide
+};
+
 function numberOrPercent(defaultValue) {
   return {
     default: defaultValue,
@@ -100,7 +106,7 @@ AFRAME.registerComponent("text", {
     mesh.anchorX = data.anchorX;
     mesh.anchorY = data.anchorY;
     mesh.color = data.color;
-    mesh.material.side = data.side;
+    mesh.material.side = THREE_SIDES[data.side];
     mesh.material.opacity = data.opacity;
     mesh.curveRadius = data.curveRadius;
     mesh.depthOffset = data.depthOffset || 0;


### PR DESCRIPTION
[Three.js `Material.side` takes `THREE.FrontSide/BackSide/DoubleSide` constants](https://threejs.org/docs/#api/en/materials/Material.side) but `troika-text` wrongly sets invalid strings `'front/back/double'`. Due to this problem, troika-text may not be rendered expectedly.

This PR fixes the problem by setting valid parameters.
