### PR TITLE
Allow newlines in troika-text

### DIFF
--- a/src/components/troika-text.js
+++ b/src/components/troika-text.js
@@ -95,7 +95,7 @@ AFRAME.registerComponent("text", {
     const mesh = this.troikaTextMesh;
 
     // Update the text mesh
-    mesh.text = data.value || "";
+    mesh.text = (data.value || "").replace(/\\n/g, "\n").replace(/\\t/g, "\t");
     mesh.textAlign = data.textAlign;
     mesh.anchorX = data.anchorX;
     mesh.anchorY = data.anchorY;


### PR DESCRIPTION
With the switch to troika text, we lost processing of newline characters in text values. 
![Screenshot from 2022-06-17 14-07-43](https://user-images.githubusercontent.com/10034859/174390713-5674618b-c5d5-4996-868c-6f2800ef26aa.png)

Troika's docs said they support them, so I took a peek at their source and found [this little preprocessing on the text value](https://github.com/lojjic/aframe-troika-text/blob/master/src/aframe-troika-text-component.js#L109-L111) was not present in the hubs version. 

![Screenshot from 2022-06-17 14-24-53](https://user-images.githubusercontent.com/10034859/174390802-58605933-f39d-410a-855f-262cc896accd.png)

