### PR TITLE
Add hubs-upload-cdn.com to NON_CORS_PROXY_DOMAINS in .defaults.env

### DIFF
--- a/.defaults.env
+++ b/.defaults.env
@@ -18,7 +18,7 @@ THUMBNAIL_SERVER="nearspark-dev.reticulum.io"
 ASSET_BUNDLE_SERVER="https://asset-bundles-prod.reticulum.io"
 
 # Comma-separated list of domains which are known to not need CORS proxying
-NON_CORS_PROXY_DOMAINS="hubs.local,dev.reticulum.io"
+NON_CORS_PROXY_DOMAINS="hubs.local,dev.reticulum.io,hubs-upload-cdn.com"
 
 # The root URL under which Hubs expects static assets to be served.
 BASE_ASSETS_PATH=/


### PR DESCRIPTION
Fixes: #5576

User upload files in `hubs.local` (`npm run dev`) are uploaded to `hubs-upload-cdn.com` and they are loaded via the proxy (`hubs-proxy.com`).

`hubs-upload-cdn.com` seems to have CORS that allows `hubs.local` then the files don't need to be loaded via the proxy.

To avoid the proxy, add `hubs-upload-cdn.com` to `NON_CORS_PROXY_DOMAINS` in `.defaults.env`.