### PR TITLE
Fix pen drawing color

### DIFF
--- a/src/components/tools/networked-drawing.js
+++ b/src/components/tools/networked-drawing.js
@@ -51,7 +51,7 @@ AFRAME.registerComponent("networked-drawing", {
     this.networkBufferInitialized = false;
 
     const options = {
-      vertexColors: THREE.VertexColors
+      vertexColors: true
     };
 
     this.color = new THREE.Color();

--- a/src/systems/physics-system.js
+++ b/src/systems/physics-system.js
@@ -108,7 +108,7 @@ export class PhysicsSystem {
       this.debugGeometry.addAttribute("position", new THREE.BufferAttribute(debugVertices, 3));
       this.debugGeometry.addAttribute("color", new THREE.BufferAttribute(debugColors, 3));
       const debugMaterial = new THREE.LineBasicMaterial({
-        vertexColors: THREE.VertexColors,
+        vertexColors: true,
         depthTest: true
       });
       this.debugMesh = new THREE.LineSegments(this.debugGeometry, debugMaterial);


### PR DESCRIPTION
Fixes: #5563

This PR fixes pen drawing color. It was broken when upgrading our Three.js to r141.

The root issue is we didn't follow the latest Three.js API. Three.js materials take `vertexColors` parameter as boolean now.

https://github.com/mrdoob/three.js/wiki/Migration-Guide#r113--r114

This PR fixes by following the latest API.
