### PR TITLE
Add client development docs

### DIFF
--- a/doc/org/basics.org
+++ b/doc/org/basics.org
@@ -1,0 +1,29 @@
+The Hubs client is a web application that runs in each user's web browser. It contains the HTML, CSS, and Javascript necessary to simulate a networked 3D world and display interactive 2D menus. This document provides an overview of the Hubs client: the technologies it uses, the backend services it connects to, and how its code is organized.
+
+* Technologies and Backend Services
+The client combines several libraries and technologies to provide this experience to users, and offers developers various ways to change and extend its functionality.
+
+These are the main technologies in use by the hubs client:
+
+- ~Three.js~ : ~Three.js~ is a 3D graphics and scene graph library for building and creating 3D scenes. Three.js makes it easier to use the browser's built-in graphics capabilities, such as WebGL, WebXR, and WebGPU (someday).
+- ~bitECS~ : ~bitECS~ is an ECS library for managing game state that lives outside the Three.js scene graph. In the Hubs client, most "things" (avatars, images, an animated emoji) are referenced by an entity ID. This entity ID is used to access component data stored in pre-allocated ~TypedArrays~.
+- ~Media Capture and Streams API~, ~WebRTC~, and ~WebAudio~ : The ~Media Capture and Streams API~ allows microphones, cameras, and screencapture to be accessed within the browser. Data is captured and encoded locally before being sent (as ~WebRTC~ streams) to a backend service (~Dialog~), where they are forwarded to other clients connected to the same room. Incoming streams are decoded and transformed (e.g. by ~PannerNode~ s and ~GainNodes~ from the ~WebAudio~ API) before being played through the user's speakers.
+- ~HTTP~, ~Web Sockets~ : The Hubs client is web app, which means its code is downloaded when you visit a hubs-powered site. After its initial load, the hubs client exchanges many, many messages to the backend web server, ~Reticulum~. To download assets like 3D model files and 2D images, the client makes ~HTTP~ requests. To exchange game state information like, "where my avatar is moving", the client sends messages over a ~Web Socket~ connection (specifically, via ~Phoenix channels~).
+- ~Webpack and npm~ : The Hubs client is built and bundled by ~Webpack~. Building the client (or custom versions of the client) typically involves running a few commands with ~npm~.
+- ~Typescript~ : ~Typescript~ is a superset of Javascript that compiles to Javascript. We adopted typescript in 2022. While we are not trying to rewrite all of our existing javascript, new code is usually written in typescript.
+
+* How the code is organized
+
+There are three main sections of application code:
+
+The ~admin~ directory contains a separate application that powers the Hubs admin panel. Note that this directory will likely undergo changes in the near future.
+
+The ~react-components~ directory contains all of the 2D UI shown in menus, modals, and toolbars throughout the client. It is built with ~React~.
+
+The ~src~ directory contains of the code that powers the 3D simulation. The entry points for various pages are defined in ~webpack.config.js~.
+
+* Where to go from here
+Check out the other docs. They cover
+** Core Concepts for Gameplay Code
+** Interactivity
+** Networking

--- a/doc/org/build/README.md
+++ b/doc/org/build/README.md
@@ -1,0 +1,1 @@
+This directory contains built markdown files from source `.org` files in the parent directory. Avoid editing the markdown files directly. We will settle on a different authoring format eventually, but for now the org files are the source.

