### PR TITLE
Set transparent properly in SimpleWaterMesh

### DIFF
--- a/src/objects/SimpleWaterMesh.ts
+++ b/src/objects/SimpleWaterMesh.ts
@@ -183,9 +183,7 @@ export class SimpleWaterMesh extends Mesh {
 
   set opacity(value: number) {
     this.waterMaterial.opacity = value;
-    if (value !== 1) {
-      this.waterMaterial.transparent = true;
-    }
+    this.waterMaterial.transparent = value !== 1;
   }
 
   get color(): Color {


### PR DESCRIPTION
Related: https://github.com/mozilla/hubs/pull/5909#pullrequestreview-1271996219

Currently opacity setter in `SimpleWaterMesh` updates `waterMaterial.transparent` only when opacity is not one but it should be always updated even opacity is one.