### PR TITLE
Improved reference management to reduce memory leaks

### DIFF
--- a/src/components/action-to-remove.js
+++ b/src/components/action-to-remove.js
@@ -18,5 +18,9 @@ AFRAME.registerComponent("action-to-remove", {
     if (this.data.requireOwnership && this.networkedEl && !NAF.utils.isMine(this.networkedEl)) return;
 
     this.el.parentNode.removeChild(this.el);
+  },
+
+  remove() {
+    this.networkedEl = null;
   }
 });

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -701,6 +701,7 @@ AFRAME.registerComponent("media-pager", {
     if (this.networkedEl) {
       this.networkedEl.removeEventListener("pinned", this.update);
       this.networkedEl.removeEventListener("unpinned", this.update);
+      this.networkedEl = null;
     }
 
     window.APP.hubChannel.removeEventListener("permissions_updated", this.update);

--- a/src/components/media-video.js
+++ b/src/components/media-video.js
@@ -858,6 +858,8 @@ AFRAME.registerComponent("media-video", {
 
     window.APP.store.removeEventListener("statechanged", this.onPreferenceChanged);
     this.el.addEventListener("audio_type_changed", this.setupAudio);
+
+    this.networkedEl = null;
   },
 
   removeAudio() {

--- a/src/components/media-video.js
+++ b/src/components/media-video.js
@@ -99,6 +99,8 @@ AFRAME.registerComponent("media-video", {
     this.onSnapImageLoaded = () => (this.isSnapping = false);
     this.hasAudioTracks = false;
 
+    this.mediaEl = null;
+
     this.el.setAttribute("hover-menu__video", { template: "#video-hover-menu", isFlat: true });
     this.el.components["hover-menu__video"].getHoverMenu().then(menu => {
       // If we got removed while waiting, do nothing.
@@ -518,7 +520,7 @@ AFRAME.registerComponent("media-video", {
       };
 
       const videoEl = createVideoOrAudioEl("video");
-
+      this.mediaEl = videoEl;
       let texture, audioEl, isReady;
       if (contentType.startsWith("audio/")) {
         // We want to treat audio almost exactly like video, so we mock a video texture with an image property.
@@ -691,6 +693,7 @@ AFRAME.registerComponent("media-video", {
           // If there's an audio src, create an audio element to play it that we keep in sync
           // with the video while this component is active.
           audioEl = createVideoOrAudioEl("audio");
+          this.mediaEl = audioEl;
           audioEl.src = this.data.audioSrc;
           audioEl.onerror = failLoad;
 
@@ -810,6 +813,11 @@ AFRAME.registerComponent("media-video", {
   cleanUp() {
     if (this.videoTexture && !this.data.linkedVideoTexture) {
       disposeTexture(this.videoTexture);
+    }
+    if (this.mediaEl) {
+      // Reset to avoid circular dependency on captured failLoad function
+      this.mediaEl.onerror = null;
+      this.mediaEl = null;
     }
   },
 

--- a/src/components/media-video.js
+++ b/src/components/media-video.js
@@ -837,6 +837,7 @@ AFRAME.registerComponent("media-video", {
     if (this.networkedEl) {
       this.networkedEl.removeEventListener("pinned", this.updateHoverMenu);
       this.networkedEl.removeEventListener("unpinned", this.updateHoverMenu);
+      this.networkedEl = null;
     }
 
     window.APP.hubChannel.removeEventListener("permissions_updated", this.updateHoverMenu);
@@ -859,7 +860,6 @@ AFRAME.registerComponent("media-video", {
     window.APP.store.removeEventListener("statechanged", this.onPreferenceChanged);
     this.el.addEventListener("audio_type_changed", this.setupAudio);
 
-    this.networkedEl = null;
   },
 
   removeAudio() {

--- a/src/components/scale-button.js
+++ b/src/components/scale-button.js
@@ -168,5 +168,9 @@ AFRAME.registerComponent("scale-button", {
     this.objectMatrix.copy(this.objectToScale.matrixWorld);
     this.objectMatrix.scale(this.deltaScale);
     setMatrixWorld(this.objectToScale, this.objectMatrix);
+  },
+
+  remove() {
+    this.networkedEl = null;
   }
 });

--- a/src/components/tools/networked-drawing.js
+++ b/src/components/tools/networked-drawing.js
@@ -125,6 +125,8 @@ AFRAME.registerComponent("networked-drawing", {
     drawingManager.destroyDrawing(this);
 
     AFRAME.scenes[0].systems["hubs-systems"].drawingMenuSystem.unregisterDrawingMenu(this.el);
+
+    this.networkedEl = null;
   },
 
   tick(t) {

--- a/src/components/visibility-on-content-types.js
+++ b/src/components/visibility-on-content-types.js
@@ -52,5 +52,9 @@ AFRAME.registerComponent("visibility-on-content-types", {
       (mediaLoader.data.contentSubtype && mediaLoader.data.contentSubtype === this.data.contentSubtype);
     const matches = !!(matchesType && matchesSubtype);
     this.el.object3D.visible = this.data.visible ? matches : !matches;
+  },
+
+  remove() {
+    this.networkedEl = null;
   }
 });

--- a/src/components/visibility-while-frozen.js
+++ b/src/components/visibility-while-frozen.js
@@ -151,6 +151,10 @@ AFRAME.registerComponent("visibility-while-frozen", {
       this.hoverable.object3D.addEventListener("hovered", this.updateVisibility);
       this.hoverable.object3D.addEventListener("unhovered", this.updateVisibility);
     }
+  },
+
+  remove() {
+    this.networkedEl = null;
   }
 });
 

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -243,7 +243,6 @@ async function mediaInflator(el, componentName, componentData, components) {
         coneOuterGain: componentData.coneOuterGain,
         gain: componentData.volume
       });
-      APP.sourceType.set(el, SourceType.MEDIA_VIDEO);
 
       const audio = APP.audios.get(el);
       if (audio) {
@@ -541,7 +540,6 @@ AFRAME.GLTFModelPlus.registerComponent(
         coneOuterGain: componentData.coneOuterGain,
         gain: componentData.gain
       });
-      APP.sourceType.set(el, SourceType.AUDIO_TARGET);
 
       const audio = APP.audios.get(el);
       if (audio) {

--- a/src/systems/audio-settings-system.js
+++ b/src/systems/audio-settings-system.js
@@ -14,6 +14,7 @@ export class AudioSettingsSystem {
   }
 
   onSceneReset = () => {
+    APP.audioOverrides = new Map();
     APP.sceneAudioDefaults.delete(SourceType.AVATAR_AUDIO_SOURCE);
     APP.sceneAudioDefaults.delete(SourceType.MEDIA_VIDEO);
     for (const [el, audio] of APP.audios.entries()) {


### PR DESCRIPTION
Fast room switching [exposes a number of issues](https://github.com/mozilla/hubs/issues/4832) with reference management that lead to large memory leaks and ultimately instability, particularly on mobile platforms.

One root cause was the use of APP level globals for variables that should really be bound to the scope of the room. Rather than make any radical changes, this PR continues to rely on `AudioSettingsSystem` to reset globals when the scene changes.

The _networkedEl_ NAF parameter is now reset to null in the few components where it was being assigned. There weren't any specific leaks associated with this, but it does confuse the process of tracking down actual leaks.

The most insidious leak was in the media-video component, where captured objects and captured functions appear to confound the garbage collector. Explicitly nulling out some of the references fixes the problem.

I've tried to keep the changes small and positive in and of themselves. I expect there are some edge cases where leaks can still happen, particularly where timing is a factor.

I will keep this PR in draft until I have tested the changes more widely on my own Hubs Cloud. All suggestions are welcome.

