### PR TITLE
Remove 3D game functionality from scene page

### DIFF
--- a/admin/src/admin.js
+++ b/admin/src/admin.js
@@ -32,14 +32,13 @@ import { ServerAccess } from "./react-components/server-access";
 import { ContentCDN } from "./react-components/content-cdn";
 import { ImportContent } from "./react-components/import-content";
 import { AutoEndSessionDialog } from "./react-components/auto-end-session-dialog";
-import Store from "hubs/src/storage/store";
 import registerTelemetry from "hubs/src/telemetry";
 import { createMuiTheme, withStyles } from "@material-ui/core/styles";
 import { UnauthorizedPage } from "./react-components/unauthorized";
+import { store } from "hubs/src/utils/store-instance";
 
 const qs = new URLSearchParams(location.hash.split("?")[1]);
 
-const store = new Store();
 window.APP = { store };
 
 registerTelemetry("/admin", "Hubs Admin");

--- a/admin/src/react-components/service-editor.js
+++ b/admin/src/react-components/service-editor.js
@@ -18,7 +18,7 @@ import LinearProgress from "@material-ui/core/LinearProgress";
 import clsx from "classnames";
 import { Title } from "react-admin";
 
-import Store from "hubs/src/storage/store";
+import { store } from "hubs/src/utils/store-instance";
 import withCommonStyles from "../utils/with-common-styles";
 import {
   getEditableConfig,
@@ -462,7 +462,6 @@ const AppConfigEditor = withStyles(styles)(
   class AppConfigEditor extends ConfigurationEditor {
     constructor(props) {
       super(props);
-      const store = new Store();
       if (store.state && store.state.credentials && store.state.credentials.token) {
         AppConfigUtils.setAuthToken(store.state.credentials.token);
       }

--- a/scripts/login.js
+++ b/scripts/login.js
@@ -1,10 +1,10 @@
 import readline from "readline";
 import { connectToReticulum } from "../src/utils/phoenix-utils";
-import Store from "../src/storage/store";
 import AuthChannel from "../src/utils/auth-channel";
 import configs from "../src/utils/configs.js";
 import { Socket } from "phoenix-channels";
 import { writeFileSync } from "fs";
+import { store } from "../src/utils/store-instance";
 
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 
@@ -35,7 +35,6 @@ const ask = q => new Promise(res => rl.question(q, res));
   configs.RETICULUM_SOCKET_PROTOCOL = "wss:";
 
   const socket = await connectToReticulum(false, null, Socket);
-  const store = new Store();
 
   const email = await ask("Your admin account email (eg admin@yoursite.com): ");
   console.log(`Logging into ${host} as ${email}. Click on the link in your email to continue.`);

--- a/src/app.ts
+++ b/src/app.ts
@@ -27,6 +27,7 @@ import { DialogAdapter } from "./naf-dialog-adapter";
 import { mainTick } from "./systems/hubs-systems";
 import { waitForPreloads } from "./utils/preload";
 import SceneEntryManager from "./scene-entry-manager";
+import { store } from "./utils/store-instance";
 
 declare global {
   interface Window {
@@ -60,8 +61,8 @@ export class App {
   mediaDevicesManager?: MediaDevicesManager;
   entryManager?: SceneEntryManager;
   messageDispatch?: any;
+  store: Store;
 
-  store = new Store();
   mediaSearchStore = new MediaSearchStore();
 
   audios = new Map<AElement | number, PositionalAudio | Audio>();
@@ -100,6 +101,7 @@ export class App {
   } = {};
 
   constructor() {
+    this.store = store;
     // TODO: Create accessor / update methods for these maps / set
     this.world.eid2obj = new Map();
 

--- a/src/cloud.js
+++ b/src/cloud.js
@@ -7,9 +7,9 @@ import classNames from "classnames";
 import { WrappedIntlProvider } from "./react-components/wrapped-intl-provider";
 import { PageContainer } from "./react-components/layout/PageContainer";
 import { AuthContextProvider } from "./react-components/auth/AuthContext";
-import Store from "./storage/store";
 import { Container } from "./react-components/layout/Container";
 import { Button } from "./react-components/input/Button";
+import { store } from "./utils/store-instance";
 
 import registerTelemetry from "./telemetry";
 import { FormattedMessage } from "react-intl";
@@ -117,7 +117,6 @@ function HubsCloudPage() {
   );
 }
 
-const store = new Store();
 window.APP = { store };
 
 function Root() {

--- a/src/discord.js
+++ b/src/discord.js
@@ -8,16 +8,14 @@ import styles from "./assets/stylesheets/discord.scss";
 import discordBotLogo from "./assets/images/discord-bot-logo.png";
 import discordBotVideoMP4 from "./assets/video/discord.mp4";
 import discordBotVideoWebM from "./assets/video/discord.webm";
-import Store from "./storage/store";
 
 import registerTelemetry from "./telemetry";
 import { ThemeProvider } from "./react-components/styles/theme";
+import { store } from "./utils/store-instance";
 
 registerTelemetry("/discord", "Discord Landing Page");
 
 const inviteUrl = "https://forms.gle/GGPgarSuY5WaTNCT8";
-
-const store = new Store();
 
 class DiscordPage extends Component {
   componentDidMount() {}

--- a/src/index.js
+++ b/src/index.js
@@ -2,16 +2,15 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { WrappedIntlProvider } from "./react-components/wrapped-intl-provider";
 import registerTelemetry from "./telemetry";
-import Store from "./storage/store";
 import "./utils/theme";
 import { HomePage } from "./react-components/home/HomePage";
 import { AuthContextProvider } from "./react-components/auth/AuthContext";
 import "./react-components/styles/global.scss";
 import { ThemeProvider } from "./react-components/styles/theme";
+import { store } from "./utils/store-instance";
 
 registerTelemetry("/home", "Hubs Home Page");
 
-const store = new Store();
 window.APP = { store };
 
 function Root() {

--- a/src/link.js
+++ b/src/link.js
@@ -9,12 +9,10 @@ import registerTelemetry from "./telemetry";
 import LinkRoot from "./react-components/link-root";
 import LinkChannel from "./utils/link-channel";
 import { connectToReticulum } from "./utils/phoenix-utils";
-import Store from "./storage/store";
 import { ThemeProvider } from "./react-components/styles/theme";
+import { store } from "./utils/store-instance";
 
 registerTelemetry("/link", "Hubs Device Link");
-
-const store = new Store();
 
 const linkChannel = new LinkChannel(store);
 

--- a/src/react-components/scene-ui.js
+++ b/src/react-components/scene-ui.js
@@ -1,29 +1,20 @@
-import React, { Component, useRef } from "react";
-import PropTypes from "prop-types";
 import classNames from "classnames";
+import PropTypes from "prop-types";
+import React, { Component } from "react";
 import { FormattedMessage, injectIntl } from "react-intl";
-import configs from "../utils/configs";
-import IfFeature from "./if-feature";
 import styles from "../assets/stylesheets/scene-ui.scss";
+import configs from "../utils/configs";
 import { createAndRedirectToNewHub, getReticulumFetchUrl } from "../utils/phoenix-utils";
-import { ReactComponent as Twitter } from "./icons/Twitter.svg";
 import { ReactComponent as CodeBranch } from "./icons/CodeBranch.svg";
 import { ReactComponent as Pen } from "./icons/Pen.svg";
+import { ReactComponent as Twitter } from "./icons/Twitter.svg";
+import IfFeature from "./if-feature";
 import { AppLogo } from "./misc/AppLogo";
-
-import { useResizeViewport } from "./room/useResizeViewport";
-function ResizeHookWrapper({ store, scene }) {
-  const viewportRef = useRef(document.body);
-  useResizeViewport(viewportRef, store, scene);
-  return <></>;
-}
 
 class SceneUI extends Component {
   static propTypes = {
     intl: PropTypes.object,
-    scene: PropTypes.object,
     store: PropTypes.object,
-    sceneLoaded: PropTypes.bool,
     sceneId: PropTypes.string,
     sceneName: PropTypes.string,
     sceneDescription: PropTypes.string,
@@ -37,20 +28,8 @@ class SceneUI extends Component {
     parentScene: PropTypes.object
   };
 
-  state = {
-    showScreenshot: true
-  };
-
   constructor(props) {
     super(props);
-  }
-
-  componentDidMount() {
-    this.props.scene.addEventListener("loaded", this.onSceneLoaded);
-  }
-
-  componentWillUnmount() {
-    this.props.scene.removeEventListener("loaded", this.onSceneLoaded);
   }
 
   createRoom = () => {
@@ -206,11 +185,10 @@ class SceneUI extends Component {
       <div className={styles.ui}>
         <div
           className={classNames({
-            [styles.screenshot]: true,
-            [styles.screenshotHidden]: this.props.sceneLoaded
+            [styles.screenshot]: true
           })}
         >
-          {this.state.showScreenshot && <img src={this.props.sceneScreenshotURL} />}
+          {<img src={this.props.sceneScreenshotURL} />}
         </div>
         <div className={styles.grid}>
           <div className={styles.mainPanel}>
@@ -270,7 +248,6 @@ class SceneUI extends Component {
             <div className={styles.attribution}>{attributions}</div>
           </div>
         </div>
-        <ResizeHookWrapper store={this.props.store} scene={this.props.scene} />
       </div>
     );
   }

--- a/src/scene.html
+++ b/src/scene.html
@@ -25,20 +25,6 @@
 
 <body>
     <div id="support-root"></div>
-
-    <a-scene
-        loading-screen="enabled: false"
-        shadow="type: pcfsoft;autoUpdate: false"
-        light="defaultLightsEnabled: false"
-    >
-        <a-entity
-            id="scene-root"
-            static-body="shape: none;"
-        ></a-entity>
-
-        <a-entity id="camera" inject-main-camera-here></a-entity>
-    </a-scene>
-
     <div id="ui-root"></div>
 </body>
 

--- a/src/scene.js
+++ b/src/scene.js
@@ -31,17 +31,16 @@ const remountUI = (function () {
   };
 })();
 
-async function shouldShowCreateRoom() {
+async function shouldShowCreateRoom(joinToken) {
   const socket = await connectToReticulum();
 
   const joinParams = {
     hub_id: "scene"
   };
-  const token = window.APP?.store?.state?.credentials?.token;
-  if (token) {
+  if (joinToken) {
     // Reticulum rejects a join with { token: null }, so don't add it to joinParams if we don't have it.
     // TODO: (In reticulum) Treat { token: null } the same as not sending a token
-    joinParams.token = token;
+    joinParams.token = joinToken;
   }
   const retPhxChannel = socket.channel("ret", joinParams);
 
@@ -94,7 +93,7 @@ function onReady() {
   console.log(`Scene ID: ${sceneId}`);
   remountUI({ sceneId, store });
 
-  shouldShowCreateRoom().then(showCreateRoom => {
+  shouldShowCreateRoom(store.state.credentials.token).then(showCreateRoom => {
     remountUI({ showCreateRoom });
   });
 

--- a/src/scene.js
+++ b/src/scene.js
@@ -9,7 +9,7 @@ import { WrappedIntlProvider } from "./react-components/wrapped-intl-provider";
 import Store from "./storage/store";
 import registerTelemetry from "./telemetry";
 import { disableiOSZoom } from "./utils/disable-ios-zoom";
-import { connectToReticulum, fetchReticulumAuthenticatedWithStore } from "./utils/phoenix-utils";
+import { connectToReticulum, fetchReticulumAuthenticatedWithToken } from "./utils/phoenix-utils";
 import "./utils/theme";
 
 function mountUI(props = {}) {
@@ -71,8 +71,8 @@ async function shouldShowCreateRoom() {
   }
 }
 
-async function fetchSceneInfo(store, sceneId) {
-  const response = await fetchReticulumAuthenticatedWithStore(store, `/api/v1/scenes/${sceneId}`);
+async function fetchSceneInfo(token, sceneId) {
+  const response = await fetchReticulumAuthenticatedWithToken(token, `/api/v1/scenes/${sceneId}`);
   return response.scenes[0];
 }
 
@@ -98,7 +98,7 @@ function onReady() {
     remountUI({ showCreateRoom });
   });
 
-  fetchSceneInfo(store, sceneId).then(async sceneInfo => {
+  fetchSceneInfo(store.state.credentials.token, sceneId).then(async sceneInfo => {
     console.log(`Scene Info:`, sceneInfo);
     if (!sceneInfo) {
       // Scene is delisted or removed
@@ -118,7 +118,8 @@ function onReady() {
         sceneProjectId: sceneInfo.project_id,
         sceneAllowRemixing: sceneInfo.allow_remixing,
         isOwner: sceneInfo.account_id && sceneInfo.account_id === store.credentialsAccountId,
-        parentScene: sceneInfo.parent_scene_id && (await fetchSceneInfo(store, sceneInfo.parent_scene_id))
+        parentScene:
+          sceneInfo.parent_scene_id && (await fetchSceneInfo(store.state.credentials.token, sceneInfo.parent_scene_id))
       });
     }
   });

--- a/src/scene.js
+++ b/src/scene.js
@@ -6,11 +6,11 @@ import SceneUI from "./react-components/scene-ui";
 import "./react-components/styles/global.scss";
 import { ThemeProvider } from "./react-components/styles/theme";
 import { WrappedIntlProvider } from "./react-components/wrapped-intl-provider";
-import Store from "./storage/store";
 import registerTelemetry from "./telemetry";
 import { disableiOSZoom } from "./utils/disable-ios-zoom";
 import { connectToReticulum, fetchReticulumAuthenticatedWithToken } from "./utils/phoenix-utils";
 import "./utils/theme";
+import { store } from "./utils/store-instance";
 
 function mountUI(props = {}) {
   ReactDOM.render(
@@ -84,8 +84,6 @@ function parseSceneId() {
 
 function onReady() {
   console.log(`Hubs version: ${process.env.BUILD_VERSION || "?"}`);
-
-  const store = new Store();
 
   disableiOSZoom();
 

--- a/src/signin.js
+++ b/src/signin.js
@@ -2,7 +2,6 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { WrappedIntlProvider } from "./react-components/wrapped-intl-provider";
 import registerTelemetry from "./telemetry";
-import Store from "./storage/store";
 import "./utils/theme";
 import { AuthContextProvider } from "./react-components/auth/AuthContext";
 import { SignInModalContainer } from "./react-components/auth/SignInModalContainer";
@@ -11,10 +10,10 @@ import "./react-components/styles/global.scss";
 import "./assets/stylesheets/globals.scss";
 import { Center } from "./react-components/layout/Center";
 import { ThemeProvider } from "./react-components/styles/theme";
+import { store } from "./utils/store-instance";
 
 registerTelemetry("/signin", "Hubs Sign In Page");
 
-const store = new Store();
 window.APP = { store };
 
 function Root() {

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -12,7 +12,6 @@ const validator = new Validator();
 import { EventTarget } from "event-target-shim";
 import { fetchRandomDefaultAvatarId, generateRandomName } from "../utils/identity.js";
 import { NO_DEVICE_ID } from "../utils/media-devices-utils.js";
-import { getDefaultTheme } from "../utils/theme.js";
 import { AAModes } from "../effects";
 
 const defaultMaterialQuality = (function () {
@@ -155,7 +154,7 @@ export const SCHEMA = {
         enableAudioClipping: { type: "bool", default: false },
         audioClippingThreshold: { type: "number", default: 0.015 },
         audioPanningQuality: { type: "string", default: defaultAudioPanningQuality() },
-        theme: { type: "string", default: getDefaultTheme()?.name },
+        theme: { type: "string", default: undefined },
         cursorSize: { type: "number", default: 1 },
         nametagVisibility: { type: "string", default: "showAll" },
         nametagVisibilityDistance: { type: "number", default: 5 },

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -2,7 +2,6 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { WrappedIntlProvider } from "./react-components/wrapped-intl-provider";
 import registerTelemetry from "./telemetry";
-import Store from "./storage/store";
 import "./utils/theme";
 import { AuthContextProvider } from "./react-components/auth/AuthContext";
 import { TokensContainer } from "./react-components/tokens/TokensContainer";
@@ -11,10 +10,10 @@ import "./react-components/styles/global.scss";
 import { TokenPageLayout } from "./react-components/tokens/TokenPageLayout";
 import configs from "./utils/configs";
 import { ThemeProvider } from "./react-components/styles/theme";
+import { store } from "./utils/store-instance";
 
 registerTelemetry("/tokens", "Backend API Tokens Page");
 
-const store = new Store();
 window.APP = { store };
 
 function Root() {

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -2,8 +2,7 @@ import { Socket } from "phoenix";
 import { generateHubName } from "../utils/name-generation";
 import configs from "../utils/configs";
 import { sleep } from "../utils/async-utils";
-
-import Store from "../storage/store";
+import { store } from "../utils/store-instance";
 
 export function hasReticulumServer() {
   return !!configs.RETICULUM_SERVER;
@@ -199,7 +198,7 @@ export function fetchReticulumAuthenticatedWithToken(token, url, method = "GET",
   });
 }
 export function fetchReticulumAuthenticated(url, method = "GET", payload) {
-  return fetchReticulumAuthenticatedWithToken(window.APP.store.state.credentials.token, url, method, payload);
+  return fetchReticulumAuthenticatedWithToken(store.state.credentials.token, url, method, payload);
 }
 
 export async function createAndRedirectToNewHub(name, sceneId, replace) {
@@ -211,7 +210,6 @@ export async function createAndRedirectToNewHub(name, sceneId, replace) {
   }
 
   const headers = { "content-type": "application/json" };
-  const store = new Store();
   if (store.state && store.state.credentials.token) {
     headers.authorization = `bearer ${store.state.credentials.token}`;
   }

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -176,8 +176,8 @@ export function getLandingPageForPhoto(photoUrl) {
   return getReticulumFetchUrl(parsedUrl.pathname.replace(".png", ".html") + parsedUrl.search, true);
 }
 
-export function fetchReticulumAuthenticated(url, method = "GET", payload) {
-  const { token } = window.APP.store.state.credentials;
+export function fetchReticulumAuthenticatedWithStore(store, url, method = "GET", payload) {
+  const { token } = store.state.credentials;
   const retUrl = getReticulumFetchUrl(url);
   const params = {
     headers: { "content-type": "application/json" },
@@ -198,6 +198,9 @@ export function fetchReticulumAuthenticated(url, method = "GET", payload) {
       return result;
     }
   });
+}
+export function fetchReticulumAuthenticated(url, method = "GET", payload) {
+  return fetchReticulumAuthenticatedWithStore(window.APP.store, url, method, payload);
 }
 
 export async function createAndRedirectToNewHub(name, sceneId, replace) {
@@ -343,7 +346,10 @@ export function discordBridgesForPresences(presences) {
   for (const p of Object.values(presences)) {
     for (const m of p.metas) {
       if (m.profile && m.profile.discordBridges) {
-        Array.prototype.push.apply(channels, m.profile.discordBridges.map(b => b.channel.name));
+        Array.prototype.push.apply(
+          channels,
+          m.profile.discordBridges.map(b => b.channel.name)
+        );
       }
     }
   }

--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -176,8 +176,7 @@ export function getLandingPageForPhoto(photoUrl) {
   return getReticulumFetchUrl(parsedUrl.pathname.replace(".png", ".html") + parsedUrl.search, true);
 }
 
-export function fetchReticulumAuthenticatedWithStore(store, url, method = "GET", payload) {
-  const { token } = store.state.credentials;
+export function fetchReticulumAuthenticatedWithToken(token, url, method = "GET", payload) {
   const retUrl = getReticulumFetchUrl(url);
   const params = {
     headers: { "content-type": "application/json" },
@@ -200,7 +199,7 @@ export function fetchReticulumAuthenticatedWithStore(store, url, method = "GET",
   });
 }
 export function fetchReticulumAuthenticated(url, method = "GET", payload) {
-  return fetchReticulumAuthenticatedWithStore(window.APP.store, url, method, payload);
+  return fetchReticulumAuthenticatedWithToken(window.APP.store.state.credentials.token, url, method, payload);
 }
 
 export async function createAndRedirectToNewHub(name, sceneId, replace) {

--- a/src/utils/store-instance.ts
+++ b/src/utils/store-instance.ts
@@ -1,0 +1,3 @@
+import Store from "../storage/store";
+
+export const store = new Store();

--- a/src/verify.js
+++ b/src/verify.js
@@ -2,7 +2,6 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { WrappedIntlProvider } from "./react-components/wrapped-intl-provider";
 import registerTelemetry from "./telemetry";
-import Store from "./storage/store";
 import "./utils/theme";
 import { AuthContextProvider } from "./react-components/auth/AuthContext";
 import { VerifyModalContainer } from "./react-components/auth/VerifyModalContainer";
@@ -11,10 +10,10 @@ import "./assets/stylesheets/globals.scss";
 import { PageContainer } from "./react-components/layout/PageContainer";
 import { Center } from "./react-components/layout/Center";
 import { ThemeProvider } from "./react-components/styles/theme";
+import { store } from "./utils/store-instance";
 
 registerTelemetry("/verify", "Hubs Verify Email Page");
 
-const store = new Store();
 window.APP = { store };
 
 function Root() {

--- a/src/whats-new.js
+++ b/src/whats-new.js
@@ -4,10 +4,9 @@ import InfiniteScroll from "react-infinite-scroller";
 import markdownit from "markdown-it";
 import { FormattedMessage } from "react-intl";
 import { WrappedIntlProvider } from "./react-components/wrapped-intl-provider";
-import Store from "./storage/store";
 import { AuthContextProvider } from "./react-components/auth/AuthContext";
+import { store } from "./utils/store-instance";
 
-const store = new Store();
 window.APP = { store };
 
 import registerTelemetry from "./telemetry";


### PR DESCRIPTION
We have regressed the scene page several times over the last few months. It's difficult to ensure correct behavior when loading the 3D game functionality because many files execute functionality on load that is not valid in the context of the scene page.

Until we bundle game functionality more carefully, it will be easier not to run any 3D game code on the scene page. That way, ongoing changes to the engine won't introduce new regressions. 