### PR TITLE
"Fix" scene page

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -59,6 +59,7 @@ export class App {
   hubChannel?: HubChannel;
   mediaDevicesManager?: MediaDevicesManager;
   entryManager?: SceneEntryManager;
+  messageDispatch?: any;
 
   store = new Store();
   mediaSearchStore = new MediaSearchStore();

--- a/src/bit-systems/scene-loading.ts
+++ b/src/bit-systems/scene-loading.ts
@@ -8,7 +8,6 @@ import { AElement } from "aframe";
 import { anyEntityWith } from "../utils/bit-utils";
 import { renderAsEntity } from "../utils/jsx-entity";
 import { ScenePrefab } from "../prefabs/scene";
-import { remountUI } from "../hub";
 import { ExitReason } from "../react-components/room/ExitedRoomScreen";
 import { EnvironmentSystem } from "../systems/environment-system";
 import { Mesh } from "three";
@@ -68,7 +67,7 @@ function* loadScene(world: HubsWorld, eid: number, signal: AbortSignal, environm
   } catch (e) {
     console.error(e);
     console.error("Failed to load the scene");
-    remountUI({ roomUnavailableReason: ExitReason.sceneError });
+    APP.messageDispatch?.remountUI({ roomUnavailableReason: ExitReason.sceneError });
     APP.entryManager!.exitScene();
   }
 }

--- a/src/react-components/scene-ui.js
+++ b/src/react-components/scene-ui.js
@@ -38,18 +38,11 @@ class SceneUI extends Component {
   };
 
   state = {
-    showScreenshot: false
+    showScreenshot: true
   };
 
   constructor(props) {
     super(props);
-
-    // Show screenshot if scene isn't loaded in 5 seconds
-    setTimeout(() => {
-      if (!this.props.sceneLoaded) {
-        this.setState({ showScreenshot: true });
-      }
-    }, 5000);
   }
 
   componentDidMount() {

--- a/src/scene.js
+++ b/src/scene.js
@@ -77,7 +77,6 @@ const onReady = async () => {
     mountUI(scene, uiProps);
   };
 
-  const sceneRoot = document.querySelector("#scene-root");
   const sceneModelEntity = document.createElement("a-entity");
   const gltfEl = document.createElement("a-entity");
   const camera = document.getElementById("camera");
@@ -140,13 +139,6 @@ const onReady = async () => {
 
   const modelUrl = sceneInfo.model_url;
   console.log(`Scene Model URL: ${modelUrl}`);
-
-  gltfEl.setAttribute("gltf-model-plus", { src: modelUrl, useCache: false, inflate: true });
-  gltfEl.addEventListener("model-loaded", ({ detail: { model } }) =>
-    sceneModelEntity.emit("environment-scene-loaded", model)
-  );
-  sceneModelEntity.appendChild(gltfEl);
-  sceneRoot.appendChild(sceneModelEntity);
 
   const parentScene =
     sceneInfo.parent_scene_id &&


### PR DESCRIPTION
https://github.com/mozilla/hubs/pull/5793/ introduced a regression that caused the scene page to fail to load.

This PR stops the scene page from loading the gltf file of the scene and shows the screenshot instead. It also makes scene-loading.ts not import all of hub.js, since scene-loading.ts is imported on the scene page and we don't want everything connected to hub.js to run.

We'll need to revisit the scene page in the future but this at least shows the screenshot instead of a blank page. 