### PR TITLE
Cleanup main tick

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "linkify-it": "^2.0.3",
         "markdown-it": "^8.4.2",
         "moving-average": "^1.0.0",
-        "networked-aframe": "github:mozillareality/networked-aframe#master",
+        "networked-aframe": "github:mozillareality/networked-aframe#6093c3a0b2867a9e141cd5c19f7d13dfa7c38479",
         "nipplejs": "github:mozillareality/nipplejs#mr-social-client/master",
         "node-ensure": "0.0.0",
         "normalize.css": "^8.0.1",
@@ -22730,7 +22730,8 @@
     },
     "node_modules/networked-aframe": {
       "version": "0.6.1",
-      "resolved": "git+ssh://git@github.com/mozillareality/networked-aframe.git#25198c32d618adc5f887e70b1c4e8cb5f3d3e047",
+      "resolved": "git+ssh://git@github.com/mozillareality/networked-aframe.git#6093c3a0b2867a9e141cd5c19f7d13dfa7c38479",
+      "integrity": "sha512-T8wzMgtLYuFqWRx2cTxadNzDECir2x2gdJlV4TQTAwpZALo0PKyPie5VX3rjEIL9l4/5N3yK+dCtRW70NuUfhg==",
       "license": "MIT",
       "dependencies": {
         "buffered-interpolation": "github:Infinitelee/buffered-interpolation#5bb18421ebf2bf11664645cdc7a15bd77ee2156b"
@@ -49276,8 +49277,9 @@
       "dev": true
     },
     "networked-aframe": {
-      "version": "git+ssh://git@github.com/mozillareality/networked-aframe.git#25198c32d618adc5f887e70b1c4e8cb5f3d3e047",
-      "from": "networked-aframe@github:mozillareality/networked-aframe#master",
+      "version": "git+ssh://git@github.com/mozillareality/networked-aframe.git#6093c3a0b2867a9e141cd5c19f7d13dfa7c38479",
+      "integrity": "sha512-T8wzMgtLYuFqWRx2cTxadNzDECir2x2gdJlV4TQTAwpZALo0PKyPie5VX3rjEIL9l4/5N3yK+dCtRW70NuUfhg==",
+      "from": "networked-aframe@github:mozillareality/networked-aframe#6093c3a0b2867a9e141cd5c19f7d13dfa7c38479",
       "requires": {
         "buffered-interpolation": "github:Infinitelee/buffered-interpolation#5bb18421ebf2bf11664645cdc7a15bd77ee2156b"
       }

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "linkify-it": "^2.0.3",
     "markdown-it": "^8.4.2",
     "moving-average": "^1.0.0",
-    "networked-aframe": "github:mozillareality/networked-aframe#master",
+    "networked-aframe": "github:mozillareality/networked-aframe#6093c3a0b2867a9e141cd5c19f7d13dfa7c38479",
     "nipplejs": "github:mozillareality/nipplejs#mr-social-client/master",
     "node-ensure": "0.0.0",
     "normalize.css": "^8.0.1",

--- a/src/systems/bit-constraints-system.js
+++ b/src/systems/bit-constraints-system.js
@@ -73,8 +73,7 @@ function remove(world, offersConstraint, constraintComponent, physicsSystem, int
   }
 }
 
-export function constraintsSystem(world) {
-  const physicsSystem = AFRAME.scenes[0].systems["hubs-systems"].physicsSystem;
+export function constraintsSystem(world, physicsSystem) {
   add(world, physicsSystem, anyEntityWith(world, RemoteRight), ConstraintRemoteRight, queryEnterRemoteRight(world));
   add(world, physicsSystem, anyEntityWith(world, RemoteLeft), ConstraintRemoteLeft, queryEnterRemoteLeft(world));
   add(world, physicsSystem, anyEntityWith(world, HandRight), ConstraintHandRight, queryEnterHandRight(world));

--- a/src/systems/bit-interaction-system.js
+++ b/src/systems/bit-interaction-system.js
@@ -2,12 +2,12 @@ import { handHoverSystem } from "./bit-hand-hover-system";
 import { holdSystem } from "./hold-system";
 import { dontHoldWithHandAndRemote, dontHoverAndHold } from "./not-hovered-if-held";
 
-export function interactionSystem(world, cursorTargettingSystem, t, systems) {
+export function interactionSystem(world, cursorTargettingSystem, t, aframeSystems) {
   cursorTargettingSystem.tick(t); // handles hovers for cursors
-  handHoverSystem(world, systems.interaction);
-  holdSystem(world, systems.userinput);
+  handHoverSystem(world, aframeSystems.interaction);
+  holdSystem(world, aframeSystems.userinput);
   dontHoldWithHandAndRemote(world);
   dontHoverAndHold(world);
   // Copies hovered/held state (only for aframe entities) for querying by legacy systems/components
-  systems.interaction.updateLegacyState();
+  aframeSystems.interaction.updateLegacyState();
 }

--- a/src/systems/hubs-systems.ts
+++ b/src/systems/hubs-systems.ts
@@ -50,6 +50,13 @@ import { physicsCompatSystem } from "./bit-physics";
 import { destroyAtExtremeDistanceSystem } from "./bit-destroy-at-extreme-distances";
 import { videoMenuSystem } from "../bit-systems/video-menu-system";
 import { deleteEntitySystem } from "../bit-systems/delete-entity-system";
+import type { HubsSystems } from "aframe";
+
+declare global {
+  interface Window {
+    $S: HubsSystems;
+  }
+}
 
 AFRAME.registerSystem("hubs-systems", {
   init() {
@@ -110,7 +117,7 @@ AFRAME.registerSystem("hubs-systems", {
     interactionSystem(world, this.cursorTargettingSystem, t, systems);
 
     buttonSystems(world);
-    constraintsSystem(world, systems.userinput);
+    constraintsSystem(world, this.physicsSystem);
 
     // We run this earlier in the frame so things have a chance to override properties run by animations
     this.animationMixerSystem.tick(dt);

--- a/src/systems/hubs-systems.ts
+++ b/src/systems/hubs-systems.ts
@@ -252,7 +252,7 @@ export function mainTick(
   removeNetworkedObjectButtonSystem(world);
   removeObject3DSystem(world);
 
-  // We run hubsSystems late in the frame so that its the last thing to have an opinion about the scale of an object
+  // We run this late in the frame so that its the last thing to have an opinion about the scale of an object
   hubsSystems.boneVisibilitySystem.tick();
 
   networkSendSystem(world);

--- a/src/systems/hubs-systems.ts
+++ b/src/systems/hubs-systems.ts
@@ -139,9 +139,6 @@ export function mainTick(
   // NOTE this is now blocking execution of all components/systems, make sure that's not an issue
   if (!hubsSystems.DOMContentDidLoad) return;
 
-  // TODO audit if anything but the input system needs this, pass it in directly
-  sceneEl.frame = xrFrame;
-
   // NOTE now is probably a good time to do this, and consolidate with timeSystem
   // TODO we should probably be using time from the raf loop itself
   const dt = renderClock.getDelta() * 1000;
@@ -194,7 +191,7 @@ export function mainTick(
 
   networkedTransformSystem(world);
 
-  aframeSystems.userinput.tick2();
+  aframeSystems.userinput.tick2(xrFrame);
 
   interactionSystem(world, hubsSystems.cursorTargettingSystem, t, aframeSystems);
 

--- a/src/systems/hubs-systems.ts
+++ b/src/systems/hubs-systems.ts
@@ -118,12 +118,12 @@ AFRAME.registerSystem("hubs-systems", {
 
 export function mainTick(xrFrame: XRFrame, renderer: WebGLRenderer, scene: Scene, camera: Camera) {
   const world = APP.world;
-
   const sceneEl = AFRAME.scenes[0];
   const aframeSystems = sceneEl.systems;
   const hubsSystems = aframeSystems["hubs-systems"];
 
-  if (!hubsSystems.DOMContentDidLoad) return;
+  // TODO does anything actually ever pause the scene?
+  if (!sceneEl.isPlaying && !hubsSystems.DOMContentDidLoad) return;
 
   timeSystem(world);
   const t = world.time.elapsed;

--- a/src/systems/hubs-systems.ts
+++ b/src/systems/hubs-systems.ts
@@ -51,7 +51,7 @@ import { destroyAtExtremeDistanceSystem } from "./bit-destroy-at-extreme-distanc
 import { videoMenuSystem } from "../bit-systems/video-menu-system";
 import { deleteEntitySystem } from "../bit-systems/delete-entity-system";
 import type { HubsSystems } from "aframe";
-import { Camera, Clock, Scene, WebGLRenderer } from "three";
+import { Camera, Scene, WebGLRenderer } from "three";
 import { HubsWorld } from "../app";
 
 declare global {
@@ -63,12 +63,9 @@ declare global {
 const timeSystem = (world: HubsWorld) => {
   const { time } = world;
   const now = performance.now();
-  const delta = now - time.then;
-  time.delta = delta;
-  time.elapsed += delta;
-  time.then = now;
+  time.delta = now - time.elapsed;
+  time.elapsed = now;
   time.tick++;
-  return world;
 };
 
 // NOTE keeping this around since many things index into it to get a reference to a system. This will
@@ -122,14 +119,7 @@ AFRAME.registerSystem("hubs-systems", {
   }
 });
 
-export function mainTick(
-  _rafTime: DOMHighResTimeStamp,
-  xrFrame: XRFrame,
-  renderClock: Clock,
-  renderer: WebGLRenderer,
-  scene: Scene,
-  camera: Camera
-) {
+export function mainTick(xrFrame: XRFrame, renderer: WebGLRenderer, scene: Scene, camera: Camera) {
   const world = APP.world;
 
   const sceneEl = AFRAME.scenes[0];
@@ -139,12 +129,9 @@ export function mainTick(
   // NOTE this is now blocking execution of all components/systems, make sure that's not an issue
   if (!hubsSystems.DOMContentDidLoad) return;
 
-  // NOTE now is probably a good time to do this, and consolidate with timeSystem
-  // TODO we should probably be using time from the raf loop itself
-  const dt = renderClock.getDelta() * 1000;
-  const t = renderClock.elapsedTime * 1000;
-
   timeSystem(world);
+  const t = world.time.elapsed;
+  const dt = world.time.delta;
 
   // Tick AFrame components
   const tickComponents = sceneEl.behaviors.tick;

--- a/src/systems/userinput/devices/webxr-controller.js
+++ b/src/systems/userinput/devices/webxr-controller.js
@@ -21,8 +21,8 @@ export class WebXRControllerDevice {
     this.position = new THREE.Vector3();
     this.orientation = new THREE.Quaternion();
   }
-  write(frame, scene, referenceSpace) {
-    if (!referenceSpace || !this.gamepad) return;
+  write(frame, xrFrame, referenceSpace) {
+    if (!referenceSpace || !xrFrame || !this.gamepad) return;
 
     const hand = this.gamepad.hand || "right";
     const path = paths.device.webxr[hand];
@@ -79,16 +79,12 @@ export class WebXRControllerDevice {
 
     frame.setPose(path.pose, this.pose);
 
-    const pose = scene.frame.getPose(this.gamepad.targetRaySpace, referenceSpace);
+    const pose = xrFrame.getPose(this.gamepad.targetRaySpace, referenceSpace);
 
     if (pose && pose.transform.position && pose.transform.orientation) {
       this.position.copy(pose.transform.position);
       this.orientation.copy(pose.transform.orientation);
-      this.matrix.compose(
-        this.position,
-        this.orientation,
-        ONES
-      );
+      this.matrix.compose(this.position, this.orientation, ONES);
       this.matrix.multiply(hand === "left" ? LEFT_HAND_OFFSET : RIGHT_HAND_OFFSET);
       frame.setMatrix4(path.matrix, this.matrix);
     }

--- a/src/systems/userinput/userinput.js
+++ b/src/systems/userinput/userinput.js
@@ -207,25 +207,25 @@ AFRAME.registerSystem("userinput", {
       generation: 0,
       values: {},
       generations: {},
-      get: function(path) {
+      get: function (path) {
         if (this.generations[path] !== this.generation) return undefined;
         return this.values[path];
       },
-      setValueType: function(path, value) {
+      setValueType: function (path, value) {
         this.values[path] = value;
         this.generations[path] = this.generation;
       },
-      setVector2: function(path, a, b) {
+      setVector2: function (path, a, b) {
         const value = this.values[path] || [];
         value[0] = a;
         value[1] = b;
         this.values[path] = value;
         this.generations[path] = this.generation;
       },
-      setPose: function(path, pose) {
+      setPose: function (path, pose) {
         this.setValueType(path, pose);
       },
-      setMatrix4: function(path, mat4) {
+      setMatrix4: function (path, mat4) {
         // Should we assume the incoming mat4 is safe to store instead of copying values?
         const value = this.values[path] || new THREE.Matrix4();
         value.copy(mat4);
@@ -470,7 +470,7 @@ AFRAME.registerSystem("userinput", {
     }
   },
 
-  tick2() {
+  tick2(xrFrame) {
     this.frame.generation += 1;
     const registeredMappingsChanged = this.registeredMappingsChanged;
     if (registeredMappingsChanged) {
@@ -516,7 +516,7 @@ AFRAME.registerSystem("userinput", {
     }
 
     for (let i = 0; i < this.activeDevices.items.length; i++) {
-      this.activeDevices.items[i].write(this.frame, this.el.sceneEl, this.xrReferenceSpace);
+      this.activeDevices.items[i].write(this.frame, xrFrame, this.xrReferenceSpace);
     }
 
     for (let i = 0; i < this.sortedBindings.length; i++) {

--- a/src/utils/preload.ts
+++ b/src/utils/preload.ts
@@ -1,7 +1,6 @@
 const preloads: Promise<any>[] = [];
 
 export function waitForPreloads() {
-  console.log(preloads.length);
   return Promise.all(preloads);
 }
 

--- a/types/aframe.d.ts
+++ b/types/aframe.d.ts
@@ -1,7 +1,7 @@
 declare module "aframe" {
   import { Scene, Clock, Object3D, Mesh } from "three";
 
-  export interface AElement extends HTMLElement {
+  interface AElement extends HTMLElement {
     object3D: Object3D;
     object3DMap: {
       mesh: Mesh;
@@ -9,6 +9,61 @@ declare module "aframe" {
     };
     getObject3D(string): Object3D?;
   }
+
+  interface ASystem {
+    init?();
+    tick?(t: number, dt: number);
+    remove?();
+  }
+
+  interface HubsSystems extends ASystem {
+    cursorTogglingSystem: CursorTogglingSystem;
+    interactionSfxSystem: InteractionSfxSystem;
+    superSpawnerSystem: SuperSpawnerSystem;
+    cursorTargettingSystem: CursorTargettingSystem;
+    positionAtBorderSystem: PositionAtBorderSystem;
+    physicsSystem: PhysicsSystem;
+    twoPointStretchingSystem: TwoPointStretchingSystem;
+    holdableButtonSystem: HoldableButtonSystem;
+    hoverButtonSystem: HoverButtonSystem;
+    hoverMenuSystem: HoverMenuSystem;
+    hapticFeedbackSystem: HapticFeedbackSystem;
+    audioSystem: AudioSystem;
+    soundEffectsSystem: SoundEffectsSystem;
+    scenePreviewCameraSystem: ScenePreviewCameraSystem;
+    spriteSystem: SpriteSystem;
+    cameraSystem: CameraSystem;
+    drawingMenuSystem: DrawingMenuSystem;
+    characterController: CharacterControllerSystem;
+    waypointSystem: WaypointSystem;
+    cursorPoseTrackingSystem: CursorPoseTrackingSystem;
+    menuAnimationSystem: MenuAnimationSystem;
+    audioSettingsSystem: AudioSettingsSystem;
+    animationMixerSystem: AnimationMixerSystem;
+    boneVisibilitySystem: BoneVisibilitySystem;
+    uvScrollSystem: UVScrollSystem;
+    shadowSystem: ShadowSystem;
+    inspectYourselfSystem: InspectYourselfSystem;
+    emojiSystem: EmojiSystem;
+    audioZonesSystem: AudioZonesSystem;
+    gainSystem: GainSystem;
+    environmentSystem: EnvironmentSystem;
+    nameTagSystem: NameTagVisibilitySystem;
+  }
+
+  interface UserInputSystem extends ASystem {
+    get<T>(path: string): T;
+    toggleSet(set: string, value: boolean): T;
+    tick2();
+  }
+
+  interface InteractionSystem extends ASystem {
+    getActiveIntersection(): AElement;
+    isHoldingAnything(pred: (AEntity) => boolean): boolean;
+    isHeld(el: AElement): boolean;
+    updateLegacyState();
+  }
+
   interface AScene extends AElement {
     object3D: Scene;
     renderStarted: boolean;
@@ -16,5 +71,18 @@ declare module "aframe" {
     isPlaying: boolean;
     frame: XRFrame;
     clock: Clock;
+    systems: {
+      "hubs-systems": HubsSystems;
+      userinput: UserInputSystem;
+      /** @deprecated see bit-interaction-system */
+      interaction: InteractionSystem;
+    };
+  }
+
+  declare global {
+    const AFRAME: {
+      registerSystem: (name: string, def: ASystem) => void;
+      scenes: AScene[];
+    };
   }
 }

--- a/types/aframe.d.ts
+++ b/types/aframe.d.ts
@@ -68,7 +68,7 @@ declare module "aframe" {
   interface UserInputSystem extends ASystem {
     get<T>(path: string): T;
     toggleSet(set: string, value: boolean): T;
-    tick2();
+    tick2(xrFrame: XRFrame);
   }
 
   interface InteractionSystem extends ASystem {
@@ -83,7 +83,6 @@ declare module "aframe" {
     renderStarted: boolean;
     tick(time: number, delta: number): void;
     isPlaying: boolean;
-    frame: XRFrame;
     clock: Clock;
     behaviors: {
       tick: AComponent[];

--- a/types/aframe.d.ts
+++ b/types/aframe.d.ts
@@ -10,10 +10,22 @@ declare module "aframe" {
     getObject3D(string): Object3D?;
   }
 
+  type FnTick = (t: number, dt: number) => void;
+
   interface ASystem {
-    init?();
-    tick?(t: number, dt: number);
-    remove?();
+    init();
+    tick: FnTick;
+    tock: FnTick;
+    remove();
+    el: AScene;
+  }
+
+  interface AComponent {
+    init();
+    tick: FnTick;
+    tock: FnTick;
+    remove();
+    el: AScene;
   }
 
   interface HubsSystems extends ASystem {
@@ -49,6 +61,8 @@ declare module "aframe" {
     gainSystem: GainSystem;
     environmentSystem: EnvironmentSystem;
     nameTagSystem: NameTagVisibilitySystem;
+
+    DOMContentDidLoad: bool;
   }
 
   interface UserInputSystem extends ASystem {
@@ -71,6 +85,11 @@ declare module "aframe" {
     isPlaying: boolean;
     frame: XRFrame;
     clock: Clock;
+    behaviors: {
+      tick: AComponent[];
+      tock: AComponent[];
+    };
+    systemNames: Array<keyof AScene["systems"]>;
     systems: {
       "hubs-systems": HubsSystems;
       userinput: UserInputSystem;
@@ -81,7 +100,7 @@ declare module "aframe" {
 
   declare global {
     const AFRAME: {
-      registerSystem: (name: string, def: ASystem) => void;
+      registerSystem(name: string, def: Partial<ASystem>);
       scenes: AScene[];
     };
   }


### PR DESCRIPTION
This PR attempts to consolidate everything that happens in a frame into 1 spot so its easy to see the order things are executing in. It also cleans up several pending TODOs around it, namely unifying the various timers we were using and getting rid of some more globals being stored on a-scene. This doesn't yet attempt to handle the TODOs in bit-camera-sytem around turning off `scene.autoUpdate` (#5323). That feels like it warrants its own PR just because "matrix update bugs" are sneaky.

This is probably easiest to review commit-by-commit since I tried to break them down into logical chunks and also the intermediate commits had NOTES that might be useful to read.