### PR TITLE
Skip Physics in super-spawner in the scene preview

### DIFF
--- a/src/components/super-spawner.js
+++ b/src/components/super-spawner.js
@@ -77,8 +77,6 @@ AFRAME.registerComponent("super-spawner", {
     this.handleMediaLoaded = this.handleMediaLoaded.bind(this);
 
     this.spawnedMediaScale = null;
-
-    this.physicsSystem = this.el.sceneEl.systems["hubs-systems"].physicsSystem;
   },
 
   play() {
@@ -191,7 +189,14 @@ AFRAME.registerComponent("super-spawner", {
       }
     }
 
-    this.physicsSystem.resetDynamicBody(spawnedEntity.components["body-helper"].uuid);
+    // We skip this in the scene preview because
+    //   1. hubs-systems is not initialized in the scene preview
+    //   2. physics is not needed in the scene preview
+    if (this.el.sceneEl.systems["hubs-systems"]) {
+      this.el.sceneEl.systems["hubs-systems"].physicsSystem.resetDynamicBody(
+        spawnedEntity.components["body-helper"].uuid
+      );
+    }
 
     spawnedEntity.addEventListener(
       "media-loaded",


### PR DESCRIPTION
Fixes #5493

Currently `super-spawner` causes an error in the scene preview by accessing undefined `sceneEl.systems["hubs-systems"]` if a scene has spawners.

With this commit `super-spawner` skips Physics as workaround in the scene preview because `sceneEl.systems["hubs-systems"]` is not initialized and Physics is not needed in the scene preview.