--- a/doc/org/build/basics.md
+++ b/doc/org/build/basics.md
@@ -1,0 +1,63 @@
+
+# Table of Contents
+
+1.  [Technologies and Backend Services](#org6403180)
+2.  [How the code is organized](#org4c547eb)
+3.  [Where to go from here](#org73b2819)
+    1.  [Core Concepts for Gameplay Code](#orgff2c327)
+    2.  [Interactivity](#org1e72509)
+    3.  [Networking](#orga1b8c1a)
+
+The Hubs client is a web application that runs in each user&rsquo;s web browser. It contains the HTML, CSS, and Javascript necessary to simulate a networked 3D world and display interactive 2D menus. This document provides an overview of the Hubs client: the technologies it uses, the backend services it connects to, and how its code is organized.
+
+
+<a id="org6403180"></a>
+
+# Technologies and Backend Services
+
+The client combines several libraries and technologies to provide this experience to users, and offers developers various ways to change and extend its functionality.
+
+These are the main technologies in use by the hubs client:
+
+-   `Three.js` : `Three.js` is a 3D graphics and scene graph library for building and creating 3D scenes. Three.js makes it easier to use the browser&rsquo;s built-in graphics capabilities, such as WebGL, WebXR, and WebGPU (someday).
+-   `bitECS` : `bitECS` is an ECS library for managing game state that lives outside the Three.js scene graph. In the Hubs client, most &ldquo;things&rdquo; (avatars, images, an animated emoji) are referenced by an entity ID. This entity ID is used to access component data stored in pre-allocated `TypedArrays`.
+-   `Media Capture and Streams API`, `WebRTC`, and `WebAudio` : The `Media Capture and Streams API` allows microphones, cameras, and screencapture to be accessed within the browser. Data is captured and encoded locally before being sent (as `WebRTC` streams) to a backend service (`Dialog`), where they are forwarded to other clients connected to the same room. Incoming streams are decoded and transformed (e.g. by `PannerNode` s and `GainNodes` from the `WebAudio` API) before being played through the user&rsquo;s speakers.
+-   `HTTP`, `Web Sockets` : The Hubs client is web app, which means its code is downloaded when you visit a hubs-powered site. After its initial load, the hubs client exchanges many, many messages to the backend web server, `Reticulum`. To download assets like 3D model files and 2D images, the client makes `HTTP` requests. To exchange game state information like, &ldquo;where my avatar is moving&rdquo;, the client sends messages over a `Web Socket` connection (specifically, via `Phoenix channels`).
+-   `Webpack and npm` : The Hubs client is built and bundled by `Webpack`. Building the client (or custom versions of the client) typically involves running a few commands with `npm`.
+-   `Typescript` : `Typescript` is a superset of Javascript that compiles to Javascript. We adopted typescript in 2022. While we are not trying to rewrite all of our existing javascript, new code is usually written in typescript.
+
+
+<a id="org4c547eb"></a>
+
+# How the code is organized
+
+There are three main sections of application code:
+
+The `admin` directory contains a separate application that powers the Hubs admin panel. Note that this directory will likely undergo changes in the near future.
+
+The `react-components` directory contains all of the 2D UI shown in menus, modals, and toolbars throughout the client. It is built with `React`.
+
+The `src` directory contains of the code that powers the 3D simulation. The entry points for various pages are defined in `webpack.config.js`.
+
+
+<a id="org73b2819"></a>
+
+# Where to go from here
+
+Check out the other docs. They cover
+
+
+<a id="orgff2c327"></a>
+
+## Core Concepts for Gameplay Code
+
+
+<a id="org1e72509"></a>
+
+## Interactivity
+
+
+<a id="orga1b8c1a"></a>
+
+## Networking
+

--- a/doc/org/build/basics.md
+++ b/doc/org/build/basics.md
@@ -1,17 +1,14 @@
-
-# Table of Contents
-
-1.  [Technologies and Backend Services](#org6403180)
-2.  [How the code is organized](#org4c547eb)
-3.  [Where to go from here](#org73b2819)
-    1.  [Core Concepts for Gameplay Code](#orgff2c327)
-    2.  [Interactivity](#org1e72509)
-    3.  [Networking](#orga1b8c1a)
+- [Technologies and Backend Services](#org3f3162a)
+- [How the code is organized](#orga3ec246)
+- [Where to go from here](#org6def927)
+  - [Core Concepts for Gameplay Code](#org619c8bf)
+  - [Interactivity](#org4758997)
+  - [Networking](#orgc703920)
 
 The Hubs client is a web application that runs in each user&rsquo;s web browser. It contains the HTML, CSS, and Javascript necessary to simulate a networked 3D world and display interactive 2D menus. This document provides an overview of the Hubs client: the technologies it uses, the backend services it connects to, and how its code is organized.
 
 
-<a id="org6403180"></a>
+<a id="org3f3162a"></a>
 
 # Technologies and Backend Services
 
@@ -27,7 +24,7 @@ These are the main technologies in use by the hubs client:
 -   `Typescript` : `Typescript` is a superset of Javascript that compiles to Javascript. We adopted typescript in 2022. While we are not trying to rewrite all of our existing javascript, new code is usually written in typescript.
 
 
-<a id="org4c547eb"></a>
+<a id="orga3ec246"></a>
 
 # How the code is organized
 
@@ -40,24 +37,23 @@ The `react-components` directory contains all of the 2D UI shown in menus, modal
 The `src` directory contains of the code that powers the 3D simulation. The entry points for various pages are defined in `webpack.config.js`.
 
 
-<a id="org73b2819"></a>
+<a id="org6def927"></a>
 
 # Where to go from here
 
 Check out the other docs. They cover
 
 
-<a id="orgff2c327"></a>
+<a id="org619c8bf"></a>
 
 ## Core Concepts for Gameplay Code
 
 
-<a id="org1e72509"></a>
+<a id="org4758997"></a>
 
 ## Interactivity
 
 
-<a id="orga1b8c1a"></a>
+<a id="orgc703920"></a>
 
 ## Networking
-

--- a/doc/org/build/gameplay.md
+++ b/doc/org/build/gameplay.md
@@ -1,65 +1,62 @@
 
 # Table of Contents
 
-1.  [Intro](#org991feb0)
-2.  [Entities, components, systems.](#org949b2be)
-    1.  [`bitECS`](#org52e4c14)
-    2.  [Disclaimer](#org6abd7d0)
-3.  [Writing systems](#org4059b4f)
-    1.  [Systems are functions](#org6b83742)
-    2.  [The game loop](#org5030fa5)
-    3.  [Queries are useful](#orgaad10d1)
-    4.  [Replacing `async` functions with `JobRunner`](#org239ab65)
-4.  [Writing components](#orgb52fe0d)
-    1.  [Defining components](#org8bc2f74)
-    2.  [Data types](#org8414c54)
-    3.  [Avoid holding references](#org5941dae)
-    4.  [String data](#orgbde4b78)
-    5.  [Flags](#org7538757)
-    6.  [Tag components](#org28d3295)
-    7.  [The escape hatch](#org68cb175)
-    8.  [Associating entities with `Object3D` s](#org54bec2b)
-    9.  [Avoid duplicating state](#org2ab4512)
-5.  [Creating entities](#orgad19bee)
-    1.  [Entities are numbers](#orgb093be1)
-    2.  [Loading from prefabs](#org473a107)
-        1.  [`EntityDef` s](#orgd065b36)
-        2.  [JSX without React](#org44b9d51)
-    3.  [Loading from glb files](#org9fa25f0)
-        1.  [The Hubs Blender add-on](#org12e5028)
-    4.  [Entity creation is synchronous](#orgac98852)
-    5.  [Component inflators](#org70713be)
-        1.  [Inflator rules](#org668d885)
-        2.  [Default inflators](#org34cc0c5)
-        3.  [Associating `Object3D` s (`eid2obj`)](#org4e42a5c)
-        4.  [Associating `Material` s (`eid2mat`)](#orgc1810aa)
-        5.  [`Ref` s and node](#org8a5936a)
-        6.  [Common inflators](#org65377c5)
-        7.  [`JSX`](#orga149a6f)
-        8.  [`GLB`](#orgeade883)
-    6.  [Entity ID&rsquo;s are recycled](#orgfddb016)
-6.  [Custom clients and addons](#org95d4be1)
-    1.  [Addons aren&rsquo;t ready yet (February 2023)](#org3fbd0bb)
-    2.  [preload](#org6b91832)
-    3.  [Inserting prefabs](#org13261de)
-    4.  [Inserting inflators](#orga05a4e5)
-    5.  [Inserting system calls](#org7cd9bc6)
-    6.  [Handling interactions](#org3be1e68)
-    7.  [Handling networking](#org52f6add)
+1.  [Intro](#org6a06010)
+2.  [Entities, components, systems.](#orgdca48fd)
+    1.  [`bitECS`](#org09e4439)
+    2.  [Disclaimer](#org8691a1b)
+3.  [Writing systems](#org5384deb)
+    1.  [Systems are functions](#orgb79c3fc)
+    2.  [The game loop](#orge838be4)
+    3.  [Queries are useful](#org849bf4a)
+    4.  [Replacing `async` functions with `JobRunner`](#org14b1811)
+4.  [Writing components](#org8c21b06)
+    1.  [Defining components](#org5b1aec4)
+    2.  [Data types](#org20b3260)
+    3.  [Avoid holding references](#orgdae8d29)
+    4.  [String data](#org1f7ac35)
+    5.  [Flags](#org9d63cc3)
+    6.  [Tag components](#orga6b8ef8)
+    7.  [The escape hatch](#org2a31d13)
+    8.  [Associating entities with `Object3D` s](#orge5d0f80)
+    9.  [Avoid duplicating state](#org9d8eb03)
+5.  [Adding entities](#org142a1ca)
+    1.  [Entity basics](#orgb49d3f9)
+    2.  [Creating `EntityDef` s](#org216bef3)
+    3.  [Creating model files](#org9006e83)
+    4.  [Entity creation is synchronous](#org7b5d056)
+    5.  [Inflation](#orgd2781f3)
+        1.  [What does `renderAsEntity` do?](#orge2d89b3)
+        2.  [`Inflator` s](#orgf6fc9f9)
+        3.  [Default inflators](#org853e974)
+        4.  [Associating `Object3D` s (`eid2obj`)](#org16d072a)
+        5.  [Loading model files](#org8585d1d)
+        6.  [Common inflators, `jsxInflators`, and `gltfInflators`](#orgc2e525d)
+        7.  [Entity `Ref` s and `__mhc_link_type` : `"node"`](#orgbcb8cdc)
+        8.  [Associating `Material` s (`eid2mat`)](#orgf209653)
+    6.  [Entity ID&rsquo;s are recycled](#org9bb31b4)
+6.  [Custom clients and addons](#org978c51d)
+    1.  [Addons aren&rsquo;t ready yet (February 2023)](#org6f6abd0)
+    2.  [preload](#org4c611fc)
+    3.  [Inserting prefabs](#org520ae00)
+    4.  [Inserting inflators](#orgce11780)
+    5.  [Inserting system calls](#org30b918a)
+    6.  [Handling interactions](#org709e04f)
+    7.  [Handling networking](#orgbaeae9c)
 
 \#+TITLE Core Concepts for Gameplay Code
 
 Core Concepts for Gameplay Code
 
 
-<a id="org991feb0"></a>
+<a id="org6a06010"></a>
 
 # Intro
 
 This document gives an overview of the core concepts for writing gameplay code in the Hubs client.
 
 
-<a id="org949b2be"></a>
+<a id="orgdca48fd"></a>
 
 # Entities, components, systems.
 
@@ -71,7 +68,7 @@ ECS became a popular topic in recent years.
 Originally built with `A-Frame`, Hubs switched to `bitECS` and using `three.js` directly. Motivation, goals, and non-goals about the transition can be found in this PR from June, 2022. <https://github.com/mozilla/hubs/pull/5536>
 
 
-<a id="org52e4c14"></a>
+<a id="org09e4439"></a>
 
 ## `bitECS`
 
@@ -84,7 +81,7 @@ The `bitECS` API is minimal, and its own documentation should be consulted for d
 `bitECS` has no built-in concept of systems. We frequently refer the functions invoked during the game loop as &ldquo;systems&rdquo;, but there is no formal construct.
 
 
-<a id="org6abd7d0"></a>
+<a id="org8691a1b"></a>
 
 ## Disclaimer
 
@@ -95,12 +92,12 @@ We need to store game state somehow, and conventions are useful. We use three.js
 In other words, our game state is not &ldquo;purely&rdquo; in ECS, nor do we care to make it so. The PR linked above states the (relatively humble) goals and non-goals of our entity framework.
 
 
-<a id="org4059b4f"></a>
+<a id="org5384deb"></a>
 
 # Writing systems
 
 
-<a id="org6b83742"></a>
+<a id="orgb79c3fc"></a>
 
 ## Systems are functions
 
@@ -109,34 +106,34 @@ In other words, our game state is not &ldquo;purely&rdquo; in ECS, nor do we car
 We provide the browser&rsquo;s `requestAnimationFrame` with our game loop function (`mainTick`), to be invoked each frame.
 
 
-<a id="org5030fa5"></a>
+<a id="orge838be4"></a>
 
 ## The game loop
 
 
-<a id="orgaad10d1"></a>
+<a id="org849bf4a"></a>
 
 ## Queries are useful
 
 
-<a id="org239ab65"></a>
+<a id="org14b1811"></a>
 
 ## Replacing `async` functions with `JobRunner`
 
 
-<a id="orgb52fe0d"></a>
+<a id="org8c21b06"></a>
 
 # Writing components
 
 
-<a id="org8bc2f74"></a>
+<a id="org5b1aec4"></a>
 
 ## Defining components
 
 `bitECS` components are defined with `defineComponent`.
 
 
-<a id="org8414c54"></a>
+<a id="org20b3260"></a>
 
 ## Data types
 
@@ -154,7 +151,7 @@ We provide the browser&rsquo;s `requestAnimationFrame` with our game loop functi
 -   `eid`
 
 
-<a id="org5941dae"></a>
+<a id="orgdae8d29"></a>
 
 ## Avoid holding references
 
@@ -172,7 +169,7 @@ The most common scenario for using the `eid` type is when building multi-entity 
     });
 
 
-<a id="orgbde4b78"></a>
+<a id="org1f7ac35"></a>
 
 ## String data
 
@@ -191,7 +188,7 @@ Strings are converted to numeric `StringID` s by the `getSid` function. `StringI
     console.log(`Loading scene from this url: ${src}`);
 
 
-<a id="org7538757"></a>
+<a id="org9d63cc3"></a>
 
 ## Flags
 
@@ -212,7 +209,7 @@ Strings are converted to numeric `StringID` s by the `getSid` function. `StringI
       snapToNavMesh = 1 << 6
     }
     
-    // These values are booleans because they originate from an external source, like json in a glb file.
+    // These values are booleans because they originate from an external source, like json in a gltf file.
     export interface WaypointParams {
       canBeSpawnPoint: boolean;
       canBeOccupied: boolean;
@@ -243,14 +240,14 @@ Strings are converted to numeric `StringID` s by the `getSid` function. `StringI
     const canBeSpawnPoint = Waypoint.flags[eid] & WaypointFlags.canBeSpawnPoint;
 
 
-<a id="org28d3295"></a>
+<a id="orga6b8ef8"></a>
 
 ## Tag components
 
 `bitECS` components with no properties are called tag components. It is useful to be able to tag an entity so that it appears in queries.
 
 
-<a id="org68cb175"></a>
+<a id="org2a31d13"></a>
 
 ## The escape hatch
 
@@ -282,7 +279,7 @@ It is our responsibility to clean up anything we put into the map:
     });
 
 
-<a id="org54bec2b"></a>
+<a id="orge5d0f80"></a>
 
 ## Associating entities with `Object3D` s
 
@@ -293,7 +290,7 @@ An entity can only be associated with a single `Object3D`.
 You may find it strange that we have a different pattern for `world.eid2obj`, and that we do not simply use the same pattern as the one shown above for `MediaPDF`. Well, I do too. We wrote `world.eid2obj` long before we wrote `MediaPDF`, so this may be an accident. Perhaps we&rsquo;ll change `world.eid2obj` to `Object3DTag.map`, since the `eid2obj` map is meant to be kept in sync with the `Object3DTag` component.
 
 
-<a id="org2ab4512"></a>
+<a id="org9d8eb03"></a>
 
 ## Avoid duplicating state
 
@@ -312,132 +309,302 @@ We do not duplicate the `text` string in a `bitECS` component. We simply operate
     timeLabel.sync();
 
 
-<a id="orgad19bee"></a>
+<a id="org142a1ca"></a>
 
-# Creating entities
-
-
-<a id="orgb093be1"></a>
-
-## Entities are numbers
+# Adding entities
 
 
-<a id="org473a107"></a>
+<a id="orgb49d3f9"></a>
 
-## Loading from prefabs
+## Entity basics
 
+Entities are added to the world with `addEntity` and removed from the world with `removeEntity`. In `bitECS`, component state is stored in large, pre-allocated `TypedArrays`. In other words, entities are not objects with components inside them. Entities are simply numbers (`EntityID` s), and the `World` keeps track of things like whether an entity has a given component (`hasComponent(world, MyComponent, eid)`).
 
-<a id="orgd065b36"></a>
+You will rarely need to call `addEntity` yourself. Instead, you will write entity definitions (`EntityDef` s) using `jsx` or create model files (`gltf`) with that add entities and components when the models are loaded.
 
-### `EntityDef` s
-
-
-<a id="org44b9d51"></a>
-
-### JSX without React
+Note: We support both `glTF` formats, where binary data buffers contain base64-encoded strings (as in `.gltf`) or raw byte arrays (as in `.glb`). We refer to `gltf` and `glb` files interchangably.
 
 
-<a id="org9fa25f0"></a>
+<a id="org216bef3"></a>
 
-## Loading from glb files
+## Creating `EntityDef` s
+
+`EntityDef` s are `jsx` expressions that can be passed to `renderAsEntity` to add entities and components to the world. `EntityDef` s are commonly returned from `template` functions, which take some `InitialData` and return an `EntityDef` with the that `InitialData` applied.
+
+For example, the commonly used `MediaPrefab` function is a `template` that takes `MediaLoaderParams` as its `InitialData`, and returns an `EntityDef` for an interactable object.
+
+    export function MediaPrefab(params: MediaLoaderParams): EntityDef {
+      return (
+        <entity
+          name="Interactable Media"
+          networked
+          networkedTransform
+          mediaLoader={params}
+          deletable
+          grabbable={{ cursor: true, hand: true }}
+          destroyAtExtremeDistance
+          floatyObject={{
+            flags: FLOATY_OBJECT_FLAGS.MODIFY_GRAVITY_ON_RELEASE,
+            releaseGravity: 0
+          }}
+          networkedFloatyObject={{
+            flags: FLOATY_OBJECT_FLAGS.MODIFY_GRAVITY_ON_RELEASE
+          }}
+          rigidbody={{ collisionGroup: COLLISION_LAYERS.INTERACTABLES, collisionMask: COLLISION_LAYERS.HANDS }}
+          physicsShape={{ halfExtents: [0.22, 0.14, 0.1] }} /* TODO Physics shapes*/
+          scale={[1, 1, 1]}
+        />
+      );
+    }
+
+Although `EntityDef` s are written with `jsx` syntax, this is not `React`. The `jsx` syntax allows us to describe our desired scene graph, entities, and components. The definition is static, and there should be no expectation of &ldquo;re-rendering&rdquo; (as in `React` or `three-fiber`). Semantically, an `EntityDef` is equivalent to a model file with component data. `EntityDef` s are meant to be easy to edit by hand and to version control.
+
+For `network instantiated` entities, `template` functions are grouped together with `permission` information to form a named `Prefab`. More information about `network instantiated` entities can be found in the networking documentation.
 
 
-<a id="org12e5028"></a>
+<a id="org9006e83"></a>
 
-### The Hubs Blender add-on
+## Creating model files
+
+Equivalently, hubs components can be added to nodes in a GLTF file with the `MOZ_hubs_components` extension.
+
+The `hubs-blender-exporter` is a Blender add-on that helps artists do this.
+
+Spoke also includes component data in the gltf files that it exports and uploads.
 
 
-<a id="orgac98852"></a>
+<a id="org7b5d056"></a>
 
 ## Entity creation is synchronous
 
+It is important to realize that `renderAsEntity` is a synchronous function. That is, it will immediately return a valid `EntityID` with a corresponding `Object3D` added to the scene graph.
 
-<a id="org70713be"></a>
-
-## Component inflators
-
-
-<a id="org668d885"></a>
-
-### Inflator rules
+The presence of some components (like `MediaLoader`) cause systems to begin asynchronous work. In the case of `MediaLoader`, this work can include downloading model or image files, loading them with the GLTF loader, and ultimately creating additional entities and components. But the entity at the root of this `Object3D` hierarchy will be created synchronously/immediately when `renderAsEntity` runs.
 
 
-<a id="org34cc0c5"></a>
+<a id="orgd2781f3"></a>
+
+## Inflation
+
+
+<a id="orge2d89b3"></a>
+
+### What does `renderAsEntity` do?
+
+In the example above, we show a `template` function (`MediaPrefab`) that takes some `InitialData` (the `MediaLoaderParams`) and returns an `EntityDef`. We then said that the `EntityDef` can be passed to `renderAsEntity` which will (synchronously) add entities and components to the world. We also said this was equivalent to loading a model file (GLTF).
+
+Question: How does `renderAsEntity` (and whatever loads models) accomplish this?
+Answer: By running `inflators`.
+
+
+<a id="orgf6fc9f9"></a>
+
+### `Inflator` s
+
+An `inflator` is a function that transforms a <span class="underline">description</span> of some components/entities into real components and real entities.
+
+When `renderAsEntity` is given the `EntityDef` generated by the `MediaPrefab` above, it will run an `inflator` for each of the properties found in the `jsx` expression.
+
+For example, the `jsx` expression contains the following line:
+
+    grabbable={{ cursor: true, hand: true }}
+
+When `renderAsEntity` parses this line, it checks the `jsxInflators` map (for the key `"grabbable"` ) to find the associated inflator (`inflateGrabbable`), and calls it.
+
+The `inflateGrabbable` function transforms the description into the necessary runtime components:
+
+    export type GrabbableParams = { cursor: boolean; hand: boolean };
+    const defaults: GrabbableParams = { cursor: true, hand: true };
+    export function inflateGrabbable(world: HubsWorld, eid: number, props: GrabbableParams) {
+      props = Object.assign({}, defaults, props);
+      if (props.hand) {
+        addComponent(world, HandCollisionTarget, eid);
+        addComponent(world, OffersHandConstraint, eid);
+      }
+      if (props.cursor) {
+        addComponent(world, CursorRaycastable, eid);
+        addComponent(world, RemoteHoverTarget, eid);
+        addComponent(world, OffersRemoteConstraint, eid);
+      }
+      addComponent(world, Holdable, eid);
+    }
+
+Notice that `GrabbableParams` do not map one-to-one with runtime components. That is, there is no `Grabbable` component. This is common in situations where we want to expose user-friendly options (for use in Blender, Spoke, or when writing `EntityDef` s), while representing the information differently at runtime.
+
+
+<a id="org853e974"></a>
 
 ### Default inflators
 
+For many components, the `EntityDef` or `GLTF` representation DOES match the runtime component, and writing individual inflators for each would be unnecessary boilerplate.
 
-<a id="org4e42a5c"></a>
+For example, the `SceneLoader` component has a single property, a string `src`:
+
+    export const SceneLoader = defineComponent({ src: Types.ui32 });
+    SceneLoader.src[$isStringType] = true;
+
+It can be specified in the following `EntityDef` :
+
+    export function ScenePrefab(src: string): EntityDef {
+      return <entity name="Scene" sceneRoot sceneLoader={{ src }} />;
+    }
+
+Writing the inflator for the `SceneLoader` component is simple, except for the fact that we have to remember to convert the `string` to a `StringID`, so that the `bitECS` component can hold onto it:
+
+    export function inflateSceneLoader(world: HubsWorld, eid: number, props: { src: string }) {
+      addComponent(world, SceneLoader, eid);
+      SceneLoader.src[eid] = APP.getSid(props.src); // Convert string to string id
+    }
+
+In our `jsxInflators` map, we would associate `"sceneLoader"` with `inflateSceneLoader` :
+
+    sceneLoader: inflateSceneLoader,
+
+This situation is so common that we have a helper function, `createDefaultInflator`, that we can use instead of writing `inflateSceneLoader` manually. We simply pass the component we want to inflate to `createDefaultInflator` and we&rsquo;re done:
+
+    sceneLoader: createDefaultInflator(SceneLoader),
+
+The default inflator handles the conversion from `string` s to `StringID`, and will log an error if a property name is passed to the `inflator` that does not have a corresponding property in the underlying component.
+
+
+<a id="org16d072a"></a>
 
 ### Associating `Object3D` s (`eid2obj`)
 
+Most of the time, we add a component definition to an `EntityDef` or model file just to cause some component data to be associated with an entity. Sometimes, we want to control the `Object3D` that will be inserted into the scene graph for this entity.
 
-<a id="orgc1810aa"></a>
+We do this by calling `addObject3DComponent` from within an `inflator`.
+
+For example, when a `simpleWater` component is found within a node of a GLTF file, the `inflateSimpleWater` inflator will create a `SimpleWaterMesh` with the given params and associate it with the given `EntityID` :
+
+    export function inflateSimpleWater(world: HubsWorld, eid: EntityID, params: SimpleWaterParams) {
+      params = Object.assign({}, DEFAULTS, params);
+      const lowQuality = APP.store.state.preferences.materialQualitySetting !== "high";
+      const simpleWater = new SimpleWaterMesh({ lowQuality });
+      simpleWater.opacity = params.opacity;
+      simpleWater.color.set(params.color);
+      simpleWater.tideHeight = params.tideHeight;
+      simpleWater.tideScale.fromArray(params.tideScale);
+      simpleWater.tideSpeed.fromArray(params.tideSpeed);
+      simpleWater.waveHeight = params.waveHeight;
+      simpleWater.waveScale.fromArray(params.waveScale);
+      simpleWater.waveSpeed.fromArray(params.waveSpeed);
+      simpleWater.ripplesScale = params.ripplesScale;
+      simpleWater.ripplesSpeed = params.ripplesSpeed;
+    
+      addObject3DComponent(world, eid, simpleWater);
+      addComponent(world, SimpleWater, eid);
+    }
+
+Only one inflator per entity can create and assign an `Object3D`. An `EntityDef` that describes an entity that is both a `SimpleWaterMesh` and a `DirectionalLight` will fail to load:
+
+    renderAsEntity(
+      <entity
+          name="Buggy Entity"
+          simpleWater
+          directionalLight
+      />
+    ); // throws Error("Tried to add an object3D tag to an entity that already has one");
+
+By default, if no `inflator` creates an `Object3D` for the entity, then `renderAsEntity` will create and assign it a `Group`.
+
+
+<a id="org8585d1d"></a>
+
+### Loading model files
+
+The sections above explain how `renderAsEntity` transforms a `jsx` `EntityDef` into an entity and components, and claims that the process for loading a `gltf` file is equivalent.
+
+We are now ready to understand why, and will explain by example.
+
+The `EntityDef` returned by the `MediaPrefab` template (above) includes a `mediaLoader`, which will cause `renderAsEntity` to invoke the `inflateMediaLoader` inflator and assign a `MediaLoader` component to the entity.
+
+Assume the `MediaPrefab` template is initialized with `src` set to the url of a `gltf` file. In other words, we are trying to use the `MediaPrefab` load a `gltf` file that we can grab and interact with.
+
+We pass the `EntityDef` to `renderAsEntity`, an entity is returned synchronously, and execution continues as normal.
+
+When the `mediaLoading` system runs, it notices the new `MediaLoader` component and starts an asynchronous `coroutine` that determines the media type pointed to by the `src` property, downloads the `gltf` file and loads it as Three.js scene graph via a `GLTFLoader`. Finally, the loaded scene graph is passed into an `EntityDef`&rsquo;s `model` parameter:
+
+    export function* loadModel(world: HubsWorld, src: string, contentType: string, useCache: boolean) {
+      const { scene, animations } = yield loadGLTFModel(src, contentType, useCache, null);
+      scene.animations = animations;
+      scene.mixer = new THREE.AnimationMixer(scene);
+      return renderAsEntity(world, <entity model={{ model: scene }} />);
+    }
+
+In other words, the asynchronous work of loading the model is done `before` an entity is created for the loaded `gltf`. Despite being called after some asynchronous work, the entity creation step that happens in `renderAsEntity` itself happens synchronously.
+
+The `model` inflator (`inflateModel`) is to `gltf` files as `renderAsEntity` is to `EntityDef` s. You will notice that `inflateModel` invokes other component inflators and adds many entities to the world to match the `Object3D` hierarchy that was provided within the `ModelParams`.
+
+This is what we mean when we say that loading from `gltf` files is &ldquo;equivalent&rdquo; to loading from `EntityDef` s.
+
+
+<a id="orgc2e525d"></a>
+
+### Common inflators, `jsxInflators`, and `gltfInflators`
+
+We can now explain why there are three collections of `inflators`:
+
+-   `commonInflators` are for components can be loaded (identically) whether they are defined in `EntityDef` s or `gltf` files.
+-   `jsxInflators` are for components that are specified in `EntityDef` s.
+-   `gltfInflators` are for components that are specified in `gltf` files.
+
+Notice that in the sentences above, we overload the word `components`. As we have shown, the data in `EntityDef` s or `gltf` files are not `bitECS` components, but need to be transformed (via `inflator` s) to their runtime formats (which is usually `bitECS` components).
+
+While it might be helpful to define a `new` word (like &ldquo;pre-components&rdquo;) to describe these data, we think this is overly complicated. From the perspective of the Blender add-on for example, its job is to add components (specifically, &ldquo;`MOZ_hubs_components`&rdquo;) to nodes in the `.blend` scene and exported `gltf` files.
+
+
+<a id="orgbcb8cdc"></a>
+
+### Entity `Ref` s and `__mhc_link_type` : `"node"`
+
+
+<a id="orgf209653"></a>
 
 ### Associating `Material` s (`eid2mat`)
 
 
-<a id="org8a5936a"></a>
-
-### `Ref` s and node
-
-
-<a id="org65377c5"></a>
-
-### Common inflators
-
-
-<a id="orga149a6f"></a>
-
-### `JSX`
-
-
-<a id="orgeade883"></a>
-
-### `GLB`
-
-
-<a id="orgfddb016"></a>
+<a id="org9bb31b4"></a>
 
 ## Entity ID&rsquo;s are recycled
 
 
-<a id="org95d4be1"></a>
+<a id="org978c51d"></a>
 
 # Custom clients and addons
 
 
-<a id="org3fbd0bb"></a>
+<a id="org6f6abd0"></a>
 
 ## Addons aren&rsquo;t ready yet (February 2023)
 
 
-<a id="org6b91832"></a>
+<a id="org4c611fc"></a>
 
 ## preload
 
 
-<a id="org13261de"></a>
+<a id="org520ae00"></a>
 
 ## Inserting prefabs
 
 
-<a id="orga05a4e5"></a>
+<a id="orgce11780"></a>
 
 ## Inserting inflators
 
 
-<a id="org7cd9bc6"></a>
+<a id="org30b918a"></a>
 
 ## Inserting system calls
 
 
-<a id="org3be1e68"></a>
+<a id="org709e04f"></a>
 
 ## Handling interactions
 
 
-<a id="org52f6add"></a>
+<a id="orgbaeae9c"></a>
 
 ## Handling networking
 

--- a/doc/org/build/gameplay.md
+++ b/doc/org/build/gameplay.md
@@ -1,62 +1,59 @@
-
-# Table of Contents
-
-1.  [Intro](#org6a06010)
-2.  [Entities, components, systems.](#orgdca48fd)
-    1.  [`bitECS`](#org09e4439)
-    2.  [Disclaimer](#org8691a1b)
-3.  [Writing systems](#org5384deb)
-    1.  [Systems are functions](#orgb79c3fc)
-    2.  [The game loop](#orge838be4)
-    3.  [Queries are useful](#org849bf4a)
-    4.  [Replacing `async` functions with `JobRunner`](#org14b1811)
-4.  [Writing components](#org8c21b06)
-    1.  [Defining components](#org5b1aec4)
-    2.  [Data types](#org20b3260)
-    3.  [Avoid holding references](#orgdae8d29)
-    4.  [String data](#org1f7ac35)
-    5.  [Flags](#org9d63cc3)
-    6.  [Tag components](#orga6b8ef8)
-    7.  [The escape hatch](#org2a31d13)
-    8.  [Associating entities with `Object3D` s](#orge5d0f80)
-    9.  [Avoid duplicating state](#org9d8eb03)
-5.  [Adding entities](#org142a1ca)
-    1.  [Entity basics](#orgb49d3f9)
-    2.  [Creating `EntityDef` s](#org216bef3)
-    3.  [Creating model files](#org9006e83)
-    4.  [Entity creation is synchronous](#org7b5d056)
-    5.  [Inflation](#orgd2781f3)
-        1.  [What does `renderAsEntity` do?](#orge2d89b3)
-        2.  [`Inflator` s](#orgf6fc9f9)
-        3.  [Default inflators](#org853e974)
-        4.  [Associating `Object3D` s (`eid2obj`)](#org16d072a)
-        5.  [Loading model files](#org8585d1d)
-        6.  [Common inflators, `jsxInflators`, and `gltfInflators`](#orgc2e525d)
-        7.  [Entity `Ref` s and `__mhc_link_type` : `"node"`](#orgbcb8cdc)
-        8.  [Associating `Material` s (`eid2mat`)](#orgf209653)
-    6.  [Entity ID&rsquo;s are recycled](#org9bb31b4)
-6.  [Custom clients and addons](#org978c51d)
-    1.  [Addons aren&rsquo;t ready yet (February 2023)](#org6f6abd0)
-    2.  [preload](#org4c611fc)
-    3.  [Inserting prefabs](#org520ae00)
-    4.  [Inserting inflators](#orgce11780)
-    5.  [Inserting system calls](#org30b918a)
-    6.  [Handling interactions](#org709e04f)
-    7.  [Handling networking](#orgbaeae9c)
+- [Intro](#org4e55791)
+- [Entities, components, systems.](#orga1af0f7)
+  - [`bitECS`](#orgcffa85a)
+  - [Disclaimer](#orgcfbfbf5)
+- [Writing systems](#org3316e7a)
+  - [Systems are functions](#org7b7c6c9)
+  - [The game loop](#orgcfa22b2)
+  - [Queries are useful](#org0d64a9b)
+  - [Replacing `async` functions with `JobRunner`](#orgf1feaa4)
+- [Writing components](#orgb2ecbee)
+  - [Defining components](#orgf978235)
+  - [Data types](#orga3757d7)
+  - [Avoid holding references](#org79d322a)
+  - [Entity ID&rsquo;s are recycled](#orge0e0372)
+  - [String data](#orgc9f2288)
+  - [Flags](#org35603d1)
+  - [Tag components](#orgf59047e)
+  - [The escape hatch](#org7e9d9c3)
+  - [Associating entities with `Object3D` s](#orgba23c3c)
+  - [Avoid duplicating state](#orgae4fb77)
+- [Adding entities](#orgfe26f03)
+  - [Entity basics](#org5990fd9)
+  - [Creating `EntityDef` s](#org2933e3b)
+  - [Creating model files](#orgcf8022f)
+  - [Entity creation is synchronous](#orgb0c2aa1)
+  - [Inflation](#orgf7ad262)
+    - [What does `renderAsEntity` do?](#orgec09b67)
+    - [`Inflator` s](#org68cdb74)
+    - [Default inflators](#org1646688)
+    - [Associating `Object3D` s (`eid2obj`)](#org5c34243)
+    - [Loading model files](#orgd1fa577)
+    - [Common inflators, `jsxInflators`, and `gltfInflators`](#org0cb5922)
+    - [Entity `Ref` s and `__mhc_link_type` : `"node"`](#org7910942)
+    - [Associating `Material` s (`eid2mat`)](#orgbc310fc)
+- [Custom clients and addons](#org9086134)
+  - [Addons aren&rsquo;t ready yet (February 2023)](#orgb0f7d0c)
+  - [preload](#org25a442f)
+  - [Inserting prefabs](#org6d3a100)
+  - [Inserting inflators](#orgaeeab48)
+  - [Inserting system calls](#orgaee3fbb)
+  - [Handling interactions](#org5dfa7cf)
+  - [Handling networking](#orgb51469b)
 
 \#+TITLE Core Concepts for Gameplay Code
 
 Core Concepts for Gameplay Code
 
 
-<a id="org6a06010"></a>
+<a id="org4e55791"></a>
 
 # Intro
 
 This document gives an overview of the core concepts for writing gameplay code in the Hubs client.
 
 
-<a id="orgdca48fd"></a>
+<a id="orga1af0f7"></a>
 
 # Entities, components, systems.
 
@@ -68,7 +65,7 @@ ECS became a popular topic in recent years.
 Originally built with `A-Frame`, Hubs switched to `bitECS` and using `three.js` directly. Motivation, goals, and non-goals about the transition can be found in this PR from June, 2022. <https://github.com/mozilla/hubs/pull/5536>
 
 
-<a id="org09e4439"></a>
+<a id="orgcffa85a"></a>
 
 ## `bitECS`
 
@@ -81,7 +78,7 @@ The `bitECS` API is minimal, and its own documentation should be consulted for d
 `bitECS` has no built-in concept of systems. We frequently refer the functions invoked during the game loop as &ldquo;systems&rdquo;, but there is no formal construct.
 
 
-<a id="org8691a1b"></a>
+<a id="orgcfbfbf5"></a>
 
 ## Disclaimer
 
@@ -92,12 +89,12 @@ We need to store game state somehow, and conventions are useful. We use three.js
 In other words, our game state is not &ldquo;purely&rdquo; in ECS, nor do we care to make it so. The PR linked above states the (relatively humble) goals and non-goals of our entity framework.
 
 
-<a id="org5384deb"></a>
+<a id="org3316e7a"></a>
 
 # Writing systems
 
 
-<a id="orgb79c3fc"></a>
+<a id="org7b7c6c9"></a>
 
 ## Systems are functions
 
@@ -106,34 +103,34 @@ In other words, our game state is not &ldquo;purely&rdquo; in ECS, nor do we car
 We provide the browser&rsquo;s `requestAnimationFrame` with our game loop function (`mainTick`), to be invoked each frame.
 
 
-<a id="orge838be4"></a>
+<a id="orgcfa22b2"></a>
 
 ## The game loop
 
 
-<a id="org849bf4a"></a>
+<a id="org0d64a9b"></a>
 
 ## Queries are useful
 
 
-<a id="org14b1811"></a>
+<a id="orgf1feaa4"></a>
 
 ## Replacing `async` functions with `JobRunner`
 
 
-<a id="org8c21b06"></a>
+<a id="orgb2ecbee"></a>
 
 # Writing components
 
 
-<a id="org5b1aec4"></a>
+<a id="orgf978235"></a>
 
 ## Defining components
 
 `bitECS` components are defined with `defineComponent`.
 
 
-<a id="org20b3260"></a>
+<a id="orga3757d7"></a>
 
 ## Data types
 
@@ -151,7 +148,7 @@ We provide the browser&rsquo;s `requestAnimationFrame` with our game loop functi
 -   `eid`
 
 
-<a id="orgdae8d29"></a>
+<a id="org79d322a"></a>
 
 ## Avoid holding references
 
@@ -159,17 +156,26 @@ The `eid` type indicates that the property values will be entity IDs. Be careful
 
 The most common scenario for using the `eid` type is when building multi-entity objects, such as in-world menus. The `VideoMenu` component stores references to each entity so that it can manage them all easily.
 
-    export const VideoMenu = defineComponent({
-      videoRef: Types.eid,
-      timeLabelRef: Types.eid,
-      trackRef: Types.eid,
-      headRef: Types.eid,
-      playIndicatorRef: Types.eid,
-      pauseIndicatorRef: Types.eid
-    });
+```typescript
+export const VideoMenu = defineComponent({
+  videoRef: Types.eid,
+  timeLabelRef: Types.eid,
+  trackRef: Types.eid,
+  headRef: Types.eid,
+  playIndicatorRef: Types.eid,
+  pauseIndicatorRef: Types.eid
+});
+```
 
 
-<a id="org1f7ac35"></a>
+<a id="orge0e0372"></a>
+
+## Entity ID&rsquo;s are recycled
+
+After an entity is removed (by `removeEntity`), its `EntityID` can later be reused in subsequent calls to `addEntity`. This does not happen right away, but is something you should be aware of, and is all the more reason to avoid holding onto entity references.
+
+
+<a id="orgc9f2288"></a>
 
 ## String data
 
@@ -177,77 +183,83 @@ We sometimes want to be able to store string data in components. Since `bitECS` 
 
 For example, consider a `SceneLoader` component with a `src` property, which we wish was a string.
 
-    export const SceneLoader = defineComponent({ src: Types.ui32 });
-    SceneLoader.src[$isStringType] = true;
+```typescript
+export const SceneLoader = defineComponent({ src: Types.ui32 });
+SceneLoader.src[$isStringType] = true;
+```
 
 The symbol `$isStringType`, defined in `bit-components.js`, indicates that this property is a string handle. Code that handles component state anonymously (e.g. `createDefaultInflator`) use this to correctly handle the property values.
 
 Strings are converted to numeric `StringID` s by the `getSid` function. `StringID` s can be converted back to strings by the `getString` function.
 
-    const src = APP.getString(SceneLoader.src[loaderEid]);
-    console.log(`Loading scene from this url: ${src}`);
+```typescript
+const src = APP.getString(SceneLoader.src[loaderEid]);
+console.log(`Loading scene from this url: ${src}`);
+```
 
 
-<a id="org9d63cc3"></a>
+<a id="org35603d1"></a>
 
 ## Flags
 
 `bitECS` components do not support `boolean` properties. In lieu of boolean properties, we often define a single `flags` property as an unsigned integer type to use as a bitmask:
 
-    export const Waypoint = defineComponent({
-      flags: Types.ui8
-    });
-    
-    // Use bit shifting to create values we can use instead of booleans
-    export enum WaypointFlags {
-      canBeSpawnPoint = 1 << 0,
-      canBeOccupied = 1 << 1,
-      canBeClicked = 1 << 2,
-      willDisableMotion = 1 << 3,
-      willDisableTeleporting = 1 << 4,
-      willMaintainInitialOrientation = 1 << 5,
-      snapToNavMesh = 1 << 6
-    }
-    
-    // These values are booleans because they originate from an external source, like json in a gltf file.
-    export interface WaypointParams {
-      canBeSpawnPoint: boolean;
-      canBeOccupied: boolean;
-      canBeClicked: boolean;
-      willDisableMotion: boolean;
-      willDisableTeleporting: boolean;
-      willMaintainInitialOrientation: boolean;
-      snapToNavMesh: boolean;
-    }
-    
-    // When we inflate a waypoint component, we pack the booleans into the flags property
-    export function inflateWaypoint(world: HubsWorld, eid: number, props: WaypointParams) {
-      addComponent(world, Waypoint, eid);
-      let flags = 0;
-      if (props.canBeSpawnPoint) flags |= WaypointFlags.canBeSpawnPoint;
-      if (props.canBeOccupied) flags |= WaypointFlags.canBeOccupied;
-      if (props.canBeClicked) flags |= WaypointFlags.canBeClicked;
-      if (props.willDisableMotion) flags |= WaypointFlags.willDisableMotion;
-      if (props.willDisableTeleporting) flags |= WaypointFlags.willDisableTeleporting;
-      if (props.willMaintainInitialOrientation) flags |= WaypointFlags.willMaintainInitialOrientation;
-      if (props.snapToNavMesh) flags |= WaypointFlags.snapToNavMesh;
-      Waypoint.flags[eid] = flags;
-    
-      // More lines omitted
-    }
-    
-    // Later, we can read the waypoint flags using bitwise &:
-    const canBeSpawnPoint = Waypoint.flags[eid] & WaypointFlags.canBeSpawnPoint;
+```typescript
+export const Waypoint = defineComponent({
+  flags: Types.ui8
+});
+
+// Use bit shifting to create values we can use instead of booleans
+export enum WaypointFlags {
+  canBeSpawnPoint = 1 << 0,
+  canBeOccupied = 1 << 1,
+  canBeClicked = 1 << 2,
+  willDisableMotion = 1 << 3,
+  willDisableTeleporting = 1 << 4,
+  willMaintainInitialOrientation = 1 << 5,
+  snapToNavMesh = 1 << 6
+}
+
+// These values are booleans because they originate from an external source, like json in a gltf file.
+export interface WaypointParams {
+  canBeSpawnPoint: boolean;
+  canBeOccupied: boolean;
+  canBeClicked: boolean;
+  willDisableMotion: boolean;
+  willDisableTeleporting: boolean;
+  willMaintainInitialOrientation: boolean;
+  snapToNavMesh: boolean;
+}
+
+// When we inflate a waypoint component, we pack the booleans into the flags property
+export function inflateWaypoint(world: HubsWorld, eid: number, props: WaypointParams) {
+  addComponent(world, Waypoint, eid);
+  let flags = 0;
+  if (props.canBeSpawnPoint) flags |= WaypointFlags.canBeSpawnPoint;
+  if (props.canBeOccupied) flags |= WaypointFlags.canBeOccupied;
+  if (props.canBeClicked) flags |= WaypointFlags.canBeClicked;
+  if (props.willDisableMotion) flags |= WaypointFlags.willDisableMotion;
+  if (props.willDisableTeleporting) flags |= WaypointFlags.willDisableTeleporting;
+  if (props.willMaintainInitialOrientation) flags |= WaypointFlags.willMaintainInitialOrientation;
+  if (props.snapToNavMesh) flags |= WaypointFlags.snapToNavMesh;
+  Waypoint.flags[eid] = flags;
+
+  // More lines omitted
+}
+
+// Later, we can read the waypoint flags using bitwise &:
+const canBeSpawnPoint = Waypoint.flags[eid] & WaypointFlags.canBeSpawnPoint;
+```
 
 
-<a id="orga6b8ef8"></a>
+<a id="orgf59047e"></a>
 
 ## Tag components
 
 `bitECS` components with no properties are called tag components. It is useful to be able to tag an entity so that it appears in queries.
 
 
-<a id="org2a31d13"></a>
+<a id="org7e9d9c3"></a>
 
 ## The escape hatch
 
@@ -255,31 +267,37 @@ Sometimes, we need to store data that is just numbers and strings. Since we can&
 
 For example, the `MediaPDF` component stores a numeric `pageNumber`, and separately has a (uninspiringly named) `map` property:
 
-    export const MediaPDF = defineComponent({
-      pageNumber: Types.ui8
-    });
-    MediaPDF.map = new Map();
+```typescript
+export const MediaPDF = defineComponent({
+  pageNumber: Types.ui8
+});
+MediaPDF.map = new Map();
+```
 
 In typescript, we specify the data types we will store in the map:
 
-    export interface PDFResources {
-      pdf: PDFDocumentProxy;
-      material: MeshBasicMaterial;
-      canvasContext: CanvasRenderingContext2D;
-    }
-    export const PDFResourcesMap = (MediaPDF as any).map as Map<EntityID, PDFResources>;
+```typescript
+export interface PDFResources {
+  pdf: PDFDocumentProxy;
+  material: MeshBasicMaterial;
+  canvasContext: CanvasRenderingContext2D;
+}
+export const PDFResourcesMap = (MediaPDF as any).map as Map<EntityID, PDFResources>;
+```
 
 It is our responsibility to clean up anything we put into the map:
 
-    pdfExitQuery(world).forEach(function (eid) {
-      const resources = PDFResourcesMap.get(eid)!;
-      resources.pdf.cleanup();
-      disposeMaterial(resources.material);
-      PDFResourcesMap.delete(eid);
-    });
+```typescript
+pdfExitQuery(world).forEach(function (eid) {
+  const resources = PDFResourcesMap.get(eid)!;
+  resources.pdf.cleanup();
+  disposeMaterial(resources.material);
+  PDFResourcesMap.delete(eid);
+});
+```
 
 
-<a id="orge5d0f80"></a>
+<a id="orgba23c3c"></a>
 
 ## Associating entities with `Object3D` s
 
@@ -290,7 +308,7 @@ An entity can only be associated with a single `Object3D`.
 You may find it strange that we have a different pattern for `world.eid2obj`, and that we do not simply use the same pattern as the one shown above for `MediaPDF`. Well, I do too. We wrote `world.eid2obj` long before we wrote `MediaPDF`, so this may be an accident. Perhaps we&rsquo;ll change `world.eid2obj` to `Object3DTag.map`, since the `eid2obj` map is meant to be kept in sync with the `Object3DTag` component.
 
 
-<a id="org9d8eb03"></a>
+<a id="orgae4fb77"></a>
 
 ## Avoid duplicating state
 
@@ -300,21 +318,25 @@ For example, `TroikaText` extends `Mesh`, which extends `Object3D`. `TroikaText`
 
 In Hubs, we define the `Text` component as a tag (i.e. with no properties):
 
-    export const Text = defineComponent();
+```typescript
+export const Text = defineComponent();
+```
 
 We do not duplicate the `text` string in a `bitECS` component. We simply operate on the underlying `Object3D` (a `TroikaText`):
 
-    const timeLabel = world.eid2obj.get(VideoMenu.timeLabelRef[eid])! as TroikaText;
-    timeLabel.text = `${timeFmt(video.currentTime)} / ${timeFmt(video.duration)}`;
-    timeLabel.sync();
+```typescript
+const timeLabel = world.eid2obj.get(VideoMenu.timeLabelRef[eid])! as TroikaText;
+timeLabel.text = `${timeFmt(video.currentTime)} / ${timeFmt(video.duration)}`;
+timeLabel.sync();
+```
 
 
-<a id="org142a1ca"></a>
+<a id="orgfe26f03"></a>
 
 # Adding entities
 
 
-<a id="orgb49d3f9"></a>
+<a id="org5990fd9"></a>
 
 ## Entity basics
 
@@ -325,7 +347,7 @@ You will rarely need to call `addEntity` yourself. Instead, you will write entit
 Note: We support both `glTF` formats, where binary data buffers contain base64-encoded strings (as in `.gltf`) or raw byte arrays (as in `.glb`). We refer to `gltf` and `glb` files interchangably.
 
 
-<a id="org216bef3"></a>
+<a id="org2933e3b"></a>
 
 ## Creating `EntityDef` s
 
@@ -333,36 +355,38 @@ Note: We support both `glTF` formats, where binary data buffers contain base64-e
 
 For example, the commonly used `MediaPrefab` function is a `template` that takes `MediaLoaderParams` as its `InitialData`, and returns an `EntityDef` for an interactable object.
 
-    export function MediaPrefab(params: MediaLoaderParams): EntityDef {
-      return (
-        <entity
-          name="Interactable Media"
-          networked
-          networkedTransform
-          mediaLoader={params}
-          deletable
-          grabbable={{ cursor: true, hand: true }}
-          destroyAtExtremeDistance
-          floatyObject={{
-            flags: FLOATY_OBJECT_FLAGS.MODIFY_GRAVITY_ON_RELEASE,
-            releaseGravity: 0
-          }}
-          networkedFloatyObject={{
-            flags: FLOATY_OBJECT_FLAGS.MODIFY_GRAVITY_ON_RELEASE
-          }}
-          rigidbody={{ collisionGroup: COLLISION_LAYERS.INTERACTABLES, collisionMask: COLLISION_LAYERS.HANDS }}
-          physicsShape={{ halfExtents: [0.22, 0.14, 0.1] }} /* TODO Physics shapes*/
-          scale={[1, 1, 1]}
-        />
-      );
-    }
+```typescript
+export function MediaPrefab(params: MediaLoaderParams): EntityDef {
+  return (
+    <entity
+      name="Interactable Media"
+      networked
+      networkedTransform
+      mediaLoader={params}
+      deletable
+      grabbable={{ cursor: true, hand: true }}
+      destroyAtExtremeDistance
+      floatyObject={{
+        flags: FLOATY_OBJECT_FLAGS.MODIFY_GRAVITY_ON_RELEASE,
+        releaseGravity: 0
+      }}
+      networkedFloatyObject={{
+        flags: FLOATY_OBJECT_FLAGS.MODIFY_GRAVITY_ON_RELEASE
+      }}
+      rigidbody={{ collisionGroup: COLLISION_LAYERS.INTERACTABLES, collisionMask: COLLISION_LAYERS.HANDS }}
+      physicsShape={{ halfExtents: [0.22, 0.14, 0.1] }} /* TODO Physics shapes*/
+      scale={[1, 1, 1]}
+    />
+  );
+}
+```
 
 Although `EntityDef` s are written with `jsx` syntax, this is not `React`. The `jsx` syntax allows us to describe our desired scene graph, entities, and components. The definition is static, and there should be no expectation of &ldquo;re-rendering&rdquo; (as in `React` or `three-fiber`). Semantically, an `EntityDef` is equivalent to a model file with component data. `EntityDef` s are meant to be easy to edit by hand and to version control.
 
 For `network instantiated` entities, `template` functions are grouped together with `permission` information to form a named `Prefab`. More information about `network instantiated` entities can be found in the networking documentation.
 
 
-<a id="org9006e83"></a>
+<a id="orgcf8022f"></a>
 
 ## Creating model files
 
@@ -373,7 +397,7 @@ The `hubs-blender-exporter` is a Blender add-on that helps artists do this.
 Spoke also includes component data in the gltf files that it exports and uploads.
 
 
-<a id="org7b5d056"></a>
+<a id="orgb0c2aa1"></a>
 
 ## Entity creation is synchronous
 
@@ -382,22 +406,21 @@ It is important to realize that `renderAsEntity` is a synchronous function. That
 The presence of some components (like `MediaLoader`) cause systems to begin asynchronous work. In the case of `MediaLoader`, this work can include downloading model or image files, loading them with the GLTF loader, and ultimately creating additional entities and components. But the entity at the root of this `Object3D` hierarchy will be created synchronously/immediately when `renderAsEntity` runs.
 
 
-<a id="orgd2781f3"></a>
+<a id="orgf7ad262"></a>
 
 ## Inflation
 
 
-<a id="orge2d89b3"></a>
+<a id="orgec09b67"></a>
 
 ### What does `renderAsEntity` do?
 
 In the example above, we show a `template` function (`MediaPrefab`) that takes some `InitialData` (the `MediaLoaderParams`) and returns an `EntityDef`. We then said that the `EntityDef` can be passed to `renderAsEntity` which will (synchronously) add entities and components to the world. We also said this was equivalent to loading a model file (GLTF).
 
-Question: How does `renderAsEntity` (and whatever loads models) accomplish this?
-Answer: By running `inflators`.
+Question: How does `renderAsEntity` (and whatever loads models) accomplish this? Answer: By running `inflators`.
 
 
-<a id="orgf6fc9f9"></a>
+<a id="org68cdb74"></a>
 
 ### `Inflator` s
 
@@ -407,32 +430,36 @@ When `renderAsEntity` is given the `EntityDef` generated by the `MediaPrefab` ab
 
 For example, the `jsx` expression contains the following line:
 
-    grabbable={{ cursor: true, hand: true }}
+```typescript
+  grabbable={{ cursor: true, hand: true }}
+```
 
 When `renderAsEntity` parses this line, it checks the `jsxInflators` map (for the key `"grabbable"` ) to find the associated inflator (`inflateGrabbable`), and calls it.
 
 The `inflateGrabbable` function transforms the description into the necessary runtime components:
 
-    export type GrabbableParams = { cursor: boolean; hand: boolean };
-    const defaults: GrabbableParams = { cursor: true, hand: true };
-    export function inflateGrabbable(world: HubsWorld, eid: number, props: GrabbableParams) {
-      props = Object.assign({}, defaults, props);
-      if (props.hand) {
-        addComponent(world, HandCollisionTarget, eid);
-        addComponent(world, OffersHandConstraint, eid);
-      }
-      if (props.cursor) {
-        addComponent(world, CursorRaycastable, eid);
-        addComponent(world, RemoteHoverTarget, eid);
-        addComponent(world, OffersRemoteConstraint, eid);
-      }
-      addComponent(world, Holdable, eid);
-    }
+```typescript
+export type GrabbableParams = { cursor: boolean; hand: boolean };
+const defaults: GrabbableParams = { cursor: true, hand: true };
+export function inflateGrabbable(world: HubsWorld, eid: number, props: GrabbableParams) {
+  props = Object.assign({}, defaults, props);
+  if (props.hand) {
+    addComponent(world, HandCollisionTarget, eid);
+    addComponent(world, OffersHandConstraint, eid);
+  }
+  if (props.cursor) {
+    addComponent(world, CursorRaycastable, eid);
+    addComponent(world, RemoteHoverTarget, eid);
+    addComponent(world, OffersRemoteConstraint, eid);
+  }
+  addComponent(world, Holdable, eid);
+}
+```
 
 Notice that `GrabbableParams` do not map one-to-one with runtime components. That is, there is no `Grabbable` component. This is common in situations where we want to expose user-friendly options (for use in Blender, Spoke, or when writing `EntityDef` s), while representing the information differently at runtime.
 
 
-<a id="org853e974"></a>
+<a id="org1646688"></a>
 
 ### Default inflators
 
@@ -440,34 +467,44 @@ For many components, the `EntityDef` or `GLTF` representation DOES match the run
 
 For example, the `SceneLoader` component has a single property, a string `src`:
 
-    export const SceneLoader = defineComponent({ src: Types.ui32 });
-    SceneLoader.src[$isStringType] = true;
+```typescript
+export const SceneLoader = defineComponent({ src: Types.ui32 });
+SceneLoader.src[$isStringType] = true;
+```
 
 It can be specified in the following `EntityDef` :
 
-    export function ScenePrefab(src: string): EntityDef {
-      return <entity name="Scene" sceneRoot sceneLoader={{ src }} />;
-    }
+```typescript
+export function ScenePrefab(src: string): EntityDef {
+  return <entity name="Scene" sceneRoot sceneLoader={{ src }} />;
+}
+```
 
 Writing the inflator for the `SceneLoader` component is simple, except for the fact that we have to remember to convert the `string` to a `StringID`, so that the `bitECS` component can hold onto it:
 
-    export function inflateSceneLoader(world: HubsWorld, eid: number, props: { src: string }) {
-      addComponent(world, SceneLoader, eid);
-      SceneLoader.src[eid] = APP.getSid(props.src); // Convert string to string id
-    }
+```typescript
+export function inflateSceneLoader(world: HubsWorld, eid: number, props: { src: string }) {
+  addComponent(world, SceneLoader, eid);
+  SceneLoader.src[eid] = APP.getSid(props.src); // Convert string to string id
+}
+```
 
 In our `jsxInflators` map, we would associate `"sceneLoader"` with `inflateSceneLoader` :
 
-    sceneLoader: inflateSceneLoader,
+```typescript
+  sceneLoader: inflateSceneLoader,
+```
 
 This situation is so common that we have a helper function, `createDefaultInflator`, that we can use instead of writing `inflateSceneLoader` manually. We simply pass the component we want to inflate to `createDefaultInflator` and we&rsquo;re done:
 
-    sceneLoader: createDefaultInflator(SceneLoader),
+```typescript
+  sceneLoader: createDefaultInflator(SceneLoader),
+```
 
 The default inflator handles the conversion from `string` s to `StringID`, and will log an error if a property name is passed to the `inflator` that does not have a corresponding property in the underlying component.
 
 
-<a id="org16d072a"></a>
+<a id="org5c34243"></a>
 
 ### Associating `Object3D` s (`eid2obj`)
 
@@ -477,39 +514,44 @@ We do this by calling `addObject3DComponent` from within an `inflator`.
 
 For example, when a `simpleWater` component is found within a node of a GLTF file, the `inflateSimpleWater` inflator will create a `SimpleWaterMesh` with the given params and associate it with the given `EntityID` :
 
-    export function inflateSimpleWater(world: HubsWorld, eid: EntityID, params: SimpleWaterParams) {
-      params = Object.assign({}, DEFAULTS, params);
-      const lowQuality = APP.store.state.preferences.materialQualitySetting !== "high";
-      const simpleWater = new SimpleWaterMesh({ lowQuality });
-      simpleWater.opacity = params.opacity;
-      simpleWater.color.set(params.color);
-      simpleWater.tideHeight = params.tideHeight;
-      simpleWater.tideScale.fromArray(params.tideScale);
-      simpleWater.tideSpeed.fromArray(params.tideSpeed);
-      simpleWater.waveHeight = params.waveHeight;
-      simpleWater.waveScale.fromArray(params.waveScale);
-      simpleWater.waveSpeed.fromArray(params.waveSpeed);
-      simpleWater.ripplesScale = params.ripplesScale;
-      simpleWater.ripplesSpeed = params.ripplesSpeed;
-    
-      addObject3DComponent(world, eid, simpleWater);
-      addComponent(world, SimpleWater, eid);
-    }
+```typescript
+export function inflateSimpleWater(world: HubsWorld, eid: EntityID, params: SimpleWaterParams) {
+  params = Object.assign({}, DEFAULTS, params);
+  const lowQuality = APP.store.state.preferences.materialQualitySetting !== "high";
+  const simpleWater = new SimpleWaterMesh({ lowQuality });
+  simpleWater.opacity = params.opacity;
+  simpleWater.color.set(params.color);
+  simpleWater.tideHeight = params.tideHeight;
+  simpleWater.tideScale.fromArray(params.tideScale);
+  simpleWater.tideSpeed.fromArray(params.tideSpeed);
+  simpleWater.waveHeight = params.waveHeight;
+  simpleWater.waveScale.fromArray(params.waveScale);
+  simpleWater.waveSpeed.fromArray(params.waveSpeed);
+  simpleWater.ripplesScale = params.ripplesScale;
+  simpleWater.ripplesSpeed = params.ripplesSpeed;
+
+  addObject3DComponent(world, eid, simpleWater);
+  addComponent(world, SimpleWater, eid);
+}
+```
 
 Only one inflator per entity can create and assign an `Object3D`. An `EntityDef` that describes an entity that is both a `SimpleWaterMesh` and a `DirectionalLight` will fail to load:
 
-    renderAsEntity(
-      <entity
-          name="Buggy Entity"
-          simpleWater
-          directionalLight
-      />
-    ); // throws Error("Tried to add an object3D tag to an entity that already has one");
+```typescript
+renderAsEntity(
+  <entity
+      name="Buggy Entity"
+      simpleWater
+      directionalLight
+  />
+); // throws Error("Tried to add an object3D tag to an entity that already has one");
+
+```
 
 By default, if no `inflator` creates an `Object3D` for the entity, then `renderAsEntity` will create and assign it a `Group`.
 
 
-<a id="org8585d1d"></a>
+<a id="orgd1fa577"></a>
 
 ### Loading model files
 
@@ -525,12 +567,14 @@ We pass the `EntityDef` to `renderAsEntity`, an entity is returned synchronously
 
 When the `mediaLoading` system runs, it notices the new `MediaLoader` component and starts an asynchronous `coroutine` that determines the media type pointed to by the `src` property, downloads the `gltf` file and loads it as Three.js scene graph via a `GLTFLoader`. Finally, the loaded scene graph is passed into an `EntityDef`&rsquo;s `model` parameter:
 
-    export function* loadModel(world: HubsWorld, src: string, contentType: string, useCache: boolean) {
-      const { scene, animations } = yield loadGLTFModel(src, contentType, useCache, null);
-      scene.animations = animations;
-      scene.mixer = new THREE.AnimationMixer(scene);
-      return renderAsEntity(world, <entity model={{ model: scene }} />);
-    }
+```typescript
+export function* loadModel(world: HubsWorld, src: string, contentType: string, useCache: boolean) {
+  const { scene, animations } = yield loadGLTFModel(src, contentType, useCache, null);
+  scene.animations = animations;
+  scene.mixer = new THREE.AnimationMixer(scene);
+  return renderAsEntity(world, <entity model={{ model: scene }} />);
+}
+```
 
 In other words, the asynchronous work of loading the model is done `before` an entity is created for the loaded `gltf`. Despite being called after some asynchronous work, the entity creation step that happens in `renderAsEntity` itself happens synchronously.
 
@@ -539,7 +583,7 @@ The `model` inflator (`inflateModel`) is to `gltf` files as `renderAsEntity` is 
 This is what we mean when we say that loading from `gltf` files is &ldquo;equivalent&rdquo; to loading from `EntityDef` s.
 
 
-<a id="orgc2e525d"></a>
+<a id="org0cb5922"></a>
 
 ### Common inflators, `jsxInflators`, and `gltfInflators`
 
@@ -554,57 +598,51 @@ Notice that in the sentences above, we overload the word `components`. As we hav
 While it might be helpful to define a `new` word (like &ldquo;pre-components&rdquo;) to describe these data, we think this is overly complicated. From the perspective of the Blender add-on for example, its job is to add components (specifically, &ldquo;`MOZ_hubs_components`&rdquo;) to nodes in the `.blend` scene and exported `gltf` files.
 
 
-<a id="orgbcb8cdc"></a>
+<a id="org7910942"></a>
 
 ### Entity `Ref` s and `__mhc_link_type` : `"node"`
 
 
-<a id="orgf209653"></a>
+<a id="orgbc310fc"></a>
 
 ### Associating `Material` s (`eid2mat`)
 
 
-<a id="org9bb31b4"></a>
-
-## Entity ID&rsquo;s are recycled
-
-
-<a id="org978c51d"></a>
+<a id="org9086134"></a>
 
 # Custom clients and addons
 
 
-<a id="org6f6abd0"></a>
+<a id="orgb0f7d0c"></a>
 
 ## Addons aren&rsquo;t ready yet (February 2023)
 
 
-<a id="org4c611fc"></a>
+<a id="org25a442f"></a>
 
 ## preload
 
 
-<a id="org520ae00"></a>
+<a id="org6d3a100"></a>
 
 ## Inserting prefabs
 
 
-<a id="orgce11780"></a>
+<a id="orgaeeab48"></a>
 
 ## Inserting inflators
 
 
-<a id="org30b918a"></a>
+<a id="orgaee3fbb"></a>
 
 ## Inserting system calls
 
 
-<a id="org709e04f"></a>
+<a id="org5dfa7cf"></a>
 
 ## Handling interactions
 
 
-<a id="orgbaeae9c"></a>
+<a id="orgb51469b"></a>
 
 ## Handling networking
-

--- a/doc/org/build/gameplay.md
+++ b/doc/org/build/gameplay.md
@@ -1,0 +1,443 @@
+
+# Table of Contents
+
+1.  [Intro](#org991feb0)
+2.  [Entities, components, systems.](#org949b2be)
+    1.  [`bitECS`](#org52e4c14)
+    2.  [Disclaimer](#org6abd7d0)
+3.  [Writing systems](#org4059b4f)
+    1.  [Systems are functions](#org6b83742)
+    2.  [The game loop](#org5030fa5)
+    3.  [Queries are useful](#orgaad10d1)
+    4.  [Replacing `async` functions with `JobRunner`](#org239ab65)
+4.  [Writing components](#orgb52fe0d)
+    1.  [Defining components](#org8bc2f74)
+    2.  [Data types](#org8414c54)
+    3.  [Avoid holding references](#org5941dae)
+    4.  [String data](#orgbde4b78)
+    5.  [Flags](#org7538757)
+    6.  [Tag components](#org28d3295)
+    7.  [The escape hatch](#org68cb175)
+    8.  [Associating entities with `Object3D` s](#org54bec2b)
+    9.  [Avoid duplicating state](#org2ab4512)
+5.  [Creating entities](#orgad19bee)
+    1.  [Entities are numbers](#orgb093be1)
+    2.  [Loading from prefabs](#org473a107)
+        1.  [`EntityDef` s](#orgd065b36)
+        2.  [JSX without React](#org44b9d51)
+    3.  [Loading from glb files](#org9fa25f0)
+        1.  [The Hubs Blender add-on](#org12e5028)
+    4.  [Entity creation is synchronous](#orgac98852)
+    5.  [Component inflators](#org70713be)
+        1.  [Inflator rules](#org668d885)
+        2.  [Default inflators](#org34cc0c5)
+        3.  [Associating `Object3D` s (`eid2obj`)](#org4e42a5c)
+        4.  [Associating `Material` s (`eid2mat`)](#orgc1810aa)
+        5.  [`Ref` s and node](#org8a5936a)
+        6.  [Common inflators](#org65377c5)
+        7.  [`JSX`](#orga149a6f)
+        8.  [`GLB`](#orgeade883)
+    6.  [Entity ID&rsquo;s are recycled](#orgfddb016)
+6.  [Custom clients and addons](#org95d4be1)
+    1.  [Addons aren&rsquo;t ready yet (February 2023)](#org3fbd0bb)
+    2.  [preload](#org6b91832)
+    3.  [Inserting prefabs](#org13261de)
+    4.  [Inserting inflators](#orga05a4e5)
+    5.  [Inserting system calls](#org7cd9bc6)
+    6.  [Handling interactions](#org3be1e68)
+    7.  [Handling networking](#org52f6add)
+
+\#+TITLE Core Concepts for Gameplay Code
+
+Core Concepts for Gameplay Code
+
+
+<a id="org991feb0"></a>
+
+# Intro
+
+This document gives an overview of the core concepts for writing gameplay code in the Hubs client.
+
+
+<a id="org949b2be"></a>
+
+# Entities, components, systems.
+
+ECS became a popular topic in recent years.
+
+-   Unity&rsquo;s `DOTS` emphasizes data-oriented design for speed and control, separates behavior from data, and helps developers build multi-threaded game loops.
+-   Supermedium&rsquo;s `A-Frame` emphasizes ease of use and a low barrier to entry, exposes three.js through familiar HTML, and enables rapid prototyping with many built-in components and hundreds more from the community.
+
+Originally built with `A-Frame`, Hubs switched to `bitECS` and using `three.js` directly. Motivation, goals, and non-goals about the transition can be found in this PR from June, 2022. <https://github.com/mozilla/hubs/pull/5536>
+
+
+<a id="org52e4c14"></a>
+
+## `bitECS`
+
+The `bitECS` API is minimal, and its own documentation should be consulted for details. The main ideas from the Hubs gameplay code perspective are:
+
+-   Component data are structs of arrays. <https://en.wikipedia.org/wiki/AoS_and_SoA>
+-   Entities are indices into these arrays.
+-   Queries filter entities by their associated components.
+
+`bitECS` has no built-in concept of systems. We frequently refer the functions invoked during the game loop as &ldquo;systems&rdquo;, but there is no formal construct.
+
+
+<a id="org6abd7d0"></a>
+
+## Disclaimer
+
+Much has been written about the philosophy of various ECS frameworks and design choices. Our choices should not be interpreted fanatically.
+
+We need to store game state somehow, and conventions are useful. We use three.js, which means a lot of game state is stored in various `Object3D` subtypes. We store the rest in `bitECS` entities and components, or `map` s from entity to struct in cases where `bitECS` components won&rsquo;t do.
+
+In other words, our game state is not &ldquo;purely&rdquo; in ECS, nor do we care to make it so. The PR linked above states the (relatively humble) goals and non-goals of our entity framework.
+
+
+<a id="org4059b4f"></a>
+
+# Writing systems
+
+
+<a id="org6b83742"></a>
+
+## Systems are functions
+
+`bitECS` has no built-in concept of systems. We frequently refer the functions invoked during the game loop as &ldquo;systems&rdquo;, but there is no formal construct.
+
+We provide the browser&rsquo;s `requestAnimationFrame` with our game loop function (`mainTick`), to be invoked each frame.
+
+
+<a id="org5030fa5"></a>
+
+## The game loop
+
+
+<a id="orgaad10d1"></a>
+
+## Queries are useful
+
+
+<a id="org239ab65"></a>
+
+## Replacing `async` functions with `JobRunner`
+
+
+<a id="orgb52fe0d"></a>
+
+# Writing components
+
+
+<a id="org8bc2f74"></a>
+
+## Defining components
+
+`bitECS` components are defined with `defineComponent`.
+
+
+<a id="org8414c54"></a>
+
+## Data types
+
+`bitECS` components only store numeric types:
+
+-   `i8`
+-   `ui8`
+-   `ui8c`
+-   `i16`
+-   `ui16`
+-   `i32`
+-   `ui32`
+-   `f32`
+-   `f64`
+-   `eid`
+
+
+<a id="org5941dae"></a>
+
+## Avoid holding references
+
+The `eid` type indicates that the property values will be entity IDs. Be careful when storing references to entities. If the referenced entity is removed from the world with `removeEntity`, then you should consider the entity reference in the component to be invalid! You can use `entityExists` to check whether the referenced entity still exists, but in general it is best to avoid storing entity references if you can.
+
+The most common scenario for using the `eid` type is when building multi-entity objects, such as in-world menus. The `VideoMenu` component stores references to each entity so that it can manage them all easily.
+
+    export const VideoMenu = defineComponent({
+      videoRef: Types.eid,
+      timeLabelRef: Types.eid,
+      trackRef: Types.eid,
+      headRef: Types.eid,
+      playIndicatorRef: Types.eid,
+      pauseIndicatorRef: Types.eid
+    });
+
+
+<a id="orgbde4b78"></a>
+
+## String data
+
+We sometimes want to be able to store string data in components. Since `bitECS` does not allow strings in components, we store numeric string ID&rsquo;s instead.
+
+For example, consider a `SceneLoader` component with a `src` property, which we wish was a string.
+
+    export const SceneLoader = defineComponent({ src: Types.ui32 });
+    SceneLoader.src[$isStringType] = true;
+
+The symbol `$isStringType`, defined in `bit-components.js`, indicates that this property is a string handle. Code that handles component state anonymously (e.g. `createDefaultInflator`) use this to correctly handle the property values.
+
+Strings are converted to numeric `StringID` s by the `getSid` function. `StringID` s can be converted back to strings by the `getString` function.
+
+    const src = APP.getString(SceneLoader.src[loaderEid]);
+    console.log(`Loading scene from this url: ${src}`);
+
+
+<a id="org7538757"></a>
+
+## Flags
+
+`bitECS` components do not support `boolean` properties. In lieu of boolean properties, we often define a single `flags` property as an unsigned integer type to use as a bitmask:
+
+    export const Waypoint = defineComponent({
+      flags: Types.ui8
+    });
+    
+    // Use bit shifting to create values we can use instead of booleans
+    export enum WaypointFlags {
+      canBeSpawnPoint = 1 << 0,
+      canBeOccupied = 1 << 1,
+      canBeClicked = 1 << 2,
+      willDisableMotion = 1 << 3,
+      willDisableTeleporting = 1 << 4,
+      willMaintainInitialOrientation = 1 << 5,
+      snapToNavMesh = 1 << 6
+    }
+    
+    // These values are booleans because they originate from an external source, like json in a glb file.
+    export interface WaypointParams {
+      canBeSpawnPoint: boolean;
+      canBeOccupied: boolean;
+      canBeClicked: boolean;
+      willDisableMotion: boolean;
+      willDisableTeleporting: boolean;
+      willMaintainInitialOrientation: boolean;
+      snapToNavMesh: boolean;
+    }
+    
+    // When we inflate a waypoint component, we pack the booleans into the flags property
+    export function inflateWaypoint(world: HubsWorld, eid: number, props: WaypointParams) {
+      addComponent(world, Waypoint, eid);
+      let flags = 0;
+      if (props.canBeSpawnPoint) flags |= WaypointFlags.canBeSpawnPoint;
+      if (props.canBeOccupied) flags |= WaypointFlags.canBeOccupied;
+      if (props.canBeClicked) flags |= WaypointFlags.canBeClicked;
+      if (props.willDisableMotion) flags |= WaypointFlags.willDisableMotion;
+      if (props.willDisableTeleporting) flags |= WaypointFlags.willDisableTeleporting;
+      if (props.willMaintainInitialOrientation) flags |= WaypointFlags.willMaintainInitialOrientation;
+      if (props.snapToNavMesh) flags |= WaypointFlags.snapToNavMesh;
+      Waypoint.flags[eid] = flags;
+    
+      // More lines omitted
+    }
+    
+    // Later, we can read the waypoint flags using bitwise &:
+    const canBeSpawnPoint = Waypoint.flags[eid] & WaypointFlags.canBeSpawnPoint;
+
+
+<a id="org28d3295"></a>
+
+## Tag components
+
+`bitECS` components with no properties are called tag components. It is useful to be able to tag an entity so that it appears in queries.
+
+
+<a id="org68cb175"></a>
+
+## The escape hatch
+
+Sometimes, we need to store data that is just numbers and strings. Since we can&rsquo;t store the data in `bitECS` components, we store it in regular `Map` s instead.
+
+For example, the `MediaPDF` component stores a numeric `pageNumber`, and separately has a (uninspiringly named) `map` property:
+
+    export const MediaPDF = defineComponent({
+      pageNumber: Types.ui8
+    });
+    MediaPDF.map = new Map();
+
+In typescript, we specify the data types we will store in the map:
+
+    export interface PDFResources {
+      pdf: PDFDocumentProxy;
+      material: MeshBasicMaterial;
+      canvasContext: CanvasRenderingContext2D;
+    }
+    export const PDFResourcesMap = (MediaPDF as any).map as Map<EntityID, PDFResources>;
+
+It is our responsibility to clean up anything we put into the map:
+
+    pdfExitQuery(world).forEach(function (eid) {
+      const resources = PDFResourcesMap.get(eid)!;
+      resources.pdf.cleanup();
+      disposeMaterial(resources.material);
+      PDFResourcesMap.delete(eid);
+    });
+
+
+<a id="org54bec2b"></a>
+
+## Associating entities with `Object3D` s
+
+We often associate an entity with an `Object3D`. We do this by adding an `Object3DTag` component to the entity, storing the association in `world.eid2obj`, and setting `obj.eid` to the `EntityID`.
+
+An entity can only be associated with a single `Object3D`.
+
+You may find it strange that we have a different pattern for `world.eid2obj`, and that we do not simply use the same pattern as the one shown above for `MediaPDF`. Well, I do too. We wrote `world.eid2obj` long before we wrote `MediaPDF`, so this may be an accident. Perhaps we&rsquo;ll change `world.eid2obj` to `Object3DTag.map`, since the `eid2obj` map is meant to be kept in sync with the `Object3DTag` component.
+
+
+<a id="org2ab4512"></a>
+
+## Avoid duplicating state
+
+`Object3D` and its subtypes have many properties that change at runtime. Rather than storing a duplicate copy of these properties in `bitECS` components, we use tag components on the entity so that they show up in the necessary queries, and then operate on the associated `Object3D` directly.
+
+For example, `TroikaText` extends `Mesh`, which extends `Object3D`. `TroikaText` s have a `text` string property and a function `sync` that will flush the `text` to the underlying shader program.
+
+In Hubs, we define the `Text` component as a tag (i.e. with no properties):
+
+    export const Text = defineComponent();
+
+We do not duplicate the `text` string in a `bitECS` component. We simply operate on the underlying `Object3D` (a `TroikaText`):
+
+    const timeLabel = world.eid2obj.get(VideoMenu.timeLabelRef[eid])! as TroikaText;
+    timeLabel.text = `${timeFmt(video.currentTime)} / ${timeFmt(video.duration)}`;
+    timeLabel.sync();
+
+
+<a id="orgad19bee"></a>
+
+# Creating entities
+
+
+<a id="orgb093be1"></a>
+
+## Entities are numbers
+
+
+<a id="org473a107"></a>
+
+## Loading from prefabs
+
+
+<a id="orgd065b36"></a>
+
+### `EntityDef` s
+
+
+<a id="org44b9d51"></a>
+
+### JSX without React
+
+
+<a id="org9fa25f0"></a>
+
+## Loading from glb files
+
+
+<a id="org12e5028"></a>
+
+### The Hubs Blender add-on
+
+
+<a id="orgac98852"></a>
+
+## Entity creation is synchronous
+
+
+<a id="org70713be"></a>
+
+## Component inflators
+
+
+<a id="org668d885"></a>
+
+### Inflator rules
+
+
+<a id="org34cc0c5"></a>
+
+### Default inflators
+
+
+<a id="org4e42a5c"></a>
+
+### Associating `Object3D` s (`eid2obj`)
+
+
+<a id="orgc1810aa"></a>
+
+### Associating `Material` s (`eid2mat`)
+
+
+<a id="org8a5936a"></a>
+
+### `Ref` s and node
+
+
+<a id="org65377c5"></a>
+
+### Common inflators
+
+
+<a id="orga149a6f"></a>
+
+### `JSX`
+
+
+<a id="orgeade883"></a>
+
+### `GLB`
+
+
+<a id="orgfddb016"></a>
+
+## Entity ID&rsquo;s are recycled
+
+
+<a id="org95d4be1"></a>
+
+# Custom clients and addons
+
+
+<a id="org3fbd0bb"></a>
+
+## Addons aren&rsquo;t ready yet (February 2023)
+
+
+<a id="org6b91832"></a>
+
+## preload
+
+
+<a id="org13261de"></a>
+
+## Inserting prefabs
+
+
+<a id="orga05a4e5"></a>
+
+## Inserting inflators
+
+
+<a id="org7cd9bc6"></a>
+
+## Inserting system calls
+
+
+<a id="org3be1e68"></a>
+
+## Handling interactions
+
+
+<a id="org52f6add"></a>
+
+## Handling networking
+

--- a/doc/org/build/interactivity.md
+++ b/doc/org/build/interactivity.md
@@ -1,35 +1,26 @@
-
-# Table of Contents
-
-1.  [User input](#org51ad019)
-2.  [Standard Interactions](#orgbe4feb9)
-3.  [Collision volumes](#org929588f)
+- [User input](#orgd36457e)
+- [Standard Interactions](#orgb381e04)
+- [Collision volumes](#org327abc9)
 
 \#+TITLE Interactivity
 
 Interactivity
 
 
-<a id="org51ad019"></a>
+<a id="orgd36457e"></a>
 
 # User input
 
-Mouse, keyboard, gamepads, and webxr devices
-The userinput frame
+Mouse, keyboard, gamepads, and webxr devices The userinput frame
 
 
-<a id="orgbe4feb9"></a>
+<a id="orgb381e04"></a>
 
 # Standard Interactions
 
-Raycasting
-Hovering
-Grabbing
-Constraints
-Action Sets
+Raycasting Hovering Grabbing Constraints Action Sets
 
 
-<a id="org929588f"></a>
+<a id="org327abc9"></a>
 
 # Collision volumes
-

--- a/doc/org/build/interactivity.md
+++ b/doc/org/build/interactivity.md
@@ -1,0 +1,35 @@
+
+# Table of Contents
+
+1.  [User input](#org51ad019)
+2.  [Standard Interactions](#orgbe4feb9)
+3.  [Collision volumes](#org929588f)
+
+\#+TITLE Interactivity
+
+Interactivity
+
+
+<a id="org51ad019"></a>
+
+# User input
+
+Mouse, keyboard, gamepads, and webxr devices
+The userinput frame
+
+
+<a id="orgbe4feb9"></a>
+
+# Standard Interactions
+
+Raycasting
+Hovering
+Grabbing
+Constraints
+Action Sets
+
+
+<a id="org929588f"></a>
+
+# Collision volumes
+

--- a/doc/org/build/networking.md
+++ b/doc/org/build/networking.md
@@ -1,23 +1,20 @@
-
-# Table of Contents
-
-1.  [Intro](#orgb119da2)
-2.  [The `Networked` Component](#org2bbd35c)
-3.  [Message Types](#orgad43d30)
-    1.  [`CreateMessage`](#orgdae0b06)
-    2.  [`UpdateMessage`](#orgbd864df)
-    3.  [`DeleteMessage`](#org1c7f55f)
-    4.  [`ClientJoin`](#orge92e4e5)
-    5.  [`ClientLeave`](#org2695677)
-    6.  [`CreatorChange`](#orgc99342a)
-4.  [Eventual Consistency](#orgc85401e)
-5.  [Creating Networked Entities](#orgcc2964d)
-6.  [Writing Networked Components](#org7110b85)
-7.  [Persisting Networked Entity State](#org22fd151)
-8.  [Networked Entity Hierarchies](#org7edeaa3)
+- [Intro](#orgca5b855)
+- [The `Networked` Component](#orgabca6d0)
+- [Message Types](#orge720d3c)
+  - [`CreateMessage`](#org4f63df9)
+  - [`UpdateMessage`](#orge698598)
+  - [`DeleteMessage`](#org8f17ac8)
+  - [`ClientJoin`](#orgf98374b)
+  - [`ClientLeave`](#orgebe8740)
+  - [`CreatorChange`](#org9b3f8a5)
+- [Eventual Consistency](#orga8173d0)
+- [Creating Networked Entities](#org62cc95d)
+- [Writing Networked Components](#orgd90eddd)
+- [Persisting Networked Entity State](#orgd0901c8)
+- [Networked Entity Hierarchies](#orge3d34eb)
 
 
-<a id="orgb119da2"></a>
+<a id="orgca5b855"></a>
 
 # Intro
 
@@ -32,7 +29,7 @@ Clients send messages at fixed intervals in the `networkSendSystem`. Messages ar
 Clients receive messages outside of frame boundaries, and simply queue them for processing. Clients process queued messages each frame in the `networkReceiveSystem`.
 
 
-<a id="org2bbd35c"></a>
+<a id="orgabca6d0"></a>
 
 # The `Networked` Component
 
@@ -56,7 +53,7 @@ Conceptually, the `creator` and the `owner` act as authorities over two facets o
 -   The `owner` is the authority over the entity&rsquo;s current state. Thus, it is associated with `UpdateMessage` s. The `owner` is expected to change regularly, whenever a new client performs an action on an entity. The `takeOwnership` and `takeSoftOwnership` functions allow a client to establish itself as the `owner` of an entity.
 
 
-<a id="orgad43d30"></a>
+<a id="orge720d3c"></a>
 
 # Message Types
 
@@ -74,7 +71,7 @@ Event handlers that queue messages for later processing can be found in `listenF
 Note that this is a slight simplification. The message types are not represented in these exact terms throughout the client. For example, clients may combine `CreateMessage` s, `UpdateMessage` s, and `DeleteMessage` s into a single outgoing message, which receiving clients then separate and parse. There are also two variants of `UpdateMessage`, which will be explained below.
 
 
-<a id="orgdae0b06"></a>
+<a id="org4f63df9"></a>
 
 ## `CreateMessage`
 
@@ -89,7 +86,7 @@ Reticulum inserts a `fromClientId` into `"nn"` messages, so that clients who rec
 Entities that are created by calling `createNetworkedEntity` or receiving a `CreateMessage` are said to be `network instantiated`. `Network instantiated` entities may have many descendants. We do not say that the descendants are `network instantiated`.
 
 
-<a id="orgbd864df"></a>
+<a id="orge698598"></a>
 
 ## `UpdateMessage`
 
@@ -103,7 +100,7 @@ These tell a client to update an entity. Each `UpdateMessage` contains:
 Update messages also have the `data` needed to update an entity&rsquo;s state. An entity&rsquo;s state is simply the component data associated with this entity. Updates can be partial (updating only some components) or full (updating all components). Update messages also have two variants, depending on whether they are can be saved for long term storage in the database. This topic will be covered in another section.
 
 
-<a id="org1c7f55f"></a>
+<a id="org8f17ac8"></a>
 
 ## `DeleteMessage`
 
@@ -113,28 +110,28 @@ These tell a client to `delete` an entity. Each `DeleteMessage` contains simply 
 -   A `removed` entity was removed incidentally. For example, it may have been removed when the `creator` disconnected from the room. If the `creator` reconnects and sends a `CreateMessage` with a matching `networkId`, it is acceptable to recreate the entity.
 
 
-<a id="orge92e4e5"></a>
+<a id="orgf98374b"></a>
 
 ## `ClientJoin`
 
 These tell a client that a new client has connected. The next time the `networkSendSystem` runs, the receiving client will send the new client messages about entities it is the `creator` of, and update messages for entities it is the `owner` of.
 
 
-<a id="org2695677"></a>
+<a id="orgebe8740"></a>
 
 ## `ClientLeave`
 
 These tell a client that another client has disconnected. The next time the `networkReceiveSystem` runs, the receiving client will `remove` entities that the disconnected client was the `creator` of.
 
 
-<a id="orgc99342a"></a>
+<a id="org9b3f8a5"></a>
 
 ## `CreatorChange`
 
 These tell a client that the `creator` of an entity has been reassigned. Typically, this means that an entity has been `pinned` (or `unpinned`), and reticulum has assigned (or unassigned) itself as the entity&rsquo;s `creator`.
 
 
-<a id="orgc85401e"></a>
+<a id="orga8173d0"></a>
 
 # Eventual Consistency
 
@@ -151,14 +148,16 @@ For the most part, users of the networking systems do not need to understand the
 
 Users can inspect the state the `Networked` or `Owned` components as needed in cases when their ownership claims matter. They may find themselves writing coroutines that looks like this:
 
-    takeSoftOwnership(world, eid);
-    yield sleep( 3000 ); // Wait a few seconds to see if we "win" ownership
-    if (!hasComponent(world, Owned, eid)) return;
+```typescript
+takeSoftOwnership(world, eid);
+yield sleep( 3000 ); // Wait a few seconds to see if we "win" ownership
+if (!hasComponent(world, Owned, eid)) return;
+```
 
 If this becomes a common and error-prone pattern, then we may introduce helper functions or additional semantics to cover these cases.
 
 
-<a id="orgcc2964d"></a>
+<a id="org62cc95d"></a>
 
 # Creating Networked Entities
 
@@ -173,36 +172,38 @@ Prefabs must be registered in `prefabs` , a map from `PrefabName` to `PrefabDefi
 
 For example, the commonly used `"media"` prefab&rsquo;s `template` is:
 
-    export function MediaPrefab(params: MediaLoaderParams): EntityDef {
-      return (
-        <entity
-          name="Interactable Media"
-          networked
-          networkedTransform
-          mediaLoader={params}
-          deletable
-          grabbable={{ cursor: true, hand: true }}
-          destroyAtExtremeDistance
-          floatyObject={{
-            flags: FLOATY_OBJECT_FLAGS.MODIFY_GRAVITY_ON_RELEASE,
-            releaseGravity: 0
-          }}
-          networkedFloatyObject={{
-            flags: FLOATY_OBJECT_FLAGS.MODIFY_GRAVITY_ON_RELEASE
-          }}
-          rigidbody={{ collisionGroup: COLLISION_LAYERS.INTERACTABLES, collisionMask: COLLISION_LAYERS.HANDS }}
-          physicsShape={{ halfExtents: [0.22, 0.14, 0.1] }} /* TODO Physics shapes*/
-          scale={[1, 1, 1]}
-        />
-      );
-    }
+```typescript
+export function MediaPrefab(params: MediaLoaderParams): EntityDef {
+  return (
+    <entity
+      name="Interactable Media"
+      networked
+      networkedTransform
+      mediaLoader={params}
+      deletable
+      grabbable={{ cursor: true, hand: true }}
+      destroyAtExtremeDistance
+      floatyObject={{
+        flags: FLOATY_OBJECT_FLAGS.MODIFY_GRAVITY_ON_RELEASE,
+        releaseGravity: 0
+      }}
+      networkedFloatyObject={{
+        flags: FLOATY_OBJECT_FLAGS.MODIFY_GRAVITY_ON_RELEASE
+      }}
+      rigidbody={{ collisionGroup: COLLISION_LAYERS.INTERACTABLES, collisionMask: COLLISION_LAYERS.HANDS }}
+      physicsShape={{ halfExtents: [0.22, 0.14, 0.1] }} /* TODO Physics shapes*/
+      scale={[1, 1, 1]}
+    />
+  );
+}
+```
 
 When supplied with `MediaLoaderParams` as its `InitialData`, this prefab `template` creates an entity with several components, including a `Networked` and `NetworkedTransform` component.
 
 Calling `createNetworkedEntity(world, "media", mediaLoaderParams)` would cause the `networkSendSystem` to send a `CreateMessage` the next time it sends messages.
 
 
-<a id="org7110b85"></a>
+<a id="orgd90eddd"></a>
 
 # Writing Networked Components
 
@@ -221,7 +222,7 @@ The `serializeForStorage` and `deserializeForStorage` functions need careful aut
 Note that `NetworkSchema` s are likely to change in the near future, as we are looking for ways to simplify the complexity that `serializeForStorage` and `deserializeForStorage` introduce.
 
 
-<a id="org22fd151"></a>
+<a id="orgd0901c8"></a>
 
 # Persisting Networked Entity State
 
@@ -238,7 +239,7 @@ When the client connects to a hub channel, it calls `listEntityStates` in order 
 Saved entity states include `CreateMessage` s for the `network instantiated` entity and `UpdateMessage` s for itself and its descendants. These messages are queued and later processed by the `networkReceiveSystem` like any other messages. The client&rsquo;s eventually consistent properties guarantee that if entity state updates that come from the database are out-of-date, they will be appropriately handled (i.e. ignored).
 
 
-<a id="org7edeaa3"></a>
+<a id="orge3d34eb"></a>
 
 # Networked Entity Hierarchies
 
@@ -253,4 +254,3 @@ Between the time that the `network instantiated` entity is created (e.g. upon re
 Clients store these `UpdateMessage` s until they can be applied.
 
 A critical property of the networked system that enables this to work is that descendants of `networked instantiated` entities are assigned network IDs deterministically, even in cases where some parts of a descendant hierarchy fails to load. This ensures that the descendants can load in any order (or even fail to load) without causing a client to delete, overwrite, or ignore descendant updates.
-

--- a/doc/org/build/networking.md
+++ b/doc/org/build/networking.md
@@ -1,0 +1,256 @@
+
+# Table of Contents
+
+1.  [Intro](#orgb119da2)
+2.  [The `Networked` Component](#org2bbd35c)
+3.  [Message Types](#orgad43d30)
+    1.  [`CreateMessage`](#orgdae0b06)
+    2.  [`UpdateMessage`](#orgbd864df)
+    3.  [`DeleteMessage`](#org1c7f55f)
+    4.  [`ClientJoin`](#orge92e4e5)
+    5.  [`ClientLeave`](#org2695677)
+    6.  [`CreatorChange`](#orgc99342a)
+4.  [Eventual Consistency](#orgc85401e)
+5.  [Creating Networked Entities](#orgcc2964d)
+6.  [Writing Networked Components](#org7110b85)
+7.  [Persisting Networked Entity State](#org22fd151)
+8.  [Networked Entity Hierarchies](#org7edeaa3)
+
+
+<a id="orgb119da2"></a>
+
+# Intro
+
+This document describes the way that entity state is networked across clients and optionally persisted to the database.
+
+Entity state includes things like what objects should be created by each client in a room, where those objects are, and various properties about them. `WebRTC` (voice, video, screenshare) connections are out of scope for this document: Those are handled separately by `dialog` and the `DialogAdapter`.
+
+Each client is connected to a reticulum node via a phoenix channel. The relevant channel for entity state networking is the `HubChannel`. Each client sends and receives `"nn"` messages containing entity state information over the `HubChannel`.
+
+Clients send messages at fixed intervals in the `networkSendSystem`. Messages are sent at fixed intervals (rather than anytime entity state is updated) so that frequently updated components (like `NetworkedTransform`) do not cause a client to flood the network with an unnecessary amount of `UpdateMessage` s.
+
+Clients receive messages outside of frame boundaries, and simply queue them for processing. Clients process queued messages each frame in the `networkReceiveSystem`.
+
+
+<a id="org2bbd35c"></a>
+
+# The `Networked` Component
+
+Networked entities are any entities with the `Networked` component. The `Networked` component contains:
+
+-   A (networked) `id`, which clients use to uniquely identify this entity across the network. This cannot simply be the `eid` of an entity, because `eid` s are assigned locally to each client.
+-   A `creator`, which is used at various times to determine whether or not an entity should be created or removed.
+-   An `owner`, which is used to determine which `client` has authority to update the state of this entity.
+-   A `lastOwnerTime`, which is used to determine the most recent time that an `owner` was assigned.
+-   A `timestamp`, which is the most recent time the networked state of this entity has been updated.
+
+The `creator` can be set to a `ClientId`, `"reticulum"` , or a `NetworkID` .
+
+-   When the `creator` is a `ClientID`, it means that a client in the room has caused this &ldquo;root&rdquo; entity (and its descendants) to be created, and the entity (and its descendants) should be removed when the client leaves the room.
+-   When the `creator` is `"reticulum"` , it means that the Reticulum is responsible for deciding whether this &ldquo;root&rdquo; entity should be created or removed.
+-   When the `creator` is a `NetworkID`, it means that the entity is a descendant of a &ldquo;root&rdquo; entity, and its creation/removal will be subject to its ancestor.
+
+Conceptually, the `creator` and the `owner` act as authorities over two facets of a networked entity.
+
+-   The `creator` is the authority over the entity&rsquo;s existence. Thus, it is checked when processing `CreateMessage` s and before an entity may be removed. For an entity to be created, its `creator` must have the appropriate permission. An entity&rsquo;s `creator` changes infrequently. It only happens when a client `pins` (or `unpins`) an entity, which changes the `creator` to (or from) `"reticulum"`.
+-   The `owner` is the authority over the entity&rsquo;s current state. Thus, it is associated with `UpdateMessage` s. The `owner` is expected to change regularly, whenever a new client performs an action on an entity. The `takeOwnership` and `takeSoftOwnership` functions allow a client to establish itself as the `owner` of an entity.
+
+
+<a id="orgad43d30"></a>
+
+# Message Types
+
+Clients send and receive these types of messages:
+
+-   `CreateMessage`
+-   `UpdateMessage`
+-   `DeleteMessage`
+-   `ClientJoin`
+-   `ClientLeave`
+-   `CreatorChange`
+
+Event handlers that queue messages for later processing can be found in `listenForNetworkMessages`.
+
+Note that this is a slight simplification. The message types are not represented in these exact terms throughout the client. For example, clients may combine `CreateMessage` s, `UpdateMessage` s, and `DeleteMessage` s into a single outgoing message, which receiving clients then separate and parse. There are also two variants of `UpdateMessage`, which will be explained below.
+
+
+<a id="orgdae0b06"></a>
+
+## `CreateMessage`
+
+These tell a client to create an entity. Each `CreateMessage` contains:
+
+-   A `networkId`, which clients will use to uniquely identify this entity.
+-   A `prefabName`, to know which prefab to initialize,
+-   An `initialData` struct, to know how to initialize the prefab,
+
+Reticulum inserts a `fromClientId` into `"nn"` messages, so that clients who receive a `CreateMessage` can check whether the sending client has permission to create the entity. These `fromClientId` s are guaranteed to be sent by reticulum in a way that clients are unable to spoof.
+
+Entities that are created by calling `createNetworkedEntity` or receiving a `CreateMessage` are said to be `network instantiated`. `Network instantiated` entities may have many descendants. We do not say that the descendants are `network instantiated`.
+
+
+<a id="orgbd864df"></a>
+
+## `UpdateMessage`
+
+These tell a client to update an entity. Each `UpdateMessage` contains:
+
+-   A `networkId`, which clients use to uniquely identify which entity the message refers to,
+-   A `lastOwnerTime`, which tells clients when the sender of this message most recently witnessed ownership being transferred.
+-   A `timestamp`, which indicates when a message was sent.
+-   An `owner`, which indicates which `client` should have authority over updating this entity&rsquo;s state.
+
+Update messages also have the `data` needed to update an entity&rsquo;s state. An entity&rsquo;s state is simply the component data associated with this entity. Updates can be partial (updating only some components) or full (updating all components). Update messages also have two variants, depending on whether they are can be saved for long term storage in the database. This topic will be covered in another section.
+
+
+<a id="org1c7f55f"></a>
+
+## `DeleteMessage`
+
+These tell a client to `delete` an entity. Each `DeleteMessage` contains simply the `NetworkID` of the entity to be deleted. We distinguish between entities that have been `deleted` and those that are simply `removed`:
+
+-   A `deleted` entity was explicitly deleted by a client. That is, someone pressed a button or took some action to delete it on purpose. Entities that have been `deleted` cannot be recreated.
+-   A `removed` entity was removed incidentally. For example, it may have been removed when the `creator` disconnected from the room. If the `creator` reconnects and sends a `CreateMessage` with a matching `networkId`, it is acceptable to recreate the entity.
+
+
+<a id="orge92e4e5"></a>
+
+## `ClientJoin`
+
+These tell a client that a new client has connected. The next time the `networkSendSystem` runs, the receiving client will send the new client messages about entities it is the `creator` of, and update messages for entities it is the `owner` of.
+
+
+<a id="org2695677"></a>
+
+## `ClientLeave`
+
+These tell a client that another client has disconnected. The next time the `networkReceiveSystem` runs, the receiving client will `remove` entities that the disconnected client was the `creator` of.
+
+
+<a id="orgc99342a"></a>
+
+## `CreatorChange`
+
+These tell a client that the `creator` of an entity has been reassigned. Typically, this means that an entity has been `pinned` (or `unpinned`), and reticulum has assigned (or unassigned) itself as the entity&rsquo;s `creator`.
+
+
+<a id="orgc85401e"></a>
+
+# Eventual Consistency
+
+Reticulum does not enforce a single, consistent networked entity state. In fact, reticulum knows very little about the messages it is passing between clients. Furthermore, messages are not guaranteed to be received in the same order by all clients. Therefore, it is each client&rsquo;s responsibility to handle messages in such a way that all clients will eventually recreate identical entity state. This general concept is called eventual consistency.
+
+Most of the complexity in the `networkSendSystem` and the `networkReceiveSystem` stem from this property of the network. Here are some examples where this complexity reveals itself:
+
+-   The `lastOwnerTime` is used to ensure that ownership transfer is handled identically by all clients, even when messages arrive out of order.
+-   The `deletedNids` collection ensures that out-of-order `CreateMessage` s do not cause `deleted` entities to be accidentally recreated.
+-   The `storedUpdates` allows a client to save `UpdateMessage` s it has received but has no way to process, as can happen when it receives an `UpdateMessage` from the `owner` of an entity before it receives a `CreateMessage` from its `creator`.
+-   The `takeSoftOwnership` function allows clients to take ownership of unowned entities in such a way that only clients with the most recent information about that entity will be eligible as the new owner.
+
+For the most part, users of the networking systems do not need to understand these concepts. These are handled internally by the systems themselves. However, users do need to understand that ownership is not transactional or guaranteed. That is, ownership is not &ldquo;requested and then transferred&rdquo;, and just because one client claims ownership of an entity does not mean that other clients will respect that claim.
+
+Users can inspect the state the `Networked` or `Owned` components as needed in cases when their ownership claims matter. They may find themselves writing coroutines that looks like this:
+
+    takeSoftOwnership(world, eid);
+    yield sleep( 3000 ); // Wait a few seconds to see if we "win" ownership
+    if (!hasComponent(world, Owned, eid)) return;
+
+If this becomes a common and error-prone pattern, then we may introduce helper functions or additional semantics to cover these cases.
+
+
+<a id="orgcc2964d"></a>
+
+# Creating Networked Entities
+
+Client code creates networked entities by calling `createNetworkedEntity`, passing:
+
+-   A `prefabName`, to indicate which prefab to initialize,
+-   An `initialData` struct, to know how to initialize the prefab.
+
+Prefabs must be registered in `prefabs` , a map from `PrefabName` to `PrefabDefinition`.
+
+`PrefabDefinition` s include `template` functions that take `InitialData` and return `EntityDef` s. `EntityDef` s are defined in `jsx`, using the `createElementEntity` transformer (not `React` &rsquo;s `createEntity` transformer).
+
+For example, the commonly used `"media"` prefab&rsquo;s `template` is:
+
+    export function MediaPrefab(params: MediaLoaderParams): EntityDef {
+      return (
+        <entity
+          name="Interactable Media"
+          networked
+          networkedTransform
+          mediaLoader={params}
+          deletable
+          grabbable={{ cursor: true, hand: true }}
+          destroyAtExtremeDistance
+          floatyObject={{
+            flags: FLOATY_OBJECT_FLAGS.MODIFY_GRAVITY_ON_RELEASE,
+            releaseGravity: 0
+          }}
+          networkedFloatyObject={{
+            flags: FLOATY_OBJECT_FLAGS.MODIFY_GRAVITY_ON_RELEASE
+          }}
+          rigidbody={{ collisionGroup: COLLISION_LAYERS.INTERACTABLES, collisionMask: COLLISION_LAYERS.HANDS }}
+          physicsShape={{ halfExtents: [0.22, 0.14, 0.1] }} /* TODO Physics shapes*/
+          scale={[1, 1, 1]}
+        />
+      );
+    }
+
+When supplied with `MediaLoaderParams` as its `InitialData`, this prefab `template` creates an entity with several components, including a `Networked` and `NetworkedTransform` component.
+
+Calling `createNetworkedEntity(world, "media", mediaLoaderParams)` would cause the `networkSendSystem` to send a `CreateMessage` the next time it sends messages.
+
+
+<a id="org7110b85"></a>
+
+# Writing Networked Components
+
+Networked components are `Component` s that have been associated with a `NetworkSchema` in the `schemas` map.
+
+A `NetworkSchema` indicates how to pack networked component data into `UpdateMessage` s, and has the following properties:
+
+-   A `componentName` that uniquely identifies the component.
+-   A `serialize` (and `deserialize`) function that defines how component data is packed into (and unpacked from) `UpdateMessage` s.
+-   An optional `serializeForStorage` (and `deserializeForStorage`) function that defines how component data is packed into (and unpacked from) `StorableUpdateMessages` s, able to be saved (and loaded) from the database.
+
+The `serialize` and `deserialize` functions can be generated by calling `defineNetworkSchema`.
+
+The `serializeForStorage` and `deserializeForStorage` functions need careful authoring to allow for reading component state that has been saved to the database in a backwards-compatible way. More information about this will be written later.
+
+Note that `NetworkSchema` s are likely to change in the near future, as we are looking for ways to simplify the complexity that `serializeForStorage` and `deserializeForStorage` introduce.
+
+
+<a id="org22fd151"></a>
+
+# Persisting Networked Entity State
+
+By default, `network instantiated` entities are removed when its `creator` (a client) disconnects. In order to persist these entities (and its descendants) the entity must be `pinned`. Only `network instantiated` entities can be `pinned`.
+
+To `pin` an `network instantiated` entity, a client calls `createEntityState` . This will save the current state of the entity (and its descendants) to the database. We say that the entity (and its descendants) are `persistent`.
+
+To update the state of a persistent entity, a client calls `updateEntityState`.
+
+To delete the saved entity state of a persistent entity, a client calls `deleteEntityState`. Note that deleting the saved entity state is not the same as deleting the entity. It simply means that the information saved to the database about this entity will be deleted.
+
+When the client connects to a hub channel, it calls `listEntityStates` in order to receive the entity states that have been saved to the database.
+
+Saved entity states include `CreateMessage` s for the `network instantiated` entity and `UpdateMessage` s for itself and its descendants. These messages are queued and later processed by the `networkReceiveSystem` like any other messages. The client&rsquo;s eventually consistent properties guarantee that if entity state updates that come from the database are out-of-date, they will be appropriately handled (i.e. ignored).
+
+
+<a id="org7edeaa3"></a>
+
+# Networked Entity Hierarchies
+
+When `createNetworkedEntity` is called, a `network instantiated` entity is created synchronously. That is, any asynchronous loading that an entity needs to do to be &ldquo;fully realized&rdquo; will happen later.
+
+For example, consider a call to `createNetworkedEntity(world, "media", params)` . The media prefab&rsquo;s template function (shown in a previous section) will cause an entity with a `MediaLoader` to be created.
+
+If `params.src` point at a URL where a GLB model file is hosted, then the model will be downloaded, loaded by the THREE GLTFLoader, its nested components will be inflated by inflators, and finally those `object3D` s will be added to the scene graph.
+
+Between the time that the `network instantiated` entity is created (e.g. upon receiving a `CreateMessage`) and the time that the descendant entities are created (with associated `object3D` s), clients may receive `UpdateMessage` s about descendant entities it does not recognize.
+
+Clients store these `UpdateMessage` s until they can be applied.
+
+A critical property of the networked system that enables this to work is that descendants of `networked instantiated` entities are assigned network IDs deterministically, even in cases where some parts of a descendant hierarchy fails to load. This ensures that the descendants can load in any order (or even fail to load) without causing a client to delete, overwrite, or ignore descendant updates.
+

--- a/doc/org/gameplay.org
+++ b/doc/org/gameplay.org
@@ -1,0 +1,240 @@
+#+TITLE Core Concepts for Gameplay Code
+
+Core Concepts for Gameplay Code
+
+* Intro
+This document gives an overview of the core concepts for writing gameplay code in the Hubs client.
+
+* Entities, components, systems.
+ECS became a popular topic in recent years.
+- Unity's ~DOTS~ emphasizes data-oriented design for speed and control, separates behavior from data, and helps developers build multi-threaded game loops.
+- Supermedium's ~A-Frame~ emphasizes ease of use and a low barrier to entry, exposes three.js through familiar HTML, and enables rapid prototyping with many built-in components and hundreds more from the community.
+
+Originally built with ~A-Frame~, Hubs switched to ~bitECS~ and using ~three.js~ directly. Motivation, goals, and non-goals about the transition can be found in this PR from June, 2022. https://github.com/mozilla/hubs/pull/5536
+
+** ~bitECS~
+The ~bitECS~ API is minimal, and its own documentation should be consulted for details. The main ideas from the Hubs gameplay code perspective are:
+
+- Component data are structs of arrays. https://en.wikipedia.org/wiki/AoS_and_SoA
+- Entities are indices into these arrays.
+- Queries filter entities by their associated components.
+
+~bitECS~ has no built-in concept of systems. We frequently refer the functions invoked during the game loop as "systems", but there is no formal construct.
+
+** Disclaimer
+Much has been written about the philosophy of various ECS frameworks and design choices. Our choices should not be interpreted fanatically.
+
+We need to store game state somehow, and conventions are useful. We use three.js, which means a lot of game state is stored in various ~Object3D~ subtypes. We store the rest in ~bitECS~ entities and components, or ~map~ s from entity to struct in cases where ~bitECS~ components won't do.
+
+In other words, our game state is not "purely" in ECS, nor do we care to make it so. The PR linked above states the (relatively humble) goals and non-goals of our entity framework.
+
+* Writing systems
+
+** Systems are functions
+
+~bitECS~ has no built-in concept of systems. We frequently refer the functions invoked during the game loop as "systems", but there is no formal construct.
+
+We provide the browser's ~requestAnimationFrame~ with our game loop function (~mainTick~), to be invoked each frame.
+
+** The game loop
+** Queries are useful
+** Replacing ~async~ functions with ~JobRunner~
+
+* Writing components
+
+** Defining components
+
+~bitECS~ components are defined with ~defineComponent~.
+
+** Data types
+
+~bitECS~ components only store numeric types:
+- ~i8~
+- ~ui8~
+- ~ui8c~
+- ~i16~
+- ~ui16~
+- ~i32~
+- ~ui32~
+- ~f32~
+- ~f64~
+- ~eid~
+
+** Avoid holding references
+
+The ~eid~ type indicates that the property values will be entity IDs. Be careful when storing references to entities. If the referenced entity is removed from the world with ~removeEntity~, then you should consider the entity reference in the component to be invalid! You can use ~entityExists~ to check whether the referenced entity still exists, but in general it is best to avoid storing entity references if you can.
+
+The most common scenario for using the ~eid~ type is when building multi-entity objects, such as in-world menus. The ~VideoMenu~ component stores references to each entity so that it can manage them all easily.
+
+#+begin_src typescript
+export const VideoMenu = defineComponent({
+  videoRef: Types.eid,
+  timeLabelRef: Types.eid,
+  trackRef: Types.eid,
+  headRef: Types.eid,
+  playIndicatorRef: Types.eid,
+  pauseIndicatorRef: Types.eid
+});
+#+end_src
+
+** String data
+We sometimes want to be able to store string data in components. Since ~bitECS~ does not allow strings in components, we store numeric string ID's instead.
+
+For example, consider a ~SceneLoader~ component with a ~src~ property, which we wish was a string.
+
+#+begin_src typescript
+export const SceneLoader = defineComponent({ src: Types.ui32 });
+SceneLoader.src[$isStringType] = true;
+#+end_src
+
+The symbol ~$isStringType~, defined in ~bit-components.js~, indicates that this property is a string handle. Code that handles component state anonymously (e.g. ~createDefaultInflator~) use this to correctly handle the property values.
+
+Strings are converted to numeric ~StringID~ s by the ~getSid~ function. ~StringID~ s can be converted back to strings by the ~getString~ function.
+
+#+begin_src typescript
+const src = APP.getString(SceneLoader.src[loaderEid]);
+console.log(`Loading scene from this url: ${src}`);
+#+end_src
+
+** Flags
+
+~bitECS~ components do not support ~boolean~ properties. In lieu of boolean properties, we often define a single ~flags~ property as an unsigned integer type to use as a bitmask:
+
+#+begin_src typescript
+export const Waypoint = defineComponent({
+  flags: Types.ui8
+});
+
+// Use bit shifting to create values we can use instead of booleans
+export enum WaypointFlags {
+  canBeSpawnPoint = 1 << 0,
+  canBeOccupied = 1 << 1,
+  canBeClicked = 1 << 2,
+  willDisableMotion = 1 << 3,
+  willDisableTeleporting = 1 << 4,
+  willMaintainInitialOrientation = 1 << 5,
+  snapToNavMesh = 1 << 6
+}
+
+// These values are booleans because they originate from an external source, like json in a glb file.
+export interface WaypointParams {
+  canBeSpawnPoint: boolean;
+  canBeOccupied: boolean;
+  canBeClicked: boolean;
+  willDisableMotion: boolean;
+  willDisableTeleporting: boolean;
+  willMaintainInitialOrientation: boolean;
+  snapToNavMesh: boolean;
+}
+
+// When we inflate a waypoint component, we pack the booleans into the flags property
+export function inflateWaypoint(world: HubsWorld, eid: number, props: WaypointParams) {
+  addComponent(world, Waypoint, eid);
+  let flags = 0;
+  if (props.canBeSpawnPoint) flags |= WaypointFlags.canBeSpawnPoint;
+  if (props.canBeOccupied) flags |= WaypointFlags.canBeOccupied;
+  if (props.canBeClicked) flags |= WaypointFlags.canBeClicked;
+  if (props.willDisableMotion) flags |= WaypointFlags.willDisableMotion;
+  if (props.willDisableTeleporting) flags |= WaypointFlags.willDisableTeleporting;
+  if (props.willMaintainInitialOrientation) flags |= WaypointFlags.willMaintainInitialOrientation;
+  if (props.snapToNavMesh) flags |= WaypointFlags.snapToNavMesh;
+  Waypoint.flags[eid] = flags;
+
+  // More lines omitted
+}
+
+// Later, we can read the waypoint flags using bitwise &:
+const canBeSpawnPoint = Waypoint.flags[eid] & WaypointFlags.canBeSpawnPoint;
+#+end_src
+
+** Tag components
+
+~bitECS~ components with no properties are called tag components. It is useful to be able to tag an entity so that it appears in queries.
+
+** The escape hatch
+
+Sometimes, we need to store data that is just numbers and strings. Since we can't store the data in ~bitECS~ components, we store it in regular ~Map~ s instead.
+
+For example, the ~MediaPDF~ component stores a numeric ~pageNumber~, and separately has a (uninspiringly named) ~map~ property:
+
+#+begin_src typescript
+export const MediaPDF = defineComponent({
+  pageNumber: Types.ui8
+});
+MediaPDF.map = new Map();
+#+end_src
+
+In typescript, we specify the data types we will store in the map:
+#+begin_src typescript
+export interface PDFResources {
+  pdf: PDFDocumentProxy;
+  material: MeshBasicMaterial;
+  canvasContext: CanvasRenderingContext2D;
+}
+export const PDFResourcesMap = (MediaPDF as any).map as Map<EntityID, PDFResources>;
+#+end_src
+
+It is our responsibility to clean up anything we put into the map:
+#+begin_src typescript
+pdfExitQuery(world).forEach(function (eid) {
+  const resources = PDFResourcesMap.get(eid)!;
+  resources.pdf.cleanup();
+  disposeMaterial(resources.material);
+  PDFResourcesMap.delete(eid);
+});
+#+end_src
+
+
+** Associating entities with ~Object3D~ s
+We often associate an entity with an ~Object3D~. We do this by adding an ~Object3DTag~ component to the entity, storing the association in ~world.eid2obj~, and setting ~obj.eid~ to the ~EntityID~.
+
+An entity can only be associated with a single ~Object3D~.
+
+You may find it strange that we have a different pattern for ~world.eid2obj~, and that we do not simply use the same pattern as the one shown above for ~MediaPDF~. Well, I do too. We wrote ~world.eid2obj~ long before we wrote ~MediaPDF~, so this may be an accident. Perhaps we'll change ~world.eid2obj~ to ~Object3DTag.map~, since the ~eid2obj~ map is meant to be kept in sync with the ~Object3DTag~ component.
+
+** Avoid duplicating state
+
+~Object3D~ and its subtypes have many properties that change at runtime. Rather than storing a duplicate copy of these properties in ~bitECS~ components, we use tag components on the entity so that they show up in the necessary queries, and then operate on the associated ~Object3D~ directly.
+
+For example, ~TroikaText~ extends ~Mesh~, which extends ~Object3D~. ~TroikaText~ s have a ~text~ string property and a function ~sync~ that will flush the ~text~ to the underlying shader program.
+
+In Hubs, we define the ~Text~ component as a tag (i.e. with no properties):
+#+begin_src typescript
+export const Text = defineComponent();
+#+end_src
+
+We do not duplicate the ~text~ string in a ~bitECS~ component. We simply operate on the underlying ~Object3D~ (a ~TroikaText~):
+
+#+begin_src typescript
+const timeLabel = world.eid2obj.get(VideoMenu.timeLabelRef[eid])! as TroikaText;
+timeLabel.text = `${timeFmt(video.currentTime)} / ${timeFmt(video.duration)}`;
+timeLabel.sync();
+#+end_src
+
+* Creating entities
+** Entities are numbers
+** Loading from prefabs
+*** ~EntityDef~ s
+*** JSX without React
+** Loading from glb files
+*** The Hubs Blender add-on
+** Entity creation is synchronous
+** Component inflators
+*** Inflator rules
+*** Default inflators
+*** Associating ~Object3D~ s (~eid2obj~)
+*** Associating ~Material~ s (~eid2mat~)
+*** ~Ref~ s and node
+*** Common inflators
+*** ~JSX~
+*** ~GLB~
+** Entity ID's are recycled
+
+* Custom clients and addons
+** Addons aren't ready yet (February 2023)
+** preload
+** Inserting prefabs
+** Inserting inflators
+** Inserting system calls
+** Handling interactions
+** Handling networking

--- a/doc/org/gameplay.org
+++ b/doc/org/gameplay.org
@@ -77,6 +77,10 @@ export const VideoMenu = defineComponent({
 });
 #+end_src
 
+** Entity ID's are recycled
+
+After an entity is removed (by ~removeEntity~), its ~EntityID~ can later be reused in subsequent calls to ~addEntity~. This does not happen right away, but is something you should be aware of, and is all the more reason to avoid holding onto entity references.
+
 ** String data
 We sometimes want to be able to store string data in components. Since ~bitECS~ does not allow strings in components, we store numeric string ID's instead.
 
@@ -438,8 +442,6 @@ While it might be helpful to define a ~new~ word (like "pre-components") to desc
 
 *** Entity ~Ref~ s and ~__mhc_link_type~ : ~"node"~
 *** Associating ~Material~ s (~eid2mat~)
-
-** Entity ID's are recycled
 
 * Custom clients and addons
 ** Addons aren't ready yet (February 2023)

--- a/doc/org/gameplay.org
+++ b/doc/org/gameplay.org
@@ -116,7 +116,7 @@ export enum WaypointFlags {
   snapToNavMesh = 1 << 6
 }
 
-// These values are booleans because they originate from an external source, like json in a glb file.
+// These values are booleans because they originate from an external source, like json in a gltf file.
 export interface WaypointParams {
   canBeSpawnPoint: boolean;
   canBeOccupied: boolean;
@@ -211,23 +211,234 @@ timeLabel.text = `${timeFmt(video.currentTime)} / ${timeFmt(video.duration)}`;
 timeLabel.sync();
 #+end_src
 
-* Creating entities
-** Entities are numbers
-** Loading from prefabs
-*** ~EntityDef~ s
-*** JSX without React
-** Loading from glb files
-*** The Hubs Blender add-on
+* Adding entities
+** Entity basics
+
+Entities are added to the world with ~addEntity~ and removed from the world with ~removeEntity~. In ~bitECS~, component state is stored in large, pre-allocated ~TypedArrays~. In other words, entities are not objects with components inside them. Entities are simply numbers (~EntityID~ s), and the ~World~ keeps track of things like whether an entity has a given component (~hasComponent(world, MyComponent, eid)~).
+
+You will rarely need to call ~addEntity~ yourself. Instead, you will write entity definitions (~EntityDef~ s) using ~jsx~ or create model files (~gltf~) with that add entities and components when the models are loaded.
+
+Note: We support both ~glTF~ formats, where binary data buffers contain base64-encoded strings (as in ~.gltf~) or raw byte arrays (as in ~.glb~). We refer to ~gltf~ and ~glb~ files interchangably.
+
+** Creating ~EntityDef~ s
+
+~EntityDef~ s are ~jsx~ expressions that can be passed to ~renderAsEntity~ to add entities and components to the world. ~EntityDef~ s are commonly returned from ~template~ functions, which take some ~InitialData~ and return an ~EntityDef~ with the that ~InitialData~ applied.
+
+For example, the commonly used ~MediaPrefab~ function is a ~template~ that takes ~MediaLoaderParams~ as its ~InitialData~, and returns an ~EntityDef~ for an interactable object.
+
+#+begin_src typescript
+export function MediaPrefab(params: MediaLoaderParams): EntityDef {
+  return (
+    <entity
+      name="Interactable Media"
+      networked
+      networkedTransform
+      mediaLoader={params}
+      deletable
+      grabbable={{ cursor: true, hand: true }}
+      destroyAtExtremeDistance
+      floatyObject={{
+        flags: FLOATY_OBJECT_FLAGS.MODIFY_GRAVITY_ON_RELEASE,
+        releaseGravity: 0
+      }}
+      networkedFloatyObject={{
+        flags: FLOATY_OBJECT_FLAGS.MODIFY_GRAVITY_ON_RELEASE
+      }}
+      rigidbody={{ collisionGroup: COLLISION_LAYERS.INTERACTABLES, collisionMask: COLLISION_LAYERS.HANDS }}
+      physicsShape={{ halfExtents: [0.22, 0.14, 0.1] }} /* TODO Physics shapes*/
+      scale={[1, 1, 1]}
+    />
+  );
+}
+#+end_src
+
+Although ~EntityDef~ s are written with ~jsx~ syntax, this is not ~React~. The ~jsx~ syntax allows us to describe our desired scene graph, entities, and components. The definition is static, and there should be no expectation of "re-rendering" (as in ~React~ or ~three-fiber~). Semantically, an ~EntityDef~ is equivalent to a model file with component data. ~EntityDef~ s are meant to be easy to edit by hand and to version control.
+
+For ~network instantiated~ entities, ~template~ functions are grouped together with ~permission~ information to form a named ~Prefab~. More information about ~network instantiated~ entities can be found in the networking documentation.
+
+** Creating model files
+
+Equivalently, hubs components can be added to nodes in a GLTF file with the ~MOZ_hubs_components~ extension.
+
+The ~hubs-blender-exporter~ is a Blender add-on that helps artists do this.
+
+Spoke also includes component data in the gltf files that it exports and uploads.
+
 ** Entity creation is synchronous
-** Component inflators
-*** Inflator rules
+
+It is important to realize that ~renderAsEntity~ is a synchronous function. That is, it will immediately return a valid ~EntityID~ with a corresponding ~Object3D~ added to the scene graph.
+
+The presence of some components (like ~MediaLoader~) cause systems to begin asynchronous work. In the case of ~MediaLoader~, this work can include downloading model or image files, loading them with the GLTF loader, and ultimately creating additional entities and components. But the entity at the root of this ~Object3D~ hierarchy will be created synchronously/immediately when ~renderAsEntity~ runs.
+
+** Inflation
+*** What does ~renderAsEntity~ do?
+
+In the example above, we show a ~template~ function (~MediaPrefab~) that takes some ~InitialData~ (the ~MediaLoaderParams~) and returns an ~EntityDef~. We then said that the ~EntityDef~ can be passed to ~renderAsEntity~ which will (synchronously) add entities and components to the world. We also said this was equivalent to loading a model file (GLTF).
+
+Question: How does ~renderAsEntity~ (and whatever loads models) accomplish this?
+Answer: By running ~inflators~.
+
+*** ~Inflator~ s
+
+An ~inflator~ is a function that transforms a _description_ of some components/entities into real components and real entities.
+
+When ~renderAsEntity~ is given the ~EntityDef~ generated by the ~MediaPrefab~ above, it will run an ~inflator~ for each of the properties found in the ~jsx~ expression.
+
+For example, the ~jsx~ expression contains the following line:
+#+begin_src typescript
+  grabbable={{ cursor: true, hand: true }}
+#+end_src
+
+When ~renderAsEntity~ parses this line, it checks the ~jsxInflators~ map (for the key ~"grabbable"~ ) to find the associated inflator (~inflateGrabbable~), and calls it.
+
+The ~inflateGrabbable~ function transforms the description into the necessary runtime components:
+
+#+begin_src typescript
+export type GrabbableParams = { cursor: boolean; hand: boolean };
+const defaults: GrabbableParams = { cursor: true, hand: true };
+export function inflateGrabbable(world: HubsWorld, eid: number, props: GrabbableParams) {
+  props = Object.assign({}, defaults, props);
+  if (props.hand) {
+    addComponent(world, HandCollisionTarget, eid);
+    addComponent(world, OffersHandConstraint, eid);
+  }
+  if (props.cursor) {
+    addComponent(world, CursorRaycastable, eid);
+    addComponent(world, RemoteHoverTarget, eid);
+    addComponent(world, OffersRemoteConstraint, eid);
+  }
+  addComponent(world, Holdable, eid);
+}
+#+end_src
+
+Notice that ~GrabbableParams~ do not map one-to-one with runtime components. That is, there is no ~Grabbable~ component. This is common in situations where we want to expose user-friendly options (for use in Blender, Spoke, or when writing ~EntityDef~ s), while representing the information differently at runtime.
+
 *** Default inflators
+
+For many components, the ~EntityDef~ or ~GLTF~ representation DOES match the runtime component, and writing individual inflators for each would be unnecessary boilerplate.
+
+For example, the ~SceneLoader~ component has a single property, a string ~src~:
+#+begin_src typescript
+export const SceneLoader = defineComponent({ src: Types.ui32 });
+SceneLoader.src[$isStringType] = true;
+#+end_src
+
+It can be specified in the following ~EntityDef~ :
+#+begin_src typescript
+export function ScenePrefab(src: string): EntityDef {
+  return <entity name="Scene" sceneRoot sceneLoader={{ src }} />;
+}
+#+end_src
+
+Writing the inflator for the ~SceneLoader~ component is simple, except for the fact that we have to remember to convert the ~string~ to a ~StringID~, so that the ~bitECS~ component can hold onto it:
+#+begin_src typescript
+export function inflateSceneLoader(world: HubsWorld, eid: number, props: { src: string }) {
+  addComponent(world, SceneLoader, eid);
+  SceneLoader.src[eid] = APP.getSid(props.src); // Convert string to string id
+}
+#+end_src
+
+In our ~jsxInflators~ map, we would associate ~"sceneLoader"~ with ~inflateSceneLoader~ :
+#+begin_src typescript
+  sceneLoader: inflateSceneLoader,
+#+end_src
+
+This situation is so common that we have a helper function, ~createDefaultInflator~, that we can use instead of writing ~inflateSceneLoader~ manually. We simply pass the component we want to inflate to ~createDefaultInflator~ and we're done:
+
+#+begin_src typescript
+  sceneLoader: createDefaultInflator(SceneLoader),
+#+end_src
+
+The default inflator handles the conversion from ~string~ s to ~StringID~, and will log an error if a property name is passed to the ~inflator~ that does not have a corresponding property in the underlying component.
+
 *** Associating ~Object3D~ s (~eid2obj~)
+
+Most of the time, we add a component definition to an ~EntityDef~ or model file just to cause some component data to be associated with an entity. Sometimes, we want to control the ~Object3D~ that will be inserted into the scene graph for this entity.
+
+We do this by calling ~addObject3DComponent~ from within an ~inflator~.
+
+For example, when a ~simpleWater~ component is found within a node of a GLTF file, the ~inflateSimpleWater~ inflator will create a ~SimpleWaterMesh~ with the given params and associate it with the given ~EntityID~ :
+
+#+begin_src typescript
+export function inflateSimpleWater(world: HubsWorld, eid: EntityID, params: SimpleWaterParams) {
+  params = Object.assign({}, DEFAULTS, params);
+  const lowQuality = APP.store.state.preferences.materialQualitySetting !== "high";
+  const simpleWater = new SimpleWaterMesh({ lowQuality });
+  simpleWater.opacity = params.opacity;
+  simpleWater.color.set(params.color);
+  simpleWater.tideHeight = params.tideHeight;
+  simpleWater.tideScale.fromArray(params.tideScale);
+  simpleWater.tideSpeed.fromArray(params.tideSpeed);
+  simpleWater.waveHeight = params.waveHeight;
+  simpleWater.waveScale.fromArray(params.waveScale);
+  simpleWater.waveSpeed.fromArray(params.waveSpeed);
+  simpleWater.ripplesScale = params.ripplesScale;
+  simpleWater.ripplesSpeed = params.ripplesSpeed;
+
+  addObject3DComponent(world, eid, simpleWater);
+  addComponent(world, SimpleWater, eid);
+}
+#+end_src
+
+Only one inflator per entity can create and assign an ~Object3D~. An ~EntityDef~ that describes an entity that is both a ~SimpleWaterMesh~ and a ~DirectionalLight~ will fail to load:
+
+#+begin_src typescript
+renderAsEntity(
+  <entity
+      name="Buggy Entity"
+      simpleWater
+      directionalLight
+  />
+); // throws Error("Tried to add an object3D tag to an entity that already has one");
+
+#+end_src
+
+By default, if no ~inflator~ creates an ~Object3D~ for the entity, then ~renderAsEntity~ will create and assign it a ~Group~.
+
+*** Loading model files
+
+The sections above explain how ~renderAsEntity~ transforms a ~jsx~ ~EntityDef~ into an entity and components, and claims that the process for loading a ~gltf~ file is equivalent.
+
+We are now ready to understand why, and will explain by example.
+
+The ~EntityDef~ returned by the ~MediaPrefab~ template (above) includes a ~mediaLoader~, which will cause ~renderAsEntity~ to invoke the ~inflateMediaLoader~ inflator and assign a ~MediaLoader~ component to the entity.
+
+Assume the ~MediaPrefab~ template is initialized with ~src~ set to the url of a ~gltf~ file. In other words, we are trying to use the ~MediaPrefab~ load a ~gltf~ file that we can grab and interact with.
+
+We pass the ~EntityDef~ to ~renderAsEntity~, an entity is returned synchronously, and execution continues as normal.
+
+When the ~mediaLoading~ system runs, it notices the new ~MediaLoader~ component and starts an asynchronous ~coroutine~ that determines the media type pointed to by the ~src~ property, downloads the ~gltf~ file and loads it as Three.js scene graph via a ~GLTFLoader~. Finally, the loaded scene graph is passed into an ~EntityDef~'s ~model~ parameter:
+
+#+begin_src typescript
+export function* loadModel(world: HubsWorld, src: string, contentType: string, useCache: boolean) {
+  const { scene, animations } = yield loadGLTFModel(src, contentType, useCache, null);
+  scene.animations = animations;
+  scene.mixer = new THREE.AnimationMixer(scene);
+  return renderAsEntity(world, <entity model={{ model: scene }} />);
+}
+#+end_src
+
+In other words, the asynchronous work of loading the model is done ~before~ an entity is created for the loaded ~gltf~. Despite being called after some asynchronous work, the entity creation step that happens in ~renderAsEntity~ itself happens synchronously.
+
+The ~model~ inflator (~inflateModel~) is to ~gltf~ files as ~renderAsEntity~ is to ~EntityDef~ s. You will notice that ~inflateModel~ invokes other component inflators and adds many entities to the world to match the ~Object3D~ hierarchy that was provided within the ~ModelParams~.
+
+This is what we mean when we say that loading from ~gltf~ files is "equivalent" to loading from ~EntityDef~ s.
+
+*** Common inflators, ~jsxInflators~, and ~gltfInflators~
+
+We can now explain why there are three collections of ~inflators~:
+
+- ~commonInflators~ are for components can be loaded (identically) whether they are defined in ~EntityDef~ s or ~gltf~ files.
+- ~jsxInflators~ are for components that are specified in ~EntityDef~ s.
+- ~gltfInflators~ are for components that are specified in ~gltf~ files.
+
+Notice that in the sentences above, we overload the word ~components~. As we have shown, the data in ~EntityDef~ s or ~gltf~ files are not ~bitECS~ components, but need to be transformed (via ~inflator~ s) to their runtime formats (which is usually ~bitECS~ components).
+
+While it might be helpful to define a ~new~ word (like "pre-components") to describe these data, we think this is overly complicated. From the perspective of the Blender add-on for example, its job is to add components (specifically, "~MOZ_hubs_components~") to nodes in the ~.blend~ scene and exported ~gltf~ files.
+
+*** Entity ~Ref~ s and ~__mhc_link_type~ : ~"node"~
 *** Associating ~Material~ s (~eid2mat~)
-*** ~Ref~ s and node
-*** Common inflators
-*** ~JSX~
-*** ~GLB~
+
 ** Entity ID's are recycled
 
 * Custom clients and addons

--- a/doc/org/gameplay.org
+++ b/doc/org/gameplay.org
@@ -34,11 +34,17 @@ In other words, our game state is not "purely" in ECS, nor do we care to make it
 
 ~bitECS~ has no built-in concept of systems. We frequently refer the functions invoked during the game loop as "systems", but there is no formal construct.
 
+** The game loop
+
 We provide the browser's ~requestAnimationFrame~ with our game loop function (~mainTick~), to be invoked each frame.
 
-** The game loop
 ** Queries are useful
-** Replacing ~async~ functions with ~JobRunner~
+
+~bitECS~ queries allow us to find entities based on the components that are attached to them. ~enterQuery~ and ~exitQuery~ wrap regular queries so that we handle when an entity first matches or stops matching a given query. The ~bitECS~ documentation should be consulted for more details.
+
+** Replacing ~async~ functions with ~coroutines~
+
+TODO: Describe ~JobRunner~ and ~coroutine~ s.
 
 * Writing components
 
@@ -48,17 +54,9 @@ We provide the browser's ~requestAnimationFrame~ with our game loop function (~m
 
 ** Data types
 
-~bitECS~ components only store numeric types:
-- ~i8~
-- ~ui8~
-- ~ui8c~
-- ~i16~
-- ~ui16~
-- ~i32~
-- ~ui32~
-- ~f32~
-- ~f64~
-- ~eid~
+~bitECS~ components only store numeric types: ~i8~, ~ui8~, ~ui8c~, ~i16~, ~ui16~, ~i32~, ~ui32~, ~f32~, ~f64~, and ~eid~.
+
+The sections below describe what we do when we need to store non-numeric data.
 
 ** Avoid holding references
 
@@ -444,10 +442,89 @@ While it might be helpful to define a ~new~ word (like "pre-components") to desc
 *** Associating ~Material~ s (~eid2mat~)
 
 * Custom clients and addons
-** Addons aren't ready yet (February 2023)
-** preload
+** Addons are not ready yet (February 2023)
+We are exploring ways to enable add-ons within the Hubs client. This work is not complete, so expect this section to change in the near future.
+
+We will need to start versioning each client deliberately so that developers can test and report which clients versions their add-on are compatible with. We will need to aim for backwards-compatibility and avoid breaking addons with changes, but we should things to be bumpy as we learn how best to structure the client.
+
+Add-ons will require us to change how we update the hubs client on Managed or Hubs Cloud instances. If an add-on is installed on the instance that is not compatible with a new client version, we cannot auto-update the client without risking breaking the installed add-on.
+
+Wordpress and Blender are good models to follow here. In general, if an add-on is not compatible with a new client version, upgrading the instance can be a user-initiated action. However, we may be required in some cases to push updates or partial updates that fix critical security vulnerabilities.
+
+We will need to figure out how / where these addons will be hosted, how they will be installed, and to what extent Mozilla verifies that a given add-on is safe. We suspect that in the early days, add-ons will likely be installed via the admin interface, with a warning from us saying that you must trust the add-on developer is not doing anything nefarious, and that we have not validated or audited the code. This is similar to the warning that appears when installing add-ons to Firefox.
+
+It will be easier for us to support custom clients than to support add-ons. Users should expect better support for writing, loading, and sharing custom clients soon, including on Managed instances.
+
+In order for addons to do meaningful work, we need to expose a number of functions and data structures (and relax their types). The sections below describe the extension points we expect add-ons and custom clients will need to access.
+
+** Creating an add-on
+Hubs client add-ons will work similarly to how add-ons work in Blender. An addon will be a module that exports an ~info : AddonInfo~, a ~load~ function, and an ~unload~ function:
+
+#+begin_src typescript
+export const info : AddonInfo = {
+  name: "My Special Addon",
+  // etc
+}
+
+export function load( params : LoadCallbackParams ) {
+  // Do whatever initialization you need to do when your add on is loaded
+}
+
+export function unload () {
+  // Do whatever cleanup you need to do when your add on is unloaded
+
+  // TODO Is it even possible for add-ons to be unloaded at runtime like this?
+  //      If they are added/removed from the admin panel for the whole hub, then maybe unload is not needed.
+}
+#+end_src
+
+Where the types will look something like this:
+#+begin_src typescript
+type AddonInfo = {
+  name: string;
+  author?: string;
+  description?; string;
+  compatibleWith?: ClientVersion[];
+  version?: AddonVersion;
+  location?: string;
+  wikiUrl?: string;
+  trackerUrl?: string;
+  warning?: string;
+  category?: AddonCategory;
+  tags: AddonTag[];
+}
+
+interface LoadCallbackParams = {
+  world: HubsWorld
+  // Maybe other things?
+}
+#+end_src
+
+
+** ~preload~
+
+If your addon needs to complete some work before the main tick game loop runs, pass a ~Promise~ to the ~preload~ function that resolves once you are ready.
+
 ** Inserting prefabs
+
+~Network instantiated~ entities must be registered in the ~prefabs~ map. See the ~networking~ documentation for more information.
+
 ** Inserting inflators
+
+Custom components require you to register ~inflator~ s. Be sure to insert your ~inflator~ s into ~commonInflators~, ~jsxInflators~, or ~gltfInflators~ before calling ~renderAsEntity~ or invoking ~inflateModel~.
+
 ** Inserting system calls
+
+The ~mainTick~ function calls all of the systems that need to run in a given animation frame. You will need to insert your system calls into this main game loop in the appropriate spot. We are not sure yet how we will expose this to addons. Custom client developers can insert it directly into the file that defines ~mainTick~.
+
 ** Handling interactions
+
+Basic interactions like hovering, holding, and moving objects can be achieved with built-in components or inflators (like ~inflateGrabbable~).
+
+Custom interactions that define their own ~actions~, ~action sets~, and ~device bindings~ need to be able to append their ~device bindings~ and change the logic of ~resolveActionSets~. We are not sure yet how we will expose these capabilities.
+
+More information can be found in the interactions documentation.
+
 ** Handling networking
+
+Add-ons and custom clients can define their own networked components. Developers will need to be especially careful when saving data to the database, as maintaining backwards compatibility with their chosen schema will be their responsibility. More information can be found in the networking documentation.

--- a/doc/org/interactivity.org
+++ b/doc/org/interactivity.org
@@ -1,0 +1,16 @@
+#+TITLE Interactivity
+
+Interactivity
+
+* User input
+Mouse, keyboard, gamepads, and webxr devices
+The userinput frame
+
+* Standard Interactions
+Raycasting
+Hovering
+Grabbing
+Constraints
+Action Sets
+
+* Collision volumes

--- a/doc/org/networking.org
+++ b/doc/org/networking.org
@@ -1,0 +1,182 @@
+* Intro
+This document describes the way that entity state is networked across clients and optionally persisted to the database.
+
+Entity state includes things like what objects should be created by each client in a room, where those objects are, and various properties about them. ~WebRTC~ (voice, video, screenshare) connections are out of scope for this document: Those are handled separately by ~dialog~ and the ~DialogAdapter~.
+
+Each client is connected to a reticulum node via a phoenix channel. The relevant channel for entity state networking is the ~HubChannel~. Each client sends and receives ~"nn"~ messages containing entity state information over the ~HubChannel~.
+
+Clients send messages at fixed intervals in the ~networkSendSystem~. Messages are sent at fixed intervals (rather than anytime entity state is updated) so that frequently updated components (like ~NetworkedTransform~) do not cause a client to flood the network with an unnecessary amount of ~UpdateMessage~ s.
+
+Clients receive messages outside of frame boundaries, and simply queue them for processing. Clients process queued messages each frame in the ~networkReceiveSystem~.
+
+* The ~Networked~ Component
+
+Networked entities are any entities with the ~Networked~ component. The ~Networked~ component contains:
+- A (networked) ~id~, which clients use to uniquely identify this entity across the network. This cannot simply be the ~eid~ of an entity, because ~eid~ s are assigned locally to each client.
+- A ~creator~, which is used at various times to determine whether or not an entity should be created or removed.
+- An ~owner~, which is used to determine which ~client~ has authority to update the state of this entity.
+- A ~lastOwnerTime~, which is used to determine the most recent time that an ~owner~ was assigned.
+- A ~timestamp~, which is the most recent time the networked state of this entity has been updated.
+
+The ~creator~ can be set to a ~ClientId~, ~"reticulum"~ , or a ~NetworkID~ .
+- When the ~creator~ is a ~ClientID~, it means that a client in the room has caused this "root" entity (and its descendants) to be created, and the entity (and its descendants) should be removed when the client leaves the room.
+- When the ~creator~ is ~"reticulum"~ , it means that the Reticulum is responsible for deciding whether this "root" entity should be created or removed.
+- When the ~creator~ is a ~NetworkID~, it means that the entity is a descendant of a "root" entity, and its creation/removal will be subject to its ancestor.
+
+Conceptually, the ~creator~ and the ~owner~ act as authorities over two facets of a networked entity.
+- The ~creator~ is the authority over the entity's existence. Thus, it is checked when processing ~CreateMessage~ s and before an entity may be removed. For an entity to be created, its ~creator~ must have the appropriate permission. An entity's ~creator~ changes infrequently. It only happens when a client ~pins~ (or ~unpins~) an entity, which changes the ~creator~ to (or from) ~"reticulum"~.
+- The ~owner~ is the authority over the entity's current state. Thus, it is associated with ~UpdateMessage~ s. The ~owner~ is expected to change regularly, whenever a new client performs an action on an entity. The ~takeOwnership~ and ~takeSoftOwnership~ functions allow a client to establish itself as the ~owner~ of an entity.
+
+* Message Types
+Clients send and receive these types of messages:
+- ~CreateMessage~
+- ~UpdateMessage~
+- ~DeleteMessage~
+- ~ClientJoin~
+- ~ClientLeave~
+- ~CreatorChange~
+
+Event handlers that queue messages for later processing can be found in ~listenForNetworkMessages~.
+
+Note that this is a slight simplification. The message types are not represented in these exact terms throughout the client. For example, clients may combine ~CreateMessage~ s, ~UpdateMessage~ s, and ~DeleteMessage~ s into a single outgoing message, which receiving clients then separate and parse. There are also two variants of ~UpdateMessage~, which will be explained below.
+
+** ~CreateMessage~
+These tell a client to create an entity. Each ~CreateMessage~ contains:
+- A ~networkId~, which clients will use to uniquely identify this entity.
+- A ~prefabName~, to know which prefab to initialize,
+- An ~initialData~ struct, to know how to initialize the prefab,
+
+Reticulum inserts a ~fromClientId~ into ~"nn"~ messages, so that clients who receive a ~CreateMessage~ can check whether the sending client has permission to create the entity. These ~fromClientId~ s are guaranteed to be sent by reticulum in a way that clients are unable to spoof.
+
+Entities that are created by calling ~createNetworkedEntity~ or receiving a ~CreateMessage~ are said to be ~network instantiated~. ~Network instantiated~ entities may have many descendants. We do not say that the descendants are ~network instantiated~.
+
+** ~UpdateMessage~
+These tell a client to update an entity. Each ~UpdateMessage~ contains:
+- A ~networkId~, which clients use to uniquely identify which entity the message refers to,
+- A ~lastOwnerTime~, which tells clients when the sender of this message most recently witnessed ownership being transferred.
+- A ~timestamp~, which indicates when a message was sent.
+- An ~owner~, which indicates which ~client~ should have authority over updating this entity's state.
+
+Update messages also have the ~data~ needed to update an entity's state. An entity's state is simply the component data associated with this entity. Updates can be partial (updating only some components) or full (updating all components). Update messages also have two variants, depending on whether they are can be saved for long term storage in the database. This topic will be covered in another section.
+
+** ~DeleteMessage~
+These tell a client to ~delete~ an entity. Each ~DeleteMessage~ contains simply the ~NetworkID~ of the entity to be deleted. We distinguish between entities that have been ~deleted~ and those that are simply ~removed~:
+- A ~deleted~ entity was explicitly deleted by a client. That is, someone pressed a button or took some action to delete it on purpose. Entities that have been ~deleted~ cannot be recreated.
+- A ~removed~ entity was removed incidentally. For example, it may have been removed when the ~creator~ disconnected from the room. If the ~creator~ reconnects and sends a ~CreateMessage~ with a matching ~networkId~, it is acceptable to recreate the entity.
+
+** ~ClientJoin~
+These tell a client that a new client has connected. The next time the ~networkSendSystem~ runs, the receiving client will send the new client messages about entities it is the ~creator~ of, and update messages for entities it is the ~owner~ of.
+
+** ~ClientLeave~
+These tell a client that another client has disconnected. The next time the ~networkReceiveSystem~ runs, the receiving client will ~remove~ entities that the disconnected client was the ~creator~ of.
+
+** ~CreatorChange~
+These tell a client that the ~creator~ of an entity has been reassigned. Typically, this means that an entity has been ~pinned~ (or ~unpinned~), and reticulum has assigned (or unassigned) itself as the entity's ~creator~.
+
+* Eventual Consistency
+
+Reticulum does not enforce a single, consistent networked entity state. In fact, reticulum knows very little about the messages it is passing between clients. Furthermore, messages are not guaranteed to be received in the same order by all clients. Therefore, it is each client's responsibility to handle messages in such a way that all clients will eventually recreate identical entity state. This general concept is called eventual consistency.
+
+Most of the complexity in the ~networkSendSystem~ and the ~networkReceiveSystem~ stem from this property of the network. Here are some examples where this complexity reveals itself:
+
+- The ~lastOwnerTime~ is used to ensure that ownership transfer is handled identically by all clients, even when messages arrive out of order.
+- The ~deletedNids~ collection ensures that out-of-order ~CreateMessage~ s do not cause ~deleted~ entities to be accidentally recreated.
+- The ~storedUpdates~ allows a client to save ~UpdateMessage~ s it has received but has no way to process, as can happen when it receives an ~UpdateMessage~ from the ~owner~ of an entity before it receives a ~CreateMessage~ from its ~creator~.
+- The ~takeSoftOwnership~ function allows clients to take ownership of unowned entities in such a way that only clients with the most recent information about that entity will be eligible as the new owner.
+
+For the most part, users of the networking systems do not need to understand these concepts. These are handled internally by the systems themselves. However, users do need to understand that ownership is not transactional or guaranteed. That is, ownership is not "requested and then transferred", and just because one client claims ownership of an entity does not mean that other clients will respect that claim.
+
+Users can inspect the state the ~Networked~ or ~Owned~ components as needed in cases when their ownership claims matter. They may find themselves writing coroutines that looks like this:
+
+#+begin_src typescript
+takeSoftOwnership(world, eid);
+yield sleep( 3000 ); // Wait a few seconds to see if we "win" ownership
+if (!hasComponent(world, Owned, eid)) return;
+#+end_src
+
+If this becomes a common and error-prone pattern, then we may introduce helper functions or additional semantics to cover these cases.
+
+* Creating Networked Entities
+
+Client code creates networked entities by calling ~createNetworkedEntity~, passing:
+- A ~prefabName~, to indicate which prefab to initialize,
+- An ~initialData~ struct, to know how to initialize the prefab.
+
+Prefabs must be registered in ~prefabs~ , a map from ~PrefabName~ to ~PrefabDefinition~.
+
+~PrefabDefinition~ s include ~template~ functions that take ~InitialData~ and return ~EntityDef~ s. ~EntityDef~ s are defined in ~jsx~, using the ~createElementEntity~ transformer (not ~React~ 's ~createEntity~ transformer).
+
+For example, the commonly used ~"media"~ prefab's ~template~ is:
+
+#+begin_src typescript
+export function MediaPrefab(params: MediaLoaderParams): EntityDef {
+  return (
+    <entity
+      name="Interactable Media"
+      networked
+      networkedTransform
+      mediaLoader={params}
+      deletable
+      grabbable={{ cursor: true, hand: true }}
+      destroyAtExtremeDistance
+      floatyObject={{
+        flags: FLOATY_OBJECT_FLAGS.MODIFY_GRAVITY_ON_RELEASE,
+        releaseGravity: 0
+      }}
+      networkedFloatyObject={{
+        flags: FLOATY_OBJECT_FLAGS.MODIFY_GRAVITY_ON_RELEASE
+      }}
+      rigidbody={{ collisionGroup: COLLISION_LAYERS.INTERACTABLES, collisionMask: COLLISION_LAYERS.HANDS }}
+      physicsShape={{ halfExtents: [0.22, 0.14, 0.1] }} /* TODO Physics shapes*/
+      scale={[1, 1, 1]}
+    />
+  );
+}
+#+end_src
+
+When supplied with ~MediaLoaderParams~ as its ~InitialData~, this prefab ~template~ creates an entity with several components, including a ~Networked~ and ~NetworkedTransform~ component.
+
+Calling ~createNetworkedEntity(world, "media", mediaLoaderParams)~ would cause the ~networkSendSystem~ to send a ~CreateMessage~ the next time it sends messages.
+
+* Writing Networked Components
+
+Networked components are ~Component~ s that have been associated with a ~NetworkSchema~ in the ~schemas~ map.
+
+A ~NetworkSchema~ indicates how to pack networked component data into ~UpdateMessage~ s, and has the following properties:
+- A ~componentName~ that uniquely identifies the component.
+- A ~serialize~ (and ~deserialize~) function that defines how component data is packed into (and unpacked from) ~UpdateMessage~ s.
+- An optional ~serializeForStorage~ (and ~deserializeForStorage~) function that defines how component data is packed into (and unpacked from) ~StorableUpdateMessages~ s, able to be saved (and loaded) from the database.
+
+The ~serialize~ and ~deserialize~ functions can be generated by calling ~defineNetworkSchema~.
+
+The ~serializeForStorage~ and ~deserializeForStorage~ functions need careful authoring to allow for reading component state that has been saved to the database in a backwards-compatible way. More information about this will be written later.
+
+Note that ~NetworkSchema~ s are likely to change in the near future, as we are looking for ways to simplify the complexity that ~serializeForStorage~ and ~deserializeForStorage~ introduce.
+
+* Persisting Networked Entity State
+
+By default, ~network instantiated~ entities are removed when its ~creator~ (a client) disconnects. In order to persist these entities (and its descendants) the entity must be ~pinned~. Only ~network instantiated~ entities can be ~pinned~.
+
+To ~pin~ an ~network instantiated~ entity, a client calls ~createEntityState~ . This will save the current state of the entity (and its descendants) to the database. We say that the entity (and its descendants) are ~persistent~.
+
+To update the state of a persistent entity, a client calls ~updateEntityState~.
+
+To delete the saved entity state of a persistent entity, a client calls ~deleteEntityState~. Note that deleting the saved entity state is not the same as deleting the entity. It simply means that the information saved to the database about this entity will be deleted.
+
+When the client connects to a hub channel, it calls ~listEntityStates~ in order to receive the entity states that have been saved to the database.
+
+Saved entity states include ~CreateMessage~ s for the ~network instantiated~ entity and ~UpdateMessage~ s for itself and its descendants. These messages are queued and later processed by the ~networkReceiveSystem~ like any other messages. The client's eventually consistent properties guarantee that if entity state updates that come from the database are out-of-date, they will be appropriately handled (i.e. ignored).
+
+* Networked Entity Hierarchies
+
+When ~createNetworkedEntity~ is called, a ~network instantiated~ entity is created synchronously. That is, any asynchronous loading that an entity needs to do to be "fully realized" will happen later.
+
+For example, consider a call to ~createNetworkedEntity(world, "media", params)~ . The media prefab's template function (shown in a previous section) will cause an entity with a ~MediaLoader~ to be created.
+
+If ~params.src~ point at a URL where a GLB model file is hosted, then the model will be downloaded, loaded by the THREE GLTFLoader, its nested components will be inflated by inflators, and finally those ~object3D~ s will be added to the scene graph.
+
+Between the time that the ~network instantiated~ entity is created (e.g. upon receiving a ~CreateMessage~) and the time that the descendant entities are created (with associated ~object3D~ s), clients may receive ~UpdateMessage~ s about descendant entities it does not recognize.
+
+Clients store these ~UpdateMessage~ s until they can be applied.
+
+A critical property of the networked system that enables this to work is that descendants of ~networked instantiated~ entities are assigned network IDs deterministically, even in cases where some parts of a descendant hierarchy fails to load. This ensures that the descendants can load in any order (or even fail to load) without causing a client to delete, overwrite, or ignore descendant updates.


### PR DESCRIPTION
The Hubs Client has undergone significant changes. By the time we finish migrating from `Aframe` to `bitECS`, we will have rewritten several core subsystems including:
  - Basic interactions (clicking, holding, moving)
  - Loading media (images, videos, models)
  - Entity state networking & persistence
  - Most components/systems that `tick`

Although this work is ongoing, enough of the foundations are in place to start documenting the new systems to help client developers (and soon, add-on developers) to build custom behaviors, interactions, etc.

This PR is an attempt to start documenting this information. If all goes well, these docs will be ready by the time we remove the `newLoader` query string parameter (making the `bitECS` loading path the default for media and scenes), and users will be able to build & deploy custom clients to their managed hub instances.
