### PR TITLE
Load scenes with bitECS

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -26,6 +26,7 @@ import { createEffectsComposer } from "./effects";
 import { DialogAdapter } from "./naf-dialog-adapter";
 import { mainTick } from "./systems/hubs-systems";
 import { waitForPreloads } from "./utils/preload";
+import SceneEntryManager from "./scene-entry-manager";
 
 declare global {
   interface Window {
@@ -57,6 +58,7 @@ export class App {
   scene?: AScene;
   hubChannel?: HubChannel;
   mediaDevicesManager?: MediaDevicesManager;
+  entryManager?: SceneEntryManager;
 
   store = new Store();
   mediaSearchStore = new MediaSearchStore();

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -131,6 +131,9 @@ export const MediaLoader = defineComponent({
 });
 MediaLoader.src[$isStringType] = true;
 
+export const SceneLoader = defineComponent({ src: Types.ui32 });
+SceneLoader.src[$isStringType] = true;
+
 export const TextureCacheKey = defineComponent({
   src: Types.ui32,
   version: Types.ui8

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -132,6 +132,7 @@ export const MediaLoader = defineComponent({
 });
 MediaLoader.src[$isStringType] = true;
 
+export const SceneRoot = defineComponent();
 export const SceneLoader = defineComponent({ src: Types.ui32 });
 SceneLoader.src[$isStringType] = true;
 

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -47,6 +47,7 @@ export const NetworkedTransform = defineComponent({
 export const AEntity = defineComponent();
 export const Object3DTag = defineComponent();
 export const GLTFModel = defineComponent();
+export const DirectionalLight = defineComponent();
 export const CursorRaycastable = defineComponent();
 export const RemoteHoverTarget = defineComponent();
 export const NotRemoteHoverTarget = defineComponent();

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -138,10 +138,10 @@ export const NavMesh = defineComponent();
 export const SceneLoader = defineComponent({ src: Types.ui32 });
 SceneLoader.src[$isStringType] = true;
 
-export const Image = defineComponent({
+export const MediaImage = defineComponent({
   cacheKey: Types.ui32
 });
-Image.cacheKey[$isStringType] = true;
+MediaImage.cacheKey[$isStringType] = true;
 
 export const MediaVideo = defineComponent({
   autoPlay: Types.ui8

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -33,6 +33,7 @@ export const MediaFrame = defineComponent({
   previewingNid: Types.eid
 });
 export const Text = defineComponent();
+export const ReflectionProbe = defineComponent();
 export const Slice9 = defineComponent({
   insets: [Types.ui32, 4],
   size: [Types.f32, 2]
@@ -136,11 +137,10 @@ export const SceneRoot = defineComponent();
 export const SceneLoader = defineComponent({ src: Types.ui32 });
 SceneLoader.src[$isStringType] = true;
 
-export const TextureCacheKey = defineComponent({
-  src: Types.ui32,
-  version: Types.ui8
+export const Image = defineComponent({
+  cacheKey: Types.ui32
 });
-TextureCacheKey.src[$isStringType] = true;
+Image.cacheKey[$isStringType] = true;
 
 export const MediaVideo = defineComponent({
   autoPlay: Types.ui8
@@ -165,3 +165,6 @@ export const VideoMenu = defineComponent({
 export const AudioEmitter = defineComponent();
 export const AudioSettingsChanged = defineComponent();
 export const Deletable = defineComponent();
+
+export const EnvironmentSettings = defineComponent();
+EnvironmentSettings.map = new Map();

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -134,6 +134,7 @@ export const MediaLoader = defineComponent({
 MediaLoader.src[$isStringType] = true;
 
 export const SceneRoot = defineComponent();
+export const NavMesh = defineComponent();
 export const SceneLoader = defineComponent({ src: Types.ui32 });
 SceneLoader.src[$isStringType] = true;
 

--- a/src/bit-systems/media-loading.js
+++ b/src/bit-systems/media-loading.js
@@ -116,7 +116,11 @@ function* loadMedia(world, eid) {
   let media;
   try {
     const urlData = yield resolveMediaInfo(src);
-    media = yield* loaderForMediaType[urlData.mediaType](world, urlData);
+    const loader = loaderForMediaType[urlData.mediaType];
+    if (!loader) {
+      throw new Error(`Unsupported media type: ${urlData.mediaType}`);
+    }
+    media = yield* loader(world, urlData);
   } catch (e) {
     console.error(e);
     media = renderAsEntity(world, ErrorObject());

--- a/src/bit-systems/media-loading.js
+++ b/src/bit-systems/media-loading.js
@@ -23,8 +23,7 @@ export const MEDIA_LOADER_FLAGS = {
   RESIZE: 1 << 1
 };
 
-function assignNetworkIds(world, mediaEid, mediaLoaderEid) {
-  const rootNid = APP.getString(Networked.id[mediaLoaderEid]);
+export function assignNetworkIds(world, rootNid, mediaEid, mediaLoaderEid) {
   let i = 0;
   world.eid2obj.get(mediaEid).traverse(function (obj) {
     if (obj.eid && hasComponent(world, Networked, obj.eid)) {
@@ -99,7 +98,8 @@ function* animateScale(world, media) {
   });
 }
 
-function add(world, child, parent) {
+// TODO: Move to bit utils and rename
+export function add(world, child, parent) {
   const parentObj = world.eid2obj.get(parent);
   const childObj = world.eid2obj.get(child);
   parentObj.add(childObj);
@@ -129,7 +129,7 @@ function* loadMedia(world, eid) {
 function* loadAndAnimateMedia(world, eid, signal) {
   const { value: media, canceled } = yield* cancelable(loadMedia(world, eid), signal);
   if (!canceled) {
-    assignNetworkIds(world, media, eid);
+    assignNetworkIds(world, APP.getString(Networked.id[eid]), media, eid);
     resizeAndRecenter(world, media, eid);
     add(world, media, eid);
     yield* animateScale(world, media);

--- a/src/bit-systems/media-loading.js
+++ b/src/bit-systems/media-loading.js
@@ -20,7 +20,8 @@ const loaderForMediaType = {
 
 export const MEDIA_LOADER_FLAGS = {
   RECENTER: 1 << 0,
-  RESIZE: 1 << 1
+  RESIZE: 1 << 1,
+  ANIMATE_LOAD: 1 << 2
 };
 
 export function assignNetworkIds(world, rootNid, mediaEid, mediaLoaderEid) {
@@ -146,7 +147,9 @@ function* loadAndAnimateMedia(world, eid, signal) {
     assignNetworkIds(world, APP.getString(Networked.id[eid]), media, eid);
     resizeAndRecenter(world, media, eid);
     add(world, media, eid);
-    yield* animateScale(world, media);
+    if (MediaLoader.flags[eid] & MEDIA_LOADER_FLAGS.ANIMATE_LOAD) {
+      yield* animateScale(world, media);
+    }
     removeComponent(world, MediaLoader, eid);
   }
 }

--- a/src/bit-systems/media-loading.js
+++ b/src/bit-systems/media-loading.js
@@ -4,7 +4,7 @@ import { easeOutQuadratic } from "../utils/easing";
 import { loadImage } from "../utils/load-image";
 import { loadVideo } from "../utils/load-video";
 import { loadModel } from "../utils/load-model";
-import { MediaType, resolveMediaInfo } from "../utils/media-utils";
+import { MediaType, mediaTypeName, resolveMediaInfo } from "../utils/media-utils";
 import { defineQuery, enterQuery, exitQuery, hasComponent, removeComponent, removeEntity } from "bitecs";
 import { MediaLoader, Networked } from "../bit-components";
 import { crTimeout, crClearTimeout, cancelable, coroutine, makeCancelable } from "../utils/coroutine";
@@ -105,6 +105,16 @@ export function add(world, child, parent) {
   parentObj.add(childObj);
 }
 
+class UnsupportedMediaTypeError extends Error {
+  constructor(eid, mediaType) {
+    super();
+    this.name = "UnsupportedMediaTypeError";
+    this.message = `Cannot load media for entity ${eid}. No loader for media type ${mediaType} (${mediaTypeName(
+      mediaType
+    )}).`;
+  }
+}
+
 function* loadMedia(world, eid) {
   let loadingObjEid = 0;
   const addLoadingObjectTimeout = crTimeout(() => {
@@ -118,7 +128,7 @@ function* loadMedia(world, eid) {
     const urlData = yield resolveMediaInfo(src);
     const loader = loaderForMediaType[urlData.mediaType];
     if (!loader) {
-      throw new Error(`Unsupported media type: ${urlData.mediaType}`);
+      throw new UnsupportedMediaTypeError(eid, urlData.mediaType);
     }
     media = yield* loader(world, urlData);
   } catch (e) {

--- a/src/bit-systems/media-loading.js
+++ b/src/bit-systems/media-loading.js
@@ -15,7 +15,7 @@ import { animate } from "../utils/animate";
 const loaderForMediaType = {
   [MediaType.IMAGE]: (world, { accessibleUrl, contentType }) => loadImage(world, accessibleUrl, contentType),
   [MediaType.VIDEO]: (world, { accessibleUrl }) => loadVideo(world, accessibleUrl),
-  [MediaType.MODEL]: (world, { accessibleUrl }) => loadModel(world, accessibleUrl)
+  [MediaType.MODEL]: (world, { accessibleUrl }) => loadModel(world, accessibleUrl, true)
 };
 
 export const MEDIA_LOADER_FLAGS = {

--- a/src/bit-systems/scene-loading.ts
+++ b/src/bit-systems/scene-loading.ts
@@ -1,0 +1,52 @@
+import { defineQuery, enterQuery, exitQuery, removeComponent } from "bitecs";
+import { HubsWorld } from "../app";
+import { SceneLoader } from "../bit-components";
+import { cancelable, coroutine } from "../utils/coroutine";
+import { add, assignNetworkIds } from "./media-loading";
+import { loadModel } from "../utils/load-model";
+
+function* loadScene(world: HubsWorld, eid: number, signal: AbortSignal) {
+  try {
+    const src = APP.getString(SceneLoader.src[eid]);
+    if (!src) throw new Error();
+    const { value: scene, canceled } = yield* cancelable(loadModel(world, src), signal);
+    if (!canceled) {
+      // TODO: Maybe use scene id for root nid?
+      assignNetworkIds(world, "scene", scene, eid);
+      add(world, scene, eid);
+      removeComponent(world, SceneLoader, eid);
+      AFRAME.scenes[0].emit("environment-scene-loaded", scene);
+      document.querySelector(".a-canvas")!.classList.remove("a-hidden");
+    }
+  } catch {
+    console.error("Failed to load the scene");
+  }
+}
+
+const jobs = new Set();
+const abortControllers = new Map();
+const sceneLoaderQuery = defineQuery([SceneLoader]);
+const sceneLoaderEnterQuery = enterQuery(sceneLoaderQuery);
+const sceneLoaderExitQuery = exitQuery(sceneLoaderQuery);
+export function sceneLoadingSystem(world: HubsWorld) {
+  sceneLoaderEnterQuery(world).forEach(function (eid) {
+    const ac = new AbortController();
+    abortControllers.set(eid, ac);
+    jobs.add(coroutine(loadScene(world, eid, ac.signal)));
+  });
+
+  sceneLoaderExitQuery(world).forEach(function (eid) {
+    const ac = abortControllers.get(eid);
+    ac.abort();
+    abortControllers.delete(eid);
+  });
+
+  jobs.forEach((c: Coroutine) => {
+    if (c().done) {
+      jobs.delete(c);
+    }
+  });
+}
+
+// TODO: Don't use any. Write the correct type
+type Coroutine = () => any;

--- a/src/bit-systems/scene-loading.ts
+++ b/src/bit-systems/scene-loading.ts
@@ -1,6 +1,6 @@
 import { defineQuery, enterQuery, exitQuery, hasComponent, removeComponent, removeEntity } from "bitecs";
 import { HubsWorld } from "../app";
-import { EnvironmentSettings, SceneLoader, SceneRoot } from "../bit-components";
+import { EnvironmentSettings, NavMesh, SceneLoader, SceneRoot } from "../bit-components";
 import { cancelable, coroutine } from "../utils/coroutine";
 import { add, assignNetworkIds } from "./media-loading";
 import { loadModel } from "../utils/load-model";
@@ -51,6 +51,10 @@ function* loadScene(world: HubsWorld, eid: number, signal: AbortSignal, environm
         if ((o as any).isReflectionProbe) {
           o.updateMatrices();
           (o as any).box.applyMatrix4(o.matrixWorld);
+        }
+
+        if (hasComponent(world, NavMesh, o.eid!)) {
+          AFRAME.scenes[0].systems.nav.loadMesh(o as Mesh, "character");
         }
       });
       AFRAME.scenes[0].emit("environment-scene-loaded", scene);

--- a/src/bit-systems/scene-loading.ts
+++ b/src/bit-systems/scene-loading.ts
@@ -49,7 +49,7 @@ function* loadScene(world: HubsWorld, eid: number, signal: AbortSignal, environm
           (o as Mesh).reflectionProbeMode = "static";
         }
 
-        // TODO: Update this in 3js instead
+        // TODO: In three.js, update reflection probes so that boxes are defined in local space.
         if ((o as any).isReflectionProbe) {
           o.updateMatrices();
           (o as any).box.applyMatrix4(o.matrixWorld);

--- a/src/bit-systems/scene-loading.ts
+++ b/src/bit-systems/scene-loading.ts
@@ -39,6 +39,8 @@ function* loadScene(world: HubsWorld, eid: number, signal: AbortSignal, environm
 
         const environmentSettings = (EnvironmentSettings as any).map.get(scene);
         environmentSystem.updateEnvironmentSettings(environmentSettings);
+      } else {
+        environmentSystem.updateEnvironmentSettings({});
       }
 
       world.eid2obj.get(scene)!.traverse(o => {

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -1,19 +1,19 @@
-import nextTick from "../utils/next-tick";
-import { updateMaterials, mapMaterials, convertStandardMaterial } from "../utils/material-utils";
-import SketchfabZipWorker from "../workers/sketchfab-zip.worker.js";
-import { getCustomGLTFParserURLResolver } from "../utils/media-url-utils";
-import { promisifyWorker } from "../utils/promisify-worker.js";
-import { MeshBVH, acceleratedRaycast } from "three-mesh-bvh";
-import { disposeNode, cloneObject3D } from "../utils/three-utils";
-import HubsTextureLoader from "../loaders/HubsTextureLoader";
-import { KTX2Loader } from "three/examples/jsm/loaders/KTX2Loader";
-import { RGBELoader } from "three/examples/jsm/loaders/RGBELoader";
+import GLBRangeRequests from "three-gltf-extensions/loaders/GLB_range_requests/GLB_range_requests";
+import GLTFLodExtension from "three-gltf-extensions/loaders/MSFT_lod/MSFT_lod";
+import { acceleratedRaycast, MeshBVH } from "three-mesh-bvh";
 import { BasisTextureLoader } from "three/examples/jsm/loaders/BasisTextureLoader";
 import { DRACOLoader } from "three/examples/jsm/loaders/DRACOLoader";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader";
-import GLBRangeRequests from "three-gltf-extensions/loaders/GLB_range_requests/GLB_range_requests";
-import GLTFLodExtension from "three-gltf-extensions/loaders/MSFT_lod/MSFT_lod";
+import { KTX2Loader } from "three/examples/jsm/loaders/KTX2Loader";
+import { RGBELoader } from "three/examples/jsm/loaders/RGBELoader";
+import HubsTextureLoader from "../loaders/HubsTextureLoader";
+import { convertStandardMaterial, mapMaterials, updateMaterials } from "../utils/material-utils";
+import { getCustomGLTFParserURLResolver } from "../utils/media-url-utils";
+import nextTick from "../utils/next-tick";
+import { promisifyWorker } from "../utils/promisify-worker.js";
 import qsTruthy from "../utils/qs_truthy";
+import { cloneObject3D } from "../utils/three-utils";
+import SketchfabZipWorker from "../workers/sketchfab-zip.worker.js";
 
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
 

--- a/src/components/media-image.js
+++ b/src/components/media-image.js
@@ -60,7 +60,7 @@ AFRAME.registerComponent("media-image", {
           cacheItem = textureCache.retain(src, version);
         }
       } else {
-        const inflightKey = textureCache.key(src, version);
+        const inflightKey = TextureCache.key(src, version);
 
         if (src === "error") {
           cacheItem = errorCacheItem;

--- a/src/hub.html
+++ b/src/hub.html
@@ -958,7 +958,7 @@
                 <a-entity
                     id="gaze-teleport"
                     position = "0.15 0 0"
-                    teleporter="start: /actions/startTeleport; confirm: /actions/stopTeleport; collisionEntities: [nav-mesh];"
+                    teleporter="start: /actions/startTeleport; confirm: /actions/stopTeleport;"
                 ></a-entity>
                 <a-entity id="stats" stats-plus="false" position="0 0 -1"></a-entity>
             </a-entity>
@@ -1058,7 +1058,7 @@
                 track-pose="path: /actions/leftHand/matrix"
                 visibility-by-path="path: /actions/leftHand/matrix"
                 hand-controls2="left"
-                teleporter="start: /actions/leftHand/startTeleport; confirm: /actions/leftHand/stopTeleport; collisionEntities: [nav-mesh]"
+                teleporter="start: /actions/leftHand/startTeleport; confirm: /actions/leftHand/stopTeleport;"
                 body-helper="type: kinematic; emitCollisionEvents: false; disableCollision: true; collisionFilterGroup: 8; collisionFilterMask: 3; activationState: disable_deactivation; scaleAutoUpdate: false;"
                 shape-helper="type: box; fit: manual; halfExtents: 0.03 0.04 0.05; offset: 0 0 -0.04"
                 set-yxz-order
@@ -1072,7 +1072,7 @@
                 track-pose="path: /actions/rightHand/matrix"
                 visibility-by-path="path: /actions/rightHand/matrix"
                 hand-controls2="right"
-                teleporter="start: /actions/rightHand/startTeleport; confirm: /actions/rightHand/stopTeleport; collisionEntities: [nav-mesh]"
+                teleporter="start: /actions/rightHand/startTeleport; confirm: /actions/rightHand/stopTeleport;"
                 body-helper="type: kinematic; emitCollisionEvents: false; disableCollision: true; collisionFilterGroup: 8; collisionFilterMask: 3; activationState: disable_deactivation; scaleAutoUpdate: false;"
                 shape-helper="type: box; fit: manual; halfExtents: 0.03 0.04 0.05; offset: 0 0 -0.04"
                 set-yxz-order

--- a/src/hub.js
+++ b/src/hub.js
@@ -241,6 +241,7 @@ import { SignInMessages } from "./react-components/auth/SignInModal";
 import { ThemeProvider } from "./react-components/styles/theme";
 import { LogMessageType } from "./react-components/room/ChatSidebar";
 import "./load-media-on-paste-or-drop";
+import { swapActiveScene } from "./bit-systems/scene-loading";
 
 const PHOENIX_RELIABLE_NAF = "phx-reliable";
 NAF.options.firstSyncSource = PHOENIX_RELIABLE_NAF;
@@ -392,8 +393,7 @@ export async function updateEnvironmentForHub(hub, entryManager) {
 
   if (qsTruthy("newLoader")) {
     console.log("Using new loading path for scenes.");
-    const entity = renderAsEntity(APP.world, ScenePrefab(sceneUrl));
-    document.querySelector("#environment-scene").object3D.add(APP.world.eid2obj.get(entity));
+    swapActiveScene(APP.world, sceneUrl);
     return;
   }
   console.log("Using legacy loading path for scenes.");

--- a/src/hub.js
+++ b/src/hub.js
@@ -1,3 +1,4 @@
+import "aframe";
 import {
   getCurrentHubId,
   updateVRHudPresenceCount,
@@ -7,6 +8,7 @@ import {
 import "./utils/debug-log";
 import configs from "./utils/configs";
 import "./utils/theme";
+import { ScenePrefab } from "./prefabs/scene";
 
 import "core-js/stable";
 import "regenerator-runtime/runtime";
@@ -24,7 +26,6 @@ import "./assets/stylesheets/globals.scss";
 import "./assets/stylesheets/hub.scss";
 import loadingEnvironment from "./assets/models/LoadingEnvironment.glb";
 
-import "aframe";
 import "./utils/aframe-overrides";
 
 // A-Frame hardcodes THREE.Cache.enabled = true
@@ -388,6 +389,14 @@ export async function getSceneUrlForHub(hub) {
 export async function updateEnvironmentForHub(hub, entryManager) {
   console.log("Updating environment for hub");
   const sceneUrl = await getSceneUrlForHub(hub);
+
+  if (qsTruthy("newLoader")) {
+    console.log("Using new loading path for scenes.");
+    const entity = renderAsEntity(APP.world, ScenePrefab(sceneUrl));
+    document.querySelector("#environment-scene").object3D.add(APP.world.eid2obj.get(entity));
+    return;
+  }
+  console.log("Using legacy loading path for scenes.");
 
   const sceneErrorHandler = () => {
     remountUI({ roomUnavailableReason: ExitReason.sceneError });

--- a/src/hub.js
+++ b/src/hub.js
@@ -1,4 +1,3 @@
-import "aframe";
 import {
   getCurrentHubId,
   updateVRHudPresenceCount,
@@ -8,7 +7,6 @@ import {
 import "./utils/debug-log";
 import configs from "./utils/configs";
 import "./utils/theme";
-import { ScenePrefab } from "./prefabs/scene";
 
 import "core-js/stable";
 import "regenerator-runtime/runtime";
@@ -26,6 +24,7 @@ import "./assets/stylesheets/globals.scss";
 import "./assets/stylesheets/hub.scss";
 import loadingEnvironment from "./assets/models/LoadingEnvironment.glb";
 
+import "aframe";
 import "./utils/aframe-overrides";
 
 // A-Frame hardcodes THREE.Cache.enabled = true

--- a/src/hub.js
+++ b/src/hub.js
@@ -395,7 +395,6 @@ export async function updateEnvironmentForHub(hub, entryManager) {
     swapActiveScene(APP.world, sceneUrl);
     return;
   }
-  console.log("Using legacy loading path for scenes.");
 
   const sceneErrorHandler = () => {
     remountUI({ roomUnavailableReason: ExitReason.sceneError });

--- a/src/hub.js
+++ b/src/hub.js
@@ -999,9 +999,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     remountUI({ environmentSceneLoaded: true });
     scene.emit("environment-scene-loaded", model);
 
-    // Re-bind the teleporter controls collision meshes in case the scene changed.
-    document.querySelectorAll("a-entity[teleporter]").forEach(x => x.components["teleporter"].queryCollisionEntities());
-
     for (const modelEl of environmentScene.children) {
       addAnimationComponents(modelEl);
     }

--- a/src/inflators/directional-light.ts
+++ b/src/inflators/directional-light.ts
@@ -1,0 +1,35 @@
+import { addComponent } from "bitecs";
+import { addObject3DComponent } from "../utils/jsx-entity";
+import { DirectionalLight } from "../bit-components";
+import { DirectionalLight as DL } from "three";
+import { HubsWorld } from "../app";
+
+export type DirectionalLightParams = {
+  color: string;
+  intensity: number;
+  castShadow: boolean;
+  shadowMapResolution: [number, number];
+  shadowBias: number;
+  shadowRadius: number;
+};
+
+export function inflateDirectionalLight(world: HubsWorld, eid: number, params: DirectionalLightParams) {
+  const light = new DL();
+  light.position.set(0, 0, 0);
+  light.target.position.set(0, 0, 1);
+  light.add(light.target);
+  light.color.set(params.color).convertSRGBToLinear();
+  light.intensity = params.intensity;
+  light.castShadow = params.castShadow;
+  light.shadow.bias = params.shadowBias;
+  light.shadow.radius = params.shadowRadius;
+  light.shadow.mapSize.set(params.shadowMapResolution[0], params.shadowMapResolution[1]);
+  if (light.shadow.map) {
+    light.shadow.map.dispose();
+    (light.shadow.map as any) = null; // TODO: Correct the Typescript definition in three. This /is/ nullable.
+  }
+
+  addObject3DComponent(world, eid, light);
+  addComponent(world, DirectionalLight, eid);
+  return eid;
+}

--- a/src/inflators/environment-settings.ts
+++ b/src/inflators/environment-settings.ts
@@ -1,0 +1,8 @@
+import { addComponent } from "bitecs";
+import { HubsWorld } from "../app";
+import { EnvironmentSettings } from "../bit-components";
+
+export function inflateEnvironmentSettings(world: HubsWorld, eid: number, props: any) {
+  addComponent(world, EnvironmentSettings, eid);
+  (EnvironmentSettings as any).map.set(eid, props);
+}

--- a/src/inflators/grabbable.ts
+++ b/src/inflators/grabbable.ts
@@ -1,4 +1,5 @@
 import { addComponent } from "bitecs";
+import { HubsWorld } from "../app";
 import {
   CursorRaycastable,
   HandCollisionTarget,
@@ -8,8 +9,9 @@ import {
   RemoteHoverTarget
 } from "../bit-components";
 
-const defaults = { cursor: true, hand: true };
-export function inflateGrabbable(world, eid, props) {
+export type GrabbableParams = { cursor: boolean; hand: boolean };
+const defaults: GrabbableParams = { cursor: true, hand: true };
+export function inflateGrabbable(world: HubsWorld, eid: number, props: GrabbableParams) {
   props = Object.assign({}, defaults, props);
   if (props.hand) {
     addComponent(world, HandCollisionTarget, eid);

--- a/src/inflators/image-loader.ts
+++ b/src/inflators/image-loader.ts
@@ -2,16 +2,13 @@ import { HubsWorld } from "../app";
 import { ProjectionMode } from "../utils/jsx-entity";
 import { inflateMediaLoader } from "./media-loader";
 
-export interface VideoLoaderParams {
+export interface ImageLoaderParams {
   src: string;
   projection: ProjectionMode;
-  autoPlay: boolean;
-  controls: boolean;
-  loop: boolean;
 }
 
-export function inflateVideoLoader(world: HubsWorld, eid: number, params: VideoLoaderParams) {
+export function inflateImageLoader(world: HubsWorld, eid: number, params: ImageLoaderParams) {
   inflateMediaLoader(world, eid, { src: params.src, recenter: false, resize: false, animateLoad: false });
 
-  // TODO: Use the rest of VideoLoaderParams
+  // TODO: Use projection
 }

--- a/src/inflators/image-loader.ts
+++ b/src/inflators/image-loader.ts
@@ -1,5 +1,5 @@
 import { HubsWorld } from "../app";
-import { ProjectionMode } from "../utils/jsx-entity";
+import { ProjectionMode } from "../utils/projection-mode";
 import { inflateMediaLoader } from "./media-loader";
 
 export interface ImageLoaderParams {

--- a/src/inflators/image.js
+++ b/src/inflators/image.js
@@ -1,9 +1,9 @@
 import { create360ImageMesh, createImageMesh } from "../utils/create-image-mesh";
-import { addObject3DComponent } from "../utils/jsx-entity";
+import { addObject3DComponent, ProjectionMode } from "../utils/jsx-entity";
 
 export function inflateImage(world, eid, { texture, ratio, projection, alphaMode }) {
   const mesh =
-    projection === "360-equirectangular"
+    projection === ProjectionMode.SPHERE_EQUIRECTANGULAR
       ? create360ImageMesh(texture, ratio, alphaMode)
       : createImageMesh(texture, ratio, alphaMode);
   addObject3DComponent(world, eid, mesh);

--- a/src/inflators/image.js
+++ b/src/inflators/image.js
@@ -1,7 +1,8 @@
 import { addComponent } from "bitecs";
 import { MediaImage } from "../bit-components";
+import { addObject3DComponent } from "../utils/jsx-entity";
 import { create360ImageMesh, createImageMesh } from "../utils/create-image-mesh";
-import { addObject3DComponent, ProjectionMode } from "../utils/jsx-entity";
+import { ProjectionMode } from "../utils/projection-mode";
 
 export function inflateImage(world, eid, { texture, ratio, projection, alphaMode, cacheKey }) {
   const mesh =

--- a/src/inflators/image.js
+++ b/src/inflators/image.js
@@ -1,11 +1,15 @@
+import { addComponent } from "bitecs";
+import { Image } from "../bit-components";
 import { create360ImageMesh, createImageMesh } from "../utils/create-image-mesh";
 import { addObject3DComponent, ProjectionMode } from "../utils/jsx-entity";
 
-export function inflateImage(world, eid, { texture, ratio, projection, alphaMode }) {
+export function inflateImage(world, eid, { texture, ratio, projection, alphaMode, cacheKey }) {
   const mesh =
     projection === ProjectionMode.SPHERE_EQUIRECTANGULAR
       ? create360ImageMesh(texture, ratio, alphaMode)
       : createImageMesh(texture, ratio, alphaMode);
   addObject3DComponent(world, eid, mesh);
+  addComponent(world, Image, eid);
+  Image.cacheKey[eid] = APP.getSid(cacheKey);
   return eid;
 }

--- a/src/inflators/image.js
+++ b/src/inflators/image.js
@@ -1,5 +1,5 @@
 import { addComponent } from "bitecs";
-import { Image } from "../bit-components";
+import { MediaImage } from "../bit-components";
 import { create360ImageMesh, createImageMesh } from "../utils/create-image-mesh";
 import { addObject3DComponent, ProjectionMode } from "../utils/jsx-entity";
 
@@ -9,7 +9,7 @@ export function inflateImage(world, eid, { texture, ratio, projection, alphaMode
       ? create360ImageMesh(texture, ratio, alphaMode)
       : createImageMesh(texture, ratio, alphaMode);
   addObject3DComponent(world, eid, mesh);
-  addComponent(world, Image, eid);
-  Image.cacheKey[eid] = APP.getSid(cacheKey);
+  addComponent(world, MediaImage, eid);
+  MediaImage.cacheKey[eid] = APP.getSid(cacheKey);
   return eid;
 }

--- a/src/inflators/media-loader.ts
+++ b/src/inflators/media-loader.ts
@@ -7,13 +7,19 @@ export type MediaLoaderParams = {
   src: string;
   resize: boolean;
   recenter: boolean;
+  animateLoad: boolean;
 };
 
-export function inflateMediaLoader(world: HubsWorld, eid: number, { src, recenter, resize }: MediaLoaderParams) {
+export function inflateMediaLoader(
+  world: HubsWorld,
+  eid: number,
+  { src, recenter, resize, animateLoad }: MediaLoaderParams
+) {
   addComponent(world, MediaLoader, eid);
   let flags = 0;
   if (recenter) flags |= MEDIA_LOADER_FLAGS.RECENTER;
   if (resize) flags |= MEDIA_LOADER_FLAGS.RESIZE;
+  if (animateLoad) flags |= MEDIA_LOADER_FLAGS.ANIMATE_LOAD;
   MediaLoader.flags[eid] = flags;
   MediaLoader.src[eid] = APP.getSid(src)!;
 }

--- a/src/inflators/model.tsx
+++ b/src/inflators/model.tsx
@@ -2,7 +2,7 @@ import { addComponent, addEntity } from "bitecs";
 import { Object3D } from "three";
 import { HubsWorld } from "../app";
 import { GLTFModel } from "../bit-components";
-import { addObject3DComponent, inflators, inflatorExists } from "../utils/jsx-entity";
+import { addObject3DComponent, gltfInflatorExists, gltfInflators } from "../utils/jsx-entity";
 
 function camelCase(s: string) {
   return s.replace(/-(\w)/g, (_, m) => m.toUpperCase());
@@ -18,11 +18,11 @@ export function inflateModel(world: HubsWorld, rootEid: number, { model }: Model
     const eid = obj === model ? rootEid : addEntity(world);
     Object.keys(components).forEach(name => {
       const inflatorName = camelCase(name);
-      if (!inflatorExists(inflatorName)) {
+      if (!gltfInflatorExists(inflatorName)) {
         console.warn(`Failed to inflate unknown component called ${inflatorName}`);
         return;
       }
-      inflators[inflatorName](world, eid, components[name]);
+      gltfInflators[inflatorName](world, eid, components[name]);
     });
     const replacement = world.eid2obj.get(eid);
     if (replacement) {

--- a/src/inflators/model.tsx
+++ b/src/inflators/model.tsx
@@ -40,6 +40,7 @@ export function inflateModel(world: HubsWorld, rootEid: number, { model }: Model
   });
 
   swap.forEach(([old, replacement]) => {
+    replacement.userData.wasSwapped = true;
     for (let i = old.children.length - 1; i >= 0; i--) {
       replacement.add(old.children[i]);
     }

--- a/src/inflators/model.tsx
+++ b/src/inflators/model.tsx
@@ -13,16 +13,17 @@ export type ModelParams = { model: Object3D };
 export function inflateModel(world: HubsWorld, rootEid: number, { model }: ModelParams) {
   const swap: [old: Object3D, replacement: Object3D][] = [];
   model.traverse(obj => {
-    // TODO: Which of these need "?"
-    const components = obj.userData?.gltfExtensions?.MOZ_hubs_components || {};
+    const components = obj.userData.gltfExtensions?.MOZ_hubs_components || {};
     const eid = obj === model ? rootEid : addEntity(world);
     Object.keys(components).forEach(name => {
       const inflatorName = camelCase(name);
-      if (!gltfInflatorExists(inflatorName)) {
+      if (inflatorName === "visible" || inflatorName === "frustum") {
+        // These are handled below
+      } else if (!gltfInflatorExists(inflatorName)) {
         console.warn(`Failed to inflate unknown component called ${inflatorName}`);
-        return;
+      } else {
+        gltfInflators[inflatorName](world, eid, components[name]);
       }
-      gltfInflators[inflatorName](world, eid, components[name]);
     });
     const replacement = world.eid2obj.get(eid);
     if (replacement) {
@@ -53,6 +54,24 @@ export function inflateModel(world: HubsWorld, rootEid: number, { model }: Model
 
     old.parent!.add(replacement);
     old.removeFromParent();
+  });
+
+  // These components are special because we want to do a one-off action
+  // that we can't do in a regular inflator (because they depend on the object3D).
+  // If more things need to run at this point, we may need to expand the api here.
+  model.traverse(obj => {
+    const components = obj.userData.gltfExtensions?.MOZ_hubs_components || {};
+    if (components.visible) {
+      const { visible } = components.visible;
+      obj.visible = !!visible;
+    }
+
+    if (components.frustum) {
+      const { culled } = components.frustum;
+      obj.traverse(o => {
+        o.frustumCulled = culled;
+      });
+    }
   });
 
   addComponent(world, GLTFModel, rootEid);

--- a/src/inflators/model.tsx
+++ b/src/inflators/model.tsx
@@ -40,7 +40,6 @@ export function inflateModel(world: HubsWorld, rootEid: number, { model }: Model
   });
 
   swap.forEach(([old, replacement]) => {
-    replacement.userData.wasSwapped = true;
     for (let i = old.children.length - 1; i >= 0; i--) {
       replacement.add(old.children[i]);
     }

--- a/src/inflators/reflection-probe.ts
+++ b/src/inflators/reflection-probe.ts
@@ -1,0 +1,35 @@
+import { addComponent } from "bitecs";
+import { Texture } from "three";
+import { HubsWorld } from "../app";
+import { ReflectionProbe } from "../bit-components";
+import { addObject3DComponent } from "../utils/jsx-entity";
+
+export interface ReflectionProbeParams {
+  size: number;
+  envMapTexture?: Texture;
+}
+
+const DEFAULTS = {
+  size: 1,
+  envMapTexture: null
+};
+
+export function inflateReflectionProbe(world: HubsWorld, eid: number, componentProps: ReflectionProbeParams) {
+  const { envMapTexture, size } = Object.assign({}, DEFAULTS, componentProps) as ReflectionProbeParams;
+  envMapTexture!.flipY = true;
+  envMapTexture!.mapping = THREE.EquirectangularReflectionMapping;
+  const box = new THREE.Box3().setFromCenterAndSize(new THREE.Vector3(), new THREE.Vector3().setScalar(size * 2));
+
+  addComponent(world, ReflectionProbe, eid);
+  // TODO: Add ReflectionProbe to three.js type defs
+  const probe = new (THREE as any).ReflectionProbe(box, envMapTexture);
+  addObject3DComponent(world, eid, probe);
+
+  if (AFRAME.scenes[0].systems["hubs-systems"].environmentSystem.debugMode) {
+    const debugBox = new THREE.Box3().setFromCenterAndSize(
+      new THREE.Vector3(),
+      new THREE.Vector3().setScalar(size * 2)
+    );
+    probe.add(new THREE.Box3Helper(debugBox, new THREE.Color(Math.random(), Math.random(), Math.random())));
+  }
+}

--- a/src/inflators/video-loader.ts
+++ b/src/inflators/video-loader.ts
@@ -1,0 +1,17 @@
+import { HubsWorld } from "../app";
+import { ProjectionMode } from "../utils/jsx-entity";
+import { inflateMediaLoader } from "./media-loader";
+
+export interface VideoLoaderParams {
+  src: string;
+  projection: ProjectionMode;
+  autoPlay: boolean;
+  controls: boolean;
+  loop: boolean;
+}
+
+export function inflateVideoLoader(world: HubsWorld, eid: number, params: VideoLoaderParams) {
+  inflateMediaLoader(world, eid, { src: params.src, recenter: false, resize: false });
+
+  // TODO: Use the rest of VideoLoaderParams
+}

--- a/src/inflators/video-loader.ts
+++ b/src/inflators/video-loader.ts
@@ -1,5 +1,5 @@
 import { HubsWorld } from "../app";
-import { ProjectionMode } from "../utils/jsx-entity";
+import { ProjectionMode } from "../utils/projection-mode";
 import { inflateMediaLoader } from "./media-loader";
 
 export interface VideoLoaderParams {

--- a/src/inflators/video.js
+++ b/src/inflators/video.js
@@ -1,11 +1,13 @@
 import { create360ImageMesh, createImageMesh } from "../utils/create-image-mesh";
 import { addComponent } from "bitecs";
-import { addObject3DComponent } from "../utils/jsx-entity";
+import { addObject3DComponent, ProjectionMode } from "../utils/jsx-entity";
 import { MediaVideo } from "../bit-components";
 
 export function inflateVideo(world, eid, { texture, ratio, projection, autoPlay }) {
   const mesh =
-    projection === "360-equirectangular" ? create360ImageMesh(texture, ratio) : createImageMesh(texture, ratio);
+    projection === ProjectionMode.SPHERE_EQUIRECTANGULAR
+      ? create360ImageMesh(texture, ratio)
+      : createImageMesh(texture, ratio);
   addObject3DComponent(world, eid, mesh);
   addComponent(world, MediaVideo, eid);
   MediaVideo.autoPlay[eid] = autoPlay ? 1 : 0;

--- a/src/inflators/video.js
+++ b/src/inflators/video.js
@@ -1,6 +1,7 @@
 import { create360ImageMesh, createImageMesh } from "../utils/create-image-mesh";
 import { addComponent } from "bitecs";
-import { addObject3DComponent, ProjectionMode } from "../utils/jsx-entity";
+import { addObject3DComponent } from "../utils/jsx-entity";
+import { ProjectionMode } from "../utils/projection-mode";
 import { MediaVideo } from "../bit-components";
 
 export function inflateVideo(world, eid, { texture, ratio, projection, autoPlay }) {

--- a/src/load-media-on-paste-or-drop.ts
+++ b/src/load-media-on-paste-or-drop.ts
@@ -23,7 +23,7 @@ function spawnFromUrl(text: string) {
     console.warn(`Could not parse URL. Ignoring pasted text:\n${text}`);
     return;
   }
-  const eid = createNetworkedEntity(APP.world, "media", { src: text, recenter: true, resize: true });
+  const eid = createNetworkedEntity(APP.world, "media", { src: text, recenter: true, resize: true, animateLoad: true });
   const avatarPov = (document.querySelector("#avatar-pov-node")! as AElement).object3D;
   const obj = APP.world.eid2obj.get(eid)!;
   obj.position.copy(avatarPov.localToWorld(new Vector3(0, 0, -1.5)));
@@ -43,7 +43,8 @@ async function spawnFromFileList(files: FileList) {
         return {
           src: srcUrl.href,
           recenter: true,
-          resize: true
+          resize: true,
+          animateLoad: true
         };
       })
       .catch(e => {
@@ -51,7 +52,8 @@ async function spawnFromFileList(files: FileList) {
         return {
           src: "error",
           recenter: true,
-          resize: true
+          resize: true,
+          animateLoad: true
         };
       });
 

--- a/src/loaders/HubsTextureLoader.js
+++ b/src/loaders/HubsTextureLoader.js
@@ -80,7 +80,7 @@ export default class HubsTextureLoader extends THREE.TextureLoader {
       ? this._loadImageBitmapTexture(url, callback, onProgress, onError)
       : super.load(url, callback, onProgress, onError);
 
-    texture.onUpdate = function() {
+    texture.onUpdate = function () {
       // Delete texture data once it has been uploaded to the GPU
       texture.image.close && texture.image.close();
       texture.image = null;

--- a/src/prefabs/error-object.js
+++ b/src/prefabs/error-object.js
@@ -1,5 +1,5 @@
 /** @jsx createElementEntity */
-import { createElementEntity } from "../utils/jsx-entity";
+import { createElementEntity, ProjectionMode } from "../utils/jsx-entity";
 import { errorTexture } from "../utils/error-texture";
 import { AlphaMode } from "../utils/create-image-mesh";
 
@@ -9,7 +9,7 @@ export function ErrorObject() {
       image={{
         texture: errorTexture,
         ratio: 1400 / 1200,
-        projection: "flat",
+        projection: ProjectionMode.FLAT,
         alphaMode: AlphaMode.Blend
       }}
       textureCacheKey={{

--- a/src/prefabs/error-object.js
+++ b/src/prefabs/error-object.js
@@ -1,20 +1,18 @@
 /** @jsx createElementEntity */
 import { createElementEntity, ProjectionMode } from "../utils/jsx-entity";
-import { errorTexture } from "../utils/error-texture";
 import { AlphaMode } from "../utils/create-image-mesh";
+import { TextureCache } from "../utils/texture-cache";
+import { loadTextureFromCache } from "../utils/load-texture";
 
 export function ErrorObject() {
   return (
     <entity
       image={{
-        texture: errorTexture,
+        texture: loadTextureFromCache("error", 1).texture,
         ratio: 1400 / 1200,
         projection: ProjectionMode.FLAT,
-        alphaMode: AlphaMode.Blend
-      }}
-      textureCacheKey={{
-        src: "error",
-        version: 1
+        alphaMode: AlphaMode.Blend,
+        cacheKey: TextureCache.key("error", 1)
       }}
     />
   );

--- a/src/prefabs/error-object.js
+++ b/src/prefabs/error-object.js
@@ -1,5 +1,6 @@
 /** @jsx createElementEntity */
-import { createElementEntity, ProjectionMode } from "../utils/jsx-entity";
+import { createElementEntity } from "../utils/jsx-entity";
+import { ProjectionMode } from "../utils/projection-mode";
 import { AlphaMode } from "../utils/create-image-mesh";
 import { TextureCache } from "../utils/texture-cache";
 import { loadTextureFromCache } from "../utils/load-texture";

--- a/src/prefabs/media.tsx
+++ b/src/prefabs/media.tsx
@@ -12,7 +12,7 @@ export function MediaPrefab(params: MediaLoaderParams) {
       networkedTransform
       mediaLoader={params}
       deletable
-      grabbable
+      grabbable={{ cursor: true, hand: true }}
       destroyAtExtremeDistance
       floatyObject={{
         flags: FLOATY_OBJECT_FLAGS.MODIFY_GRAVITY_ON_RELEASE,

--- a/src/prefabs/scene.tsx
+++ b/src/prefabs/scene.tsx
@@ -2,5 +2,5 @@
 import { createElementEntity } from "../utils/jsx-entity";
 
 export function ScenePrefab(src: string) {
-  return <entity name="Scene" sceneLoader={{ src }} />;
+  return <entity name="Scene" sceneRoot sceneLoader={{ src }} />;
 }

--- a/src/prefabs/scene.tsx
+++ b/src/prefabs/scene.tsx
@@ -1,0 +1,6 @@
+/** @jsx createElementEntity */
+import { createElementEntity } from "../utils/jsx-entity";
+
+export function ScenePrefab(src: string) {
+  return <entity name="Scene" sceneLoader={{ src }} />;
+}

--- a/src/prefabs/video-menu.tsx
+++ b/src/prefabs/video-menu.tsx
@@ -2,7 +2,7 @@
 import { BoxBufferGeometry, Mesh, MeshBasicMaterial, PlaneBufferGeometry } from "three";
 import { Label } from "../prefabs/camera-tool";
 import { AlphaMode } from "../utils/create-image-mesh";
-import { createElementEntity, createRef } from "../utils/jsx-entity";
+import { createElementEntity, createRef, ProjectionMode } from "../utils/jsx-entity";
 
 import { textureLoader } from "../utils/media-utils";
 import playImageUrl from "../assets/images/sprites/notice/play.png";
@@ -65,7 +65,7 @@ export function VideoMenuPrefab() {
         image={{
           texture: playTexture,
           ratio: 1,
-          projection: "flat",
+          projection: ProjectionMode.FLAT,
           alphaMode: AlphaMode.Blend
         }}
         textureCacheKey={{
@@ -81,7 +81,7 @@ export function VideoMenuPrefab() {
         image={{
           texture: pauseTexture,
           ratio: 1,
-          projection: "flat",
+          projection: ProjectionMode.FLAT,
           alphaMode: AlphaMode.Blend
         }}
         textureCacheKey={{

--- a/src/prefabs/video-menu.tsx
+++ b/src/prefabs/video-menu.tsx
@@ -7,6 +7,7 @@ import { createElementEntity, createRef, ProjectionMode } from "../utils/jsx-ent
 import { textureLoader } from "../utils/media-utils";
 import playImageUrl from "../assets/images/sprites/notice/play.png";
 import pauseImageUrl from "../assets/images/sprites/notice/pause.png";
+import { TextureCache } from "../utils/texture-cache";
 
 const playTexture = textureLoader.load(playImageUrl);
 const pauseTexture = textureLoader.load(pauseImageUrl);
@@ -66,11 +67,8 @@ export function VideoMenuPrefab() {
           texture: playTexture,
           ratio: 1,
           projection: ProjectionMode.FLAT,
-          alphaMode: AlphaMode.Blend
-        }}
-        textureCacheKey={{
-          src: playImageUrl,
-          version: 1
+          alphaMode: AlphaMode.Blend,
+          cacheKey: TextureCache.key(playImageUrl, 1)
         }}
         visible={false}
       />
@@ -82,11 +80,8 @@ export function VideoMenuPrefab() {
           texture: pauseTexture,
           ratio: 1,
           projection: ProjectionMode.FLAT,
-          alphaMode: AlphaMode.Blend
-        }}
-        textureCacheKey={{
-          src: pauseImageUrl,
-          version: 1
+          alphaMode: AlphaMode.Blend,
+          cacheKey: TextureCache.key(pauseImageUrl, 1)
         }}
         visible={false}
       />

--- a/src/prefabs/video-menu.tsx
+++ b/src/prefabs/video-menu.tsx
@@ -2,7 +2,8 @@
 import { BoxBufferGeometry, Mesh, MeshBasicMaterial, PlaneBufferGeometry } from "three";
 import { Label } from "../prefabs/camera-tool";
 import { AlphaMode } from "../utils/create-image-mesh";
-import { createElementEntity, createRef, ProjectionMode } from "../utils/jsx-entity";
+import { createElementEntity, createRef } from "../utils/jsx-entity";
+import { ProjectionMode } from "../utils/projection-mode";
 
 import { textureLoader } from "../utils/media-utils";
 import playImageUrl from "../assets/images/sprites/notice/play.png";

--- a/src/systems/environment-system.js
+++ b/src/systems/environment-system.js
@@ -31,6 +31,8 @@ const defaultEnvSettings = {
   toneMappingExposure: 1,
   physicallyCorrectLights: true,
   envMapTexture: null,
+  // TODO
+  // skybox: null,
   backgroundTexture: null,
   backgroundColor: new THREE.Color("#000000"),
 
@@ -108,6 +110,14 @@ export class EnvironmentSystem {
     };
 
     window.$E = this;
+  }
+
+  updateEnvironmentSettings(newSettings) {
+    const envSettings = {
+      ...defaultEnvSettings,
+      ...newSettings
+    };
+    this.applyEnvSettings(envSettings);
   }
 
   updateEnvironment(envEl) {

--- a/src/systems/environment-system.js
+++ b/src/systems/environment-system.js
@@ -286,7 +286,7 @@ AFRAME.registerComponent("environment-settings", {
     fogType: { type: "string", default: defaultEnvSettings.fogType },
     fogColor: { type: "color", default: defaultEnvSettings.fogColor },
     fogDensity: { type: "number", default: defaultEnvSettings.fogDensity },
-    fogNear: { type: "number", default: defaultEnvSettings.forNear },
+    fogNear: { type: "number", default: defaultEnvSettings.fogNear },
     fogFar: { type: "number", default: defaultEnvSettings.fogFar }
   }
 });

--- a/src/systems/environment-system.js
+++ b/src/systems/environment-system.js
@@ -31,8 +31,8 @@ const defaultEnvSettings = {
   toneMappingExposure: 1,
   physicallyCorrectLights: true,
   envMapTexture: null,
-  // TODO
-  // skybox: null,
+
+  skybox: null,
   backgroundTexture: null,
   backgroundColor: new THREE.Color("#000000"),
 

--- a/src/systems/hubs-systems.ts
+++ b/src/systems/hubs-systems.ts
@@ -160,7 +160,7 @@ export function mainTick(xrFrame: XRFrame, renderer: WebGLRenderer, scene: Scene
 
   networkReceiveSystem(world);
   onOwnershipLost(world);
-  sceneLoadingSystem(world);
+  sceneLoadingSystem(world, hubsSystems.environmentSystem);
   mediaLoadingSystem(world);
 
   physicsCompatSystem(world);

--- a/src/systems/hubs-systems.ts
+++ b/src/systems/hubs-systems.ts
@@ -54,6 +54,7 @@ import type { HubsSystems } from "aframe";
 import { Camera, Scene, WebGLRenderer } from "three";
 import { HubsWorld } from "../app";
 import { EffectComposer } from "postprocessing";
+import { sceneLoadingSystem } from "../bit-systems/scene-loading";
 
 declare global {
   interface Window {
@@ -159,6 +160,7 @@ export function mainTick(xrFrame: XRFrame, renderer: WebGLRenderer, scene: Scene
 
   networkReceiveSystem(world);
   onOwnershipLost(world);
+  sceneLoadingSystem(world);
   mediaLoadingSystem(world);
 
   physicsCompatSystem(world);

--- a/src/systems/nav.js
+++ b/src/systems/nav.js
@@ -2,14 +2,14 @@ const { Pathfinding } = require("three-pathfinding");
 import qsTruthy from "../utils/qs_truthy";
 
 AFRAME.registerSystem("nav", {
-  init: function() {
+  init: function () {
     this.pathfinder = new Pathfinding();
     this.mesh = null;
     this.el.addEventListener("reset_scene", this.removeNavMeshData.bind(this));
     this.el.addEventListener("leaving_loading_environment", this.removeNavMeshData.bind(this));
   },
 
-  loadMesh: function(mesh, zone) {
+  loadMesh: function (mesh, zone) {
     if (this.mesh) {
       console.error("tried to load multiple nav meshes");
       this.removeNavMeshData();

--- a/src/systems/nav.js
+++ b/src/systems/nav.js
@@ -20,11 +20,6 @@ AFRAME.registerSystem("nav", {
     this.pathfinder.setZoneData(zone, Pathfinding.createZone(geometry));
     this.mesh = mesh;
 
-    const teleporters = document.querySelectorAll("[teleporter]");
-    for (let i = 0; i < teleporters.length; i++) {
-      teleporters[i].components["teleporter"].queryCollisionEntities();
-    }
-
     this.el.sceneEl.emit("nav-mesh-loaded");
 
     if (qsTruthy("debugNavmesh")) {

--- a/src/systems/remove-object3D-system.js
+++ b/src/systems/remove-object3D-system.js
@@ -5,6 +5,7 @@ import {
   GLTFModel,
   Image,
   MediaFrame,
+  MediaVideo,
   Object3DTag,
   Slice9,
   Text,
@@ -12,6 +13,7 @@ import {
 } from "../bit-components";
 import { gltfCache } from "../components/gltf-model-plus";
 import { releaseTextureByKey } from "../utils/load-texture";
+import { disposeTexture } from "../utils/material-utils";
 import { traverseSome } from "../utils/three-utils";
 
 function cleanupObjOnExit(Component, f) {
@@ -47,6 +49,10 @@ const cleanupAudioEmitters = cleanupObjOnExit(AudioEmitter, obj => {
 });
 const cleanupImages = cleanupObjOnExit(Image, obj => {
   releaseTextureByKey(APP.getString(Image.cacheKey[obj.eid]));
+  obj.geometry.dispose();
+});
+const cleanupVideos = cleanupObjOnExit(MediaVideo, obj => {
+  disposeTexture(obj.material.map);
   obj.geometry.dispose();
 });
 const cleanupEnvironmentSettings = cleanupOnExit(EnvironmentSettings, eid => {
@@ -100,6 +106,7 @@ export function removeObject3DSystem(world) {
   cleanupTexts(world);
   cleanupMediaFrames(world);
   cleanupImages(world);
+  cleanupVideos(world);
   cleanupEnvironmentSettings(world);
   cleanupAudioEmitters(world);
 

--- a/src/systems/remove-object3D-system.js
+++ b/src/systems/remove-object3D-system.js
@@ -1,6 +1,6 @@
 import { defineQuery, exitQuery, hasComponent, removeEntity } from "bitecs";
-import { Image, GLTFModel, MediaFrame, Object3DTag, Slice9, Text, AudioEmitter, VideoMenu } from "../bit-components";
-import { gltfCache, disposeGLTFNode } from "../components/gltf-model-plus";
+import { AudioEmitter, GLTFModel, Image, MediaFrame, Object3DTag, Slice9, Text, VideoMenu } from "../bit-components";
+import { gltfCache } from "../components/gltf-model-plus";
 import { releaseTextureByKey } from "../utils/load-texture";
 import { traverseSome } from "../utils/three-utils";
 
@@ -18,7 +18,7 @@ const cleanupGLTFs = cleanupObjOnExit(GLTFModel, obj => {
   if (obj.userData.gltfCacheKey) {
     gltfCache.release(obj.userData.gltfCacheKey);
   } else {
-    obj.traverse(disposeGLTFNode);
+    obj.dispose();
   }
 });
 const cleanupTexts = cleanupObjOnExit(Text, obj => obj.dispose());

--- a/src/systems/remove-object3D-system.js
+++ b/src/systems/remove-object3D-system.js
@@ -3,7 +3,7 @@ import {
   AudioEmitter,
   EnvironmentSettings,
   GLTFModel,
-  Image,
+  MediaImage,
   MediaFrame,
   MediaVideo,
   Object3DTag,
@@ -47,8 +47,8 @@ const cleanupAudioEmitters = cleanupObjOnExit(AudioEmitter, obj => {
   const audioSystem = AFRAME.scenes[0].systems["hubs-systems"].audioSystem;
   audioSystem.removeAudio({ node: obj });
 });
-const cleanupImages = cleanupObjOnExit(Image, obj => {
-  releaseTextureByKey(APP.getString(Image.cacheKey[obj.eid]));
+const cleanupImages = cleanupObjOnExit(MediaImage, obj => {
+  releaseTextureByKey(APP.getString(MediaImage.cacheKey[obj.eid]));
   obj.geometry.dispose();
 });
 const cleanupVideos = cleanupObjOnExit(MediaVideo, obj => {

--- a/src/utils/jsx-entity.ts
+++ b/src/utils/jsx-entity.ts
@@ -27,7 +27,8 @@ import {
   VideoMenuItem,
   NotRemoteHoverTarget,
   Deletable,
-  TextureCacheKey
+  TextureCacheKey,
+  SceneLoader
 } from "../bit-components";
 import { inflateMediaLoader } from "../inflators/media-loader";
 import { inflateMediaFrame } from "../inflators/media-frame";
@@ -251,6 +252,7 @@ export interface ComponentData {
   };
   animationMixer?: any;
   mediaLoader?: MediaLoaderParams;
+  sceneLoader?: { src: string };
   mediaFrame?: any;
   object3D?: any;
   text?: any;
@@ -299,6 +301,7 @@ export const inflators: Required<{ [K in keyof ComponentData]: InflatorFn }> = {
   videoMenu: createDefaultInflator(VideoMenu),
   videoMenuItem: createDefaultInflator(VideoMenuItem),
   textureCacheKey: createDefaultInflator(TextureCacheKey),
+  sceneLoader: createDefaultInflator(SceneLoader),
   mediaLoader: inflateMediaLoader,
   grabbable: inflateGrabbable,
 

--- a/src/utils/jsx-entity.ts
+++ b/src/utils/jsx-entity.ts
@@ -43,6 +43,7 @@ import { Group, Object3D, Texture, VideoTexture } from "three";
 import { AlphaMode } from "./create-image-mesh";
 import { MediaLoaderParams } from "../inflators/media-loader";
 import { preload } from "./preload";
+import { DirectionalLightParams, inflateDirectionalLight } from "../inflators/directional-light";
 
 preload(
   new Promise(resolve => {
@@ -206,6 +207,7 @@ export interface ComponentData {
     projection: "flat" | "360-equirectangular";
     autoPlay: boolean;
   };
+  directionalLight?: DirectionalLightParams;
   networkedVideo?: true;
   videoMenu?: {
     timeLabelRef: Ref;
@@ -312,7 +314,8 @@ export const inflators: Required<{ [K in keyof ComponentData]: InflatorFn }> = {
   text: inflateText,
   model: inflateModel,
   image: inflateImage,
-  video: inflateVideo
+  video: inflateVideo,
+  directionalLight: inflateDirectionalLight
 };
 
 export function inflatorExists(name: string): name is keyof ComponentData {

--- a/src/utils/jsx-entity.ts
+++ b/src/utils/jsx-entity.ts
@@ -50,6 +50,7 @@ import { AlphaMode } from "./create-image-mesh";
 import { MediaLoaderParams } from "../inflators/media-loader";
 import { preload } from "./preload";
 import { DirectionalLightParams, inflateDirectionalLight } from "../inflators/directional-light";
+import { ProjectionMode } from "./projection-mode";
 
 preload(
   new Promise(resolve => {
@@ -237,7 +238,7 @@ export interface JSXComponentData extends ComponentData {
   makeKinematicOnRelease?: true;
   destroyAtExtremeDistance?: true;
 
-  // @TODO
+  // @TODO Define all the anys
   networked?: any;
   textButton?: any;
   hoverButton?: any;
@@ -267,11 +268,6 @@ export interface JSXComponentData extends ComponentData {
   object3D?: any;
   text?: any;
   model?: ModelParams;
-}
-
-export enum ProjectionMode {
-  FLAT = "flat",
-  SPHERE_EQUIRECTANGULAR = "360-equirectangular"
 }
 
 export interface GLTFComponentData extends ComponentData {

--- a/src/utils/jsx-entity.ts
+++ b/src/utils/jsx-entity.ts
@@ -42,6 +42,7 @@ import { inflateImageLoader, ImageLoaderParams } from "../inflators/image-loader
 import { inflateModel, ModelParams } from "../inflators/model";
 import { inflateSlice9 } from "../inflators/slice9";
 import { inflateText } from "../inflators/text";
+import { inflateEnvironmentSettings } from "../inflators/environment-settings";
 import { inflateReflectionProbe, ReflectionProbeParams } from "../inflators/reflection-probe";
 import { HubsWorld } from "../app";
 import { Group, Object3D, Texture, VideoTexture } from "three";
@@ -349,10 +350,7 @@ export const gltfInflators: Required<{ [K in keyof GLTFComponentData]: InflatorF
   image: inflateImageLoader,
   reflectionProbe: inflateReflectionProbe,
   navMesh: createDefaultInflator(NavMesh),
-  environmentSettings: (world: HubsWorld, eid: number, props: any) => {
-    addComponent(world, EnvironmentSettings, eid);
-    (EnvironmentSettings as any).map.set(eid, props);
-  }
+  environmentSettings: inflateEnvironmentSettings
 };
 
 function jsxInflatorExists(name: string): name is keyof JSXComponentData {

--- a/src/utils/jsx-entity.ts
+++ b/src/utils/jsx-entity.ts
@@ -28,6 +28,7 @@ import {
   NotRemoteHoverTarget,
   Deletable,
   SceneLoader,
+  NavMesh,
   SceneRoot,
   EnvironmentSettings
 } from "../bit-components";
@@ -275,15 +276,16 @@ export interface GLTFComponentData extends ComponentData {
   video?: VideoLoaderParams;
   environmentSettings?: any;
   reflectionProbe?: ReflectionProbeParams;
+  navMesh?: boolean;
 }
 
 declare global {
   namespace createElementEntity.JSX {
     interface IntrinsicElements {
       entity: JSXComponentData &
-      Attrs & {
-        children?: IntrinsicElements[];
-      };
+        Attrs & {
+          children?: IntrinsicElements[];
+        };
     }
 
     interface ElementChildrenAttribute {
@@ -343,6 +345,7 @@ export const gltfInflators: Required<{ [K in keyof GLTFComponentData]: InflatorF
   ...commonInflators,
   video: inflateVideoLoader,
   reflectionProbe: inflateReflectionProbe,
+  navMesh: createDefaultInflator(NavMesh),
   environmentSettings: (world: HubsWorld, eid: number, props: any) => {
     addComponent(world, EnvironmentSettings, eid);
     (EnvironmentSettings as any).map.set(eid, props);

--- a/src/utils/jsx-entity.ts
+++ b/src/utils/jsx-entity.ts
@@ -38,6 +38,7 @@ import { GrabbableParams, inflateGrabbable } from "../inflators/grabbable";
 import { inflateImage } from "../inflators/image";
 import { inflateVideo } from "../inflators/video";
 import { inflateVideoLoader, VideoLoaderParams } from "../inflators/video-loader";
+import { inflateImageLoader, ImageLoaderParams } from "../inflators/image-loader";
 import { inflateModel, ModelParams } from "../inflators/model";
 import { inflateSlice9 } from "../inflators/slice9";
 import { inflateText } from "../inflators/text";
@@ -274,6 +275,7 @@ export enum ProjectionMode {
 
 export interface GLTFComponentData extends ComponentData {
   video?: VideoLoaderParams;
+  image?: ImageLoaderParams;
   environmentSettings?: any;
   reflectionProbe?: ReflectionProbeParams;
   navMesh?: boolean;
@@ -344,6 +346,7 @@ const jsxInflators: Required<{ [K in keyof JSXComponentData]: InflatorFn }> = {
 export const gltfInflators: Required<{ [K in keyof GLTFComponentData]: InflatorFn }> = {
   ...commonInflators,
   video: inflateVideoLoader,
+  image: inflateImageLoader,
   reflectionProbe: inflateReflectionProbe,
   navMesh: createDefaultInflator(NavMesh),
   environmentSettings: (world: HubsWorld, eid: number, props: any) => {

--- a/src/utils/load-image.tsx
+++ b/src/utils/load-image.tsx
@@ -1,5 +1,5 @@
 /** @jsx createElementEntity */
-import { createElementEntity } from "../utils/jsx-entity";
+import { createElementEntity, ProjectionMode } from "../utils/jsx-entity";
 import { loadTextureCancellable } from "../utils/load-texture";
 import { renderAsEntity } from "../utils/jsx-entity";
 import { HubsWorld } from "../app";
@@ -15,7 +15,7 @@ export function* loadImage(world: HubsWorld, url: string, contentType: string) {
       image={{
         texture,
         ratio,
-        projection: "flat",
+        projection: ProjectionMode.FLAT,
         alphaMode: AlphaMode.Opaque
       }}
       textureCacheKey={{

--- a/src/utils/load-image.tsx
+++ b/src/utils/load-image.tsx
@@ -7,21 +7,18 @@ import { Texture } from "three";
 import { AlphaMode } from "./create-image-mesh";
 
 export function* loadImage(world: HubsWorld, url: string, contentType: string) {
-  const { texture, ratio }: { texture: Texture; ratio: number } = yield loadTextureCancellable(url, 1, contentType);
-  return renderAsEntity(
-    world,
-    <entity
-      name="Image"
-      image={{
-        texture,
-        ratio,
-        projection: ProjectionMode.FLAT,
-        alphaMode: AlphaMode.Opaque
-      }}
-      textureCacheKey={{
-        src: url,
-        version: 1
-      }}
-    />
-  );
+    const { texture, ratio, cacheKey }: { texture: Texture; ratio: number, cacheKey: string } = yield loadTextureCancellable(url, 1, contentType);
+    return renderAsEntity(
+        world,
+        <entity
+            name="Image"
+            image={{
+                texture,
+                ratio,
+                projection: ProjectionMode.FLAT,
+                alphaMode: AlphaMode.Opaque,
+                cacheKey
+            }}
+        />
+    );
 }

--- a/src/utils/load-image.tsx
+++ b/src/utils/load-image.tsx
@@ -1,5 +1,6 @@
 /** @jsx createElementEntity */
-import { createElementEntity, ProjectionMode } from "../utils/jsx-entity";
+import { createElementEntity } from "../utils/jsx-entity";
+import { ProjectionMode } from "./projection-mode";
 import { loadTextureCancellable } from "../utils/load-texture";
 import { renderAsEntity } from "../utils/jsx-entity";
 import { HubsWorld } from "../app";
@@ -7,18 +8,19 @@ import { Texture } from "three";
 import { AlphaMode } from "./create-image-mesh";
 
 export function* loadImage(world: HubsWorld, url: string, contentType: string) {
-    const { texture, ratio, cacheKey }: { texture: Texture; ratio: number, cacheKey: string } = yield loadTextureCancellable(url, 1, contentType);
-    return renderAsEntity(
-        world,
-        <entity
-            name="Image"
-            image={{
-                texture,
-                ratio,
-                projection: ProjectionMode.FLAT,
-                alphaMode: AlphaMode.Opaque,
-                cacheKey
-            }}
-        />
-    );
+  const { texture, ratio, cacheKey }: { texture: Texture; ratio: number; cacheKey: string } =
+    yield loadTextureCancellable(url, 1, contentType);
+  return renderAsEntity(
+    world,
+    <entity
+      name="Image"
+      image={{
+        texture,
+        ratio,
+        projection: ProjectionMode.FLAT,
+        alphaMode: AlphaMode.Opaque,
+        cacheKey
+      }}
+    />
+  );
 }

--- a/src/utils/load-model.tsx
+++ b/src/utils/load-model.tsx
@@ -5,9 +5,10 @@ import { loadModel as loadGLTFModel } from "../components/gltf-model-plus";
 import { renderAsEntity } from "../utils/jsx-entity";
 
 export function* loadModel(world: HubsWorld, src: string, useCache: boolean) {
-    const { scene, animations } = yield loadGLTFModel(src, null, useCache, null);
-    scene.animations = animations;
-    scene.mixer = new THREE.AnimationMixer(scene);
+  const { scene, animations } = yield loadGLTFModel(src, null, useCache, null);
 
-    return renderAsEntity(world, <entity model={{ model: scene }} />);
+  scene.animations = animations;
+  scene.mixer = new THREE.AnimationMixer(scene);
+
+  return renderAsEntity(world, <entity model={{ model: scene }} />);
 }

--- a/src/utils/load-model.tsx
+++ b/src/utils/load-model.tsx
@@ -5,6 +5,7 @@ import { loadModel as loadGLTFModel } from "../components/gltf-model-plus";
 import { renderAsEntity } from "../utils/jsx-entity";
 
 export function* loadModel(world: HubsWorld, src: string, useCache: boolean) {
+  // TODO: Write loadGLTFModelCancelable
   const { scene, animations } = yield loadGLTFModel(src, null, useCache, null);
 
   scene.animations = animations;

--- a/src/utils/load-model.tsx
+++ b/src/utils/load-model.tsx
@@ -4,10 +4,10 @@ import { HubsWorld } from "../app";
 import { loadModel as loadGLTFModel } from "../components/gltf-model-plus";
 import { renderAsEntity } from "../utils/jsx-entity";
 
-export function* loadModel(world: HubsWorld, src: string) {
-  const { scene, animations } = yield loadGLTFModel(src, null, true, null);
-  scene.animations = animations;
-  scene.mixer = new THREE.AnimationMixer(scene);
+export function* loadModel(world: HubsWorld, src: string, useCache: boolean) {
+    const { scene, animations } = yield loadGLTFModel(src, null, useCache, null);
+    scene.animations = animations;
+    scene.mixer = new THREE.AnimationMixer(scene);
 
-  return renderAsEntity(world, <entity model={{ model: scene }} />);
+    return renderAsEntity(world, <entity model={{ model: scene }} />);
 }

--- a/src/utils/load-video.tsx
+++ b/src/utils/load-video.tsx
@@ -1,5 +1,5 @@
 /** @jsx createElementEntity */
-import { createElementEntity } from "../utils/jsx-entity";
+import { createElementEntity, ProjectionMode } from "../utils/jsx-entity";
 import { VideoTexture } from "three";
 import { renderAsEntity } from "../utils/jsx-entity";
 import { loadVideoTexture } from "../utils/load-video-texture";
@@ -19,7 +19,7 @@ export function* loadVideo(world: HubsWorld, url: string) {
         texture,
         ratio,
         autoPlay: true,
-        projection: "flat"
+        projection: ProjectionMode.FLAT
       }}
     ></entity>
   );

--- a/src/utils/load-video.tsx
+++ b/src/utils/load-video.tsx
@@ -1,5 +1,6 @@
 /** @jsx createElementEntity */
-import { createElementEntity, ProjectionMode } from "../utils/jsx-entity";
+import { createElementEntity } from "../utils/jsx-entity";
+import { ProjectionMode } from "./projection-mode";
 import { VideoTexture } from "three";
 import { renderAsEntity } from "../utils/jsx-entity";
 import { loadVideoTexture } from "../utils/load-video-texture";

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -23,6 +23,17 @@ export const MediaType = {
 };
 MediaType.ALL = MediaType.MODEL | MediaType.IMAGE | MediaType.VIDEO | MediaType.PDF | MediaType.HTML | MediaType.AUDIO;
 MediaType.ALL_2D = MediaType.IMAGE | MediaType.VIDEO | MediaType.PDF | MediaType.HTML;
+const MediaTypeName = new Map([
+  [MediaType.MODEL, "model"],
+  [MediaType.IMAGE, "image"],
+  [MediaType.VIDEO, "video"],
+  [MediaType.PDF, "pdf"],
+  [MediaType.HTML, "html"],
+  [MediaType.AUDIO, "audio"]
+]);
+export function mediaTypeName(type) {
+  return MediaTypeName.get(type) || "unknown";
+}
 
 const linkify = Linkify();
 linkify.tlds(tlds);

--- a/src/utils/projection-mode.ts
+++ b/src/utils/projection-mode.ts
@@ -1,0 +1,4 @@
+export enum ProjectionMode {
+  FLAT = "flat",
+  SPHERE_EQUIRECTANGULAR = "360-equirectangular"
+}

--- a/src/utils/texture-cache.js
+++ b/src/utils/texture-cache.js
@@ -34,7 +34,7 @@ export class TextureCache {
   }
 
   release(src, version) {
-    releaseByKey(TextureCache.key(src, version));
+    this.releaseByKey(TextureCache.key(src, version));
   }
 
   releaseByKey(cacheKey) {

--- a/src/utils/texture-cache.js
+++ b/src/utils/texture-cache.js
@@ -3,13 +3,15 @@ import { disposeTexture } from "./material-utils";
 export class TextureCache {
   cache = new Map();
 
-  key(src, version) {
+  static key(src, version) {
     return `${src}_${version}`;
   }
 
   set(src, version, texture) {
     const image = texture.image;
-    this.cache.set(this.key(src, version), {
+    const cacheKey = TextureCache.key(src, version);
+    this.cache.set(cacheKey, {
+      cacheKey,
       texture,
       ratio: (image.videoHeight || image.height) / (image.videoWidth || image.width),
       count: 0
@@ -18,34 +20,36 @@ export class TextureCache {
   }
 
   has(src, version) {
-    return this.cache.has(this.key(src, version));
+    return this.cache.has(TextureCache.key(src, version));
   }
 
   get(src, version) {
-    return this.cache.get(this.key(src, version));
+    return this.cache.get(TextureCache.key(src, version));
   }
 
   retain(src, version) {
-    const cacheItem = this.cache.get(this.key(src, version));
+    const cacheItem = this.cache.get(TextureCache.key(src, version));
     cacheItem.count++;
-    // console.log("retain", src, cacheItem.count);
     return cacheItem;
   }
 
   release(src, version) {
-    const cacheItem = this.cache.get(this.key(src, version));
+    releaseByKey(TextureCache.key(src, version));
+  }
+
+  releaseByKey(cacheKey) {
+    const cacheItem = this.cache.get(cacheKey);
 
     if (!cacheItem) {
-      console.error(`Releasing uncached texture src ${src}`);
+      console.error(`Releasing uncached texture. The cacheKey is: ${cacheKey}`);
       return;
     }
 
     cacheItem.count--;
-    // console.log("release", src, cacheItem.count);
     if (cacheItem.count <= 0) {
       // Unload the video element to prevent it from continuing to play in the background
       disposeTexture(cacheItem.texture);
-      this.cache.delete(this.key(src, version));
+      this.cache.delete(cacheKey);
     }
   }
 }

--- a/src/utils/three-utils.js
+++ b/src/utils/three-utils.js
@@ -147,7 +147,7 @@ export function cloneObject3D(source, preserveUUIDs) {
   parallelTraverse(source, clone, (sourceNode, clonedNode) => {
     cloneLookup.set(sourceNode, clonedNode);
 
-    if (sourceNode.userData?.gltfExtensions?.MOZ_hubs_components) {
+    if (sourceNode.userData.gltfExtensions?.MOZ_hubs_components) {
       clonedNode.userData.gltfExtensions.MOZ_hubs_components = sourceNode.userData.gltfExtensions.MOZ_hubs_components;
     }
   });

--- a/src/utils/three-utils.js
+++ b/src/utils/three-utils.js
@@ -146,6 +146,10 @@ export function cloneObject3D(source, preserveUUIDs) {
 
   parallelTraverse(source, clone, (sourceNode, clonedNode) => {
     cloneLookup.set(sourceNode, clonedNode);
+
+    if (sourceNode.userData?.gltfExtensions?.MOZ_hubs_components) {
+      clonedNode.userData.gltfExtensions.MOZ_hubs_components = sourceNode.userData.gltfExtensions.MOZ_hubs_components;
+    }
   });
 
   source.traverse(sourceNode => {

--- a/types/aframe.d.ts
+++ b/types/aframe.d.ts
@@ -8,6 +8,7 @@ declare module "aframe" {
       [name: string]: Object3D;
     };
     getObject3D(string): Object3D?;
+    components: { [s: string]: AComponent };
   }
 
   type FnTick = (t: number, dt: number) => void;

--- a/types/aframe.d.ts
+++ b/types/aframe.d.ts
@@ -94,6 +94,7 @@ declare module "aframe" {
       /** @deprecated see bit-interaction-system */
       interaction: InteractionSystem;
     };
+    emit(string, any): void;
   }
 
   declare global {

--- a/types/aframe.d.ts
+++ b/types/aframe.d.ts
@@ -79,6 +79,11 @@ declare module "aframe" {
     updateLegacyState();
   }
 
+  interface NavSystem extends ASystem {
+    loadMesh(mesh: Mesh, zone: string);
+    mesh?: Mesh;
+  }
+
   interface AScene extends AElement {
     object3D: Scene;
     renderStarted: boolean;
@@ -94,6 +99,7 @@ declare module "aframe" {
       userinput: UserInputSystem;
       /** @deprecated see bit-interaction-system */
       interaction: InteractionSystem;
+      nav: NavSystem;
     };
     emit(string, any): void;
   }

--- a/types/aframe.d.ts
+++ b/types/aframe.d.ts
@@ -102,6 +102,8 @@ declare module "aframe" {
       nav: NavSystem;
     };
     emit(string, any): void;
+    addState(string): void;
+    is(string): boolean;
   }
 
   declare global {

--- a/types/three.d.ts
+++ b/types/three.d.ts
@@ -1,9 +1,13 @@
-import { Object3D } from "three";
+import { Object3D, Mesh } from "three";
+
 declare module "three" {
   interface Object3D {
     matrixNeedsUpdate: boolean;
     childrenNeedMatrixWorldUpdate: boolean;
     eid?: number;
     updateMatrices: (forceLocalUpdate?: boolean, forceWorldUpdate?: boolean, skipParents?: boolean) => void;
+  }
+  interface Mesh {
+    reflectionProbeMode: "static" | "dynamic" | false;
   }
 }


### PR DESCRIPTION
Add environment loading with bitECS behind the `newLoader` query string parameter.

Only components in `commonInflators` and `gltfInflators` are supported so far. 