### PR TITLE
Remove Quilt

### DIFF
--- a/src/react-components/avatar-editor.js
+++ b/src/react-components/avatar-editor.js
@@ -26,10 +26,8 @@ const delistAvatarInfoMessage = defineMessage({
 const AVATARS_API = "/api/v1/avatars";
 
 const defaultEditors = [
-  {
-    name: "Quilt",
-    url: "https://tryquilt.io/?gltf=$AVATAR_GLTF"
-  }
+  // TODO This previously contain tryquilt.io.  We should re-evaluate whether these types of editors are still desired,
+  // and change the related code accordingly.
 ];
 const useAllowedEditors = true;
 const allowedEditors = [


### PR DESCRIPTION
Removing reference to the Quilt avatar editor since it probably didn't get much use, and the service will probably die eventually.