### PR TITLE
Update Three.js to fix a bug that skipped matrix updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36216,7 +36216,7 @@
       "dev": true
     },
     "three": {
-      "version": "github:mozillareality/three.js#ab5d5824770dbcf6921b21a4a2faaae961f67328",
+      "version": "github:mozillareality/three.js#b907b3c1cab8b416ef63b290aa603b540dd881b8",
       "from": "github:mozillareality/three.js#hubs-patches-133"
     },
     "three-ammo": {


### PR DESCRIPTION
Our Three.js fork had a bug that invisible objects can lose an opportunity to update their matrices and they can be rendered at wrong place in the scene when it became visible. For example due to this bug particles are rendered at wrong place indeed.

[We have applied a patch to fix it on our Three.js fork end](https://github.com/MozillaReality/three.js/pull/65). With this commit the updated Three.js will be imported to resolve the problem.