### PR TITLE
Fix French translation of enable-on-screen-joystick-right

### DIFF
--- a/src/assets/locales/fr.json
+++ b/src/assets/locales/fr.json
@@ -400,7 +400,7 @@
   "preferences-screen.preference.enable-dynamic-shadows": "Activer les ombres dynamiques",
   "preferences-screen.preference.enable-gyro": "Activer le gyroscope (si compatible avec le navigateur / l'appareil)",
   "preferences-screen.preference.enable-on-screen-joystick-left": "Activer le joystick sur l'écran à gauche pour se déplacer",
-  "preferences-screen.preference.enable-on-screen-joystick-right": "Activer le joystick sur l'écran à droite pour se déplacer",
+  "preferences-screen.preference.enable-on-screen-joystick-right": "Activer le joystick sur l'écran à droite pour regarder autour de vous",
   "preferences-screen.preference.fast-room-switching": "Activer le passage rapide d'une salle à l'autre",
   "preferences-screen.preference.global-media-volume": "Volume audio des médias",
   "preferences-screen.preference.global-voice-volume": "Volume audio de la voix entrante",


### PR DESCRIPTION
"Enable left on-screen joystick for moving around"
and
"Enable right on-screen joystick for looking around"
was both translated to
"Activer le joystick sur l'écran à gauche pour se déplacer"
in French.

Change translation of
"Enable right on-screen joystick for looking around"
to
"Activer le joystick sur l'écran à droite pour regarder autour de vous"