### PR TITLE
Remove easyrtc dependancy from NAF

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -14967,23 +14967,6 @@
             "stream-shift": "^1.0.0"
           }
         },
-        "easyrtc": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/easyrtc/-/easyrtc-1.1.0.tgz",
-          "integrity": "sha1-9Ek39xMsuLW6jgvBzD48zEcqPvQ=",
-          "requires": {
-            "async": "0.2.x",
-            "colors": "*",
-            "underscore": "1.5.x"
-          },
-          "dependencies": {
-            "async": {
-              "version": "0.2.10",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-              "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
-            }
-          }
-        },
         "ecc-jsbn": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -18722,11 +18705,10 @@
           "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
         },
         "networked-aframe": {
-          "version": "github:mozillareality/networked-aframe#f4b1f1ccc8871149be2e3aaa24ca665e481c716a",
+          "version": "github:mozillareality/networked-aframe#50184f495ff1f77d0e6fe3777d73092784e3aee3",
           "from": "github:mozillareality/networked-aframe#master",
           "requires": {
-            "buffered-interpolation": "^0.2.5",
-            "easyrtc": "1.1.0"
+            "buffered-interpolation": "^0.2.5"
           }
         },
         "new-array": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21600,23 +21600,6 @@
         "stream-shift": "^1.0.0"
       }
     },
-    "easyrtc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/easyrtc/-/easyrtc-1.1.0.tgz",
-      "integrity": "sha1-9Ek39xMsuLW6jgvBzD48zEcqPvQ=",
-      "requires": {
-        "async": "0.2.x",
-        "colors": "*",
-        "underscore": "1.5.x"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
-        }
-      }
-    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -27710,11 +27693,10 @@
       "dev": true
     },
     "networked-aframe": {
-      "version": "github:mozillareality/networked-aframe#a691b90cd1c817283fbd4ce32f63b0b184311f4c",
+      "version": "github:mozillareality/networked-aframe#50184f495ff1f77d0e6fe3777d73092784e3aee3",
       "from": "github:mozillareality/networked-aframe#master",
       "requires": {
-        "buffered-interpolation": "github:Infinitelee/buffered-interpolation#5bb18421ebf2bf11664645cdc7a15bd77ee2156b",
-        "easyrtc": "1.1.0"
+        "buffered-interpolation": "github:Infinitelee/buffered-interpolation#5bb18421ebf2bf11664645cdc7a15bd77ee2156b"
       },
       "dependencies": {
         "buffered-interpolation": {


### PR DESCRIPTION
A change in easyrtc is causing issues in newer NPM versions (#5471), though we technically don't support newer versions of node, things have mostly just worked fine, and we actually don't even need the easyrtc dependency, so NAF has been updated to remove it.

fixes #5471 