### PR TITLE
fix cut off spawned messages

### DIFF
--- a/src/assets/stylesheets/presence-log.scss
+++ b/src/assets/stylesheets/presence-log.scss
@@ -46,6 +46,7 @@
       overflow-wrap: break-word;
       overflow: hidden;
       max-width: 500px;
+      padding-bottom: 8px;
     }
 
     :local(.message-body-multi) {


### PR DESCRIPTION
One line fix for https://github.com/mozilla/hubs/issues/5661 to compensate for margin bottom on spawned messages.

Before:
![before](https://user-images.githubusercontent.com/4493657/205461631-fabe57d4-9a24-4942-af4f-6b9f839d9f2e.jpg)
After:
![after](https://user-images.githubusercontent.com/4493657/205461643-bc679ed6-db05-4dfa-aa54-fbf52e46d786.jpg)
