### PR TITLE
Remove all event handler when component is removed

### DIFF
--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -654,9 +654,7 @@ AFRAME.registerComponent("media-pager", {
       })
       .catch(() => {}); //ignore exception, entity might not be networked
 
-    this.el.addEventListener("pdf-loaded", async () => {
-      this.update();
-    });
+    this.el.addEventListener("pdf-loaded", this.update);
   },
 
   async update(oldData) {
@@ -702,6 +700,12 @@ AFRAME.registerComponent("media-pager", {
       this.networkedEl.removeEventListener("unpinned", this.update);
     }
 
+    this.nextButton.object3D.removeEventListener("interact", this.onNext);
+    this.prevButton.object3D.removeEventListener("interact", this.onPrev);
+    this.snapButton.object3D.removeEventListener("interact", this.onSnap);
+
     window.APP.hubChannel.removeEventListener("permissions_updated", this.update);
+
+    this.el.removeEventListener("pdf-loaded", this.update);
   }
 });


### PR DESCRIPTION
The `media-pager` component is not correctly removing the listeners when it's removed and this causes issues when media element is refreshed.

STRs:
- Add a PDF with multiple pages to the scene
- Turn a couple of pages
- Refresh it a couple of times
- Turn a page again

Result: Multiple pages are turned at the same time
Expected: Only one page should be turned