### PR TITLE
Upgrade three-gltf-extensions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "semver": "^7.3.2",
         "three": "github:mozillareality/three.js#56e7c46d991cc16bff82bdbb03c7bfba4620567f",
         "three-ammo": "github:mozillareality/three-ammo",
-        "three-gltf-extensions": "^0.0.12",
+        "three-gltf-extensions": "^0.0.13",
         "three-mesh-bvh": "^0.3.7",
         "three-pathfinding": "^1.1.0",
         "three-to-ammo": "github:infinitelee/three-to-ammo",
@@ -29122,9 +29122,9 @@
       }
     },
     "node_modules/three-gltf-extensions": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/three-gltf-extensions/-/three-gltf-extensions-0.0.12.tgz",
-      "integrity": "sha512-TDmszo0zMUZYSCgGryILQkmEOoxXdSosqfxY2sGb/yFL9wpLIjKCTT0JGNKf7RY9weQRum28mB8sC7+V8rh79Q=="
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/three-gltf-extensions/-/three-gltf-extensions-0.0.13.tgz",
+      "integrity": "sha512-xVvDBtFEMPwfPY22O1nW/S0DQQRLPaXqptiCSXcxw2qb7uUaClXH0NbgWgyf7mztHoDWsr362rZTBM6AMzmlgg=="
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.3.7",
@@ -54297,9 +54297,9 @@
       "requires": {}
     },
     "three-gltf-extensions": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/three-gltf-extensions/-/three-gltf-extensions-0.0.12.tgz",
-      "integrity": "sha512-TDmszo0zMUZYSCgGryILQkmEOoxXdSosqfxY2sGb/yFL9wpLIjKCTT0JGNKf7RY9weQRum28mB8sC7+V8rh79Q=="
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/three-gltf-extensions/-/three-gltf-extensions-0.0.13.tgz",
+      "integrity": "sha512-xVvDBtFEMPwfPY22O1nW/S0DQQRLPaXqptiCSXcxw2qb7uUaClXH0NbgWgyf7mztHoDWsr362rZTBM6AMzmlgg=="
     },
     "three-mesh-bvh": {
       "version": "0.3.7",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "semver": "^7.3.2",
     "three": "github:mozillareality/three.js#56e7c46d991cc16bff82bdbb03c7bfba4620567f",
     "three-ammo": "github:mozillareality/three-ammo",
-    "three-gltf-extensions": "^0.0.12",
+    "three-gltf-extensions": "^0.0.13",
     "three-mesh-bvh": "^0.3.7",
     "three-pathfinding": "^1.1.0",
     "three-to-ammo": "github:infinitelee/three-to-ammo",


### PR DESCRIPTION
to ignore LOD for SkinnedMesh as workaround

Refer to https://github.com/takahirox/three-gltf-extensions/commit/b4737a2b2d855697b4b7391d25786edf2d946223 for the update.

From #5781