### PR TITLE
Release texture image more properly

### DIFF
--- a/src/loaders/HubsTextureLoader.js
+++ b/src/loaders/HubsTextureLoader.js
@@ -19,7 +19,7 @@ export default class HubsTextureLoader extends THREE.TextureLoader {
     texture.onUpdate = function() {
       // Delete texture data once it has been uploaded to the GPU
       texture.image.close && texture.image.close();
-      delete texture.image;
+      texture.image = null;
     };
 
     return texture;


### PR DESCRIPTION
`HubsTextureLoader` removes the reference to texture image for GC by using `delete texture.image` once it is uploaded.

But `delete texture.image` should be replaced with `texture.image = null` because the latter follows the Three.js API better.