### PR TITLE
Add AmbientLights to bitecs

### DIFF
--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -47,6 +47,7 @@ export const AEntity = defineComponent();
 export const Object3DTag = defineComponent();
 export const GLTFModel = defineComponent();
 export const LightTag = defineComponent();
+export const AmbientLightTag = defineComponent();
 export const DirectionalLight = defineComponent();
 export const CursorRaycastable = defineComponent();
 export const RemoteHoverTarget = defineComponent();

--- a/src/inflators/ambient-light.ts
+++ b/src/inflators/ambient-light.ts
@@ -1,0 +1,26 @@
+import { addComponent } from "bitecs";
+import { addObject3DComponent } from "../utils/jsx-entity";
+import { AmbientLightTag, LightTag } from "../bit-components";
+import { AmbientLight } from "three";
+import { HubsWorld } from "../app";
+
+export type AmbientLightParams = {
+  color: string;
+  intensity: number;
+};
+
+const DEFAULTS = {
+  intensity: 1.0
+};
+
+export function inflateAmbientLight(world: HubsWorld, eid: number, params: AmbientLightParams) {
+  params = Object.assign({}, DEFAULTS, params);
+  const light = new AmbientLight();
+  light.color.set(params.color).convertSRGBToLinear();
+  light.intensity = params.intensity;
+
+  addObject3DComponent(world, eid, light);
+  addComponent(world, LightTag, eid);
+  addComponent(world, AmbientLightTag, eid);
+  return eid;
+}

--- a/src/utils/jsx-entity.ts
+++ b/src/utils/jsx-entity.ts
@@ -66,6 +66,7 @@ import { AlphaMode } from "./create-image-mesh";
 import { MediaLoaderParams } from "../inflators/media-loader";
 import { preload } from "./preload";
 import { DirectionalLightParams, inflateDirectionalLight } from "../inflators/directional-light";
+import { AmbientLightParams, inflateAmbientLight } from "../inflators/ambient-light";
 import { ProjectionMode } from "./projection-mode";
 import { inflateSkybox, SkyboxParams } from "../inflators/skybox";
 import { inflateSpawner, SpawnerParams } from "../inflators/spawner";
@@ -221,6 +222,7 @@ interface InflatorFn {
 
 // @TODO these properties should import types from their inflators
 export interface ComponentData {
+  ambientLight?: AmbientLightParams;
   directionalLight?: DirectionalLightParams;
   grabbable?: GrabbableParams;
   billboard?: { onlyY: boolean };
@@ -365,6 +367,7 @@ export const commonInflators: Required<{ [K in keyof ComponentData]: InflatorFn 
   billboard: createDefaultInflator(Billboard),
 
   // inflators that create Object3Ds
+  ambientLight: inflateAmbientLight,
   directionalLight: inflateDirectionalLight,
   simpleWater: inflateSimpleWater
 };


### PR DESCRIPTION
This PR adds `AmbientLights` to bitecs in the same way as `DirectionalLight`.