### PR TITLE
Signing modal issues

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -777,7 +777,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       showSignInDialog: true,
       signInMessage,
       onContinueAfterSignIn: async () => {
-        remountUI({ showSignInDialog: false });
+        remountUI({ showSignInDialog: false, onContinueAfterSignIn: null });
         let actionError = null;
         if (predicate()) {
           try {

--- a/src/hub.js
+++ b/src/hub.js
@@ -791,13 +791,6 @@ document.addEventListener("DOMContentLoaded", async () => {
 
         if (actionError && onFailure) onFailure(actionError);
         exit2DInterstitialAndEnterVR();
-      },
-      onSignInDialogVisibilityChanged: visible => {
-        if (visible) {
-          remountUI({ showSignInDialog: true });
-        } else {
-          remountUI({ showSignInDialog: false, onContinueAfterSignIn: null });
-        }
       }
     });
   };

--- a/src/react-components/auth/RoomSignInModalContainer.js
+++ b/src/react-components/auth/RoomSignInModalContainer.js
@@ -40,6 +40,6 @@ RoomSignInModalContainer.propTypes = {
   onClose: PropTypes.func,
   onSubmitEmail: PropTypes.func,
   step: PropTypes.string,
-  message: PropTypes.string,
+  message: PropTypes.object,
   onContinue: PropTypes.func
 };

--- a/src/react-components/auth/SignInModal.js
+++ b/src/react-components/auth/SignInModal.js
@@ -190,7 +190,7 @@ export function SignInComplete({ message, onContinue }) {
 }
 
 SignInComplete.propTypes = {
-  message: PropTypes.string.isRequired,
+  message: PropTypes.string,
   onContinue: PropTypes.func.isRequired
 };
 

--- a/src/react-components/auth/SignInModal.js
+++ b/src/react-components/auth/SignInModal.js
@@ -129,7 +129,7 @@ SubmitEmail.defaultProps = {
 };
 
 SubmitEmail.propTypes = {
-  message: PropTypes.string,
+  message: PropTypes.object,
   termsUrl: PropTypes.string,
   privacyUrl: PropTypes.string,
   initialEmail: PropTypes.string,

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -144,7 +144,7 @@ class UIRoot extends Component {
     subscriptions: PropTypes.object,
     initialIsFavorited: PropTypes.bool,
     showSignInDialog: PropTypes.bool,
-    signInMessage: PropTypes.string,
+    signInMessage: PropTypes.object,
     onContinueAfterSignIn: PropTypes.func,
     onSignInDialogVisibilityChanged: PropTypes.func,
     showSafariMicDialog: PropTypes.bool,

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -146,7 +146,6 @@ class UIRoot extends Component {
     showSignInDialog: PropTypes.bool,
     signInMessage: PropTypes.object,
     onContinueAfterSignIn: PropTypes.func,
-    onSignInDialogVisibilityChanged: PropTypes.func,
     showSafariMicDialog: PropTypes.bool,
     onMediaSearchResultEntrySelected: PropTypes.func,
     onAvatarSaved: PropTypes.func,
@@ -401,11 +400,7 @@ class UIRoot extends Component {
   };
 
   showContextualSignInDialog = () => {
-    const { signInMessage, authChannel } = this.props;
-    const onCallback = () => {
-      const { onContinueAfterSignIn } = this.props;
-      (onContinueAfterSignIn && onContinueAfterSignIn()) || this.closeDialog();
-    };
+    const { signInMessage, authChannel, onContinueAfterSignIn } = this.props;
     this.showNonHistoriedDialog(RoomSignInModalContainer, {
       step: SignInStep.submit,
       message: signInMessage,
@@ -414,7 +409,7 @@ class UIRoot extends Component {
 
         this.showNonHistoriedDialog(RoomSignInModalContainer, {
           step: SignInStep.waitForVerification,
-          onClose: onCallback
+          onClose: onContinueAfterSignIn || this.closeDialog
         });
 
         await authComplete;
@@ -422,11 +417,11 @@ class UIRoot extends Component {
         this.setState({ signedIn: true });
         this.showNonHistoriedDialog(RoomSignInModalContainer, {
           step: SignInStep.complete,
-          onClose: onCallback,
-          onContinue: onCallback
+          onClose: onContinueAfterSignIn || this.closeDialog,
+          onContinue: onContinueAfterSignIn || this.closeDialog
         });
       },
-      onClose: onCallback
+      onClose: onContinueAfterSignIn || this.closeDialog
     });
   };
 
@@ -649,9 +644,6 @@ class UIRoot extends Component {
       this.setState({ dialog: null });
     }
 
-    const { onSignInDialogVisibilityChanged } = this.props;
-    onSignInDialogVisibilityChanged && onSignInDialogVisibilityChanged(false);
-
     if (isIn2DInterstitial()) {
       exit2DInterstitialAndEnterVR();
     } else {
@@ -660,8 +652,6 @@ class UIRoot extends Component {
   };
 
   showNonHistoriedDialog = (DialogClass, props = {}) => {
-    const { onSignInDialogVisibilityChanged } = this.props;
-    onSignInDialogVisibilityChanged && onSignInDialogVisibilityChanged(true);
     this.setState({
       dialog: <DialogClass {...{ onClose: this.closeDialog, ...props }} />
     });


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/4810

We set the modals `onClose` callback to either `onContinueAfterSignIn` or `closeDialog` depending if the dialog needs to execute an action after signing or not but we never reset `onContinueAfterSignIn`. This means that if after showing a dialog that requires an action we show one that doesn't, the second one won't close as it will keep on calling the previous `onContinueAfterSignIn`callback.

This PR reverts a previous patch, resets the `onContinueAfterSignIn`callback after it's been called and fixes some component property types that are throwing warnings.

@SV-AndreiC I think it's worth revisiting these already closed issues. I've tested them but just in case: 
https://github.com/mozilla/hubs/issues/4695
https://github.com/mozilla/hubs/issues/4367
https://github.com/mozilla/hubs/issues/3886
https://github.com/mozilla/hubs/issues/4810