### PR TITLE
Add HemisphereLight to bitecs

### DIFF
--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -50,6 +50,7 @@ export const GLTFModel = defineComponent();
 export const LightTag = defineComponent();
 export const AmbientLightTag = defineComponent();
 export const DirectionalLight = defineComponent();
+export const HemisphereLightTag = defineComponent();
 export const PointLightTag = defineComponent();
 export const SpotLightTag = defineComponent();
 export const CursorRaycastable = defineComponent();

--- a/src/inflators/hemisphere-light.ts
+++ b/src/inflators/hemisphere-light.ts
@@ -1,0 +1,31 @@
+import { addComponent } from "bitecs";
+import { addObject3DComponent } from "../utils/jsx-entity";
+import { HemisphereLightTag, LightTag } from "../bit-components";
+import { HemisphereLight } from "three";
+import { HubsWorld } from "../app";
+
+export type HemisphereLightParams = {
+  skyColor?: string;
+  groundColor?: string;
+  intensity?: number;
+};
+
+const DEFAULTS: Required<HemisphereLightParams> = {
+  skyColor: "#ffffff",
+  groundColor: "#ffffff",
+  intensity: 1.0
+};
+
+export function inflateHemisphereLight(world: HubsWorld, eid: number, params: HemisphereLightParams) {
+  const requiredParams = Object.assign({}, DEFAULTS, params) as Required<HemisphereLightParams>;
+  const light = new HemisphereLight();
+  light.position.set(0, 0, 0);
+  light.color.set(requiredParams.skyColor).convertSRGBToLinear();
+  light.groundColor.set(requiredParams.groundColor).convertSRGBToLinear();
+  light.intensity = requiredParams.intensity;
+
+  addObject3DComponent(world, eid, light);
+  addComponent(world, LightTag, eid);
+  addComponent(world, HemisphereLight, eid);
+  return eid;
+}

--- a/src/utils/jsx-entity.ts
+++ b/src/utils/jsx-entity.ts
@@ -68,6 +68,7 @@ import { MediaLoaderParams } from "../inflators/media-loader";
 import { preload } from "./preload";
 import { DirectionalLightParams, inflateDirectionalLight } from "../inflators/directional-light";
 import { AmbientLightParams, inflateAmbientLight } from "../inflators/ambient-light";
+import { HemisphereLightParams, inflateHemisphereLight } from "../inflators/hemisphere-light";
 import { PointLightParams, inflatePointLight } from "../inflators/point-light";
 import { SpotLightParams, inflateSpotLight } from "../inflators/spot-light";
 import { ProjectionMode } from "./projection-mode";
@@ -232,6 +233,7 @@ interface InflatorFn {
 export interface ComponentData {
   ambientLight?: AmbientLightParams;
   directionalLight?: DirectionalLightParams;
+  hemisphereLight?: HemisphereLightParams;
   pointLight?: PointLightParams;
   spotLight?: SpotLightParams;
   grabbable?: GrabbableParams;
@@ -383,6 +385,7 @@ export const commonInflators: Required<{ [K in keyof ComponentData]: InflatorFn 
   // inflators that create Object3Ds
   ambientLight: inflateAmbientLight,
   directionalLight: inflateDirectionalLight,
+  hemisphereLight: inflateHemisphereLight,
   pointLight: inflatePointLight,
   spotLight: inflateSpotLight,
   mirror: inflateMirror,


### PR DESCRIPTION
This PR adds `HemisphereLight` to bitecs, similar to #5918.

We may want to deprecate light components at some point and encourage to use glTF lights extension, but we don't need to drop the support right now.