### PR TITLE
Fix darkened video-texture-target

### DIFF
--- a/src/components/video-texture-target.js
+++ b/src/components/video-texture-target.js
@@ -153,9 +153,8 @@ AFRAME.registerComponent("video-texture-target", {
         const texture = videoTextureSource.renderTarget.texture;
         this.applyTexture(texture);
 
-        // Bit of a hack here to only update the renderTarget when the screens are in view
-        material.map.isVideoTexture = true;
-        material.map.update = () => {
+        // Only update the renderTarget when the screens are in view
+        material.onBeforeRender = () => {
           videoTextureSource.textureNeedsUpdate = true;
         };
       } else {


### PR DESCRIPTION
Fixes: #5599 

This PR fixes darkened video-texture-target problem caused when upgrading our Three.js to r141.

Refer to "Fix darkened camera view" PR #5577 for the details because the root issue is same.