### PR TITLE
Set a default theme to fix the rest button

### DIFF
--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -12,6 +12,7 @@ const validator = new Validator();
 import { EventTarget } from "event-target-shim";
 import { fetchRandomDefaultAvatarId, generateRandomName } from "../utils/identity.js";
 import { NO_DEVICE_ID } from "../utils/media-devices-utils.js";
+import { getDefaultTheme } from "../utils/theme.js";
 
 const defaultMaterialQuality = (function() {
   const MATERIAL_QUALITY_OPTIONS = ["low", "medium", "high"];
@@ -153,7 +154,7 @@ export const SCHEMA = {
         enableAudioClipping: { type: "bool", default: false },
         audioClippingThreshold: { type: "number", default: 0.015 },
         audioPanningQuality: { type: "string", default: defaultAudioPanningQuality() },
-        theme: { type: "string", default: undefined },
+        theme: { type: "string", default: getDefaultTheme()?.name },
         cursorSize: { type: "number", default: 1 },
         nametagVisibility: { type: "string", default: "showAll" },
         nametagVisibilityDistance: { type: "number", default: 5 },

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -1,3 +1,4 @@
+import { themes } from "../react-components/styles/theme";
 import { waitForDOMContentLoaded } from "./async-utils";
 import configs from "./configs";
 
@@ -107,4 +108,8 @@ function applyThemeToTextButton(el, highlighted) {
   );
 }
 
-export { applyThemeToTextButton, getThemeColor };
+function getDefaultTheme() {
+  return themes.find(t => t.default) || themes[0];
+}
+
+export { applyThemeToTextButton, getThemeColor, getDefaultTheme };


### PR DESCRIPTION
I've seen that this is broken while working on another PR.

We set the default theme to undefined but that breaks the reset button.  This PR sets the theme default to the default theme or the first one in case none has been tagged as default.