### PR TITLE
Bitecs particle emitter

### DIFF
--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -232,6 +232,5 @@ export const VideoTextureTarget = defineComponent({
 export const SimpleWater = defineComponent();
 export const Mirror = defineComponent();
 export const ParticleEmitterTag = defineComponent({
-  src: Types.ui32,
-  updateParticles: Types.ui8
+  src: Types.ui32
 });

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -231,3 +231,7 @@ export const VideoTextureTarget = defineComponent({
 });
 export const SimpleWater = defineComponent();
 export const Mirror = defineComponent();
+export const ParticleEmitterTag = defineComponent({
+  src: Types.ui32,
+  updateParticles: Types.ui8
+});

--- a/src/bit-systems/particle-emitter.ts
+++ b/src/bit-systems/particle-emitter.ts
@@ -1,0 +1,52 @@
+import { defineQuery, enterQuery } from "bitecs";
+import { ParticleEmitter } from "lib-hubs/packages/three-particle-emitter/lib/esm/index";
+
+import { HubsWorld } from "../app";
+import { ParticleEmitterTag } from "../bit-components";
+import { proxiedUrlFor } from "../utils/media-url-utils";
+import { resolveUrl, textureLoader } from "../utils/media-utils";
+
+const particleEmitterQuery = defineQuery([ParticleEmitterTag]);
+const particleEmitterEnterQuery = enterQuery(particleEmitterQuery);
+
+const setTexture = async (world: HubsWorld, eid: number) => {
+  let src = APP.sid2str.get(ParticleEmitterTag.src[eid]);
+
+  const result = await resolveUrl(src);
+  let canonicalUrl = result.origin;
+
+  // handle protocol relative urls
+  if (canonicalUrl.startsWith("//")) {
+    canonicalUrl = location.protocol + canonicalUrl;
+  }
+
+  // todo: we don't need to proxy for many things if the canonical URL has permissive CORS headers
+  src = proxiedUrlFor(canonicalUrl);
+
+  const texture = await textureLoader.loadAsync(src);
+
+  const particleEmitter: ParticleEmitter = world.eid2obj.get(eid)! as ParticleEmitter;
+  particleEmitter.material.uniforms.map.value = texture;
+  particleEmitter.visible = true;
+
+  ParticleEmitterTag.updateParticles[eid] = 1;
+};
+
+export function particleEmitterSystem(world: HubsWorld) {
+  particleEmitterEnterQuery(world).forEach(eid => {
+    setTexture(world, eid);
+  });
+  particleEmitterQuery(world).forEach(eid => {
+    const particleEmitter: ParticleEmitter = world.eid2obj.get(eid)! as ParticleEmitter;
+
+    if (ParticleEmitterTag.updateParticles[eid]) {
+      particleEmitter.updateParticles();
+      ParticleEmitterTag.updateParticles[eid] = 0;
+    }
+
+    if (particleEmitter.visible) {
+      particleEmitter.update(world.time.delta / 1000);
+    }
+  });
+  // The resources release happens in remove-object3D-system
+}

--- a/src/bit-systems/particle-emitter.ts
+++ b/src/bit-systems/particle-emitter.ts
@@ -1,18 +1,17 @@
-import { defineQuery, enterQuery } from "bitecs";
+import { defineQuery, enterQuery, exitQuery } from "bitecs";
 import { ParticleEmitter } from "lib-hubs/packages/three-particle-emitter/lib/esm/index";
+import { Texture } from "three";
 
 import { HubsWorld } from "../app";
 import { ParticleEmitterTag } from "../bit-components";
+import { JobRunner } from "../utils/coroutine-utils";
 import { proxiedUrlFor } from "../utils/media-url-utils";
 import { resolveUrl, textureLoader } from "../utils/media-utils";
 
-const particleEmitterQuery = defineQuery([ParticleEmitterTag]);
-const particleEmitterEnterQuery = enterQuery(particleEmitterQuery);
-
-const setTexture = async (world: HubsWorld, eid: number) => {
+function* setTexture(world: HubsWorld, eid: number) {
   let src = APP.sid2str.get(ParticleEmitterTag.src[eid]);
 
-  const result = await resolveUrl(src);
+  const result: URL = yield resolveUrl(src);
   let canonicalUrl = result.origin;
 
   // handle protocol relative urls
@@ -23,18 +22,28 @@ const setTexture = async (world: HubsWorld, eid: number) => {
   // todo: we don't need to proxy for many things if the canonical URL has permissive CORS headers
   src = proxiedUrlFor(canonicalUrl);
 
-  const texture = await textureLoader.loadAsync(src);
+  const texture: Texture = yield textureLoader.loadAsync(src);
 
   const particleEmitter: ParticleEmitter = world.eid2obj.get(eid)! as ParticleEmitter;
   particleEmitter.material.uniforms.map.value = texture;
   particleEmitter.visible = true;
 
   ParticleEmitterTag.updateParticles[eid] = 1;
-};
+}
 
+const particleEmitterQuery = defineQuery([ParticleEmitterTag]);
+const particleEmitterEnterQuery = enterQuery(particleEmitterQuery);
+const particleEmitterExitQuery = exitQuery(particleEmitterQuery);
+
+const jobs = new JobRunner();
 export function particleEmitterSystem(world: HubsWorld) {
   particleEmitterEnterQuery(world).forEach(eid => {
-    setTexture(world, eid);
+    jobs.stop(eid);
+    jobs.add(eid, () => setTexture(world, eid));
+  });
+  particleEmitterExitQuery(world).forEach(function (eid) {
+    // Object3D resources release happens in remove-object3D-system
+    jobs.stop(eid);
   });
   particleEmitterQuery(world).forEach(eid => {
     const particleEmitter: ParticleEmitter = world.eid2obj.get(eid)! as ParticleEmitter;
@@ -48,5 +57,5 @@ export function particleEmitterSystem(world: HubsWorld) {
       particleEmitter.update(world.time.delta / 1000);
     }
   });
-  // The resources release happens in remove-object3D-system
+  jobs.tick();
 }

--- a/src/bit-systems/particle-emitter.ts
+++ b/src/bit-systems/particle-emitter.ts
@@ -28,7 +28,7 @@ function* setTexture(world: HubsWorld, eid: number) {
   particleEmitter.material.uniforms.map.value = texture;
   particleEmitter.visible = true;
 
-  ParticleEmitterTag.updateParticles[eid] = 1;
+  particleEmitter.updateParticles();
 }
 
 const particleEmitterQuery = defineQuery([ParticleEmitterTag]);
@@ -47,11 +47,6 @@ export function particleEmitterSystem(world: HubsWorld) {
   });
   particleEmitterQuery(world).forEach(eid => {
     const particleEmitter: ParticleEmitter = world.eid2obj.get(eid)! as ParticleEmitter;
-
-    if (ParticleEmitterTag.updateParticles[eid]) {
-      particleEmitter.updateParticles();
-      ParticleEmitterTag.updateParticles[eid] = 0;
-    }
 
     if (particleEmitter.visible) {
       particleEmitter.update(world.time.delta / 1000);

--- a/src/bit-systems/particle-emitter.ts
+++ b/src/bit-systems/particle-emitter.ts
@@ -38,7 +38,6 @@ const particleEmitterExitQuery = exitQuery(particleEmitterQuery);
 const jobs = new JobRunner();
 export function particleEmitterSystem(world: HubsWorld) {
   particleEmitterEnterQuery(world).forEach(eid => {
-    jobs.stop(eid);
     jobs.add(eid, () => setTexture(world, eid));
   });
   particleEmitterExitQuery(world).forEach(function (eid) {
@@ -46,11 +45,11 @@ export function particleEmitterSystem(world: HubsWorld) {
     jobs.stop(eid);
   });
   particleEmitterQuery(world).forEach(eid => {
-    const particleEmitter: ParticleEmitter = world.eid2obj.get(eid)! as ParticleEmitter;
+    jobs.tick();
 
+    const particleEmitter: ParticleEmitter = world.eid2obj.get(eid)! as ParticleEmitter;
     if (particleEmitter.visible) {
       particleEmitter.update(world.time.delta / 1000);
     }
   });
-  jobs.tick();
 }

--- a/src/components/particle-emitter.js
+++ b/src/components/particle-emitter.js
@@ -3,7 +3,7 @@ import { textureLoader } from "../utils/media-utils";
 import { resolveUrl } from "../utils/media-utils";
 import { proxiedUrlFor } from "../utils/media-url-utils";
 import defaultSrcImage from "../assets/images/warning_icon.png";
-import { disposeMaterial } from "../utils/three-utils";
+import { disposeNode } from "../utils/three-utils";
 
 const defaultSrcUrl = new URL(defaultSrcImage, window.location.href).href;
 
@@ -71,8 +71,7 @@ AFRAME.registerComponent("particle-emitter", {
   },
 
   remove() {
-    disposeMaterial(this.particleEmitter.material);
-    this.particleEmitter.geometry.dispose();
+    disposeNode(this.particleEmitter);
   },
 
   update(prevData) {

--- a/src/components/particle-emitter.js
+++ b/src/components/particle-emitter.js
@@ -3,6 +3,7 @@ import { textureLoader } from "../utils/media-utils";
 import { resolveUrl } from "../utils/media-utils";
 import { proxiedUrlFor } from "../utils/media-url-utils";
 import defaultSrcImage from "../assets/images/warning_icon.png";
+import { disposeMaterial } from "../utils/three-utils";
 
 const defaultSrcUrl = new URL(defaultSrcImage, window.location.href).href;
 
@@ -67,6 +68,11 @@ AFRAME.registerComponent("particle-emitter", {
     this.particleEmitter.material.uniforms.map.value = texture;
     this.particleEmitter.visible = true;
     this.updateParticles = true;
+  },
+
+  remove() {
+    disposeMaterial(this.particleEmitter.material);
+    this.particleEmitter.geometry.dispose();
   },
 
   update(prevData) {

--- a/src/inflators/particle-emitter.ts
+++ b/src/inflators/particle-emitter.ts
@@ -1,0 +1,89 @@
+import { addComponent } from "bitecs";
+import { addObject3DComponent } from "../utils/jsx-entity";
+import { ParticleEmitterTag } from "../bit-components";
+import { HubsWorld } from "../app";
+import defaultSrcImage from "../assets/images/warning_icon.png";
+import { ParticleEmitter } from "lib-hubs/packages/three-particle-emitter/lib/esm/index";
+
+const defaultSrcUrl = new URL(defaultSrcImage, window.location.href).href;
+
+export type ParticleEmitterParams = {
+  src: string;
+  startColor: string;
+  middleColor: string;
+  endColor: string;
+  startOpacity: number;
+  middleOpacity: number;
+  endOpacity: number;
+  colorCurve: string;
+  sizeCurve: string;
+  startSize: number;
+  endSize: number;
+  sizeRandomness: number;
+  ageRandomness: number;
+  lifetime: number;
+  lifetimeRandomness: number;
+  particleCount: number;
+  startVelocity: [number, number];
+  endVelocity: [number, number, number];
+  velocityCurve: string;
+  angularVelocity: number;
+};
+
+const DEFAULTS = {
+  src: defaultSrcImage,
+  startColor: "#ffffff",
+  middleColor: "#ffffff",
+  endColor: "#ffffff",
+  startOpacity: 1,
+  middleOpacity: 1,
+  endOpacity: 1,
+  colorCurve: "linear",
+  sizeCurve: "linear",
+  startSize: 0.25,
+  endSize: 0.25,
+  sizeRandomness: 0,
+  ageRandomness: 10,
+  lifetime: 5,
+  lifetimeRandomness: 5,
+  particleCount: 100,
+  startVelocity: [0, 0, 0.5],
+  endVelocity: [0, 0, 0],
+  velocityCurve: "linear",
+  angularVelocity: 0
+};
+
+export function inflateParticleEmitter(world: HubsWorld, eid: number, params: ParticleEmitterParams) {
+  params = Object.assign({}, DEFAULTS, params);
+
+  const particleEmitter = new ParticleEmitter(null);
+  particleEmitter.visible = false;
+
+  addObject3DComponent(world, eid, particleEmitter);
+  addComponent(world, ParticleEmitterTag, eid);
+
+  ParticleEmitterTag.updateParticles[eid] = false ? 0 : 1;
+  ParticleEmitterTag.src[eid] = APP.getSid(params.src || defaultSrcUrl);
+
+  particleEmitter.startColor.set(params.startColor);
+  particleEmitter.middleColor.set(params.middleColor);
+  particleEmitter.endColor.set(params.endColor);
+  particleEmitter.startOpacity = params.startOpacity;
+  particleEmitter.middleOpacity = params.middleOpacity;
+  particleEmitter.endOpacity = params.endOpacity;
+  particleEmitter.colorCurve = params.colorCurve;
+  particleEmitter.sizeCurve = params.sizeCurve;
+  particleEmitter.startSize = params.startSize;
+  particleEmitter.endSize = params.endSize;
+  particleEmitter.sizeRandomness = params.sizeRandomness;
+  particleEmitter.ageRandomness = params.ageRandomness;
+  particleEmitter.lifetime = params.lifetime;
+  particleEmitter.lifetimeRandomness = params.lifetimeRandomness;
+  particleEmitter.particleCount = params.particleCount;
+  particleEmitter.startVelocity.fromArray(params.startVelocity);
+  particleEmitter.endVelocity.fromArray(params.endVelocity);
+  particleEmitter.velocityCurve = params.velocityCurve;
+  particleEmitter.angularVelocity = params.angularVelocity;
+
+  return eid;
+}

--- a/src/inflators/particle-emitter.ts
+++ b/src/inflators/particle-emitter.ts
@@ -62,7 +62,6 @@ export function inflateParticleEmitter(world: HubsWorld, eid: number, params: Pa
   addObject3DComponent(world, eid, particleEmitter);
   addComponent(world, ParticleEmitterTag, eid);
 
-  ParticleEmitterTag.updateParticles[eid] = false ? 0 : 1;
   ParticleEmitterTag.src[eid] = APP.getSid(params.src || defaultSrcUrl);
 
   particleEmitter.startColor.set(params.startColor);

--- a/src/systems/hubs-systems.ts
+++ b/src/systems/hubs-systems.ts
@@ -66,7 +66,7 @@ import { videoTextureSystem } from "../bit-systems/video-texture";
 import { uvScrollSystem } from "../bit-systems/uv-scroll";
 import { simpleWaterSystem } from "../bit-systems/simple-water";
 import { pdfSystem } from "../bit-systems/pdf-system";
-
+import { particleEmitterSystem } from "../bit-systems/particle-emitter";
 
 declare global {
   interface Window {
@@ -192,6 +192,7 @@ export function mainTick(xrFrame: XRFrame, renderer: WebGLRenderer, scene: Scene
   hubsSystems.animationMixerSystem.tick(dt);
 
   billboardSystem(world, hubsSystems.cameraSystem.viewingCamera);
+  particleEmitterSystem(world);
   waypointSystem(world, hubsSystems.characterController, sceneEl.is("frozen"));
   hubsSystems.characterController.tick(t, dt);
   hubsSystems.cursorTogglingSystem.tick(aframeSystems.interaction, aframeSystems.userinput, hubsSystems.el);
@@ -243,7 +244,7 @@ export function mainTick(xrFrame: XRFrame, renderer: WebGLRenderer, scene: Scene
   hubsSystems.gainSystem.tick();
   hubsSystems.nameTagSystem.tick();
   simpleWaterSystem(world);
-  
+
   videoTextureSystem(world);
 
   deleteEntitySystem(world, aframeSystems.userinput);

--- a/src/systems/remove-object3D-system.js
+++ b/src/systems/remove-object3D-system.js
@@ -14,7 +14,8 @@ import {
   Skybox,
   Slice9,
   Text,
-  VideoMenu
+  VideoMenu,
+  ParticleEmitterTag
 } from "../bit-components";
 import { gltfCache } from "../components/gltf-model-plus";
 import { releaseTextureByKey } from "../utils/load-texture";
@@ -73,6 +74,10 @@ const cleanupSimpleWaters = cleanupObjOnExit(SimpleWater, obj => {
   forEachMaterial(obj.material, material => material.dispose());
 });
 const cleanupMirrors = cleanupObjOnExit(Mirror, obj => obj.dispose());
+const cleanupParticleSystem = cleanupObjOnExit(ParticleEmitterTag, obj => {
+  disposeMaterial(obj.material);
+  obj.geometry.dispose();
+});
 
 // TODO This feels messy and brittle
 //
@@ -135,6 +140,7 @@ export function removeObject3DSystem(world) {
   cleanupSkyboxes(world);
   cleanupSimpleWaters(world);
   cleanupMirrors(world);
+  cleanupParticleSystem(world);
 
   // Finally remove all the entities we just removed from the eid2obj map
   entities.forEach(removeObjFromMap);

--- a/src/systems/remove-object3D-system.js
+++ b/src/systems/remove-object3D-system.js
@@ -19,7 +19,7 @@ import {
 } from "../bit-components";
 import { gltfCache } from "../components/gltf-model-plus";
 import { releaseTextureByKey } from "../utils/load-texture";
-import { disposeMaterial, traverseSome } from "../utils/three-utils";
+import { disposeMaterial, traverseSome, disposeNode } from "../utils/three-utils";
 import { forEachMaterial } from "../utils/material-utils";
 
 function cleanupObjOnExit(Component, f) {
@@ -75,8 +75,7 @@ const cleanupSimpleWaters = cleanupObjOnExit(SimpleWater, obj => {
 });
 const cleanupMirrors = cleanupObjOnExit(Mirror, obj => obj.dispose());
 const cleanupParticleSystem = cleanupObjOnExit(ParticleEmitterTag, obj => {
-  disposeMaterial(obj.material);
-  obj.geometry.dispose();
+  disposeNode(obj);
 });
 
 // TODO This feels messy and brittle

--- a/src/systems/remove-object3D-system.js
+++ b/src/systems/remove-object3D-system.js
@@ -74,9 +74,7 @@ const cleanupSimpleWaters = cleanupObjOnExit(SimpleWater, obj => {
   forEachMaterial(obj.material, material => material.dispose());
 });
 const cleanupMirrors = cleanupObjOnExit(Mirror, obj => obj.dispose());
-const cleanupParticleSystem = cleanupObjOnExit(ParticleEmitterTag, obj => {
-  disposeNode(obj);
-});
+const cleanupParticleSystem = cleanupObjOnExit(ParticleEmitterTag, obj => disposeNode(obj));
 
 // TODO This feels messy and brittle
 //

--- a/src/utils/jsx-entity.ts
+++ b/src/utils/jsx-entity.ts
@@ -76,6 +76,7 @@ import { inflateUVScroll, UVScrollParams } from "../inflators/uv-scroll";
 import { SimpleWaterParams, inflateSimpleWater } from "../inflators/simple-water";
 import { inflatePDF, PDFParams } from "../inflators/pdf";
 import { MirrorParams, inflateMirror } from "../inflators/mirror";
+import { inflateParticleEmitter, ParticleEmitterParams } from "../inflators/particle-emitter";
 
 preload(
   new Promise(resolve => {
@@ -230,6 +231,7 @@ export interface ComponentData {
   billboard?: { onlyY: boolean };
   simpleWater?: SimpleWaterParams;
   mirror?: MirrorParams;
+  particleEmitter?: ParticleEmitterParams;
 }
 
 export interface JSXComponentData extends ComponentData {
@@ -373,7 +375,8 @@ export const commonInflators: Required<{ [K in keyof ComponentData]: InflatorFn 
   ambientLight: inflateAmbientLight,
   directionalLight: inflateDirectionalLight,
   simpleWater: inflateSimpleWater,
-  mirror: inflateMirror
+  mirror: inflateMirror,
+  particleEmitter: inflateParticleEmitter
 };
 
 const jsxInflators: Required<{ [K in keyof JSXComponentData]: InflatorFn }> = {

--- a/types/lib-hubs.d.ts
+++ b/types/lib-hubs.d.ts
@@ -1,0 +1,8 @@
+declare module "lib-hubs/packages/three-particle-emitter/lib/esm/index" {
+  import { ParticleEmitter as PE } from "lib-hubs/packages/three-particle-emitter/lib/types";
+
+  export class ParticleEmitter extends PE {
+    material: ShaderMaterial;
+    constructor(texture: Texture);
+  }
+}


### PR DESCRIPTION
This PR adds support for the bit-ecs particle-system counterpart.

We also should move the particle system to a more modern GPU based particle system like https://github.com/fazeaction/three-gpu-particle-system/ but I have left that for a post bit-ecs migration step.