### PR TITLE
Fix a media-image transparent bug

### DIFF
--- a/src/components/media-image.js
+++ b/src/components/media-image.js
@@ -140,18 +140,13 @@ AFRAME.registerComponent("media-image", {
         case "opaque":
           this.mesh.material.transparent = false;
           break;
-        case "blend":
-          this.mesh.material.transparent = true;
-          this.mesh.material.alphaTest = 0;
-          break;
         case "mask":
           this.mesh.material.transparent = false;
           this.mesh.material.alphaTest = this.data.alphaCutoff;
           break;
+        case "blend":
         default:
-          this.mesh.material.transparent =
-            this.data.contentType.includes("image/gif") ||
-            !!(texture.image && texture.image.hasAlpha);
+          this.mesh.material.transparent = true;
           this.mesh.material.alphaTest = 0;
       }
     }


### PR DESCRIPTION
In the three-batch-manager removal commit (#5479), in `media-image` `mesh.material.transparent` has been wrongly set for default
alphaMode. This commit fixes it. Refer to https://github.com/mozilla/hubs/pull/5479/files#r890466313