### PR TITLE
Don't use avatar-rig for audio-zone tracking if not entering scene yet

### DIFF
--- a/src/components/avatar-audio-source.js
+++ b/src/components/avatar-audio-source.js
@@ -242,6 +242,8 @@ AFRAME.registerComponent("zone-audio-source", {
         const avatar = playerInfo.el;
 
         if (this.data.onlyMods && !playerInfo.can("amplify_audio")) continue;
+        // don't use avatar-rig if not entering scene yet.
+        if (avatar.id === "avatar-rig" && !this.el.sceneEl.is("entered")) continue;
 
         const distanceSquared = avatar.object3D.position.distanceToSquared(tmpWorldPos);
         if (distanceSquared < this.boundingRadiusSquared) {


### PR DESCRIPTION
Otherwise, getOwnerId will fails with following message if audio source captured the player in lobby.

`Could not find networked el. Entity does not have and is not a child of an entity with the [networked] component`