### PR TITLE
Fix media-frame release race condition

### DIFF
--- a/src/systems/media-frames.js
+++ b/src/systems/media-frames.js
@@ -378,9 +378,11 @@ AFRAME.registerComponent("media-frame", {
         capturedEl.object3D.scale.copy(this.data.originalTargetScale);
         capturedEl.object3D.matrixNeedsUpdate = true;
         capturedEl.components["floaty-object"].setLocked(false);
+
+        if (!NAF.utils.isMine(capturedEl) && !NAF.utils.takeOwnership(capturedEl)) {
+          console.error("failed to take ownership of media frame object");
+        }
       }
-    } else {
-      console.error("failed to take ownership of media frame");
     }
   }
 });

--- a/src/systems/media-frames.js
+++ b/src/systems/media-frames.js
@@ -367,7 +367,7 @@ AFRAME.registerComponent("media-frame", {
   },
 
   release() {
-    if (NAF.utils.isMine(this.el) || NAF.utils.takeOwnership(this.el)) {
+    if (NAF.utils.isMine(this.el)) {
       const capturedEl = document.getElementById(this.data.targetId);
 
       this.el.setAttribute("media-frame", {


### PR DESCRIPTION
This PR is based on this stalled community PR: https://github.com/mozilla/hubs/pull/4780

and Fixes https://github.com/mozilla/hubs/issues/4779

An issue that happens when multiple clients try to take ownership of a media-frame after it's been released. This PR limits the release only allowing the media frame owner to release it and also makes the releaser take ownership of the target object.