### PR TITLE
Prevent fullscreen request in fullscreen mode

### DIFF
--- a/src/utils/fullscreen.js
+++ b/src/utils/fullscreen.js
@@ -13,7 +13,7 @@ export function willRequireUserGesture() {
 }
 
 export async function showFullScreenIfAvailable() {
-  if (shouldShowFullScreen()) {
+  if (shouldShowFullScreen() && !screenfull.isFullscreen) {
     hasEnteredFullScreenThisSession = true;
     await screenfull.request();
   }


### PR DESCRIPTION
Fixes: #4933 

`screenfull.request()` doesn't seem to be resolved if it is called in full screen mode. So add `if !screenfull.isFullscreen` guard`to prevent the call in full screen mode.