### PR TITLE
Rename certs to RootCA.*; Doc the existence of the generated RootCAs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ The backend dev server is configured with CORS to only accept connections from "
 127.0.0.1	hubs-proxy.local
 ```
 
-Then visit https://hubs.local:8080 (note: HTTPS is required, you'll need to accept the warning for the self-signed SSL certificate)
+Then visit https://hubs.local:8080 (Note: HTTPS is required)
+
+To pass the HTTPS warning in your browser, you'll need to either:
+* accept the warning for the self-signed SSL certificate;
+* or, the root certificates, `RootCA.pem` and `RootCA.key` in the `certs` folder, can be used to generate a self-signed certificate for `hubs.local`; the root certificates are generated on first `npm run`; and, OpenSSL can be used to generate `crt` files. 
+
 
 > Note: When running the Hubs client locally, you will still connect to the development versions of our [Janus WebRTC](https://github.com/mozilla/janus-plugin-sfu) and [reticulum](https://github.com/mozilla/reticulum) servers. These servers do not allow being accessed outside of localhost. If you want to host your own Hubs servers, please check out [Hubs Cloud](https://hubs.mozilla.com/docs/hubs-cloud-intro.html).
 

--- a/admin/webpack.config.js
+++ b/admin/webpack.config.js
@@ -11,8 +11,8 @@ const CopyWebpackPlugin = require("copy-webpack-plugin");
 function createHTTPSConfig() {
   // Generate certs for the local webpack-dev-server.
   if (fs.existsSync(path.join(__dirname, "certs"))) {
-    const key = fs.readFileSync(path.join(__dirname, "certs", "key.pem"));
-    const cert = fs.readFileSync(path.join(__dirname, "certs", "cert.pem"));
+    const key = fs.readFileSync(path.join(__dirname, "certs", "RootCA.key"));
+    const cert = fs.readFileSync(path.join(__dirname, "certs", "RootCA.pem"));
 
     return { key, cert };
   } else {
@@ -45,8 +45,8 @@ function createHTTPSConfig() {
     );
 
     fs.mkdirSync(path.join(__dirname, "certs"));
-    fs.writeFileSync(path.join(__dirname, "certs", "cert.pem"), pems.cert);
-    fs.writeFileSync(path.join(__dirname, "certs", "key.pem"), pems.private);
+    fs.writeFileSync(path.join(__dirname, "certs", "RootCA.pem"), pems.cert);
+    fs.writeFileSync(path.join(__dirname, "certs", "RootCA.key"), pems.private);
 
     return {
       key: pems.private,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,8 +17,8 @@ const internalIp = require("internal-ip");
 function createHTTPSConfig() {
   // Generate certs for the local webpack-dev-server.
   if (fs.existsSync(path.join(__dirname, "certs"))) {
-    const key = fs.readFileSync(path.join(__dirname, "certs", "key.pem"));
-    const cert = fs.readFileSync(path.join(__dirname, "certs", "cert.pem"));
+    const key = fs.readFileSync(path.join(__dirname, "certs", "RootCA.key"));
+    const cert = fs.readFileSync(path.join(__dirname, "certs", "RootCA.pem"));
 
     return { key, cert };
   } else {
@@ -52,8 +52,8 @@ function createHTTPSConfig() {
     );
 
     fs.mkdirSync(path.join(__dirname, "certs"));
-    fs.writeFileSync(path.join(__dirname, "certs", "cert.pem"), pems.cert);
-    fs.writeFileSync(path.join(__dirname, "certs", "key.pem"), pems.private);
+    fs.writeFileSync(path.join(__dirname, "certs", "RootCA.pem"), pems.cert);
+    fs.writeFileSync(path.join(__dirname, "certs", "RootCA.key"), pems.private);
 
     return {
       key: pems.private,


### PR DESCRIPTION
Make it easier for the user of the repo to know RootCAs are generated and how they can be used to create a self-signed certificate for `hubs.local`.