### PR TITLE
Fix embed codes for anonymous users or non-owners

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -537,15 +537,6 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data,
   }
 
   const hub = data.hubs[0];
-  let embedToken = hub.embed_token;
-
-  if (!embedToken) {
-    const embedTokenEntry = store.state.embedTokens && store.state.embedTokens.find(t => t.hubId === hub.hub_id);
-
-    if (embedTokenEntry) {
-      embedToken = embedTokenEntry.embedToken;
-    }
-  }
 
   console.log(`Dialog host: ${hub.host}:${hub.port}`);
 
@@ -556,8 +547,7 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data,
     onMediaSearchResultEntrySelected: (entry, selectAction) =>
       scene.emit("action_selected_media_result_entry", { entry, selectAction }),
     onMediaSearchCancelled: entry => scene.emit("action_media_search_cancelled", entry),
-    onAvatarSaved: entry => scene.emit("action_avatar_saved", entry),
-    embedToken: embedToken
+    onAvatarSaved: entry => scene.emit("action_avatar_saved", entry)
   });
 
   scene.addEventListener("action_selected_media_result_entry", e => {

--- a/src/react-components/room/InvitePopover.js
+++ b/src/react-components/room/InvitePopover.js
@@ -23,11 +23,13 @@ function InvitePopoverContent({ url, embed, inviteRequired, fetchingInvite, invi
             value={url}
             buttonPreset="accent3"
           />
-          <CopyableTextInputField
-            label={<FormattedMessage id="invite-popover.embed-code" defaultMessage="Embed Code" />}
-            value={embed}
-            buttonPreset="accent5"
-          />
+          {embed && (
+            <CopyableTextInputField
+              label={<FormattedMessage id="invite-popover.embed-code" defaultMessage="Embed Code" />}
+              value={embed}
+              buttonPreset="accent5"
+            />
+          )}
         </>
       )}
     </Column>
@@ -36,7 +38,7 @@ function InvitePopoverContent({ url, embed, inviteRequired, fetchingInvite, invi
 
 InvitePopoverContent.propTypes = {
   url: PropTypes.string.isRequired,
-  embed: PropTypes.string.isRequired,
+  embed: PropTypes.string,
   inviteRequired: PropTypes.bool,
   fetchingInvite: PropTypes.bool,
   inviteUrl: PropTypes.string,

--- a/src/react-components/room/InvitePopoverContainer.js
+++ b/src/react-components/room/InvitePopoverContainer.js
@@ -6,12 +6,18 @@ import { InvitePopoverButton } from "./InvitePopover";
 import { handleExitTo2DInterstitial } from "../../utils/vr-interstitial";
 import { useInviteUrl } from "./useInviteUrl";
 
-export function InvitePopoverContainer({ hub, hubChannel, scene, ...rest }) {
+export function InvitePopoverContainer({ hub, hubChannel, scene, store, ...rest }) {
   // TODO: Move to Hub class
   const shortUrl = `https://${configs.SHORTLINK_DOMAIN}`;
   const url = `${shortUrl}/${hub.hub_id}`;
-  const embedUrl = hubUrl(hub.hub_id, { embed_token: hub.embed_token });
-  const embedText = `<iframe src="${embedUrl}" style="width: 1024px; height: 768px;" allow="microphone; camera; vr; speaker;"></iframe>`;
+
+  let embedText = null;
+  const embedToken = hub.embed_token || store.getEmbedTokenForHub(hub);
+  if (embedToken) {
+    const embedUrl = hubUrl(hub.hub_id, { embed_token: embedToken });
+    embedText = `<iframe src="${embedUrl}" style="width: 1024px; height: 768px;" allow="microphone; camera; vr; speaker;"></iframe>`;
+  }
+
   const popoverApiRef = useRef();
 
   // Handle clicking on the invite button while in VR.
@@ -61,5 +67,6 @@ export function InvitePopoverContainer({ hub, hubChannel, scene, ...rest }) {
 InvitePopoverContainer.propTypes = {
   hub: PropTypes.object.isRequired,
   scene: PropTypes.object.isRequired,
-  hubChannel: PropTypes.object.isRequired
+  hubChannel: PropTypes.object.isRequired,
+  store: PropTypes.object.isRequired
 };

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -158,7 +158,6 @@ class UIRoot extends Component {
     showPreload: PropTypes.bool,
     onPreloadLoadClicked: PropTypes.func,
     embed: PropTypes.bool,
-    embedToken: PropTypes.string,
     onLoaded: PropTypes.func,
     activeObject: PropTypes.object,
     selectedObject: PropTypes.object,
@@ -1518,6 +1517,7 @@ class UIRoot extends Component {
                     hub={this.props.hub}
                     hubChannel={this.props.hubChannel}
                     scene={this.props.scene}
+                    store={this.props.store}
                   />
                 }
                 toolbarCenter={

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -434,6 +434,15 @@ export default class Store extends EventTarget {
     return finalState;
   }
 
+  getEmbedTokenForHub(hub) {
+    const embedTokenEntry = this.state.embedTokens.find(embedTokenEntry => embedTokenEntry.hubId === hub.hub_id);
+    if (embedTokenEntry) {
+      return embedTokenEntry.embedToken;
+    } else {
+      return null;
+    }
+  }
+
   get schema() {
     return SCHEMA;
   }


### PR DESCRIPTION
If a user is not signed in and they create a room, we store the embed token for the room in the local store. We had some code that retrieved it from the store, but that code wasn't actually in use. This resulted in the embed token being null in the embed code.

Additionally, if a user is not an owner of a room, they will not have an embed token for the room, by design. In those cases, we should hide the embed code UI altogether.

Fixes #5622 Fixes #3570