### PR TITLE
Restore derivatives support and limit the uniform vectors number

### DIFF
--- a/src/systems/audio-debug-system.js
+++ b/src/systems/audio-debug-system.js
@@ -20,16 +20,16 @@ AFRAME.registerSystem("audio-debug", {
   },
 
   init() {
-    this.max_debug_sources = 64;
+    this.maxDebugSources = 64;
     this.unsupported = false;
     const webGLVersion = getWebGLVersion(this.el.sceneEl.renderer);
     if (webGLVersion < "2.0") {
       this.unsupported = true;
     } else {
       const gl = this.el.sceneEl.renderer.getContext();
-      const max_f_vectors = gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS);
+      const maxUniformVectors = gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS);
       // 10 is the number of uniform vectors in the shader. If we update that, this number must be updated accordingly.
-      this.max_debug_sources = Math.min(Math.floor(max_f_vectors / 10), this.max_debug_sources);
+      this.maxDebugSources = Math.min(Math.floor(maxUniformVectors / 10), this.maxDebugSources);
     }
 
     window.APP.store.addEventListener("statechanged", this.updateState.bind(this));
@@ -64,27 +64,27 @@ AFRAME.registerSystem("audio-debug", {
     this.material.side = THREE.FrontSide;
     this.material.transparent = true;
     this.material.uniforms.count.value = 0;
-    this.material.defines.MAX_DEBUG_SOURCES = this.max_debug_sources;
+    this.material.defines.MAX_DEBUG_SOURCES = this.maxDebugSources;
 
-    this.sourcePositions = new Array(this.max_debug_sources);
+    this.sourcePositions = new Array(this.maxDebugSources);
     this.sourcePositions.fill(new THREE.Vector3());
-    this.sourceOrientations = new Array(this.max_debug_sources);
+    this.sourceOrientations = new Array(this.maxDebugSources);
     this.sourceOrientations.fill(new THREE.Vector3());
-    this.distanceModels = new Array(this.max_debug_sources);
+    this.distanceModels = new Array(this.maxDebugSources);
     this.distanceModels.fill(0);
-    this.maxDistances = new Array(this.max_debug_sources);
+    this.maxDistances = new Array(this.maxDebugSources);
     this.maxDistances.fill(0.0);
-    this.refDistances = new Array(this.max_debug_sources);
+    this.refDistances = new Array(this.maxDebugSources);
     this.refDistances.fill(0.0);
-    this.rolloffFactors = new Array(this.max_debug_sources);
+    this.rolloffFactors = new Array(this.maxDebugSources);
     this.rolloffFactors.fill(0.0);
-    this.coneInnerAngles = new Array(this.max_debug_sources);
+    this.coneInnerAngles = new Array(this.maxDebugSources);
     this.coneInnerAngles.fill(0.0);
-    this.coneOuterAngles = new Array(this.max_debug_sources);
+    this.coneOuterAngles = new Array(this.maxDebugSources);
     this.coneOuterAngles.fill(0.0);
-    this.gains = new Array(this.max_debug_sources);
+    this.gains = new Array(this.maxDebugSources);
     this.gains.fill(0.0);
-    this.clipped = new Array(this.max_debug_sources);
+    this.clipped = new Array(this.maxDebugSources);
     this.clipped.fill(0.0);
   },
 
@@ -115,7 +115,7 @@ AFRAME.registerSystem("audio-debug", {
 
       let sourceNum = 0;
       for (const [el, audio] of APP.audios.entries()) {
-        if (sourceNum >= this.max_debug_sources) continue;
+        if (sourceNum >= this.maxDebugSources) continue;
         if (APP.isAudioPaused.has(el)) continue;
 
         audio.getWorldPosition(sourcePos);

--- a/src/systems/audio-debug.frag
+++ b/src/systems/audio-debug.frag
@@ -48,21 +48,28 @@ float att_exponential(float x, float rolloff, float dref) {
   return pow((max(x, dref)/dref),-rolloff);
 }
 
-vec4 circle(vec2 center, float d, float len, float radius, float holeRadius, vec3 color, float offset, float blurriness) {  
+vec4 circle(vec2 center, float d, float len, float radius, float holeRadius, vec3 color, float offset) {  
+  // Define how blurry the circle should be. 
+  // A value of 1.0 means 'sharp', larger values
+  // will increase the bluriness.
+  float bluriness = 1.0;
+  
   // Calculate angle, so we can draw segments, too.
   float angle = atan( center.x, center.y ) * kInvPi * 0.5;
   angle = fract( angle + offset);
   
   // Create an anti-aliased circle.
-  float circle = smoothstep( radius + blurriness, radius - blurriness, d );
+  float wd = bluriness * fwidth( d );
+  float circle = smoothstep( radius + wd, radius - wd, d );
   
   // Optionally, you could create a hole in it:
   float inner = holeRadius;
-  circle -= smoothstep( inner + blurriness, inner - blurriness, d );
+  circle -= smoothstep( inner + wd, inner - wd, d );
   
   // Or only draw a portion (segment) of the circle.
-  float segment = smoothstep( len + blurriness, len - blurriness, angle );
-  segment *= smoothstep( 0.0, 2.0 * blurriness, angle );
+  float wa = bluriness * fwidth( angle );
+  float segment = smoothstep( len + wa, len - wa, angle );
+  segment *= smoothstep( 0.0, 2.0 * wa, angle );
   circle *= mix( segment, 1.0, step( 1.0, len ) );
       
   // Let's define the circle's color now.
@@ -121,31 +128,31 @@ void main() {
     // Draw inner cone
     float innerAngle = coneInnerAngle[i] * kDegToRad * kInvPi * 0.5;
     float innerStartAngle = startOffset[i] + innerAngle * 0.5;
-    vec4 innerLayer = circle(center[i], distance[i], innerAngle, 10000.0, 1.0, colorInner, innerStartAngle, .001);
+    vec4 innerLayer = circle(center[i], distance[i], innerAngle, 10000.0, 1.0, colorInner, innerStartAngle);
     innerLayer = draw_att(distance[i], attenuation, innerLayer);
     background = mix(background, innerLayer, innerLayer.a * clampedGain[i]);
 
     // Draw outer cone
     float outerAngle = coneOuterAngle[i] * kDegToRad * kInvPi * 0.5;
     float outerAngleDiffHalf = (outerAngle - innerAngle) * 0.5;
-    vec4 outerLayer1 = circle(center[i], distance[i], outerAngleDiffHalf, 10000.0, 1.0, colorOuter, innerStartAngle + outerAngleDiffHalf, .001);
+    vec4 outerLayer1 = circle(center[i], distance[i], outerAngleDiffHalf, 10000.0, 1.0, colorOuter, innerStartAngle + outerAngleDiffHalf);
     outerLayer1 = draw_att(distance[i], attenuation, outerLayer1);
     background = mix(background, outerLayer1, outerLayer1.a * clampedGain[i]);
-    vec4 outerLayer2 = circle(center[i], distance[i], outerAngleDiffHalf, 10000.0, 1.0, colorOuter, innerStartAngle - innerAngle, .001);
+    vec4 outerLayer2 = circle(center[i], distance[i], outerAngleDiffHalf, 10000.0, 1.0, colorOuter, innerStartAngle - innerAngle);
     outerLayer2 = draw_att(distance[i], attenuation, outerLayer2);
     background = mix(background, outerLayer2, outerLayer2.a * (clipped[i] ? 0.0 : 1.0) * clampedGain[i]);
   }
 
   for (int i=0; i<count; i++) {
     // Draw base
-    vec4 baseLayer = circle(center[i], distance[i], 1.0, 1.0, 0.1, vec3(0.5, 0.5, 0.5), 0.0, .001);
+    vec4 baseLayer = circle(center[i], distance[i], 1.0, 1.0, 0.1, vec3(0.5, 0.5, 0.5), 0.0);
     background = mix(background, baseLayer, baseLayer.a);
 
     // Draw gain
-    vec4 gainLayer = circle(center[i], distance[i], clampedGain[i], 1.0, 0.5, colorGain, startOffset[i], .001);
+    vec4 gainLayer = circle(center[i], distance[i], clampedGain[i], 1.0, 0.5, colorGain, startOffset[i]);
     background = mix(background, gainLayer, gainLayer.a);
     if (gain[i] > 1.0) {
-      vec4 overGainLayer = circle(center[i], distance[i], gain[i] -  clampedGain[i], 1.0, 0.5, vec3(1.0, 0.0, 0.0), startOffset[i], .001);
+      vec4 overGainLayer = circle(center[i], distance[i], gain[i] -  clampedGain[i], 1.0, 0.5, vec3(1.0, 0.0, 0.0), startOffset[i]);
       background = mix(background, overGainLayer, overGainLayer.a);
     }
   } 


### PR DESCRIPTION
After looking deeper into this I've seen that the issue was not related with the standard derivatives support but with the amount of fragment uniform vectors that Safari supports. We were limiting the number of displayed audio debug elements to 64 by default but in some platforms like Safari that exceeds the amount of supported uniform vectors (256 Vs 1024 in Chrome/FF). Our shader is using 10 uniform vectors right now to store audio elements data and 64x10 exceeded the Safari 256 limit and that's why the shader didn't work in that platform.

We can revisit this in the future to find a more efficient approach like using a texture to pass the uniform audio element data but for now this seems to work fine.

Fixes [#4942](https://github.com/mozilla/hubs/issues/4942)