### PR TITLE
Fix bot duplicated audio track issue

### DIFF
--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -521,7 +521,9 @@ export default class SceneEntryManager {
       audioSource.connect(gainNode);
       gainNode.connect(audioDestination);
       gainNode.gain.value = audioVolume;
-      this.mediaDevicesManager.mediaStream.addTrack(audioDestination.stream.getAudioTracks()[0]);
+
+      const audioSystem = AFRAME.scenes[0].systems["hubs-systems"].audioSystem
+      audioSystem.addStreamToOutboundAudio("microphone", audioDestination.stream);
     }
 
     const connect = async () => {


### PR DESCRIPTION
The bot is adding the track to the WebRTC media stream track which makes it send two tracks. This PR adds the destination stream to the outbound stream as we do with the mic stream, that fixes the double track issue.