### PR TITLE
properly dispose geometry and material in simple-water

### DIFF
--- a/src/components/simple-water.js
+++ b/src/components/simple-water.js
@@ -335,6 +335,10 @@ AFRAME.registerComponent("simple-water", {
   },
 
   remove() {
+    const mesh = this.el.getObject3D("mesh");
+    mesh.geometry.dispose();
+    // mesh.material.normalMap.dispose(); // the texture may be used by another component
+    mesh.material.dispose();
     this.el.removeObject3D("mesh");
   }
 });


### PR DESCRIPTION
Properly dispose geometry and material to free memory in simple-water component when the component instance is removed.
The normal map shouldn't be disposed because it can be used by another instance, and you probably don't want to reload the texture if you switch to another scene that also use a simple-water component.