### PR TITLE
Re-enable Positional audio on Safari

### DIFF
--- a/src/systems/sound-effects-system.js
+++ b/src/systems/sound-effects-system.js
@@ -17,7 +17,6 @@ import URL_MEDIA_LOADING from "../assets/sfx/suspense.mp3";
 import URL_SPAWN_EMOJI from "../assets/sfx/emoji.mp3";
 import URL_SPEAKER_TONE from "../assets/sfx/tone.mp3";
 import { setMatrixWorld } from "../utils/three-utils";
-import { isSafari } from "../utils/detect-safari";
 import { SourceType } from "../components/audio-params";
 
 let soundEnum = 0;
@@ -142,7 +141,7 @@ export class SoundEffectsSystem {
     const audioBuffer = this.sounds.get(sound);
     if (!audioBuffer) return null;
 
-    const disablePositionalAudio = isSafari() || window.APP.store.state.preferences.disableLeftRightPanning;
+    const disablePositionalAudio = window.APP.store.state.preferences.disableLeftRightPanning;
     const positionalAudio = disablePositionalAudio
       ? new THREE.Audio(this.scene.audioListener)
       : new THREE.PositionalAudio(this.scene.audioListener);

--- a/src/update-audio-settings.js
+++ b/src/update-audio-settings.js
@@ -5,7 +5,6 @@ import {
   AvatarAudioDefaults,
   TargetAudioDefaults
 } from "./components/audio-params";
-import { isSafari } from "./utils/detect-safari";
 
 const defaultSettingsForSourceType = Object.freeze(
   new Map([
@@ -38,7 +37,6 @@ export function getCurrentAudioSettings(el) {
   const preferencesOverrides = APP.store.state.preferences.disableLeftRightPanning
     ? { audioType: AudioType.Stereo }
     : {};
-  const safariOverrides = isSafari() ? { audioType: AudioType.Stereo } : {};
   const settings = Object.assign(
     {},
     defaults,
@@ -46,8 +44,7 @@ export function getCurrentAudioSettings(el) {
     audioOverrides,
     audioDebugPanelOverrides,
     zoneSettings,
-    preferencesOverrides,
-    safariOverrides
+    preferencesOverrides
   );
 
   if (APP.clippingState.has(el) || APP.mutedState.has(el)) {


### PR DESCRIPTION
Safari WebAudio Panner node seemed to have a problem that the audio can be broken. We decided to force to disable panning audio on Safari. See #4411 for details.

The problem seems to have been resolved on Safari end. We can re-enable the panning audio even on Safari.

Just in case we should test again to check if the problem is no longer reproducible before merging this PR.