### PR TITLE
updated turkey's container entrypoint for a better parameterization pattern in k8s

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package-lock.json" }}
-          - v1-dependencies-
-      - run: npm ci
+            - v1-dependencies-{{ checksum "package-lock.json" }}
+            - v1-dependencies-
+      - run: npm ci --loglevel verbose
       - save_cache:
           paths:
             - node_modules

--- a/scripts/docker/run.sh
+++ b/scripts/docker/run.sh
@@ -1,14 +1,14 @@
 
-turkeyCfg_postgrest_server=""
-turkeyCfg_thumbnail_server="nearspark.reticulum.io"
-turkeyCfg_base_assets_path="https://$SUB_DOMAIN-assets.$DOMAIN/hubs/"
-turkeyCfg_non_cors_proxy_domains="$SUB_DOMAIN.$DOMAIN,$SUB_DOMAIN-assets.$DOMAIN"
-turkeyCfg_reticulum_server="$SUB_DOMAIN.$DOMAIN"
-turkeyCfg_cors_proxy_server="$SUB_DOMAIN-cors.$DOMAIN"
-turkeyCfg_ga_tracking_id=""
-turkeyCfg_shortlink_domain="$SUB_DOMAIN.$DOMAIN"
-turkeyCfg_ita_server=""
-turkeyCfg_sentry_dsn=""
+export turkeyCfg_postgrest_server=""
+export turkeyCfg_thumbnail_server="nearspark.reticulum.io"
+export turkeyCfg_base_assets_path="https://$SUB_DOMAIN-assets.$DOMAIN/hubs/"
+export turkeyCfg_non_cors_proxy_domains="$SUB_DOMAIN.$DOMAIN,$SUB_DOMAIN-assets.$DOMAIN"
+export turkeyCfg_reticulum_server="$SUB_DOMAIN.$DOMAIN"
+export turkeyCfg_cors_proxy_server="$SUB_DOMAIN-cors.$DOMAIN"
+export turkeyCfg_ga_tracking_id=""
+export turkeyCfg_shortlink_domain="$SUB_DOMAIN.$DOMAIN"
+export turkeyCfg_ita_server=""
+export turkeyCfg_sentry_dsn=""
 
 find /www/hubs/ -type f -name *.html -exec sed -i "s/{{rawhubs-base-assets-path}}\//https:\/\/${SUB_DOMAIN}-assets.${DOMAIN}\/hubs\//g" {} \;           
 find /www/hubs/ -type f -name *.html -exec sed -i "s/{{rawhubs-base-assets-path}}/https:\/\/${SUB_DOMAIN}-assets.${DOMAIN}\/hubs\//g" {} \; 

--- a/scripts/docker/run.sh
+++ b/scripts/docker/run.sh
@@ -1,8 +1,14 @@
 
-# TODO: need a better one
-healthcheck(){
-    while true; do (echo -e 'HTTP/1.1 200 OK\r\n\r\n 1') | nc -lp 1111 > /dev/null; done
-}
+turkeyCfg_postgrest_server=""
+turkeyCfg_thumbnail_server="nearspark.reticulum.io"
+turkeyCfg_base_assets_path="https://$SUB_DOMAIN-assets.$DOMAIN/hubs/"
+turkeyCfg_non_cors_proxy_domains="$SUB_DOMAIN.$DOMAIN,$SUB_DOMAIN-assets.$DOMAIN"
+turkeyCfg_reticulum_server="$SUB_DOMAIN.$DOMAIN"
+turkeyCfg_cors_proxy_server="$SUB_DOMAIN-cors.$DOMAIN"
+turkeyCfg_ga_tracking_id=""
+turkeyCfg_shortlink_domain="$SUB_DOMAIN.$DOMAIN"
+turkeyCfg_ita_server=""
+turkeyCfg_sentry_dsn=""
 
 find /www/hubs/ -type f -name *.html -exec sed -i "s/{{rawhubs-base-assets-path}}\//https:\/\/${SUB_DOMAIN}-assets.${DOMAIN}\/hubs\//g" {} \;           
 find /www/hubs/ -type f -name *.html -exec sed -i "s/{{rawhubs-base-assets-path}}/https:\/\/${SUB_DOMAIN}-assets.${DOMAIN}\/hubs\//g" {} \; 
@@ -15,5 +21,4 @@ for f in /www/hubs/pages/*.html; do
     [[ $var == $prefix* ]] && sed -i "s/$anchor/ <meta name=\"env:${var#$prefix}\" content=\"${!var//\//\\\/}\"\/> $anchor/" $f; 
     done 
 done 
-healthcheck &
 nginx -g "daemon off;"


### PR DESCRIPTION
- move env var configs to container entrypoint to remove the needs to update the k8s-deployment for subdomain changes
- also added "--loglevel verbose" to [.circleci](https://github.com/mozilla/hubs/tree/master/.circleci)/config.yml for the false negative build_test_and_deploy_storybook check caused by circle ci's default 10 min no-output timeout