### PR TITLE
Add Admin Panel UI for account deletion

### DIFF
--- a/admin/src/react-components/account-edit-toolbar.js
+++ b/admin/src/react-components/account-edit-toolbar.js
@@ -1,0 +1,107 @@
+import React, { useState } from "react";
+import { Toolbar, SaveButton } from "react-admin";
+import { withStyles } from "@material-ui/core/styles";
+import Button from "@material-ui/core/Button";
+import { Dialog, DialogContent, DialogContentText, DialogActions } from "@material-ui/core";
+
+const accountEditToolbarStyles = {
+  spaceBetween: { justifyContent: "space-between" },
+  dialogActions: { padding: "0 5px" }
+};
+
+const DeleteStates = Object.freeze({
+  Confirming: Symbol("confirming"),
+  Deleting: Symbol("deleting"),
+  Succeeded: Symbol("succeeded"),
+  Failed: Symbol("failed")
+});
+
+export const AccountEditToolbar = withStyles(accountEditToolbarStyles)(props => {
+  const { classes, ...other } = props;
+  const { Confirming, Deleting, Succeeded, Failed } = DeleteStates;
+  const [openConfirmationDialog, setOpenConfirmationDialog] = useState(false);
+  const [deleteState, setDeleteState] = useState(Confirming);
+
+  const onDeleteAccount = async () => {
+    setDeleteState(Deleting);
+
+    try {
+      const resp = await fetch(`/api/v1/accounts/${props.id}`, {
+        method: "DELETE",
+        headers: {
+          "content-type": "application/json",
+          authorization: `bearer ${window.APP.store.state.credentials.token}`
+        }
+      });
+
+      setDeleteState(resp.ok ? Succeeded : Failed);
+    } catch {
+      setDeleteState(Failed);
+    }
+  };
+
+  return (
+    <Toolbar {...other} className={`${classes.spaceBetween}`}>
+      <SaveButton />
+
+      {!props.record.is_admin && (
+        <Button label="Delete" onClick={() => setOpenConfirmationDialog(true)} variant="outlined">
+          Delete
+        </Button>
+      )}
+
+      <Dialog open={openConfirmationDialog}>
+        <DialogContent>
+          <DialogContentText>
+            {(() => { 
+              switch (deleteState) {
+                case Confirming:
+                  return (
+                    <>
+                      Are you sure you want to delete account {props.id}?<br />
+                      <br />
+                      <b>WARNING!</b> This account will be permanently deleted, including all its scenes, assets, avatars,
+                      rooms and files. <b>This cannot be undone.</b>
+                    </>
+                  )
+                case Deleting:
+                  return <>Deleting account {props.id}...</>
+                case Succeeded:
+                  return <>Successfully deleted account {props.id}.</>
+                case Failed:
+                  return <>Failed to delete account {props.id}.</>
+              }
+            })()}
+          </DialogContentText>
+        </DialogContent>
+
+        <DialogActions className={`${classes.dialogActions} ${classes.spaceBetween}`}>
+          {[Succeeded, Failed].includes(deleteState) && (
+            <Button
+              variant="outlined"
+              onClick={() => {
+                setOpenConfirmationDialog(false);
+                if (deleteState === Succeeded) {
+                  props.history.push("/accounts");
+                }
+              }}
+            >
+              Okay
+            </Button>
+          )}
+
+          {deleteState === Confirming && (
+            <>
+              <Button variant="outlined" onClick={onDeleteAccount}>
+                Yes, permanently delete this account
+              </Button>
+              <Button variant="outlined" onClick={() => setOpenConfirmationDialog(false)}>
+                Cancel
+              </Button>
+            </>
+          )}
+        </DialogActions>
+      </Dialog>
+    </Toolbar>
+  );
+});

--- a/admin/src/react-components/accounts.js
+++ b/admin/src/react-components/accounts.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { IdentityEditLink, IdentityCreateLink } from "./fields";
+import { AccountEditToolbar } from "./account-edit-toolbar";
 import { withStyles } from "@material-ui/core/styles";
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
@@ -10,7 +11,6 @@ import Typography from "@material-ui/core/Typography";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import Snackbar from "@material-ui/core/Snackbar";
 import SnackbarContent from "@material-ui/core/SnackbarContent";
-import { ToolbarWithoutDelete } from "./toolbar-without-delete";
 
 import {
   BooleanField,
@@ -234,7 +234,7 @@ export const AccountList = withStyles(styles)(
                 </form>
               </CardContent>
             </Card>
-            <List {...other} filters={<AccountFilter />}>
+            <List {...other} filters={<AccountFilter />} bulkActionButtons={false}>
               <Datagrid>
                 <TextField source="id" />
                 <DateField source="inserted_at" />
@@ -264,7 +264,7 @@ export const AccountEdit = withStyles(styles)(props => {
 
   return (
     <Edit {...other}>
-      <SimpleForm toolbar={<ToolbarWithoutDelete />}>
+      <SimpleForm toolbar={<AccountEditToolbar {...other} />}>
         <TextField label="Account ID" source="id" />
         <BooleanInput source="is_admin" />
         <SelectInput


### PR DESCRIPTION
Adds a delete button to the account edit screen in the admin panel. Includes a confirmation dialog and states. Also removes the bulk delete capability from the account list.

Goes with https://github.com/mozilla/reticulum/pull/628