### PR TITLE
Add button to remove bit-ecs entities

### DIFF
--- a/src/react-components/debug-panel/ECSSidebar.js
+++ b/src/react-components/debug-panel/ECSSidebar.js
@@ -7,7 +7,7 @@ import { IconButton } from "../input/IconButton";
 import { FormattedMessage } from "react-intl";
 
 import * as bitComponents from "../../bit-components";
-import { defineQuery, getEntityComponents } from "bitecs";
+import { defineQuery, getEntityComponents, removeEntity } from "bitecs";
 
 const bitComponentNames = new Map();
 for (const [name, Component] of Object.entries(bitComponents)) {
@@ -126,6 +126,9 @@ function ObjectProperties({ obj }) {
         <span>{displayName}</span>
         <button onClick={() => console.log(obj)}>
           <FormattedMessage id="ecs-sidebar.log-button" defaultMessage="log" />
+        </button>
+        <button onClick={() => removeEntity(APP.world, obj.eid)}>
+          <FormattedMessage id="ecs-sidebar.remove-button" defaultMessage="remove" />
         </button>
       </div>
       <div className="content">{obj.eid && <EntityInfo eid={obj.eid} />}</div>

--- a/src/react-components/debug-panel/ECSSidebar.scss
+++ b/src/react-components/debug-panel/ECSSidebar.scss
@@ -11,7 +11,8 @@
         padding: 8px 0;
     }
 
-    .object-list, .object-properties {
+    .object-list,
+    .object-properties {
         height: 50%;
         overflow: auto;
     }
@@ -34,6 +35,7 @@
         display: flex;
         flex-direction: column;
         .title {
+            border-top: 1px solid #6220d3;
             border-bottom: 1px solid #6220d3;
             padding: 10px;
             display: flex;
@@ -42,6 +44,11 @@
                 flex: 1;
                 text-align: center;
                 padding: 5px;
+            }
+
+            button {
+                margin-left: 5px;
+                margin-right: 5px;
             }
         }
         .content {
@@ -65,7 +72,5 @@
         font-size: 10px;
         border-radius: 10px;
         border: none;
-
     }
-
 }


### PR DESCRIPTION
I find the ecsDebug panel pretty useful while debugging components, I just missed a way to easily remove a bit-ecs entity to test exit cases. This PRs adds such a button to the object properties panel.