### PR TITLE
Fix some lint warnings

### DIFF
--- a/src/change-hub.js
+++ b/src/change-hub.js
@@ -1,4 +1,3 @@
-/* global APP*/
 import { getReticulumFetchUrl, hubUrl } from "./utils/phoenix-utils";
 import { updateEnvironmentForHub, getSceneUrlForHub, updateUIForHub, remountUI } from "./hub";
 

--- a/src/components/emoji.js
+++ b/src/components/emoji.js
@@ -1,4 +1,3 @@
-/* global performance */
 import { addMedia } from "../utils/media-utils";
 import { SOUND_SPAWN_EMOJI } from "../systems/sound-effects-system";
 import emoji0Particle from "../assets/images/emojis/emoji_0.png";

--- a/src/components/floaty-object.js
+++ b/src/components/floaty-object.js
@@ -1,7 +1,6 @@
 import { addComponent } from "bitecs";
 import { FloatyObject } from "../bit-components";
 import { FLOATY_OBJECT_FLAGS } from "../systems/floaty-object-system";
-/* global AFRAME */
 
 AFRAME.registerComponent("floaty-object", {
   schema: {

--- a/src/components/media-video.js
+++ b/src/components/media-video.js
@@ -1,4 +1,3 @@
-/* global performance THREE AFRAME NAF MediaStream setTimeout */
 import configs from "../utils/configs";
 import audioIcon from "../assets/images/audio.png";
 import { paths } from "../systems/userinput/paths";

--- a/src/components/networked-counter.js
+++ b/src/components/networked-counter.js
@@ -1,4 +1,3 @@
-/* global AFRAME performance */
 /**
  * Limits networked interactables to a maximum number at any given time
  * @namespace network

--- a/src/components/owned-object-cleanup-timeout.js
+++ b/src/components/owned-object-cleanup-timeout.js
@@ -1,4 +1,3 @@
-/* global performance */
 AFRAME.registerComponent("owned-object-cleanup-timeout", {
   schema: {
     ttl: { default: 0 }

--- a/src/components/owned-object-limiter.js
+++ b/src/components/owned-object-limiter.js
@@ -1,4 +1,3 @@
-/* global AFRAME NAF performance */
 AFRAME.registerComponent("owned-object-limiter", {
   schema: {
     counter: { type: "selector" }

--- a/src/components/set-unowned-body-kinematic.js
+++ b/src/components/set-unowned-body-kinematic.js
@@ -1,4 +1,3 @@
-/* global NAF */
 const COLLISION_LAYERS = require("../constants").COLLISION_LAYERS;
 
 AFRAME.registerComponent("set-unowned-body-kinematic", {

--- a/src/components/slice9.js
+++ b/src/components/slice9.js
@@ -1,4 +1,3 @@
-/* global AFRAME */
 import { textureLoader } from "../utils/media-utils";
 
 import actionButtonSrc from "../assets/hud/action_button.9.png";

--- a/src/components/super-spawner.js
+++ b/src/components/super-spawner.js
@@ -1,4 +1,3 @@
-/* global require AFRAME THREE setTimeout clearTimeout */
 import { addMedia } from "../utils/media-utils";
 import { waitForEvent } from "../utils/async-utils";
 import { ObjectContentOrigins } from "../object-types";

--- a/src/components/tools/networked-drawing.js
+++ b/src/components/tools/networked-drawing.js
@@ -1,4 +1,3 @@
-/* global THREE */
 /**
  * Networked Drawing
  * Creates procedurally generated 'lines' (or tubes) that are networked.

--- a/src/react-components/banner/Banner.js
+++ b/src/react-components/banner/Banner.js
@@ -62,7 +62,7 @@ const Banner = () => {
     newsletterSuccess();
   };
 
-  const onSubmit = useCallback(async data => {
+  const onSubmit = async data => {
     const url = "https://basket.mozilla.org/news/subscribe/";
     const body =
       "email=" +
@@ -88,7 +88,7 @@ const Banner = () => {
       console.error(error);
       newsletterError();
     }
-  });
+  };
 
   /**
    * Emain input change
@@ -105,7 +105,7 @@ const Banner = () => {
    */
   const onConfirm = useCallback(() => {
     setConfirm(state => !state);
-  });
+  }, []);
 
   /**
    * Checkbox Label

--- a/src/systems/app-mode.js
+++ b/src/systems/app-mode.js
@@ -1,5 +1,3 @@
-/* global AFRAME */
-
 /**
  * Toggle visibility of an entity based on if the user is in vr mode or not
  * @namespace vr-mode

--- a/src/systems/interactions.js
+++ b/src/systems/interactions.js
@@ -1,4 +1,3 @@
-/* global AFRAME */
 import { paths } from "./userinput/paths";
 import { waitForDOMContentLoaded } from "../utils/async-utils";
 import { isTagged } from "../components/tags";

--- a/src/systems/sound-effects-system.js
+++ b/src/systems/sound-effects-system.js
@@ -1,4 +1,3 @@
-/* global fetch THREE */
 import URL_TICK from "../assets/sfx/tick.mp3";
 import URL_TELEPORT_LOOP from "../assets/sfx/teleport-loop.mp3";
 import URL_QUICK_TURN from "../assets/sfx/quickTurn.mp3";

--- a/src/systems/sprites.js
+++ b/src/systems/sprites.js
@@ -1,5 +1,3 @@
-/* global AFRAME THREE */
-
 // See doc/spritesheet-generation.md for information about this spritesheet
 import spritesheetAction from "../assets/images/spritesheets/sprite-system-action-spritesheet.json";
 import spritesheetNotice from "../assets/images/spritesheets/sprite-system-notice-spritesheet.json";

--- a/src/systems/two-point-stretching-system.js
+++ b/src/systems/two-point-stretching-system.js
@@ -1,4 +1,3 @@
-/* global THREE AFRAME */
 const COLLISION_LAYERS = require("../constants").COLLISION_LAYERS;
 const COLLISION_FILTER_MASK_HANDS = { collisionFilterMask: COLLISION_LAYERS.HANDS };
 export const distanceBetweenStretchers = (() => {


### PR DESCRIPTION
Fix some of the obvious linter warnings that came with the recent node/npm upgrade, to cut down on noise in github PRs. The `useCallback` in banner.js was ineffective, since it didn't list dependencies, so the behavior is unaffected there.