### PR TITLE
Fix teleporting on invisible navmeshes

### DIFF
--- a/src/components/teleporter.js
+++ b/src/components/teleporter.js
@@ -285,9 +285,11 @@ AFRAME.registerComponent("teleporter", {
       parabolicCurve(this.p0, this.v0, t, vecHelper);
       this.parabola[i].copy(vecHelper);
 
-      if (
-        navMesh &&
-        checkLineIntersection(
+      if (navMesh) {
+        // HACK TODO Fix navmesh visibility + raycasting
+        const visible = navMesh.visible;
+        navMesh.visible = true;
+        const result = checkLineIntersection(
           this.parabola[i - 1],
           this.parabola[i],
           [navMesh],
@@ -295,11 +297,13 @@ AFRAME.registerComponent("teleporter", {
           LANDING_NORMAL,
           MAX_LANDING_ANGLE,
           this.hitPoint
-        )
-      ) {
-        this.hit = true;
-        collidedIndex = i;
-        break;
+        );
+        navMesh.visible = visible;
+        if (result) {
+          this.hit = true;
+          collidedIndex = i;
+          break;
+        }
       }
     }
     if (this.characterController.isTeleportingDisabled) {


### PR DESCRIPTION
Nav meshes are supposed to be invisible, but raycasting ignores invisible objects. 

A more desireable fix might be to have a raycasting function that does not ignore invisible objects. For now, toggle visibility ON before raycasting and restore its initial value after the raycast.

This only happens while the user is attempting to teleport.