### PR TITLE
Adding feature to block access and/or chat functionality (mozfest features)

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -1003,7 +1003,7 @@
         </a-assets>
 
         <!-- Interactables -->
-        <a-entity id="media-counter" networked-counter="max: 20;"></a-entity>
+        <a-entity id="media-counter" networked-counter="max: 100;"></a-entity>
 
         <a-entity id="pen-counter" networked-counter="max: 10;"></a-entity>
 

--- a/src/react-components/room/RoomSettingsSidebar.js
+++ b/src/react-components/room/RoomSettingsSidebar.js
@@ -195,6 +195,16 @@ export function RoomSettingsSidebar({
               label={<FormattedMessage id="room-settings-sidebar.fly" defaultMessage="Allow flying" />}
               ref={register}
             />
+            <ToggleInput
+              name="user_data.block_access"
+              label={<FormattedMessage id="user_data.block_access" defaultMessage="Block access" />}
+              ref={register}
+            />
+            <ToggleInput
+              name="user_data.block_chat"
+              label={<FormattedMessage id="user_data.block_chat" defaultMessage="Block chat" />}
+              ref={register}
+            />
           </div>
         </InputField>
         <ApplyButton type="submit" />

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1090,6 +1090,7 @@ class UIRoot extends Component {
 
     const canCreateRoom = !configs.feature("disable_room_creation") || configs.isAdmin();
     const canCloseRoom = this.props.hubChannel && !!this.props.hubChannel.canOrWillIfCreator("close_hub");
+    const canChat = this.props.hub.user_data === null ? true : (this.props.hub.user_data.block_chat !== undefined && !this.props.hub.user_data.block_chat);
     const isModerator = this.props.hubChannel && this.props.hubChannel.canOrWillIfCreator("kick_users") && !isMobileVR;
 
     const moreMenu = [
@@ -1430,7 +1431,7 @@ class UIRoot extends Component {
                 sidebar={
                   this.state.sidebarId ? (
                     <>
-                      {this.state.sidebarId === "chat" && (
+                      {this.state.sidebarId === "chat" && canChat && (
                         <ChatSidebarContainer
                           presences={this.props.presences}
                           occupantCount={this.occupantCount()}
@@ -1569,7 +1570,9 @@ class UIRoot extends Component {
                         )}
                       </>
                     )}
-                    <ChatToolbarButtonContainer onClick={() => this.toggleSidebar("chat")} />
+                    {canChat && (
+                      <ChatToolbarButtonContainer onClick={() => this.toggleSidebar("chat")} />
+                    )}
                     {entered &&
                       isMobileVR && (
                         <ToolbarButton

--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -68,6 +68,10 @@ export default class HubChannel extends EventTarget {
     if (!hub) return false;
     if (this.canOrWillIfCreator("update_hub")) return true;
 
+    if(hub.user_data !== null ) {
+                       if(hub.user_data.block_access !== undefined && hub.user_data.block_access)  return false;
+               }
+
     const roomEntrySlotCount = Object.values(this.presence.state).reduce((acc, { metas }) => {
       const meta = metas[metas.length - 1];
       const usingSlot = meta.presence === "room" || (meta.context && meta.context.entering);

--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -69,8 +69,8 @@ export default class HubChannel extends EventTarget {
     if (this.canOrWillIfCreator("update_hub")) return true;
 
     if(hub.user_data !== null ) {
-                       if(hub.user_data.block_access !== undefined && hub.user_data.block_access)  return false;
-               }
+    	if(hub.user_data.block_access !== undefined && hub.user_data.block_access)  return false;
+    }
 
     const roomEntrySlotCount = Object.values(this.presence.state).reduce((acc, { metas }) => {
       const meta = metas[metas.length - 1];


### PR DESCRIPTION
In Room settings, you have now two new toggles, one to block chat (both button and side bar) and one to block access (allowing only to spectate) for new comers.

![blockaccesschat](https://user-images.githubusercontent.com/94193669/175779214-8dc89bef-b2f5-4ac9-a2cc-895420326c0d.png)


Both features are an updated version of those being used during MozFest.

