### PR TITLE
newLoader anoyances

### DIFF
--- a/src/load-media-on-paste-or-drop.ts
+++ b/src/load-media-on-paste-or-drop.ts
@@ -94,10 +94,21 @@ async function onPaste(e: ClipboardEvent) {
   spawnFromUrl(text);
 }
 
+let lastDebugScene: string;
 function onDrop(e: DragEvent) {
   if (!(AFRAME as any).scenes[0].is("entered")) {
     return;
   }
+
+  if (qsTruthy("debugLocalScene")) {
+    URL.revokeObjectURL(lastDebugScene);
+    if (!e.dataTransfer?.files.length) return;
+    const url = URL.createObjectURL(e.dataTransfer.files[0]);
+    APP.hubChannel!.updateScene(url);
+    lastDebugScene = url;
+    return;
+  }
+
   const files = e.dataTransfer?.files;
   if (files && files.length) {
     e.preventDefault();

--- a/src/load-media-on-paste-or-drop.ts
+++ b/src/load-media-on-paste-or-drop.ts
@@ -15,7 +15,7 @@ type UploadResponse = {
   origin: string;
 };
 
-function spawnFromUrl(text: string) {
+export function spawnFromUrl(text: string) {
   if (!text) {
     return;
   }
@@ -36,7 +36,7 @@ function spawnFromUrl(text: string) {
   obj.lookAt(avatarPov.getWorldPosition(new Vector3()));
 }
 
-async function spawnFromFileList(files: FileList) {
+export async function spawnFromFileList(files: FileList) {
   for (const file of files) {
     const desiredContentType = file.type || guessContentType(file.name);
     const params = await upload(file, desiredContentType)

--- a/src/utils/load-image.tsx
+++ b/src/utils/load-image.tsx
@@ -12,7 +12,6 @@ type AlphaModeType = typeof AlphaMode.Opaque | typeof AlphaMode.Mask | typeof Al
 export function* loadImage(world: HubsWorld, url: string, contentType: string) {
   const { texture, ratio, cacheKey }: { texture: Texture; ratio: number; cacheKey: string } =
     yield loadTextureCancellable(url, 1, contentType);
-  console.log(url, contentType, texture);
 
   // TODO it would be nice if we could be less agressive with transparency here.
   // Doing so requires inspecting the raw file data upstream of here and passing

--- a/src/utils/load-image.tsx
+++ b/src/utils/load-image.tsx
@@ -7,9 +7,23 @@ import { HubsWorld } from "../app";
 import { Texture } from "three";
 import { AlphaMode } from "./create-image-mesh";
 
+// TODO AlphaMode is written in JS and should be a ts enum
+type AlphaModeType = typeof AlphaMode.Opaque | typeof AlphaMode.Mask | typeof AlphaMode.Blend;
 export function* loadImage(world: HubsWorld, url: string, contentType: string) {
   const { texture, ratio, cacheKey }: { texture: Texture; ratio: number; cacheKey: string } =
     yield loadTextureCancellable(url, 1, contentType);
+  console.log(url, contentType, texture);
+
+  // TODO it would be nice if we could be less agressive with transparency here.
+  // Doing so requires inspecting the raw file data upstream of here and passing
+  // that info through somehow which feels tricky.
+  let alphaMode: AlphaModeType = AlphaMode.Blend;
+  if (contentType === "image/gif") {
+    alphaMode = AlphaMode.Mask;
+  } else if (contentType === "image/jpeg") {
+    alphaMode = AlphaMode.Opaque;
+  }
+
   return renderAsEntity(
     world,
     <entity
@@ -18,7 +32,7 @@ export function* loadImage(world: HubsWorld, url: string, contentType: string) {
         texture,
         ratio,
         projection: ProjectionMode.FLAT,
-        alphaMode: AlphaMode.Opaque,
+        alphaMode,
         cacheKey
       }}
     />


### PR DESCRIPTION
Fixes a few misc annoyances when using `newLoader`:
- Images were always set to opaque. This restores a slightly less aggressive version of what we had before. gifs will be set to "clip",  jpegs will be set to "opaque", and everything else will be "blend". 
- `debugLocalScene` did not work with `newLoader`
- Codepaths other than ctrl+v or drag+drop file did not use new loader. This PR captures most of the rest of the path's by implementing newLoader in `spawnObjectInFrontOfPlayer` which is used by chat spawning, the place menu, uploads, etc.