### PR TITLE
Handle some networking edge-cases

### DIFF
--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -11,7 +11,8 @@ export const Networked = defineComponent({
   creator: Types.ui32,
   owner: Types.ui32,
 
-  lastOwnerTime: Types.ui32
+  lastOwnerTime: Types.ui32,
+  timestamp: Types.ui32
 });
 Networked.id[$isStringType] = true;
 Networked.creator[$isStringType] = true;

--- a/src/hub.js
+++ b/src/hub.js
@@ -241,7 +241,7 @@ import { ThemeProvider } from "./react-components/styles/theme";
 import { LogMessageType } from "./react-components/room/ChatSidebar";
 import "./load-media-on-paste-or-drop";
 import { swapActiveScene } from "./bit-systems/scene-loading";
-import { listenForNetworkMessages } from "./bit-systems/networking";
+import { listenForNetworkMessages, setLocalClientID } from "./bit-systems/networking";
 
 const PHOENIX_RELIABLE_NAF = "phx-reliable";
 NAF.options.firstSyncSource = PHOENIX_RELIABLE_NAF;
@@ -1239,6 +1239,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   hubPhxChannel
     .join()
     .receive("ok", async data => {
+      setLocalClientID(data.session_id);
       APP.hideHubPresenceEvents = true;
       presenceSync.promise = new Promise(resolve => {
         presenceSync.resolve = resolve;

--- a/src/phoenix-adapter.js
+++ b/src/phoenix-adapter.js
@@ -45,6 +45,10 @@ const getAverageTimeOffset = (() => {
   };
 })();
 
+export function getServerTime() {
+  return Date.now() + getAverageTimeOffset();
+}
+
 export default class PhoenixAdapter {
   constructor() {
     this.refs = new Map();
@@ -101,7 +105,7 @@ export default class PhoenixAdapter {
   }
 
   getServerTime() {
-    return Date.now() + getAverageTimeOffset();
+    return getServerTime();
   }
 
   sendData(clientId, dataType, data) {

--- a/src/utils/bit-utils.js
+++ b/src/utils/bit-utils.js
@@ -46,7 +46,7 @@ export function defineNetworkSchema(Component) {
   });
 
   return {
-    serialize(_world, eid, data, isFullSync = false) {
+    serialize(_world, eid, data, isFullSync, writeToShadow) {
       const changedPids = [];
       data.push(changedPids);
       for (let pid = 0; pid < componentProps.length; pid++) {
@@ -62,14 +62,14 @@ export function defineNetworkSchema(Component) {
               break;
             }
           }
-          if (!isFullSync) shadow[eid].set(prop[eid]);
+          if (writeToShadow) shadow[eid].set(prop[eid]);
         } else {
           if (isFullSync || shadow[eid] !== prop[eid]) {
             changedPids.push(pid);
             // TODO handle EID type
             data.push(prop[$isStringType] ? APP.getString(prop[eid]) : prop[eid]);
           }
-          if (!isFullSync) shadow[eid] = prop[eid];
+          if (writeToShadow) shadow[eid] = prop[eid];
         }
       }
       if (!changedPids.length) {


### PR DESCRIPTION
- When owners leave, take ownership with a timestamp from the most recently received (valid) update message about that entity.
- When replaying stored updates, rewrite ownership if the message came from a client that has already left, as if we had taken ownership at at that time.
- Always send full-sync messages when ownership changes, so that rejectable in-flight updates don't break eventual consistency guarantees.
- Do not send or receive messages until we are assigned a client ID (which happens after the phoenix channel connects.)
- (Minor) Schedule network ticks to more consistently send at the configured frequency.

Builds on https://github.com/mozilla/hubs/pull/5811
