### PR TITLE
Prepare for local orchestration

### DIFF
--- a/admin/webpack.config.js
+++ b/admin/webpack.config.js
@@ -86,6 +86,7 @@ module.exports = (env, argv) => {
   const defaultHostName = "hubs.local";
   const host = process.env.HOST_IP || defaultHostName;
 
+  const internalHostname = process.env.INTERNAL_HOSTNAME || "hubs.local";
   return {
     cache: {
       type: "filesystem"
@@ -135,7 +136,7 @@ module.exports = (env, argv) => {
       },
       host: process.env.HOST_IP || "0.0.0.0",
       port: process.env.PORT || "8989",
-      allowedHosts: [host],
+      allowedHosts: [host, internalHostname],
       headers: {
         "Access-Control-Allow-Origin": "*"
       },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -285,6 +285,7 @@ module.exports = async (env, argv) => {
     // .replaceAll("connect-src", "connect-src https://example.com");
   }
 
+  const internalHostname = process.env.INTERNAL_HOSTNAME || "hubs.local";
   return {
     cache: {
       type: "filesystem"
@@ -350,7 +351,7 @@ module.exports = async (env, argv) => {
       },
       host: "0.0.0.0",
       port: 8080,
-      allowedHosts: [host, "hubs.local"],
+      allowedHosts: [host, internalHostname],
       headers: devServerHeaders,
       hot: liveReload,
       liveReload: liveReload,


### PR DESCRIPTION
Why
---
An “Invalid Host header” error message appears in the browser when Hubs is orchestrated with Docker Compose

What
----
Allow internal hostname to be supplied by OS var