### PR TITLE
reset padding on side chat logs

### DIFF
--- a/src/assets/stylesheets/presence-log.scss
+++ b/src/assets/stylesheets/presence-log.scss
@@ -48,6 +48,10 @@
       max-width: 500px;
       padding-bottom: 8px;
     }
+    /* this checks if a sibling has the message source for when have chat closed and resets padding */
+    :local(.message-source + .message-body) {
+      padding-bottom: 0px;
+    }
 
     :local(.message-body-multi) {
       margin-left: 0px;


### PR DESCRIPTION
missed an issue from https://github.com/mozilla/hubs/pull/5836

to solve, I reset the padding in the case where it has a message-source sibling.

testing in the smoke test I didn't close the chat so I missed it. We may want to consider explicitly calling that out for manual testing.
<img width="1340" alt="Screen Shot 2022-12-06 at 12 43 02" src="https://user-images.githubusercontent.com/4493657/206019099-8b07279d-c9c0-48e2-bcda-8b41d2497bf8.png">
