### PR TITLE
Revert "Hardcode HMC as a hub origin"

### DIFF
--- a/src/utils/media-url-utils.js
+++ b/src/utils/media-url-utils.js
@@ -162,9 +162,6 @@ export const guessContentType = url => {
 };
 
 const originIsHubsServer = new Map();
-// HACK hubs.mozilla.com is now technically not a "hub" root, but we route existing links as if it is, so treat it as one.
-originIsHubsServer.set("http://hubs.mozilla.com", true);
-originIsHubsServer.set("https://hubs.mozilla.com", true);
 async function isHubsServer(url) {
   if (!url) return false;
   if (!url.startsWith("http")) {


### PR DESCRIPTION
We ended up fixing this at the ingress level. No longer need the hack.

Reverts mozilla/hubs#5823