### PR TITLE
Update browserstack ie11 test to use /demo

### DIFF
--- a/test/browser-stack/tests/ie11.js
+++ b/test/browser-stack/tests/ie11.js
@@ -14,7 +14,7 @@ async function runIE11UnsupportedTest() {
   });
 
   try {
-    await driver.get("https://hubs.mozilla.com");
+    await driver.get("https://hubs.mozilla.com/demo");
 
     const unsupportedNotice = await driver.wait(until.elementLocated(by.id("support-root")), 10000);
     const unsupportedNoticeText = await unsupportedNotice.getText();


### PR DESCRIPTION
The browserstack ie11 test checks the root of a hub to ensure the "unsupported browser" message doesn't break. The root of HMC is now a marketing site, so change to test to point at /demo