### PR TITLE
Add PointLight to bitecs

### DIFF
--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -50,6 +50,7 @@ export const GLTFModel = defineComponent();
 export const LightTag = defineComponent();
 export const AmbientLightTag = defineComponent();
 export const DirectionalLight = defineComponent();
+export const PointLightTag = defineComponent();
 export const SpotLightTag = defineComponent();
 export const CursorRaycastable = defineComponent();
 export const RemoteHoverTarget = defineComponent();

--- a/src/inflators/point-light.ts
+++ b/src/inflators/point-light.ts
@@ -1,0 +1,45 @@
+import { addComponent } from "bitecs";
+import { addObject3DComponent } from "../utils/jsx-entity";
+import { PointLightTag, LightTag } from "../bit-components";
+import { PointLight } from "three";
+import { HubsWorld } from "../app";
+
+export type PointLightParams = {
+  color?: string;
+  intensity?: number;
+  range?: number;
+  decay?: number;
+  castShadow?: boolean;
+  shadowMapResolution?: [number, number],
+  shadowBias?: number;
+  shadowRadius?: number;
+};
+
+const DEFAULTS: Required<PointLightParams> = {
+  color: "#ffffff",
+  intensity: 1.0,
+  range: 0,
+  decay: 2.0,
+  castShadow: true,
+  shadowMapResolution: [512, 512],
+  shadowBias: 0,
+  shadowRadius: 1.0
+};
+
+export function inflatePointLight(world: HubsWorld, eid: number, params: PointLightParams) {
+  const requiredParams = Object.assign({}, DEFAULTS, params) as Required<PointLightParams>;
+  const light = new PointLight();
+  light.color.set(requiredParams.color).convertSRGBToLinear();
+  light.intensity = requiredParams.intensity;
+  light.distance = requiredParams.range;
+  light.decay = requiredParams.decay;
+  light.castShadow = requiredParams.castShadow;
+  light.shadow.bias = requiredParams.shadowBias;
+  light.shadow.mapSize.fromArray(requiredParams.shadowMapResolution);
+  light.shadow.camera.matrixAutoUpdate = true;
+
+  addObject3DComponent(world, eid, light);
+  addComponent(world, LightTag, eid);
+  addComponent(world, PointLightTag, eid);
+  return eid;
+}

--- a/src/utils/jsx-entity.ts
+++ b/src/utils/jsx-entity.ts
@@ -68,6 +68,7 @@ import { MediaLoaderParams } from "../inflators/media-loader";
 import { preload } from "./preload";
 import { DirectionalLightParams, inflateDirectionalLight } from "../inflators/directional-light";
 import { AmbientLightParams, inflateAmbientLight } from "../inflators/ambient-light";
+import { PointLightParams, inflatePointLight } from "../inflators/point-light";
 import { SpotLightParams, inflateSpotLight } from "../inflators/spot-light";
 import { ProjectionMode } from "./projection-mode";
 import { inflateSkybox, SkyboxParams } from "../inflators/skybox";
@@ -231,6 +232,7 @@ interface InflatorFn {
 export interface ComponentData {
   ambientLight?: AmbientLightParams;
   directionalLight?: DirectionalLightParams;
+  pointLight?: PointLightParams;
   spotLight?: SpotLightParams;
   grabbable?: GrabbableParams;
   billboard?: { onlyY: boolean };
@@ -381,6 +383,7 @@ export const commonInflators: Required<{ [K in keyof ComponentData]: InflatorFn 
   // inflators that create Object3Ds
   ambientLight: inflateAmbientLight,
   directionalLight: inflateDirectionalLight,
+  pointLight: inflatePointLight,
   spotLight: inflateSpotLight,
   mirror: inflateMirror,
   audioZone: inflateAudioZone,


### PR DESCRIPTION
This PR adds `PointLight` to bitecs, similar to #5918.

We may want to deprecate light components at some point and encourage to use glTF lights extension, but we don't need to drop the support right now.