### PR TITLE
Fix avatar page not loading

### DIFF
--- a/src/systems/netcode.js
+++ b/src/systems/netcode.js
@@ -87,11 +87,16 @@ const pendingJoins = [];
 const pendingParts = [];
 
 // TODO messaging, joining, and leaving should not be using NAF
-NAF.connection.subscribeToDataChannel("nn", function (fromClientId, _dataType, data) {
-  data.fromClientId = fromClientId;
-  pendingMessages.push(data);
-});
-
+if (!window.NAF) {
+  console.warn(
+    "NAF is currently required for the new networking system but is not loaded. This is only expected on secondary pages like avatar.html."
+  );
+} else {
+  NAF.connection.subscribeToDataChannel("nn", function (fromClientId, _dataType, data) {
+    data.fromClientId = fromClientId;
+    pendingMessages.push(data);
+  });
+}
 document.addEventListener("DOMContentLoaded", function () {
   document.body.addEventListener("clientConnected", function ({ detail: { clientId } }) {
     console.log("client joined", clientId);


### PR DESCRIPTION
Avatar page fails to load because a roundabout dependency chain[^1] ends up loading netcode.js, which expects NAF to exist. Untangling that is a bit difficult, but also we don't want to be using NAF in the new netcode anyway, so for now just add a check to prevent the page from failing to load.

The real fix is to continue removing use of globals like APP and NAF and to figure out a better solution for system initialization than directly executing code in the module.

[^1]: **avatar.js** loads **app.ts** to define the `APP` global, since various things rely on it. **app.ts** needs `mainTick` from **hubs-systems.ts** which in turns ends up also loading all the systems code, including **netcode.ts** which immediately executes some code relying on `NAF` global.