### PR TITLE
Enable the virtual joysticks by default on mobiles

### DIFF
--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -3,6 +3,7 @@ import merge from "deepmerge";
 import Cookies from "js-cookie";
 import jwtDecode from "jwt-decode";
 import { qsGet } from "../utils/qs_truthy.js";
+import detectMobile from "../utils/is-mobile";
 
 const LOCAL_STORE_KEY = "___hubs_store";
 const STORE_STATE_CACHE_KEY = Symbol();
@@ -104,8 +105,8 @@ export const SCHEMA = {
         disableLeftRightPanning: { type: "bool", default: false },
         audioNormalization: { type: "bool", default: 0.0 },
         invertTouchscreenCameraMove: { type: "bool", default: true },
-        enableOnScreenJoystickLeft: { type: "bool", default: false },
-        enableOnScreenJoystickRight: { type: "bool", default: false },
+        enableOnScreenJoystickLeft: { type: "bool", default: detectMobile() },
+        enableOnScreenJoystickRight: { type: "bool", default: detectMobile() },
         enableGyro: { type: "bool", default: true },
         animateWaypointTransitions: { type: "bool", default: true },
         showFPSCounter: { type: "bool", default: false },


### PR DESCRIPTION
#5196 

The virtual joysticks are more intuitive to generic mobile users. And the recent and upcoming joystics and 2D UI improvement, the virtual joysticks become more useful. I would like to suggest to enable the virtual joysticks by default on mobiles.

Of course there are users who prefer the pinching/dragging controls. But probably most people who prefer the pinching/dragging controls may already got used to Hubs and easily find joystickswith the preferences. I hope it's acceptable.