### PR TITLE
Typo in token page code causes distracting warning

### DIFF
--- a/src/tokens.html
+++ b/src/tokens.html
@@ -14,7 +14,7 @@
     if (navigator.doNotTrack !== "1") {
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBeforea,m)
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
     }
     </script>


### PR DESCRIPTION
Trivial issue, but the console log warning was annoying me.

You don't really need the GA code on this page at all, but there's some sense in keeping all the HTML template pages the same.