### PR TITLE
Sep 2022 Hubs Cloud hotfixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10466,7 +10466,7 @@
     },
     "node_modules/aframe": {
       "version": "1.0.3",
-      "resolved": "git+ssh://git@github.com/mozillareality/aframe.git#3155ad3df9632ee84d93d3cd8250a4c44767e70e",
+      "resolved": "git+ssh://git@github.com/mozillareality/aframe.git#0fa14187b8f3e90726385904591eba799380df79",
       "license": "MIT",
       "dependencies": {
         "custom-event-polyfill": "^1.0.6",
@@ -39336,7 +39336,7 @@
       "dev": true
     },
     "aframe": {
-      "version": "git+ssh://git@github.com/mozillareality/aframe.git#3155ad3df9632ee84d93d3cd8250a4c44767e70e",
+      "version": "git+ssh://git@github.com/mozillareality/aframe.git#0fa14187b8f3e90726385904591eba799380df79",
       "from": "aframe@github:mozillareality/aframe#hubs/master",
       "requires": {
         "custom-event-polyfill": "^1.0.6",

--- a/src/components/video-texture-target.js
+++ b/src/components/video-texture-target.js
@@ -179,6 +179,8 @@ AFRAME.registerComponent("video-texture-target", {
 
           const video = createVideoOrAudioEl("video");
           video.srcObject = stream;
+          // Video is muted so autoplay is allowed
+          video.play();
 
           const texture = new THREE.VideoTexture(video);
           texture.flipY = false;


### PR DESCRIPTION
Fixes issues found during testing of the Sep 2022 Hubs Cloud Release:
- Avatars with video-texture-target were not correctly rendering videos. This was a regression introduced by #5550, as the videos no longer autoplay when muted (and not in the DOM). Fix is to manually call play() on them. (This is safe to do since the video is muted so does not require a user gesture.
- When exiting VR (such as when hitting the magic want to find a model from Sketchfab) an exception was thrown and you are unable to enter VR again. This was a regression from our ThreeJS 141 upgrade. This update intruded additional cleanup code in **WebXRManager** that conflicts with aframe's cleanup code. Rather than rewrite all of aframe's enter/exit logic to deal with this it seems simplest/safest to just work around it. We want to remove all this logic and directly work with WebXRManager in Hubs code anyway. See https://github.com/MozillaReality/aframe/commit/0fa14187b8f3e90726385904591eba799380df79