### PR TITLE
Introduce slider for max resolution preference

### DIFF
--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -17,6 +17,8 @@ import {
   removeOrientationChangeListener,
   getMaxResolutionWidth,
   getMaxResolutionHeight,
+  getScreenResolutionWidth,
+  getScreenResolutionHeight,
   setMaxResolution
 } from "../utils/screen-orientation-utils";
 
@@ -294,40 +296,38 @@ export class MaxResolutionPreferenceItem extends Component {
   }
 
   render() {
-    const onChange = () => {
-      const numWidth = parseInt(document.getElementById("maxResolutionWidth").value);
-      const numHeight = parseInt(document.getElementById("maxResolutionHeight").value);
-      setMaxResolution(this.props.store, numWidth ? numWidth : 0, numHeight ? numHeight : 0);
+    const onChange = multiplier => {
+      setMaxResolution(
+        this.props.store,
+        Math.floor(getScreenResolutionWidth() * multiplier),
+        Math.floor(getScreenResolutionHeight() * multiplier)
+      );
     };
     return (
       <div className={classNames(styles.maxResolutionPreferenceItem)}>
         <input
-          id="maxResolutionWidth"
           tabIndex="0"
           type="number"
           step="1"
           min="0"
           value={getMaxResolutionWidth(this.props.store)}
-          onClick={e => {
-            e.preventDefault();
-            e.target.focus();
-            e.target.select();
-          }}
-          onChange={onChange}
+          readOnly={true}
         />
         &nbsp;{"x"}&nbsp;
         <input
-          id="maxResolutionHeight"
           tabIndex="0"
           type="number"
           step="1"
           min="0"
           value={getMaxResolutionHeight(this.props.store)}
-          onClick={e => {
-            e.preventDefault();
-            e.target.focus();
-            e.target.select();
-          }}
+          readOnly={true}
+        />
+        &nbsp;
+        <Slider
+          step={0.1}
+          min={0.1}
+          max={1.0}
+          value={getMaxResolutionWidth(this.props.store) / getScreenResolutionWidth()}
           onChange={onChange}
         />
       </div>

--- a/src/utils/screen-orientation-utils.js
+++ b/src/utils/screen-orientation-utils.js
@@ -66,6 +66,16 @@ const getDefaultMaxResolutionHeight = () => {
   return getScreenHeight();
 };
 
+// Return the screen resolution width in physical pixels based on the current screen orientation
+export const getScreenResolutionWidth = () => {
+  return getScreenWidth() * window.devicePixelRatio;
+};
+
+// Return the screen resolution height in physical pixels based on the current screen orientation
+export const getScreenResolutionHeight = () => {
+  return getScreenHeight() * window.devicePixelRatio;
+};
+
 // Take width and height based on the current screen orientation and
 // store them based on natural orientation.
 // Width and height paremeters must be in physical pixels.


### PR DESCRIPTION
Fixes: #5466

Currently max resolution preference directly takes numbers but most users may not know what numbers to enter.

This commit introduces a slider for max resolution preference for easier controls. The slider value is multipler against screen resolution in physical pixels.

![image](https://user-images.githubusercontent.com/7637832/173757612-3eaf791b-d248-4bdc-b9b8-fde08242738b.png)

Note: I made the two right number input fields readonly for simplicity. Is there any use case that users want custom max resolution numbers?