### PR TITLE
Fix pen on touchscreen devices

### DIFF
--- a/src/systems/userinput/devices/app-aware-touchscreen.js
+++ b/src/systems/userinput/devices/app-aware-touchscreen.js
@@ -41,7 +41,7 @@ const getPlayerCamera = function() {
 
 function shouldMoveCursor(touch, rect, raycaster) {
   const isCursorGrabbing = anyEntityWith(APP.world, HeldRemoteRight);
-  if (isCursorGrabbing) return false;
+  if (isCursorGrabbing) return true;
 
   // Check if this touch might result in an interact or grab eventually
   const rawIntersections = [];


### PR DESCRIPTION
Using pen tool on mobile just moved the camera. It looks like this condition was incorrectly flipped in https://github.com/mozilla/hubs/commit/e435a26038d25109a7aa21e8693e7160841ecea7#diff-d1a069083e7ddf815d4cb70b5efd9fc03300602d02f0452139d20f5274dc747dR44