### PR TITLE
Fix issue switching between scenes with many entities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19022,9 +19022,8 @@
       "dev": true
     },
     "bitecs": {
-      "version": "0.3.38",
-      "resolved": "https://registry.npmjs.org/bitecs/-/bitecs-0.3.38.tgz",
-      "integrity": "sha512-vfz6wjPElg/0O7c06Ttb/BeWMInBspSuekRvNoLqPyEZV87tLWipxqpjtGPKZBhin8jv4OuQkrkZZfZpaqOndQ=="
+      "version": "github:mozilla/bitECS#cf937ab118c1235d4800ac0ae68c582805894b04",
+      "from": "github:mozilla/bitECS#hubs-patches"
     },
     "bluebird": {
       "version": "3.5.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "ammo-debug-drawer": "github:infinitelee/ammo-debug-drawer",
     "ammo.js": "github:mozillareality/ammo.js#hubs/master",
     "animejs": "github:mozillareality/anime#hubs/master",
-    "bitecs": "^0.3.38",
+    "bitecs": "github:mozilla/bitECS#hubs-patches",
     "buffered-interpolation": "github:Infinitelee/buffered-interpolation",
     "classnames": "^2.2.5",
     "color": "^3.1.2",

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -1,7 +1,8 @@
-import { defineComponent, setDefaultSize, Types } from "bitecs";
+import { defineComponent, setDefaultSize, setRemovedRecycleThreshold, Types } from "bitecs";
 
 // TODO this has to happen before all components are defined. Is there a better spot to be doing this?
 setDefaultSize(10000);
+setRemovedRecycleThreshold(0.2);
 
 export const $isStringType = Symbol("isStringType");
 

--- a/src/systems/remove-object3D-system.js
+++ b/src/systems/remove-object3D-system.js
@@ -24,11 +24,11 @@ const cleanupMediaFrames = cleanupObjOnExit(MediaFrame, obj => obj.geometry.disp
 // When we remove an entity with an Object3DTag:
 // - The associated object3D will be removed from the scene graph.
 // - The rest of the scene graph will be left intact.
-// - We will call removeEntity for all entities associated with the object3D's descendents.
-// - The descendents won't be removed from their parents.
+// - We will call removeEntity for all entities associated with the object3D's descendants.
+// - The descendants won't be removed from their parents.
 //
 // TODO AFRAME entities get cleaned up in an an odd way:
-//      When we remove an AFRAME entity, AFRAME will call `removeEntity` for all of its descendents,
+//      When we remove an AFRAME entity, AFRAME will call `removeEntity` for all of its descendants,
 //      which means we will remove each descendent from its parent.
 const exitedObject3DQuery = exitQuery(defineQuery([Object3DTag]));
 export function removeObject3DSystem(world) {
@@ -38,7 +38,7 @@ export function removeObject3DSystem(world) {
     o.eid = null;
   }
 
-  // remove entities that are children of any removed entiteis
+  // remove entities that are children of any removed entities
   const entities = exitedObject3DQuery(world);
   entities.forEach(eid => {
     const obj = world.eid2obj.get(eid);
@@ -52,7 +52,7 @@ export function removeObject3DSystem(world) {
   cleanupTexts(world);
   cleanupMediaFrames(world);
 
-  // Finally remove all the entiteis we just removed from the eid2obj map
+  // Finally remove all the entities we just removed from the eid2obj map
   entities.forEach(removeFromMap);
   exitedObject3DQuery(world).forEach(removeFromMap);
 }


### PR DESCRIPTION
When switching between scenes with > 100 entities (which is not even all that many) BitECS's entity id recycling causes some strange behavior in our object3d cleanup code. 

![image](https://user-images.githubusercontent.com/130735/180354660-7388ba63-9587-4798-9ce6-9b0867005417.png)

This PR (along with a [patch](https://github.com/NateTheGreatt/bitECS/pull/93) to BitECS) allows entity id recycling to be configured, and configures it to 20% of our 10,000 entity max (2000). This points at our own fork of BitECS for now until the change lands upstream. This is still only a partial solution, as the issue would still happen if entities are added on a frame where > 2000 entities were also removed, but this is very unlikely to happen. 

There was some discussion of further solutions on [github](https://github.com/NateTheGreatt/bitECS/issues/68) and [discord](https://discord.com/channels/654487419407826945/817507396317741106/999788262900117714)