### PR TITLE
Fix scene deletion

### DIFF
--- a/admin/src/react-components/featured-scene-listings.js
+++ b/admin/src/react-components/featured-scene-listings.js
@@ -25,7 +25,7 @@ const SceneFilter = props => (
 );
 
 export const FeaturedSceneListingList = props => (
-  <List {...props} filters={<SceneFilter />} sort={{ field: "order", order: "ASC" }}>
+  <List {...props} filters={<SceneFilter />} sort={{ field: "order", order: "ASC" }} bulkActionButtons={false}>
     <Datagrid>
       <OwnedFileImage source="screenshot_owned_file_id" />
       <OwnedFileSizeField label="Model size" source="model_owned_file_id" />

--- a/admin/src/react-components/pending-scenes.js
+++ b/admin/src/react-components/pending-scenes.js
@@ -14,7 +14,7 @@ const SceneFilter = props => (
 );
 
 export const PendingSceneList = props => (
-  <List {...props} filters={<SceneFilter />}>
+  <List {...props} filters={<SceneFilter />} bulkActionButtons={false}>
     <Datagrid>
       <OwnedFileImage source="screenshot_owned_file_id" />
       <OwnedFileSizeField label="Model size" source="model_owned_file_id" />

--- a/admin/src/react-components/scene-listings.js
+++ b/admin/src/react-components/scene-listings.js
@@ -50,7 +50,7 @@ export const SceneListingEdit = props => (
 );
 
 export const SceneListingList = props => (
-  <List {...props} filters={<SceneListingFilter />}>
+  <List {...props} filters={<SceneListingFilter />} bulkActionButtons={false}>
     <Datagrid>
       <OwnedFileImage source="screenshot_owned_file_id" />
       <OwnedFileSizeField label="Model size" source="model_owned_file_id" />

--- a/admin/src/react-components/scenes.js
+++ b/admin/src/react-components/scenes.js
@@ -45,7 +45,7 @@ export const SceneEdit = props => (
 );
 
 export const SceneList = props => (
-  <List {...props} filters={<SceneFilter />}>
+  <List {...props} filters={<SceneFilter />} bulkActionButtons={false}>
     <Datagrid>
       <OwnedFileImage source="screenshot_owned_file_id" />
       <OwnedFileSizeField label="Model size" source="model_owned_file_id" />


### PR DESCRIPTION
Why
---

The _Pending scenes_, _Approved scenes_, _Featured scenes_, and _Scenes_
admin pages offer a UI to delete scenes.  Scene deletion does not exist
as a back-end feature, so an error occurs.

What
----

Remove bulk action buttons from the affected pages