### PR TITLE
Update networked-aframe dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27693,7 +27693,7 @@
       "dev": true
     },
     "networked-aframe": {
-      "version": "github:mozillareality/networked-aframe#50184f495ff1f77d0e6fe3777d73092784e3aee3",
+      "version": "github:mozillareality/networked-aframe#b6d1b7bd21889274098b16d6f1de9a510e8b6ae3",
       "from": "github:mozillareality/networked-aframe#master",
       "requires": {
         "buffered-interpolation": "github:Infinitelee/buffered-interpolation#5bb18421ebf2bf11664645cdc7a15bd77ee2156b"


### PR DESCRIPTION
For https://github.com/MozillaReality/networked-aframe/pull/49

With this update, unnecessary matrices update caused by non-moving remote objects can be avoided and better performance can be expected.