### PR TITLE
Add query string parameter for forcing alpha clip on uploaded media

### DIFF
--- a/src/components/media-image.js
+++ b/src/components/media-image.js
@@ -161,11 +161,16 @@ AFRAME.registerComponent("media-image", {
           this.mesh.material.alphaTest = this.data.alphaCutoff;
           break;
         default:
-          this.mesh.material.transparent =
-            !this.data.batch ||
-            this.data.contentType.includes("image/gif") ||
-            !!(texture.image && texture.image.hasAlpha);
-          this.mesh.material.alphaTest = 0;
+          if (qsTruthy("force_alpha_clip")) {
+            this.mesh.material.transparent = false;
+            this.mesh.material.alphaTest = 0.5;
+          else {
+            this.mesh.material.transparent =
+              !this.data.batch ||
+              this.data.contentType.includes("image/gif") ||
+              !!(texture.image && texture.image.hasAlpha);
+            this.mesh.material.alphaTest = 0;
+          }
       }
     }
 


### PR DESCRIPTION
This small change would force alpha clip (instead of blend) for uploaded images, to try resolving a bug in rendering stacked transparent images, as documented in https://github.com/mozilla/hubs/issues/5297

There's some uncertainty as to whether this affects .glb files which have alpha blend (for example i am adding semitransparent windows to some models) and whether that will cause problems for such scenes. 

Overall I'd like a little more control or transparency (no pun) on which uploaded media get which alpha behavior, so this is a very minimally invasive way to try resolving this bug. There's suggestion of later having a scene setting but I think it's too early for that. 

Thank you and many thanks to @Exairnous for a ton of help understanding and tracing this!