### PR TITLE
Fix avatar pages

### DIFF
--- a/src/avatar.js
+++ b/src/avatar.js
@@ -17,8 +17,6 @@ import configs from "./utils/configs";
 import { disableiOSZoom } from "./utils/disable-ios-zoom";
 disableiOSZoom();
 
-import { App } from "./app";
-
 import AvatarPreview from "./react-components/avatar-preview";
 
 import { fetchAvatar, remixAvatar } from "./utils/avatar-utils";
@@ -29,9 +27,10 @@ import styles from "./assets/stylesheets/avatar.scss";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClone } from "@fortawesome/free-solid-svg-icons/faClone";
 import { ThemeProvider } from "./react-components/styles/theme";
+import Store from "./storage/store";
 
 const qs = new URLSearchParams(location.search);
-window.APP = new App();
+window.APP = { store: new Store() };
 
 class AvatarPage extends React.Component {
   static propTypes = {


### PR DESCRIPTION
This PR makes it so that we do not import App.ts into the avatar preview page. This is a similar to the dependency problems pointed out in https://github.com/mozilla/hubs/pull/5796 and https://github.com/mozilla/hubs/pull/5797 .

