### PR TITLE
Always visible and fixed position virtual joysticks

### DIFF
--- a/src/components/virtual-gamepad-controls.css
+++ b/src/components/virtual-gamepad-controls.css
@@ -10,13 +10,11 @@
 }
 
 :local(.touchZone.left) {
-  left: 0;
-  right: 55%;
+  left: 80px;
 }
 
 :local(.touchZone.right) {
-  left: 55%;
-  right: 0;
+  right: 80px;
 }
 
 :local(.mockJoystickContainer) {

--- a/src/components/virtual-gamepad-controls.js
+++ b/src/components/virtual-gamepad-controls.js
@@ -127,6 +127,8 @@ AFRAME.registerComponent("virtual-gamepad-controls", {
     this.rightTouchZone.classList.add(styles.touchZone, styles.right);
     insertAfter(this.rightTouchZone, this.mockJoystickContainer);
     this.rightStick = nipplejs.create({
+      mode: "static",
+      position: {left: "50%", top: "50%"},
       zone: this.rightTouchZone,
       color: "white",
       fadeTime: 0
@@ -141,6 +143,8 @@ AFRAME.registerComponent("virtual-gamepad-controls", {
     this.leftTouchZone.classList.add(styles.touchZone, styles.left);
     insertAfter(this.leftTouchZone, this.mockJoystickContainer);
     this.leftStick = nipplejs.create({
+      mode: "static",
+      position: {left: "50%", top: "50%"},
       zone: this.leftTouchZone,
       color: "white",
       fadeTime: 0


### PR DESCRIPTION
With this commit the virtual joysticks will be always visible if they are enabled. They are transparent and they will be less transparent if they are touched.

And they will be placed at fixed position.

These may be more intuitive to users.

![image](https://user-images.githubusercontent.com/7637832/174212526-967460c3-fb36-4d73-9720-34052bd3544d.png)
