### PR TITLE
Use low quality audio panning mode for Android

### DIFF
--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -3,7 +3,7 @@ import merge from "deepmerge";
 import Cookies from "js-cookie";
 import jwtDecode from "jwt-decode";
 import { qsGet } from "../utils/qs_truthy.js";
-import detectMobile from "../utils/is-mobile";
+import detectMobile, { isAndroid, isMobileVR } from "../utils/is-mobile";
 
 const LOCAL_STORE_KEY = "___hubs_store";
 const STORE_STATE_CACHE_KEY = Symbol();
@@ -35,6 +35,19 @@ const defaultMaterialQuality = (function() {
 
   return "high";
 })();
+
+// WebAudio on Android devices (only non-VR devices?) seems to have
+// a bug and audio can be broken if there are many people in a room.
+// We have reported the problem to the Android devs. We found that
+// using equal power panning mode can mitigate the problem so we
+// use low audio panning quality (= equal power mode) by default
+// on Android as workaround until the root issue is fixed on
+// Android end. See
+//   - https://github.com/mozilla/hubs/issues/5057
+//   - https://bugs.chromium.org/p/chromium/issues/detail?id=1308962
+const defaultAudioPanningQuality = () => {
+  return isAndroid() && !isMobileVR() ? "Low" : "High";
+};
 
 //workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1626081 : disable echoCancellation, noiseSuppression, autoGainControl
 const isFirefoxReality = window.AFRAME?.utils.device.isMobileVR() && navigator.userAgent.match(/Firefox/);
@@ -139,7 +152,7 @@ export const SCHEMA = {
         showAudioDebugPanel: { type: "bool", default: false },
         enableAudioClipping: { type: "bool", default: false },
         audioClippingThreshold: { type: "number", default: 0.015 },
-        audioPanningQuality: { type: "string", default: "High" },
+        audioPanningQuality: { type: "string", default: defaultAudioPanningQuality() },
         theme: { type: "string", default: undefined },
         cursorSize: { type: "number", default: 1 },
         nametagVisibility: { type: "string", default: "showAll" },

--- a/src/utils/is-mobile.js
+++ b/src/utils/is-mobile.js
@@ -3,6 +3,10 @@ import { hackyMobileSafariTest } from "./detect-touchscreen";
 const MOBILE_RE = /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino|android|ipad|playbook|silk/i;
 const TABLET_RE = /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw-(n|u)|c55\/|capi|ccwa|cdm-|cell|chtm|cldc|cmd-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc-s|devi|dica|dmob|do(c|p)o|ds(12|-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(-|_)|g1 u|g560|gene|gf-5|g-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd-(m|p|t)|hei-|hi(pt|ta)|hp( i|ip)|hs-c|ht(c(-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i-(20|go|ma)|i230|iac( |-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|-[a-w])|libw|lynx|m1-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|-([1-8]|c))|phil|pire|pl(ay|uc)|pn-2|po(ck|rt|se)|prox|psio|pt-g|qa-a|qc(07|12|21|32|60|-[2-7]|i-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h-|oo|p-)|sdk\/|se(c(-|0|1)|47|mc|nd|ri)|sgh-|shar|sie(-|m)|sk-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h-|v-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl-|tdg-|tel(i|m)|tim-|t-mo|to(pl|sh)|ts(70|m-|m3|m5)|tx-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas-|your|zeto|zte-/i;
 
+export function isAndroid() {
+  return /Android/.test(window.navigator.userAgent);
+}
+
 // from https://stackoverflow.com/questions/57776001/how-to-detect-ipad-pro-as-ipad-using-javascript
 function isIpadOS() {
   return window.navigator.maxTouchPoints && window.navigator.maxTouchPoints > 2 && /MacIntel/.test(navigator.platform);
@@ -30,7 +34,7 @@ function isFirefoxReality() {
   return /(Mobile VR)/i.test(window.navigator.userAgent);
 }
 
-function isMobileVR() {
+export function isMobileVR() {
   return isOculusBrowser() || isFirefoxReality();
 }
 


### PR DESCRIPTION
From #5057

`WebAudio` on Android devices (only non-VR devices?) seems to have a bug and audio can be broken if there are many people in a room.

We have reported the problem to the Android devs. We found that using equal power panning mode can mitigate the problem so I would like to suggest that we use low audio panning quality (= equal power mode) by default on Android as workaround until the root issue is fixed on Android end.