### PR TITLE
Fixes #4877

### DIFF
--- a/src/change-hub.js
+++ b/src/change-hub.js
@@ -25,7 +25,7 @@ function loadRoomObjects(hubId) {
   objectsScene.appendChild(objectsEl);
 }
 
-export async function changeHub(hubId, addToHistory = true) {
+export async function changeHub(hubId, addToHistory = true, waypoint = null) {
   if (hubId === APP.hub.hub_id) {
     console.log("Change hub called with the current hub id. This is a noop.");
     return;
@@ -46,7 +46,7 @@ export async function changeHub(hubId, addToHistory = true) {
   const hub = data.hubs[0];
 
   if (addToHistory) {
-    window.history.pushState(null, null, hubUrl(hubId, {}, hub.slug));
+    window.history.pushState(null, null, hubUrl(hubId, {}, hub.slug, waypoint));
   }
 
   APP.hub = hub;

--- a/src/components/open-media-button.js
+++ b/src/components/open-media-button.js
@@ -61,8 +61,9 @@ AFRAME.registerComponent("open-media-button", {
           // move to waypoint w/o writing to history
           window.history.replaceState(null, null, window.location.href.split("#")[0] + url.hash);
         } else if (APP.store.state.preferences.fastRoomSwitching && isLocalHubsUrl(this.src)) {
+          const waypoint = url.hash && url.hash.substring(1);
           // move to new room without page load or entry flow
-          changeHub(hubId);
+          changeHub(hubId, true, waypoint);
         } else {
           await exitImmersive();
           location.href = this.src;

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -13,7 +13,7 @@ export function isLocalClient() {
   return hasReticulumServer() && document.location.host !== configs.RETICULUM_SERVER;
 }
 
-export function hubUrl(hubId, extraParams, slug) {
+export function hubUrl(hubId, extraParams, slug, waypoint) {
   if (!hubId) {
     if (isLocalClient()) {
       hubId = new URLSearchParams(location.search).get("hub_id");
@@ -35,6 +35,10 @@ export function hubUrl(hubId, extraParams, slug) {
     if (extraParams.hasOwnProperty(key)) {
       url.searchParams.set(key, extraParams[key]);
     }
+  }
+
+  if (waypoint) {
+    url.hash = waypoint;
   }
 
   return url;


### PR DESCRIPTION
This prevents losing the url hash (waypoint name) while moving to a new hub using fast switching