### PR TITLE
Add LightTag and call Three.js light.dispose when removed

### DIFF
--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -46,6 +46,7 @@ export const NetworkedTransform = defineComponent({
 export const AEntity = defineComponent();
 export const Object3DTag = defineComponent();
 export const GLTFModel = defineComponent();
+export const LightTag = defineComponent();
 export const DirectionalLight = defineComponent();
 export const CursorRaycastable = defineComponent();
 export const RemoteHoverTarget = defineComponent();

--- a/src/inflators/directional-light.ts
+++ b/src/inflators/directional-light.ts
@@ -1,6 +1,6 @@
 import { addComponent } from "bitecs";
 import { addObject3DComponent } from "../utils/jsx-entity";
-import { DirectionalLight } from "../bit-components";
+import { DirectionalLight, LightTag } from "../bit-components";
 import { DirectionalLight as DL } from "three";
 import { HubsWorld } from "../app";
 
@@ -24,12 +24,9 @@ export function inflateDirectionalLight(world: HubsWorld, eid: number, params: D
   light.shadow.bias = params.shadowBias;
   light.shadow.radius = params.shadowRadius;
   light.shadow.mapSize.set(params.shadowMapResolution[0], params.shadowMapResolution[1]);
-  if (light.shadow.map) {
-    light.shadow.map.dispose();
-    (light.shadow.map as any) = null; // TODO: Correct the Typescript definition in three. This /is/ nullable.
-  }
 
   addObject3DComponent(world, eid, light);
+  addComponent(world, LightTag, eid);
   addComponent(world, DirectionalLight, eid);
   return eid;
 }

--- a/src/systems/remove-object3D-system.js
+++ b/src/systems/remove-object3D-system.js
@@ -3,6 +3,7 @@ import {
   AudioEmitter,
   EnvironmentSettings,
   GLTFModel,
+  LightTag,
   MediaImage,
   MediaFrame,
   MediaVideo,
@@ -40,6 +41,7 @@ const cleanupGLTFs = cleanupObjOnExit(GLTFModel, obj => {
     obj.dispose();
   }
 });
+const cleanupLights = cleanupObjOnExit(LightTag, obj => obj.dispose());
 const cleanupTexts = cleanupObjOnExit(Text, obj => obj.dispose());
 const cleanupMediaFrames = cleanupObjOnExit(MediaFrame, obj => obj.geometry.dispose());
 const cleanupAudioEmitters = cleanupObjOnExit(AudioEmitter, obj => {
@@ -107,6 +109,7 @@ export function removeObject3DSystem(world) {
   // cleanup any component specific resources
   cleanupGLTFs(world);
   cleanupSlice9s(world);
+  cleanupLights(world);
   cleanupTexts(world);
   cleanupMediaFrames(world);
   cleanupImages(world);


### PR DESCRIPTION
Add `LightTag` component that must be set for all lights. Call Three.js `light.dispose()` when removed in `remove-object3D-system`.

This new tag and flow provides a proper light resource disposing.

Currently `light.dispose()` is called right after `DirectionalLight` creation in `inflator/directional-light` if `light.shadow.map` is non-null but it seems a bug because `light.shadow.map` should be null when light is created. This commit also fixes it by removing the lines. Lights will be properly disposed when removed with the change.