### PR TITLE
Rewrite idle-detector with the one with the new framework

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -166,7 +166,6 @@ import "./systems/app-mode";
 import "./systems/permissions";
 import "./systems/exit-on-blur";
 import "./systems/auto-pixel-ratio";
-import "./systems/idle-detector";
 import "./systems/pen-tools";
 import "./systems/userinput/userinput";
 import "./systems/userinput/userinput-debug";

--- a/src/systems/hubs-systems.js
+++ b/src/systems/hubs-systems.js
@@ -46,6 +46,7 @@ import { cameraToolSystem } from "../bit-systems/camera-tool";
 // import { holdableButtonSystem } from "./holdable-button-system";
 import { physicsCompatSystem } from "./bit-physics";
 import { destroyAtExtremeDistanceSystem } from "./bit-destroy-at-extreme-distances";
+import { idleDetectSystem } from "./idle-detector";
 
 AFRAME.registerSystem("hubs-systems", {
   init() {
@@ -153,6 +154,7 @@ AFRAME.registerSystem("hubs-systems", {
     destroyAtExtremeDistanceSystem(world);
     removeNetworkedObjectButtonSystem(world);
     removeObject3DSystem(world);
+    idleDetectSystem(t);
 
     // We run this late in the frame so that its the last thing to have an opinion about the scale of an object
     this.boneVisibilitySystem.tick();


### PR DESCRIPTION
I rewrote `idle-detector` with the one with the new framework to get used to the new framework and to reduce the dependency with Aframe.

Notes:
* It needs some initializations. I used module locales for them.
* Should the userinputs be represented as entities?