### PR TITLE
Add Mixer Animation to bitecs

### DIFF
--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -178,7 +178,28 @@ MediaPDF.map = new Map();
 export const MediaVideo = defineComponent({
   autoPlay: Types.ui8
 });
-export const AnimationMixer = defineComponent();
+export const MixerAnimatableInitialize = defineComponent({});
+export const MixerAnimatable = defineComponent({});
+/**
+ * @type {Map<EntityId, AnimationMixer}>}
+ */
+export const MixerAnimatableData = new Map();
+export const LoopAnimationInitialize = defineComponent({});
+/**
+ * @type {Map<EntityId, {
+ *          activeClipIndices: number[],
+ *          clip: number,
+ *          paused: boolean,
+ *          startOffset: number,
+ *          timeScale: number
+ *        }[]>}
+ */
+export const LoopAnimationInitializeData = new Map();
+export const LoopAnimation = defineComponent();
+/**
+ * @type {Map<EntityId, AnimationAction[]>}
+ */
+export const LoopAnimationData = new Map();
 export const NetworkedVideo = defineComponent({
   time: Types.f32,
   flags: Types.ui8

--- a/src/bit-systems/loop-animation.ts
+++ b/src/bit-systems/loop-animation.ts
@@ -1,0 +1,105 @@
+import { addComponent, defineQuery, enterQuery, exitQuery, hasComponent, removeComponent } from "bitecs";
+import { AnimationAction, AnimationClip, AnimationMixer, LoopRepeat } from "three";
+import {
+  MixerAnimatable,
+  MixerAnimatableData,
+  LoopAnimation,
+  LoopAnimationData,
+  LoopAnimationInitialize,
+  LoopAnimationInitializeData,
+  Object3DTag
+} from "../bit-components";
+import { HubsWorld } from "../app";
+
+const loopAnimationInitializeQuery = defineQuery([LoopAnimationInitialize, MixerAnimatable, Object3DTag]);
+const loopAnimationInitializeEnterQuery = enterQuery(loopAnimationInitializeQuery);
+
+const loopAnimationQuery = defineQuery([LoopAnimation, MixerAnimatable, Object3DTag]);
+const loopAnimationExitQuery = exitQuery(loopAnimationQuery);
+
+// Question: Who should have AnimationMixer?
+//           MixerAnimatable component or Scene/App?
+
+const getActiveClips = (
+  animations: Array<AnimationClip>,
+  activeClipIndices: number[],
+  clip: string
+): AnimationClip[] => {
+  if (clip !== "") {
+    const activeClips = [];
+    const clipNames = clip.split(",");
+    for (let i = 0; i < clipNames.length; i++) {
+      const clipName = clipNames[i];
+      const foundClip = animations.find((clip: AnimationClip) => {
+        return clip.name === clipName;
+      });
+      if (foundClip) {
+        activeClips.push(foundClip);
+      } else {
+        console.warn(`Could not find animation names '${clipName}' in `, animations);
+      }
+    }
+    return activeClips;
+  } else {
+    return activeClipIndices.map((index: number) => animations[index]);
+  }
+};
+
+export function loopAnimationSystem(world: HubsWorld): void {
+  loopAnimationInitializeEnterQuery(world).forEach((eid: number): void => {
+    const object = world.eid2obj.get(eid)!;
+    const mixer = MixerAnimatableData.get(eid)!;
+
+    addComponent(world, LoopAnimation, eid);
+
+    const params = LoopAnimationInitializeData.get(eid)!;
+    const activeAnimations = [];
+
+    for (let i = 0; i < params.length; i++) {
+      const p = params[i];
+      // TODO: Consider where animations are stored.
+      //       Currently they are stored in Object3D but
+      //       it isn't aligned with the Three.js official API.
+      //       Move to Component?
+      const activeClips = getActiveClips(object.animations, p.activeClipIndices, APP.getString(p.clip)!);
+
+      for (let j = 0; j < activeClips.length; j++) {
+        const clip = activeClips[j];
+
+        // Ignore if activeClipIndex is out of range from the animations
+        if (!clip) {
+          continue;
+        }
+
+        const action = mixer.clipAction(activeClips[j], object);
+        action.enabled = true;
+        action.paused = p.paused;
+        action.time = p.startOffset;
+        action.timeScale = p.timeScale;
+        action.setLoop(LoopRepeat, Infinity);
+        action.play();
+
+        activeAnimations.push(action);
+      }
+    }
+
+    LoopAnimationData.set(eid, activeAnimations);
+
+    removeComponent(world, LoopAnimationInitialize, eid);
+    LoopAnimationInitializeData.delete(eid);
+  });
+
+  loopAnimationExitQuery(world).forEach((eid: number): void => {
+    const mixer = hasComponent(world, MixerAnimatable, eid) ? MixerAnimatableData.get(eid)! : null;
+    const activeAnimations = LoopAnimationData.get(eid)!;
+    for (let i = 0; i < activeAnimations.length; i++) {
+      const action = activeAnimations[i];
+      action.enabled = false;
+      action.stop();
+      if (mixer !== null) {
+        mixer.uncacheAction(action);
+      }
+    }
+    LoopAnimationData.delete(eid);
+  });
+}

--- a/src/bit-systems/mixer-animatable.ts
+++ b/src/bit-systems/mixer-animatable.ts
@@ -1,0 +1,33 @@
+import { addComponent, defineQuery, enterQuery, exitQuery, removeComponent } from "bitecs";
+import { AnimationMixer } from "three";
+import { MixerAnimatable, MixerAnimatableInitialize, MixerAnimatableData, Object3DTag } from "../bit-components";
+import { HubsWorld } from "../app";
+
+const initializeQuery = defineQuery([MixerAnimatableInitialize, Object3DTag]);
+const initializeEnterQuery = enterQuery(initializeQuery);
+const mixerQuery = defineQuery([MixerAnimatable, Object3DTag]);
+const mixerExitQuery = exitQuery(mixerQuery);
+
+export function mixerAnimatableSystem(world: HubsWorld): void {
+  initializeEnterQuery(world).forEach(eid => {
+    addComponent(world, MixerAnimatable, eid);
+
+    const object = world.eid2obj.get(eid)!;
+    const mixer = new AnimationMixer(object);
+    MixerAnimatableData.set(eid, mixer);
+
+    removeComponent(world, MixerAnimatableInitialize, eid);
+  });
+
+  mixerQuery(world).forEach(eid => {
+    const mixer = MixerAnimatableData.get(eid)!;
+    mixer.update(world.time.delta / 1000.0);
+  });
+
+  mixerExitQuery(world).forEach(eid => {
+    const mixer = MixerAnimatableData.get(eid)!;
+    mixer.stopAllAction();
+    mixer.uncacheRoot(mixer.getRoot());
+    MixerAnimatableData.delete(eid);
+  });
+}

--- a/src/inflators/loop-animation.ts
+++ b/src/inflators/loop-animation.ts
@@ -1,0 +1,60 @@
+import { addComponent } from "bitecs";
+import { LoopAnimationInitialize, LoopAnimationInitializeData } from "../bit-components";
+import { HubsWorld } from "../app";
+
+type ElementParams = {
+  activeClipIndex?: number;
+  // TODO: Do we need to keep supporting the following two params?
+  //       Perhaps we should detemine which one should be the
+  //       the canonical presentation and then handle converting
+  //       the others to that.
+  // DEPRECATED: Use activeClipIndex instead since animation
+  //             names are not unique
+  clip?: string;
+  // Support for Spoke->Hubs activeClipIndices struct
+  activeClipIndices?: number[];
+  paused?: boolean;
+  startOffset?: number;
+  timeScale?: number;
+};
+
+export type LoopAnimationParams = ElementParams[];
+
+const ELEMENT_DEFAULTS: Required<ElementParams> = {
+  activeClipIndex: 0,
+  clip: "",
+  activeClipIndices: [],
+  paused: false,
+  startOffset: 0,
+  timeScale: 1.0
+};
+
+const DEFAULTS: Required<LoopAnimationParams> = [ELEMENT_DEFAULTS];
+
+export function inflateLoopAnimationInitialize(
+  world: HubsWorld,
+  eid: number,
+  params: LoopAnimationParams = []
+): number {
+  if (params.length === 0) {
+    params = DEFAULTS;
+  }
+
+  const componentParams = [];
+  for (let i = 0; i < params.length; i++) {
+    const requiredParams = Object.assign({}, ELEMENT_DEFAULTS, params[i]) as Required<ElementParams>;
+    const activeClipIndices =
+      requiredParams.activeClipIndices.length > 0 ? requiredParams.activeClipIndices : [requiredParams.activeClipIndex];
+    componentParams.push({
+      activeClipIndices,
+      clip: APP.getSid(requiredParams.clip),
+      paused: requiredParams.paused,
+      startOffset: requiredParams.startOffset,
+      timeScale: requiredParams.timeScale
+    });
+  }
+
+  addComponent(world, LoopAnimationInitialize, eid);
+  LoopAnimationInitializeData.set(eid, componentParams);
+  return eid;
+}

--- a/src/prefabs/loading-object.js
+++ b/src/prefabs/loading-object.js
@@ -1,16 +1,19 @@
 /** @jsx createElementEntity */
+import { BoxGeometry, Mesh, MeshBasicMaterial } from "three";
 import { createElementEntity } from "../utils/jsx-entity";
 import { loadModel } from "../components/gltf-model-plus";
 import loadingObjectSrc from "../assets/models/LoadingObject_Atom.glb";
-import { disposeNode } from "../utils/three-utils";
+import { cloneObject3D, disposeNode } from "../utils/three-utils";
 
 // TODO We should have an explicit "preload assets" step
-let loadingObject = new THREE.Mesh(new THREE.BoxGeometry(), new THREE.MeshBasicMaterial());
+let loadingObject = new Mesh(new BoxGeometry(), new MeshBasicMaterial());
 loadModel(loadingObjectSrc, null, true).then(gltf => {
   disposeNode(loadingObject);
   loadingObject = gltf.scene;
 });
 
+// TODO: Do we really need to clone the loadingObject every time?
+//       Should we use a pool?
 export function LoadingObject() {
-  return <entity name="Loading Object" object3D={loadingObject.clone()} />;
+  return <entity name="Loading Object" object3D={cloneObject3D(loadingObject)} mixerAnimatable loopAnimation={[]} />;
 }

--- a/src/systems/hubs-systems.ts
+++ b/src/systems/hubs-systems.ts
@@ -75,6 +75,8 @@ import { audioDebugSystem } from "../bit-systems/audio-debug-system";
 import { textSystem } from "../bit-systems/text";
 import { scenePreviewCameraSystem } from "../bit-systems/scene-preview-camera-system";
 import { linearTransformSystem } from "../bit-systems/linear-transform";
+import { mixerAnimatableSystem } from "../bit-systems/mixer-animatable";
+import { loopAnimationSystem } from "../bit-systems/loop-animation";
 
 declare global {
   interface Window {
@@ -257,6 +259,8 @@ export function mainTick(xrFrame: XRFrame, renderer: WebGLRenderer, scene: Scene
   hubsSystems.nameTagSystem.tick();
   simpleWaterSystem(world);
   linearTransformSystem(world);
+  mixerAnimatableSystem(world);
+  loopAnimationSystem(world);
 
   // All systems that update text properties should run before this
   textSystem(world);

--- a/src/utils/jsx-entity.ts
+++ b/src/utils/jsx-entity.ts
@@ -15,7 +15,6 @@ import {
   HoldableButton,
   HoverButton,
   MakeKinematicOnRelease,
-  AnimationMixer,
   Networked,
   NetworkedTransform,
   Object3DTag,
@@ -38,7 +37,8 @@ import {
   Billboard,
   MaterialTag,
   VideoTextureSource,
-  Mirror
+  Mirror,
+  MixerAnimatableInitialize
 } from "../bit-components";
 import { inflateMediaLoader } from "../inflators/media-loader";
 import { inflateMediaFrame } from "../inflators/media-frame";
@@ -51,6 +51,7 @@ import { inflateVideoLoader, VideoLoaderParams } from "../inflators/video-loader
 import { inflateImageLoader, ImageLoaderParams } from "../inflators/image-loader";
 import { inflateModelLoader, ModelLoaderParams } from "../inflators/model-loader";
 import { inflateLink, LinkParams } from "../inflators/link";
+import { inflateLoopAnimationInitialize, LoopAnimationParams } from "../inflators/loop-animation";
 import { inflateSlice9 } from "../inflators/slice9";
 import { TextParams, inflateText } from "../inflators/text";
 import {
@@ -343,8 +344,8 @@ export interface JSXComponentData extends ComponentData {
     captureDurLblRef: Ref;
     sndToggleRef: Ref;
   };
-  animationMixer?: any;
   mediaLoader?: MediaLoaderParams;
+  mixerAnimatable?: boolean;
   sceneRoot?: boolean;
   sceneLoader?: { src: string };
   mediaFrame?: any;
@@ -354,6 +355,7 @@ export interface JSXComponentData extends ComponentData {
   networkDebug?: boolean;
   waypointPreview?: boolean;
   pdf?: PDFParams;
+  loopAnimation?: LoopAnimationParams;
 }
 
 export interface GLTFComponentData extends ComponentData {
@@ -442,7 +444,6 @@ const jsxInflators: Required<{ [K in keyof JSXComponentData]: InflatorFn }> = {
   linkHoverMenuItem: createDefaultInflator(LinkHoverMenuItem),
   pdfMenu: createDefaultInflator(PDFMenu),
   cameraTool: createDefaultInflator(CameraTool, { captureDurIdx: 1 }),
-  animationMixer: createDefaultInflator(AnimationMixer),
   networkedVideo: createDefaultInflator(NetworkedVideo),
   videoMenu: createDefaultInflator(VideoMenu),
   videoMenuItem: createDefaultInflator(VideoMenuItem),
@@ -452,6 +453,8 @@ const jsxInflators: Required<{ [K in keyof JSXComponentData]: InflatorFn }> = {
   waypointPreview: createDefaultInflator(WaypointPreview),
   pdf: inflatePDF,
   mediaLoader: inflateMediaLoader,
+  mixerAnimatable: createDefaultInflator(MixerAnimatableInitialize),
+  loopAnimation: inflateLoopAnimationInitialize,
 
   // inflators that create Object3Ds
   mediaFrame: inflateMediaFrame,


### PR DESCRIPTION
This PR adds animation handled with `AnimationMixer` to bitecs.

The changes are
* Add `MixerAnimatable` component which should be added to an entity whose `Object3D` has `AnimationClips` in `object.animations` and manages `AnimationMixer` for the `Object3D`.
* Add `MixerAnimatableInitialize` component which triggers `MixerAnimatable` component initialization that will be done in a system. `AnimationMixer` needs to be created with `Object3D` so it needs to be initialized after `Object3D` is initialized.
* Add `LoopAnimation` component which manages `AnimationActions` composed from `AnimationClips` assigned to `Object3D`.
* Add `LoopAnimationInitialize` component which triggers `LoopAnimation` component initialization that will be done in a system. `AnimationActions` needs to be created from `AnimcationClips` with `AnimationMixer` so it needs to be initialized after `MixerAnimatable` is initialized.
* Add `mixerAnimatableSystem` which initializes and cleans up `MixerAnimatable` component and calls `AnimationMixer.update()` for animatable entities every tick.
* Add `loopAnimationSystem` which initializes and cleans up `LoopAnimation` component.
* Add `MixerAnimatable` and `LoopAnimation` inflators that set up `MixerAnimatableInitialize` and `LoopAnimationInitialize`. (`MixerAnimatable inflator` is a default inflator.)
* Register the inflators to JSX inflators
* Add a special path in model inflator for inflating `MixerAnimatableInitialize` and `LoopAnimationInitialize` components because Hubs `animation-mixer` and `loop-animation` components don't greatly fit to the bitECS `MixerAnimatable` and `LoopAnimation` components and systems.

Note that this PR attempts to move the current functionality and capability of the old `animation-mixer` and `loop-animation` components. Advanced features (eg: Network animation) should be in another commit.