### PR TITLE
Refresh dialog join token when the phoenix channel reconnects

### DIFF
--- a/src/change-hub.js
+++ b/src/change-hub.js
@@ -86,7 +86,6 @@ export async function changeHub(hubId, addToHistory = true) {
     APP.dialog.connect({
       serverUrl: `wss://${hub.host}:${hub.port}`,
       roomId: hub.hub_id,
-      joinToken: data.perms_token,
       serverParams: { host: hub.host, port: hub.port, turn: hub.turn },
       scene,
       clientId: APP.dialog._clientId,

--- a/src/hub.js
+++ b/src/hub.js
@@ -503,7 +503,7 @@ function onConnectionError(entryManager, connectError) {
 // TODO: Find a home for this
 // TODO: Naming. Is this an "event bus"?
 const events = emitter();
-function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data, permsToken) {
+function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data) {
   const scene = document.querySelector("a-scene");
   const isRejoin = NAF.connection.isConnected();
 
@@ -598,7 +598,6 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data,
       APP.dialog.connect({
         serverUrl: `wss://${hub.host}:${hub.port}`,
         roomId: hub.hub_id,
-        joinToken: permsToken,
         serverParams: { host: hub.host, port: hub.port, turn: hub.turn },
         scene,
         clientId: data.session_id,
@@ -1253,7 +1252,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       });
 
       await presenceSync.promise;
-      handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data, permsToken, hubChannel, events);
+      handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data);
     })
     .receive("error", res => {
       if (res.reason === "closed") {

--- a/src/naf-dialog-adapter.js
+++ b/src/naf-dialog-adapter.js
@@ -241,7 +241,6 @@ export class DialogAdapter extends EventEmitter {
   async connect({
     serverUrl,
     roomId,
-    joinToken,
     serverParams,
     scene,
     clientId,
@@ -251,7 +250,6 @@ export class DialogAdapter extends EventEmitter {
   }) {
     this._serverUrl = serverUrl;
     this._roomId = roomId;
-    this._joinToken = joinToken;
     this._serverParams = serverParams;
     this._clientId = clientId;
     this.scene = scene;
@@ -467,7 +465,6 @@ export class DialogAdapter extends EventEmitter {
     await this.connect({
       serverUrl: newServerUrl,
       roomId: this._roomId,
-      joinToken: APP.hubChannel.token,
       serverParams,
       scene: this.scene,
       clientId: this._clientId,
@@ -747,7 +744,7 @@ export class DialogAdapter extends EventEmitter {
       device: this._device,
       rtpCapabilities: this._mediasoupDevice.rtpCapabilities,
       sctpCapabilities: this._useDataChannel ? this._mediasoupDevice.sctpCapabilities : undefined,
-      token: this._joinToken
+      token: APP.hubChannel.token
     });
 
     if (this._localMediaStream) {
@@ -955,7 +952,7 @@ export class DialogAdapter extends EventEmitter {
       .request("kick", {
         room_id: this.room,
         user_id: clientId,
-        token: this._joinToken
+        token: APP.hubChannel.token
       })
       .then(() => {
         document.body.dispatchEvent(new CustomEvent("kicked", { detail: { clientId: clientId } }));

--- a/src/react-components/debug-panel/RtcDebugPanel.js
+++ b/src/react-components/debug-panel/RtcDebugPanel.js
@@ -566,7 +566,6 @@ export default class RtcDebugPanel extends Component {
     APP.dialog.connect({
       serverUrl: APP.dialog._serverUrl,
       roomId: APP.dialog._roomId,
-      joinToken: APP.hubChannel.token,
       serverParams: APP.dialog._serverParams,
       scene: APP.dialog.scene,
       clientId: APP.dialog._clientId,


### PR DESCRIPTION
When the phoenix channel is reconnected the JWT token might have changed but we weren't updating the dialog adapter token. This can cause issues if we try to reconnect to dialog after the token has changed.