### PR TITLE
Handle max resolution properly based on the screen orientation

### DIFF
--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -12,6 +12,13 @@ import { themes } from "./styles/theme";
 import MediaDevicesManager from "../utils/media-devices-manager";
 import { MediaDevicesEvents } from "../utils/media-devices-utils";
 import { Slider } from "./input/Slider";
+import {
+  addOrientationChangeListener,
+  removeOrientationChangeListener,
+  getMaxResolutionWidth,
+  getMaxResolutionHeight,
+  setMaxResolution
+} from "../utils/screen-orientation-utils";
 
 export const CLIPPING_THRESHOLD_MIN = 0.0;
 export const CLIPPING_THRESHOLD_MAX = 0.1;
@@ -271,16 +278,26 @@ export class MaxResolutionPreferenceItem extends Component {
   static propTypes = {
     store: PropTypes.object
   };
+
+  onOrientationChange = () => {
+    // Width and height should be swapped on screen orientation change
+    // then need to update.
+    this.forceUpdate();
+  };
+
+  componentDidMount() {
+    addOrientationChangeListener(this.onOrientationChange);
+  }
+
+  componentWillUnmount() {
+    removeOrientationChangeListener(this.onOrientationChange);
+  }
+
   render() {
     const onChange = () => {
       const numWidth = parseInt(document.getElementById("maxResolutionWidth").value);
       const numHeight = parseInt(document.getElementById("maxResolutionHeight").value);
-      this.props.store.update({
-        preferences: {
-          maxResolutionWidth: numWidth ? numWidth : 0,
-          maxResolutionHeight: numHeight ? numHeight : 0
-        }
-      });
+      setMaxResolution(this.props.store, numWidth ? numWidth : 0, numHeight ? numHeight : 0);
     };
     return (
       <div className={classNames(styles.maxResolutionPreferenceItem)}>
@@ -290,11 +307,7 @@ export class MaxResolutionPreferenceItem extends Component {
           type="number"
           step="1"
           min="0"
-          value={
-            this.props.store.state.preferences.maxResolutionWidth === undefined
-              ? window.screen.width
-              : this.props.store.state.preferences.maxResolutionWidth
-          }
+          value={getMaxResolutionWidth(this.props.store)}
           onClick={e => {
             e.preventDefault();
             e.target.focus();
@@ -309,11 +322,7 @@ export class MaxResolutionPreferenceItem extends Component {
           type="number"
           step="1"
           min="0"
-          value={
-            this.props.store.state.preferences.maxResolutionHeight === undefined
-              ? window.screen.height
-              : this.props.store.state.preferences.maxResolutionHeight
-          }
+          value={getMaxResolutionHeight(this.props.store)}
           onClick={e => {
             e.preventDefault();
             e.target.focus();

--- a/src/react-components/room/useResizeViewport.js
+++ b/src/react-components/room/useResizeViewport.js
@@ -1,6 +1,12 @@
 import { useState, useEffect } from "react";
 // ResizeObserver not currently supported in Firefox Android
 import ResizeObserver from "resize-observer-polyfill";
+import {
+  addOrientationChangeListener,
+  removeOrientationChangeListener,
+  getMaxResolutionWidth,
+  getMaxResolutionHeight
+} from "../../utils/screen-orientation-utils";
 
 // Modified from AFrame
 function getRenderResolution(canvasRect, maxResolution, isVR) {
@@ -35,17 +41,16 @@ function getRenderResolution(canvasRect, maxResolution, isVR) {
 
 export function useResizeViewport(viewportRef, store, scene) {
   const [maxResolution, setMaxResolution] = useState({
-    width: window.screen.width,
-    height: window.screen.height
+    width: getMaxResolutionWidth(store),
+    height: getMaxResolutionHeight(store)
   });
 
   useEffect(
     () => {
       function onStoreChanged() {
-        const { maxResolutionWidth, maxResolutionHeight } = store.state.preferences;
         setMaxResolution({
-          width: maxResolutionWidth === undefined ? window.screen.width : maxResolutionWidth,
-          height: maxResolutionHeight === undefined ? window.screen.height : maxResolutionHeight
+          width: getMaxResolutionWidth(store),
+          height: getMaxResolutionHeight(store)
         });
       }
 
@@ -101,5 +106,23 @@ export function useResizeViewport(viewportRef, store, scene) {
       };
     },
     [viewportRef, scene, maxResolution]
+  );
+
+  useEffect(
+    () => {
+      function onOrientationChange() {
+        setMaxResolution({
+          width: getMaxResolutionWidth(store),
+          height: getMaxResolutionHeight(store)
+        });
+      }
+
+      addOrientationChangeListener(onOrientationChange);
+
+      return () => {
+        removeOrientationChangeListener(onOrientationChange);
+      };
+    },
+    [store]
   );
 }

--- a/src/utils/screen-orientation-utils.js
+++ b/src/utils/screen-orientation-utils.js
@@ -1,0 +1,79 @@
+// What this screen-orientation-utils does are
+// 1. Hide the screen orientation API difference across browsers
+//    ScreenOrientation API should be used but Safari doesn't support it yet.
+//    Instead deprecated window.orientation and orientationchange event
+//    need to be used on Safari for now.
+// 2. Manage maxResolution preferences values based on the screen orientation
+
+import { isIOS as detectIOS } from "./is-mobile";
+
+const isIOS = detectIOS();
+
+export const addOrientationChangeListener = (callback, useCapture = false) => {
+  if (typeof ScreenOrientation !== "undefined") {
+    screen.orientation.addEventListener("change", callback, useCapture);
+  } else {
+    window.addEventListener("orientationchange", callback, useCapture);
+  }
+};
+
+export const removeOrientationChangeListener = (callback, useCapture = false) => {
+  if (typeof ScreenOrientation !== "undefined") {
+    screen.orientation.removeEventListener("change", callback, useCapture);
+  } else {
+    window.removeEventListener("orientationchange", callback, useCapture);
+  }
+};
+
+const getAngle = () => {
+  return typeof ScreenOrientation !== "undefined" ? screen.orientation.angle : window.orientation;
+};
+
+const isNaturalOrientation = () => {
+  return getAngle() % 180 === 0;
+};
+
+// Return the screen width based on the current screen orientation
+const getScreenWidth = () => {
+  // Is seems screen.width value is based on the natural screen orientation on iOS
+  // while it is based on the current screen orientation on Android (and other devices?).
+  if (isIOS) {
+    return isNaturalOrientation() ? screen.width : screen.height;
+  }
+  return screen.width;
+};
+
+// Return the screen height based on the current screen orientation
+const getScreenHeight = () => {
+  // Is seems screen.height value is based on the natural screen orientation on iOS
+  // while it is based on the current screen orientation on Android (and other devices?).
+  if (isIOS) {
+    return isNaturalOrientation() ? screen.height : screen.width;
+  }
+  return screen.height;
+};
+
+// Take width and height based on the current screen orientation and
+// store them based on natural orientation
+export const setMaxResolution = (store, width, height) => {
+  store.update({
+    preferences: {
+      maxResolutionWidth: isNaturalOrientation() ? width : height,
+      maxResolutionHeight: isNaturalOrientation() ? height : width
+    }
+  });
+};
+
+// Return width based on the current screen orientation
+export const getMaxResolutionWidth = store => {
+  const preferences = store.state.preferences;
+  const width = isNaturalOrientation() ? preferences.maxResolutionWidth : preferences.maxResolutionHeight;
+  return width !== undefined ? width : getScreenWidth();
+};
+
+// Return height based on the current screen orientation
+export const getMaxResolutionHeight = store => {
+  const preferences = store.state.preferences;
+  const height = isNaturalOrientation() ? preferences.maxResolutionHeight : preferences.maxResolutionWidth;
+  return height !== undefined ? height : getScreenHeight();
+};


### PR DESCRIPTION
Resolves: #5431

Currently Hubs Client doesn't care screen orientation. So for example if mobile device users rotate their devices the visual quality can be bad because max resolution width and height should be swapped but they aren't.

With this commit Hubs Client will manage max resolution based on the screen orientation and the problem will be resolved.