### PR TITLE
Add SpotLight to bitecs

### DIFF
--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -50,6 +50,7 @@ export const GLTFModel = defineComponent();
 export const LightTag = defineComponent();
 export const AmbientLightTag = defineComponent();
 export const DirectionalLight = defineComponent();
+export const SpotLightTag = defineComponent();
 export const CursorRaycastable = defineComponent();
 export const RemoteHoverTarget = defineComponent();
 export const NotRemoteHoverTarget = defineComponent();

--- a/src/inflators/spot-light.ts
+++ b/src/inflators/spot-light.ts
@@ -1,0 +1,53 @@
+import { addComponent } from "bitecs";
+import { addObject3DComponent } from "../utils/jsx-entity";
+import { SpotLightTag, LightTag } from "../bit-components";
+import { SpotLight } from "three";
+import { HubsWorld } from "../app";
+
+export type SpotLightParams = {
+  color: string;
+  intensity: number;
+  range: number;
+  decay: number;
+  innerConeAngle: number;
+  outerConeAngle: number;
+  castShadow: boolean;
+  shadowMapResolution: [number, number];
+  shadowBias: number;
+  shadowRadius: number;
+};
+
+const DEFAULTS = {
+  intensity: 1.0,
+  range: 0,
+  decay: 2.0,
+  innerConeAngle: 0,
+  outerConeAngle: Math.PI / 4.0,
+  castShadow: true,
+  shadowMapResolution: [512, 512],
+  shadowBias: 0,
+  shadowRadius: 1.0
+};
+
+export function inflateSpotLight(world: HubsWorld, eid: number, params: SpotLightParams) {
+  params = Object.assign({}, DEFAULTS, params);
+  const light = new SpotLight();
+  light.position.set(0, 0, 0);
+  light.target.position.set(0, 0, 1);
+  light.add(light.target);
+  light.color.set(params.color).convertSRGBToLinear();
+  light.intensity = params.intensity;
+  light.distance = params.range;
+  light.decay = params.decay;
+  light.angle = params.outerConeAngle;
+  light.penumbra = 1.0 - params.innerConeAngle / params.outerConeAngle;
+  light.castShadow = params.castShadow;
+  light.shadow.mapSize.set(params.shadowMapResolution[0], params.shadowMapResolution[1]);
+  light.shadow.bias = params.shadowBias;
+  light.shadow.radius = params.shadowRadius;
+
+  addObject3DComponent(world, eid, light);
+  addComponent(world, LightTag, eid);
+  addComponent(world, SpotLightTag, eid);
+  return eid;
+}

--- a/src/inflators/spot-light.ts
+++ b/src/inflators/spot-light.ts
@@ -5,19 +5,20 @@ import { SpotLight } from "three";
 import { HubsWorld } from "../app";
 
 export type SpotLightParams = {
-  color: string;
-  intensity: number;
-  range: number;
-  decay: number;
-  innerConeAngle: number;
-  outerConeAngle: number;
-  castShadow: boolean;
-  shadowMapResolution: [number, number];
-  shadowBias: number;
-  shadowRadius: number;
+  color?: string;
+  intensity?: number;
+  range?: number;
+  decay?: number;
+  innerConeAngle?: number;
+  outerConeAngle?: number;
+  castShadow?: boolean;
+  shadowMapResolution?: [width: number, height: number];
+  shadowBias?: number;
+  shadowRadius?: number;
 };
 
-const DEFAULTS = {
+const DEFAULTS: Required<SpotLightParams> = {
+  color: "#ffffff",
   intensity: 1.0,
   range: 0,
   decay: 2.0,
@@ -30,21 +31,21 @@ const DEFAULTS = {
 };
 
 export function inflateSpotLight(world: HubsWorld, eid: number, params: SpotLightParams) {
-  params = Object.assign({}, DEFAULTS, params);
+  const requiredParams = Object.assign({}, DEFAULTS, params) as Required<SpotLightParams>;
   const light = new SpotLight();
   light.position.set(0, 0, 0);
   light.target.position.set(0, 0, 1);
   light.add(light.target);
-  light.color.set(params.color).convertSRGBToLinear();
-  light.intensity = params.intensity;
-  light.distance = params.range;
-  light.decay = params.decay;
-  light.angle = params.outerConeAngle;
-  light.penumbra = 1.0 - params.innerConeAngle / params.outerConeAngle;
-  light.castShadow = params.castShadow;
-  light.shadow.mapSize.set(params.shadowMapResolution[0], params.shadowMapResolution[1]);
-  light.shadow.bias = params.shadowBias;
-  light.shadow.radius = params.shadowRadius;
+  light.color.set(requiredParams.color).convertSRGBToLinear();
+  light.intensity = requiredParams.intensity;
+  light.distance = requiredParams.range;
+  light.decay = requiredParams.decay;
+  light.angle = requiredParams.outerConeAngle;
+  light.penumbra = 1.0 - requiredParams.innerConeAngle / requiredParams.outerConeAngle;
+  light.castShadow = requiredParams.castShadow;
+  light.shadow.mapSize.set(requiredParams.shadowMapResolution[0], requiredParams.shadowMapResolution[1]);
+  light.shadow.bias = requiredParams.shadowBias;
+  light.shadow.radius = requiredParams.shadowRadius;
 
   addObject3DComponent(world, eid, light);
   addComponent(world, LightTag, eid);

--- a/src/utils/jsx-entity.ts
+++ b/src/utils/jsx-entity.ts
@@ -68,6 +68,7 @@ import { MediaLoaderParams } from "../inflators/media-loader";
 import { preload } from "./preload";
 import { DirectionalLightParams, inflateDirectionalLight } from "../inflators/directional-light";
 import { AmbientLightParams, inflateAmbientLight } from "../inflators/ambient-light";
+import { SpotLightParams, inflateSpotLight } from "../inflators/spot-light";
 import { ProjectionMode } from "./projection-mode";
 import { inflateSkybox, SkyboxParams } from "../inflators/skybox";
 import { inflateSpawner, SpawnerParams } from "../inflators/spawner";
@@ -230,6 +231,7 @@ interface InflatorFn {
 export interface ComponentData {
   ambientLight?: AmbientLightParams;
   directionalLight?: DirectionalLightParams;
+  spotLight?: SpotLightParams;
   grabbable?: GrabbableParams;
   billboard?: { onlyY: boolean };
   mirror?: MirrorParams;
@@ -379,6 +381,7 @@ export const commonInflators: Required<{ [K in keyof ComponentData]: InflatorFn 
   // inflators that create Object3Ds
   ambientLight: inflateAmbientLight,
   directionalLight: inflateDirectionalLight,
+  spotLight: inflateSpotLight,
   mirror: inflateMirror,
   audioZone: inflateAudioZone,
   audioParams: inflateAudioParams


### PR DESCRIPTION
This PR adds `SpotLight` to bitecs, similar to #5918.

We may want to deprecate light components at some point and encourage to use glTF lights extension, but we don't need to drop the support right now.