### PR TITLE
Hardcode HMC as a hub origin

### DIFF
--- a/src/utils/media-url-utils.js
+++ b/src/utils/media-url-utils.js
@@ -162,6 +162,9 @@ export const guessContentType = url => {
 };
 
 const originIsHubsServer = new Map();
+// HACK hubs.mozilla.com is now technically not a "hub" root, but we route existing links as if it is, so treat it as one.
+originIsHubsServer.set("http://hubs.mozilla.com", true);
+originIsHubsServer.set("https://hubs.mozilla.com", true);
 async function isHubsServer(url) {
   if (!url) return false;
   if (!url.startsWith("http")) {


### PR DESCRIPTION
After the launch of managed hubs early access, the root of hubs.mozilla.com is no longer a "hub" but instead a marketing site. This site does not return the `hub-name` header, so the client no longer recognizes HMC links as links to avatars/scenes/rooms. This PR hardcodes that check in for now. Depending on the plan for the "demo hub" going forward we may want to have the marketing site return this header so that external tools (and old builds of hubs) still see it as a "hub".