### PR TITLE
Fix darkened MeshBasicMaterial lightMap

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -562,6 +562,12 @@ class GLTFHubsLightMapExtension {
       const lightMap = results[1];
       material.lightMap = lightMap;
       material.lightMapIntensity = extensionDef.intensity !== undefined ? extensionDef.intensity : 1;
+
+      // See https://github.com/mrdoob/three.js/pull/23613
+      if (material.isMeshBasicMaterial) {
+        material.lightMapIntensity *= Math.PI;
+      }
+
       return material;
     });
   }

--- a/src/utils/material-utils.js
+++ b/src/utils/material-utils.js
@@ -45,7 +45,8 @@ class HubsMeshBasicMaterial extends THREE.MeshBasicMaterial {
     material.map = source.map;
 
     material.lightMap = source.lightMap;
-    material.lightMapIntensity = source.lightMapIntensity;
+    // See https://github.com/mrdoob/three.js/pull/23613 for "* Math.PI"
+    material.lightMapIntensity = source.lightMapIntensity * Math.PI;
 
     material.aoMap = source.aoMap;
     material.aoMapIntensity = source.aoMapIntensity;


### PR DESCRIPTION
Fixes #5562

The recent `Three.js` changed the light map intensity handling a bit and it affected `MeshBasicMaterial` light map. Due to it scenes having light map and materials unlit can be darkened after our `Three.js` upgrade.

This commit fixes it adjusting the light map intensity for `MeshBasicMaterial`.

See https://github.com/mrdoob/three.js/pull/23613 for the details.