### PR TITLE
Media audio can be very loud on room entry and scene changes

### DIFF
--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -61,6 +61,9 @@ AFRAME.registerComponent("avatar-audio-source", {
     } else {
       audio = new THREE.Audio(audioListener);
     }
+    // Default to being quiet so it fades in when volume is set by audio systems
+    audio.gain.gain.value = 0;
+
     this.audioSystem.addAudio({ sourceType: SourceType.AVATAR_AUDIO_SOURCE, node: audio });
 
     if (SHOULD_CREATE_SILENT_AUDIO_ELS) {

--- a/src/components/media-video.js
+++ b/src/components/media-video.js
@@ -358,6 +358,8 @@ AFRAME.registerComponent("media-video", {
     } else {
       this.audio = new THREE.Audio(audioListener);
     }
+    // Default to being quiet so it fades in when volume is set by audio systems
+    this.audio.gain.gain.value = 0;
     this.audioSystem.addAudio({ sourceType: SourceType.MEDIA_VIDEO, node: this.audio });
 
     this.audio.setNodeSource(this.mediaElementAudioSource);
@@ -370,6 +372,8 @@ AFRAME.registerComponent("media-video", {
 
     APP.audios.set(this.el, this.audio);
     updateAudioSettings(this.el, this.audio);
+    // Original audio source volume can now be restored as audio systems will take over
+    this.mediaElementAudioSource.mediaElement.volume = 1;
   },
 
   async updateSrc(oldData) {

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -470,7 +470,8 @@ export function createVideoOrAudioEl(type) {
   el.muted = isIOS;
   el.preload = "auto";
   el.crossOrigin = "anonymous";
-
+  // Audio should default to zero or it be heard before it is positioning and adjusted
+  el.volume = 0;
   return el;
 }
 


### PR DESCRIPTION
When you enter a room with audio or video media there can be a short period of very load audio output. The principle reason for this is that when the HTML Audio and Video elements are created there can be a delay before the various audio systems adopt them and start controlling their volumes. This has been addressed by setting the volume to zero by default and then reseting it to one once control has been passed over.

A secondary issue is that the default audio gain for the THREE sources is one and volume is interpolated to it's proper value over time using `setTargetAtTime`. If the gain is set to zero by default then the audio will fade up rather than down, which is less jarring.

The last issue is that before the room is entered, the player is positioned at the scene preview camera position and the audio will be set accordingly. This PR does not address this issue because it is not clear what the desired behaviour is.

Here is a test room that demonstrates all of these elements: [https://dev.reticulum.io/2D9w2Y4](https://dev.reticulum.io/2D9w2Y4). Without the PR applied you will hear a loud blast on first load, followed by the volume decreasing because the preview position in near the audio source, then on scene entry the volume will drop to being low. With the PR you will not have the initial blast of sound and instead jump straight to the volume of the preview sound.

Note that you might need to click the page a bit during load to tell the browser you are happy to hear audio at all. While this would appear to make the PR less relevant, remember that this approval is already given in the case of scene changes or fast room switching, where the sound blast can be significant.

I'm happy to take advice on whether I'm using the right properties in the right places, but I hope the underlying principles are sound.