### PR TITLE
Hide LOD progressive loading mode behind the flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "semver": "^7.3.2",
         "three": "github:mozillareality/three.js#56e7c46d991cc16bff82bdbb03c7bfba4620567f",
         "three-ammo": "github:mozillareality/three-ammo",
-        "three-gltf-extensions": "^0.0.13",
+        "three-gltf-extensions": "^0.0.14",
         "three-mesh-bvh": "^0.3.7",
         "three-pathfinding": "^1.1.0",
         "three-to-ammo": "github:infinitelee/three-to-ammo",
@@ -29122,9 +29122,9 @@
       }
     },
     "node_modules/three-gltf-extensions": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/three-gltf-extensions/-/three-gltf-extensions-0.0.13.tgz",
-      "integrity": "sha512-xVvDBtFEMPwfPY22O1nW/S0DQQRLPaXqptiCSXcxw2qb7uUaClXH0NbgWgyf7mztHoDWsr362rZTBM6AMzmlgg=="
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/three-gltf-extensions/-/three-gltf-extensions-0.0.14.tgz",
+      "integrity": "sha512-fTaO/aZgF1tG98eIb/kFGYivQ/KHJdGGBHK1zuZLV6q2MrehP9P+oV42Ijtkv2Hze0VZLz9UJCXgePovjACMcw=="
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.3.7",
@@ -54297,9 +54297,9 @@
       "requires": {}
     },
     "three-gltf-extensions": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/three-gltf-extensions/-/three-gltf-extensions-0.0.13.tgz",
-      "integrity": "sha512-xVvDBtFEMPwfPY22O1nW/S0DQQRLPaXqptiCSXcxw2qb7uUaClXH0NbgWgyf7mztHoDWsr362rZTBM6AMzmlgg=="
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/three-gltf-extensions/-/three-gltf-extensions-0.0.14.tgz",
+      "integrity": "sha512-fTaO/aZgF1tG98eIb/kFGYivQ/KHJdGGBHK1zuZLV6q2MrehP9P+oV42Ijtkv2Hze0VZLz9UJCXgePovjACMcw=="
     },
     "three-mesh-bvh": {
       "version": "0.3.7",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "semver": "^7.3.2",
     "three": "github:mozillareality/three.js#56e7c46d991cc16bff82bdbb03c7bfba4620567f",
     "three-ammo": "github:mozillareality/three-ammo",
-    "three-gltf-extensions": "^0.0.13",
+    "three-gltf-extensions": "^0.0.14",
     "three-mesh-bvh": "^0.3.7",
     "three-pathfinding": "^1.1.0",
     "three-to-ammo": "github:infinitelee/three-to-ammo",


### PR DESCRIPTION
From the internal discussion with @netpro2k and @johnshaughnessy 

Currently LOD progressive loading mode is chosen by default but it may be useless without rangerequests that is hidden by flag because without rangerequests the glTF loader starts with loading entire file and just lazily parse higher levels on demand.
Just lazy parsing isn't worth. It just makes the loading path complex.

So better to hide LOD progressive loading mode behind the flag. Enable both range requests and LOD progressive loading mode if rangerequests query strings is in URL.