### PR TITLE
Replace deprecated prettier eslint integration with the vscode plugin

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,7 @@
 {
   "printWidth": 120,
   "trailingComma": "none",
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "tabWidth": 2,
+  "semi": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,8 +5,20 @@
   "html.format.enable": false,
   // Disable the default javascript formatter
   "javascript.format.enable": false,
-  // Use 'prettier-eslint' instead of 'prettier'. Other settings will only be fallbacks in case they could not be inferred from eslint rules.
-  "prettier.eslintIntegration": true,
+  // Using the prettier-vscode plugin as the old eslint integration has been deprecated. More here: https://github.com/prettier/prettier-vscode/issues/870
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   // Enable eslint for JavaScript files.
   "eslint.enable": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,6 @@
 {
   // Format on save for Prettier
   "editor.formatOnSave": true,
-  // Disable html formatting for now
-  "html.format.enable": false,
-  // Disable the default javascript formatter
-  "javascript.format.enable": false,
   // Using the prettier-vscode plugin as the old eslint integration has been deprecated. More here: https://github.com/prettier/prettier-vscode/issues/870
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[javascriptreact]": {
@@ -19,6 +15,7 @@
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  // Enable eslint for JavaScript files.
-  "eslint.enable": true
+  "[html]": {
+    "editor.defaultFormatter": "vscode.html-language-features" // Set to esbenp.prettier-vscode when we are ready to reformat all HTML files
+  }
 }


### PR DESCRIPTION
The prettier eslint integration has been deprecated so in VSCode we are falling back to the default formatter on save that doesn't follow the same rules as the ones defined in eslintrc.

This only affect people using VSCode.

Read more here: https://github.com/prettier/prettier-vscode/issues/870