### PR TITLE
bitecs audio-zone-system & audio-debug-system

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,6 @@
 import { addComponent, addEntity, createWorld, IWorld } from "bitecs";
 import "./aframe-to-bit-components";
-import { AEntity, AudioListenerTag, Networked, Object3DTag, Owned } from "./bit-components";
+import { AEntity, Networked, Object3DTag, Owned } from "./bit-components";
 import MediaSearchStore from "./storage/media-search-store";
 import Store from "./storage/store";
 import qsTruthy from "./utils/qs_truthy";
@@ -199,7 +199,6 @@ export class App {
     this.audioListener = audioListener;
     const audioListenerEid = addEntity(this.world);
     addObject3DComponent(this.world, audioListenerEid, this.audioListener);
-    addComponent(this.world, AudioListenerTag, audioListenerEid);
 
     camera.add(audioListener);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,6 @@
-import { addEntity, createWorld, IWorld } from "bitecs";
+import { addComponent, addEntity, createWorld, IWorld } from "bitecs";
 import "./aframe-to-bit-components";
-import { AEntity, Networked, Object3DTag, Owned } from "./bit-components";
+import { AEntity, AudioListenerTag, Networked, Object3DTag, Owned } from "./bit-components";
 import MediaSearchStore from "./storage/media-search-store";
 import Store from "./storage/store";
 import qsTruthy from "./utils/qs_truthy";
@@ -28,6 +28,7 @@ import { mainTick } from "./systems/hubs-systems";
 import { waitForPreloads } from "./utils/preload";
 import SceneEntryManager from "./scene-entry-manager";
 import { store } from "./utils/store-instance";
+import { addObject3DComponent } from "./utils/jsx-entity";
 
 declare global {
   interface Window {
@@ -196,6 +197,10 @@ export class App {
 
     const audioListener = new AudioListener();
     this.audioListener = audioListener;
+    const audioListenerEid = addEntity(this.world);
+    addObject3DComponent(this.world, audioListenerEid, this.audioListener);
+    addComponent(this.world, AudioListenerTag, audioListenerEid);
+
     camera.add(audioListener);
 
     this.world.time = {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import { addComponent, addEntity, createWorld, IWorld } from "bitecs";
+import { addEntity, createWorld, IWorld } from "bitecs";
 import "./aframe-to-bit-components";
 import { AEntity, Networked, Object3DTag, Owned } from "./bit-components";
 import MediaSearchStore from "./storage/media-search-store";

--- a/src/app.ts
+++ b/src/app.ts
@@ -79,15 +79,15 @@ export class App {
 
   audios = new Map<AElement | number, PositionalAudio | Audio>();
   sourceType = new Map<AElement | number, SourceType>();
-  audioOverrides = new Map<AElement | number, AudioSettings>();
-  zoneOverrides = new Map<AElement | number, AudioSettings>();
+  audioOverrides = new Map<AElement | number, Partial<AudioSettings>>();
+  zoneOverrides = new Map<AElement | number, Partial<AudioSettings>>();
   gainMultipliers = new Map<AElement | number, number>();
   supplementaryAttenuation = new Map<AElement | number, number>();
   clippingState = new Set<AElement | number>();
   mutedState = new Set<AElement | number>();
   isAudioPaused = new Set<AElement | number>();
-  audioDebugPanelOverrides = new Map<SourceType, AudioSettings>();
-  sceneAudioDefaults = new Map<SourceType, AudioSettings>();
+  audioDebugPanelOverrides = new Map<SourceType, Partial<AudioSettings>>();
+  sceneAudioDefaults = new Map<SourceType, Partial<AudioSettings>>();
   moderatorAudioSource = new Set<AElement | number>();
 
   world: HubsWorld = createWorld();

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -235,3 +235,19 @@ export const Mirror = defineComponent();
 export const ParticleEmitterTag = defineComponent({
   src: Types.ui32
 });
+export const AudioZone = defineComponent({
+  flags: Types.ui8
+});
+export const AudioListenerTag = defineComponent();
+export const AudioParams = defineComponent({
+  audioType: Types.ui32,
+  distanceModel: Types.ui32,
+  panningModel: Types.ui32,
+  rolloffFactor: Types.ui32,
+  refDistance: Types.ui32,
+  maxDistance: Types.ui32,
+  coneInnerAngle: Types.ui32,
+  coneOuterAngle: Types.ui32,
+  coneOuterGain: Types.ui32,
+  gain: Types.ui32
+});

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -150,6 +150,7 @@ MediaPDF.map = new Map();
 export const MediaVideo = defineComponent({
   autoPlay: Types.ui8
 });
+export const MediaVideoPlaybackChanged = defineComponent();
 export const AnimationMixer = defineComponent();
 export const NetworkedVideo = defineComponent({
   time: Types.f32,

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -242,7 +242,6 @@ export const ParticleEmitterTag = defineComponent({
 export const AudioZone = defineComponent({
   flags: Types.ui8
 });
-export const AudioListenerTag = defineComponent();
 export const AudioParams = defineComponent({
   audioType: Types.ui32,
   distanceModel: Types.ui32,

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -128,6 +128,9 @@ export const MediaLoader = defineComponent({
   flags: Types.ui8
 });
 MediaLoader.src[$isStringType] = true;
+export const MediaLoaded = defineComponent({
+  rootRef: Types.eid
+});
 
 export const SceneRoot = defineComponent();
 export const NavMesh = defineComponent();

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -242,15 +242,3 @@ export const ParticleEmitterTag = defineComponent({
 export const AudioZone = defineComponent({
   flags: Types.ui8
 });
-export const AudioParams = defineComponent({
-  audioType: Types.ui32,
-  distanceModel: Types.ui32,
-  panningModel: Types.ui32,
-  rolloffFactor: Types.ui32,
-  refDistance: Types.ui32,
-  maxDistance: Types.ui32,
-  coneInnerAngle: Types.ui32,
-  coneOuterAngle: Types.ui32,
-  coneOuterGain: Types.ui32,
-  gain: Types.ui32
-});

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -252,4 +252,3 @@ export const AudioParams = defineComponent({
   coneOuterGain: Types.ui32,
   gain: Types.ui32
 });
-export const AudioDebugChanged = defineComponent();

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -128,9 +128,7 @@ export const MediaLoader = defineComponent({
   flags: Types.ui8
 });
 MediaLoader.src[$isStringType] = true;
-export const MediaLoaded = defineComponent({
-  rootRef: Types.eid
-});
+export const MediaLoaded = defineComponent();
 
 export const SceneRoot = defineComponent();
 export const NavMesh = defineComponent();
@@ -153,7 +151,6 @@ MediaPDF.map = new Map();
 export const MediaVideo = defineComponent({
   autoPlay: Types.ui8
 });
-MediaVideo.map = new Map();
 export const AnimationMixer = defineComponent();
 export const NetworkedVideo = defineComponent({
   time: Types.f32,
@@ -171,6 +168,8 @@ export const VideoMenu = defineComponent({
 export const AudioEmitter = defineComponent({
   flags: Types.ui8
 });
+AudioEmitter.audios = new Map();
+AudioEmitter.params = new Map();
 export const AudioSettingsChanged = defineComponent();
 export const Deletable = defineComponent();
 export const EnvironmentSettings = defineComponent();
@@ -244,3 +243,4 @@ export const ParticleEmitterTag = defineComponent({
 export const AudioZone = defineComponent({
   flags: Types.ui8
 });
+export const AudioParams = defineComponent();

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -153,7 +153,7 @@ MediaPDF.map = new Map();
 export const MediaVideo = defineComponent({
   autoPlay: Types.ui8
 });
-export const MediaVideoPlaybackChanged = defineComponent();
+MediaVideo.map = new Map();
 export const AnimationMixer = defineComponent();
 export const NetworkedVideo = defineComponent({
   time: Types.f32,
@@ -168,7 +168,9 @@ export const VideoMenu = defineComponent({
   playIndicatorRef: Types.eid,
   pauseIndicatorRef: Types.eid
 });
-export const AudioEmitter = defineComponent();
+export const AudioEmitter = defineComponent({
+  flags: Types.ui8
+});
 export const AudioSettingsChanged = defineComponent();
 export const Deletable = defineComponent();
 export const EnvironmentSettings = defineComponent();

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -251,3 +251,4 @@ export const AudioParams = defineComponent({
   coneOuterGain: Types.ui32,
   gain: Types.ui32
 });
+export const AudioDebugChanged = defineComponent();

--- a/src/bit-systems/audio-debug-system.ts
+++ b/src/bit-systems/audio-debug-system.ts
@@ -175,8 +175,8 @@ export function audioDebugSystem(world: HubsWorld) {
 
       const panner = isPositionalAudio(audio) ? audio.panner : fakePanner;
 
-      uniforms.sourcePositions[idx] = emitterPos;
-      uniforms.sourceOrientations[idx] = emitterDir;
+      uniforms.sourcePositions[idx] = emitterPos.clone();
+      uniforms.sourceOrientations[idx] = emitterDir.clone();
       uniforms.distanceModels[idx] = 0;
       if (panner.distanceModel === DistanceModelType.Linear) {
         uniforms.distanceModels[idx] = 0;

--- a/src/bit-systems/audio-debug-system.ts
+++ b/src/bit-systems/audio-debug-system.ts
@@ -5,7 +5,7 @@ import { getScene, HubsWorld } from "../app";
 import { AudioEmitter, NavMesh } from "../bit-components";
 import { DistanceModelType } from "../components/audio-params";
 import { getWebGLVersion } from "../utils/webgl";
-import { isPositionalAudio } from "./audio-emitter-system";
+import { EMITTER_FLAGS, isPositionalAudio } from "./audio-emitter-system";
 import { Mesh, Material, Vector3, ShaderMaterial } from "three";
 import { disposeMaterial } from "../utils/three-utils";
 
@@ -160,7 +160,12 @@ export function audioDebugSystem(world: HubsWorld) {
     });
     let idx = 0;
     audioEmittersQuery(world).forEach(emitterEid => {
-      if (APP.isAudioPaused.has(emitterEid)) return;
+      if (
+        AudioEmitter.flags[emitterEid] & EMITTER_FLAGS.PAUSED ||
+        AudioEmitter.flags[emitterEid] & EMITTER_FLAGS.MUTED
+      ) {
+        return;
+      }
       if (idx >= maxDebugEmitters) return;
 
       const audio = APP.audios.get(emitterEid)!;

--- a/src/bit-systems/audio-debug-system.ts
+++ b/src/bit-systems/audio-debug-system.ts
@@ -31,58 +31,22 @@ interface DebugUniforms {
   clipped: Array<number>;
 }
 
-const nav2uni = new Map<number, DebugUniforms>();
-
 let isEnabled = false;
 let unsupported = false;
 let maxDebugSources = 64;
-
-const DEBUG_MATERIAL = new THREE.ShaderMaterial({
-  uniforms: {
-    time: { value: 0.0 },
-    colorInner: { value: new THREE.Color("#7AFF59") },
-    colorOuter: { value: new THREE.Color("#FF6340") },
-    colorGain: { value: new THREE.Color("#70DBFF") },
-    count: { value: 0 },
-    maxDistance: { value: [] },
-    refDistance: { value: [] },
-    rolloffFactor: { value: [] },
-    distanceModel: { value: [] },
-    sourcePosition: { value: [] },
-    sourceOrientation: { value: [] },
-    coneInnerAngle: { value: [] },
-    coneOuterAngle: { value: [] },
-    gain: { value: [] },
-    clipped: { value: [] }
-  },
-  vertexShader: audioDebugVert,
-  fragmentShader: audioDebugFrag
-});
-DEBUG_MATERIAL.side = THREE.FrontSide;
-DEBUG_MATERIAL.transparent = true;
-DEBUG_MATERIAL.uniforms.count.value = 0;
+let uniforms: DebugUniforms;
+let debugMaterial: ShaderMaterial;
 const nav2mat = new Map<number, Material | Material[]>();
 
 const addDebugMaterial = (world: HubsWorld, nav: number) => {
   if (nav2mat.has(nav)) return;
+  setupMaterial();
   const obj = world.eid2obj.get(nav);
   if (obj) {
     const navMesh = obj as Mesh;
     navMesh.visible = isEnabled;
     nav2mat.set(nav, navMesh.material);
-    nav2uni.set(nav, {
-      sourcePositions: new Array<Vector3>(maxDebugSources).fill(new Vector3()),
-      sourceOrientations: new Array<Vector3>(maxDebugSources).fill(new Vector3()),
-      distanceModels: new Array<number>(maxDebugSources).fill(0),
-      maxDistances: new Array<number>(maxDebugSources).fill(0),
-      refDistances: new Array<number>(maxDebugSources).fill(0),
-      rolloffFactors: new Array<number>(maxDebugSources).fill(0),
-      coneInnerAngles: new Array<number>(maxDebugSources).fill(0),
-      coneOuterAngles: new Array<number>(maxDebugSources).fill(0),
-      gains: new Array<number>(maxDebugSources).fill(0),
-      clipped: new Array<number>(maxDebugSources).fill(0)
-    } as DebugUniforms);
-    navMesh.material = DEBUG_MATERIAL;
+    navMesh.material = debugMaterial;
     navMesh.material.needsUpdate = true;
     navMesh.geometry.computeVertexNormals();
   }
@@ -97,13 +61,67 @@ const removeDebugMaterial = (world: HubsWorld, nav: number) => {
     disposeMaterial(navMesh.material);
     navMesh.material = nav2mat.get(nav)!;
     nav2mat.delete(nav);
-    nav2uni.delete(nav);
     (navMesh.material as Material).needsUpdate = true;
     navMesh.geometry.computeVertexNormals();
   }
 };
 
 export const cleanupAudioDebugNavMesh = (nav: number) => removeDebugMaterial(APP.world, nav);
+
+const setupMaterial = () => {
+  if (isEnabled) {
+    if (!uniforms) {
+      uniforms = {
+        sourcePositions: new Array<Vector3>(maxDebugSources).fill(new Vector3()),
+        sourceOrientations: new Array<Vector3>(maxDebugSources).fill(new Vector3()),
+        distanceModels: new Array<number>(maxDebugSources).fill(0),
+        maxDistances: new Array<number>(maxDebugSources).fill(0),
+        refDistances: new Array<number>(maxDebugSources).fill(0),
+        rolloffFactors: new Array<number>(maxDebugSources).fill(0),
+        coneInnerAngles: new Array<number>(maxDebugSources).fill(0),
+        coneOuterAngles: new Array<number>(maxDebugSources).fill(0),
+        gains: new Array<number>(maxDebugSources).fill(0),
+        clipped: new Array<number>(maxDebugSources).fill(0)
+      } as DebugUniforms;
+    }
+    if (!debugMaterial) {
+      debugMaterial = new THREE.ShaderMaterial({
+        uniforms: {
+          time: { value: 0.0 },
+          colorInner: { value: new THREE.Color("#7AFF59") },
+          colorOuter: { value: new THREE.Color("#FF6340") },
+          colorGain: { value: new THREE.Color("#70DBFF") },
+          count: { value: 0 },
+          maxDistance: { value: [] },
+          refDistance: { value: [] },
+          rolloffFactor: { value: [] },
+          distanceModel: { value: [] },
+          sourcePosition: { value: [] },
+          sourceOrientation: { value: [] },
+          coneInnerAngle: { value: [] },
+          coneOuterAngle: { value: [] },
+          gain: { value: [] },
+          clipped: { value: [] }
+        },
+        vertexShader: audioDebugVert,
+        fragmentShader: audioDebugFrag
+      });
+      debugMaterial.side = THREE.DoubleSide;
+      debugMaterial.transparent = true;
+      debugMaterial.uniforms.count.value = 0;
+      debugMaterial.defines.MAX_DEBUG_SOURCES = maxDebugSources;
+    }
+  }
+};
+
+const updateDebugConfig = (nav: number) => {
+  if (unsupported) return;
+  if (isEnabled) {
+    addDebugMaterial(APP.world, nav);
+  } else {
+    removeDebugMaterial(APP.world, nav);
+  }
+};
 
 getScene().then(() => {
   const webGLVersion = getWebGLVersion(APP.scene!.renderer);
@@ -114,22 +132,12 @@ getScene().then(() => {
     const maxUniformVectors = gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS);
     // 10 is the number of uniform vectors in the shader. If we update that, this number must be updated accordingly.
     maxDebugSources = Math.min(Math.floor(maxUniformVectors / 10), maxDebugSources);
-    DEBUG_MATERIAL.defines.MAX_DEBUG_SOURCES = maxDebugSources;
   }
-
+  if (unsupported) return;
   (APP.store as any).addEventListener("statechanged", () => {
     isEnabled = APP.store.state.preferences.showAudioDebugPanel;
-    defineQuery([NavMesh])(APP.world).forEach(nav => {
-      if (!unsupported) {
-        if (isEnabled) {
-          addDebugMaterial(APP.world, nav);
-        } else {
-          removeDebugMaterial(APP.world, nav);
-        }
-      }
-    });
+    defineQuery([NavMesh])(APP.world).forEach(nav => updateDebugConfig(nav));
   });
-
   isEnabled = APP.store.state.preferences.showAudioDebugPanel;
 });
 
@@ -140,14 +148,15 @@ const navMeshQuery = defineQuery([NavMesh]);
 const navMeshEnterQuery = enterQuery(navMeshQuery);
 const navMeshExitQuery = exitQuery(navMeshQuery);
 export function audioDebugSystem(world: HubsWorld) {
+  if (unsupported) return;
   navMeshEnterQuery(world).forEach(nav => {
-    isEnabled && !unsupported && addDebugMaterial(world, nav);
+    addDebugMaterial(world, nav);
   });
   navMeshExitQuery(world).forEach(nav => {
     removeDebugMaterial(world, nav);
   });
-  let idx = 0;
-  if (isEnabled && !unsupported) {
+  if (isEnabled && uniforms) {
+    let idx = 0;
     audioEmittersQuery(world).forEach(emitter => {
       if (APP.isAudioPaused.has(emitter)) return;
       if (idx >= maxDebugSources) return;
@@ -159,44 +168,37 @@ export function audioDebugSystem(world: HubsWorld) {
 
       const panner = isPositionalAudio(audio) ? audio.panner : fakePanner;
 
-      nav2uni.forEach((uniforms: DebugUniforms, nav: number) => {
-        const navMesh = world.eid2obj.get(nav)! as Mesh;
-        uniforms.sourcePositions[idx] = navMesh.worldToLocal(sourcePos).clone(); // TODO: Use Vector3 pool
-        uniforms.sourceOrientations[idx] = navMesh.worldToLocal(sourceDir).clone();
+      uniforms.sourcePositions[idx] = sourcePos;
+      uniforms.sourceOrientations[idx] = sourceDir;
+      uniforms.distanceModels[idx] = 0;
+      if (panner.distanceModel === DistanceModelType.Linear) {
         uniforms.distanceModels[idx] = 0;
-        if (panner.distanceModel === DistanceModelType.Linear) {
-          uniforms.distanceModels[idx] = 0;
-        } else if (panner.distanceModel === DistanceModelType.Inverse) {
-          uniforms.distanceModels[idx] = 1;
-        } else if (panner.distanceModel === DistanceModelType.Exponential) {
-          uniforms.distanceModels[idx] = 2;
-        }
-        uniforms.maxDistances[idx] = panner.maxDistance;
-        uniforms.refDistances[idx] = panner.refDistance;
-        uniforms.rolloffFactors[idx] = panner.rolloffFactor;
-        uniforms.coneInnerAngles[idx] = panner.coneInnerAngle;
-        uniforms.coneOuterAngles[idx] = panner.coneOuterAngle;
-        uniforms.gains[idx] = audio.gain.gain.value;
-        uniforms.clipped[idx] = APP.clippingState.has(emitter) ? 1 : 0;
-      });
+      } else if (panner.distanceModel === DistanceModelType.Inverse) {
+        uniforms.distanceModels[idx] = 1;
+      } else if (panner.distanceModel === DistanceModelType.Exponential) {
+        uniforms.distanceModels[idx] = 2;
+      }
+      uniforms.maxDistances[idx] = panner.maxDistance;
+      uniforms.refDistances[idx] = panner.refDistance;
+      uniforms.rolloffFactors[idx] = panner.rolloffFactor;
+      uniforms.coneInnerAngles[idx] = panner.coneInnerAngle;
+      uniforms.coneOuterAngles[idx] = panner.coneOuterAngle;
+      uniforms.gains[idx] = audio.gain.gain.value;
+      uniforms.clipped[idx] = APP.clippingState.has(emitter) ? 1 : 0;
+
       idx++;
     });
-    nav2uni.forEach((uniforms: DebugUniforms, nav: number) => {
-      const navMesh = world.eid2obj.get(nav)! as Mesh;
-      const debugMaterial = navMesh.material as ShaderMaterial;
-      debugMaterial.uniforms.time.value = world.time.elapsed;
-      debugMaterial.uniforms.distanceModel.value = uniforms.distanceModels;
-      debugMaterial.uniforms.maxDistance.value = uniforms.maxDistances;
-      debugMaterial.uniforms.refDistance.value = uniforms.refDistances;
-      debugMaterial.uniforms.rolloffFactor.value = uniforms.rolloffFactors;
-      debugMaterial.uniforms.sourcePosition.value = uniforms.sourcePositions;
-      debugMaterial.uniforms.sourceOrientation.value = uniforms.sourceOrientations;
-      debugMaterial.uniforms.count.value = idx;
-      debugMaterial.uniforms.coneInnerAngle.value = uniforms.coneInnerAngles;
-      debugMaterial.uniforms.coneOuterAngle.value = uniforms.coneOuterAngles;
-      debugMaterial.uniforms.gain.value = uniforms.gains;
-      debugMaterial.uniforms.clipped.value = uniforms.clipped;
-      debugMaterial.uniformsNeedUpdate = true;
-    });
+    debugMaterial.uniforms.time.value = world.time.elapsed;
+    debugMaterial.uniforms.distanceModel.value = uniforms.distanceModels;
+    debugMaterial.uniforms.maxDistance.value = uniforms.maxDistances;
+    debugMaterial.uniforms.refDistance.value = uniforms.refDistances;
+    debugMaterial.uniforms.rolloffFactor.value = uniforms.rolloffFactors;
+    debugMaterial.uniforms.sourcePosition.value = uniforms.sourcePositions;
+    debugMaterial.uniforms.sourceOrientation.value = uniforms.sourceOrientations;
+    debugMaterial.uniforms.count.value = idx;
+    debugMaterial.uniforms.coneInnerAngle.value = uniforms.coneInnerAngles;
+    debugMaterial.uniforms.coneOuterAngle.value = uniforms.coneOuterAngles;
+    debugMaterial.uniforms.gain.value = uniforms.gains;
+    debugMaterial.uniforms.clipped.value = uniforms.clipped;
   }
 }

--- a/src/bit-systems/audio-debug-system.ts
+++ b/src/bit-systems/audio-debug-system.ts
@@ -1,0 +1,202 @@
+import audioDebugVert from "../systems/audio-debug.vert";
+import audioDebugFrag from "../systems/audio-debug.frag";
+import { defineQuery, enterQuery, exitQuery } from "bitecs";
+import { getScene, HubsWorld } from "../app";
+import { AudioEmitter, NavMesh } from "../bit-components";
+import { DistanceModelType } from "../components/audio-params";
+import { getWebGLVersion } from "../utils/webgl";
+import { isPositionalAudio } from "./audio-emitter-system";
+import { Mesh, Material, Vector3, ShaderMaterial } from "three";
+import { disposeMaterial } from "../utils/three-utils";
+
+const fakePanner = {
+  distanceModel: DistanceModelType.Inverse,
+  maxDistance: 0,
+  refDistance: 0,
+  rolloffFactor: 0,
+  coneInnerAngle: 0,
+  coneOuterAngle: 0
+};
+
+interface DebugUniforms {
+  sourcePositions: Array<Vector3>;
+  sourceOrientations: Array<Vector3>;
+  distanceModels: Array<number>;
+  maxDistances: Array<number>;
+  refDistances: Array<number>;
+  rolloffFactors: Array<number>;
+  coneInnerAngles: Array<number>;
+  coneOuterAngles: Array<number>;
+  gains: Array<number>;
+  clipped: Array<number>;
+}
+
+const nav2uni = new Map<number, DebugUniforms>();
+
+let isEnabled = false;
+let unsupported = false;
+let maxDebugSources = 64;
+
+const DEBUG_MATERIAL = new THREE.ShaderMaterial({
+  uniforms: {
+    time: { value: 0.0 },
+    colorInner: { value: new THREE.Color("#7AFF59") },
+    colorOuter: { value: new THREE.Color("#FF6340") },
+    colorGain: { value: new THREE.Color("#70DBFF") },
+    count: { value: 0 },
+    maxDistance: { value: [] },
+    refDistance: { value: [] },
+    rolloffFactor: { value: [] },
+    distanceModel: { value: [] },
+    sourcePosition: { value: [] },
+    sourceOrientation: { value: [] },
+    coneInnerAngle: { value: [] },
+    coneOuterAngle: { value: [] },
+    gain: { value: [] },
+    clipped: { value: [] }
+  },
+  vertexShader: audioDebugVert,
+  fragmentShader: audioDebugFrag
+});
+DEBUG_MATERIAL.side = THREE.FrontSide;
+DEBUG_MATERIAL.transparent = true;
+DEBUG_MATERIAL.uniforms.count.value = 0;
+const nav2mat = new Map<number, Material | Material[]>();
+
+const addDebugMaterial = (world: HubsWorld, nav: number) => {
+  if (nav2mat.has(nav)) return;
+  const obj = world.eid2obj.get(nav);
+  if (obj) {
+    const navMesh = obj as Mesh;
+    navMesh.visible = isEnabled;
+    nav2mat.set(nav, navMesh.material);
+    nav2uni.set(nav, {
+      sourcePositions: new Array<Vector3>(maxDebugSources).fill(new Vector3()),
+      sourceOrientations: new Array<Vector3>(maxDebugSources).fill(new Vector3()),
+      distanceModels: new Array<number>(maxDebugSources).fill(0),
+      maxDistances: new Array<number>(maxDebugSources).fill(0),
+      refDistances: new Array<number>(maxDebugSources).fill(0),
+      rolloffFactors: new Array<number>(maxDebugSources).fill(0),
+      coneInnerAngles: new Array<number>(maxDebugSources).fill(0),
+      coneOuterAngles: new Array<number>(maxDebugSources).fill(0),
+      gains: new Array<number>(maxDebugSources).fill(0),
+      clipped: new Array<number>(maxDebugSources).fill(0)
+    } as DebugUniforms);
+    navMesh.material = DEBUG_MATERIAL;
+    navMesh.material.needsUpdate = true;
+    navMesh.geometry.computeVertexNormals();
+  }
+};
+
+const removeDebugMaterial = (world: HubsWorld, nav: number) => {
+  if (!nav2mat.has(nav)) return;
+  const obj = world.eid2obj.get(nav);
+  if (obj) {
+    const navMesh = obj as Mesh;
+    navMesh.visible = false;
+    disposeMaterial(navMesh.material);
+    navMesh.material = nav2mat.get(nav)!;
+    nav2mat.delete(nav);
+    nav2uni.delete(nav);
+    (navMesh.material as Material).needsUpdate = true;
+    navMesh.geometry.computeVertexNormals();
+  }
+};
+
+export const cleanupAudioDebugNavMesh = (nav: number) => removeDebugMaterial(APP.world, nav);
+
+getScene().then(() => {
+  const webGLVersion = getWebGLVersion(APP.scene!.renderer);
+  if (webGLVersion < "2.0") {
+    unsupported = true;
+  } else {
+    const gl = APP.scene!.renderer.getContext();
+    const maxUniformVectors = gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS);
+    // 10 is the number of uniform vectors in the shader. If we update that, this number must be updated accordingly.
+    maxDebugSources = Math.min(Math.floor(maxUniformVectors / 10), maxDebugSources);
+    DEBUG_MATERIAL.defines.MAX_DEBUG_SOURCES = maxDebugSources;
+  }
+
+  (APP.store as any).addEventListener("statechanged", () => {
+    isEnabled = APP.store.state.preferences.showAudioDebugPanel;
+    defineQuery([NavMesh])(APP.world).forEach(nav => {
+      if (!unsupported) {
+        if (isEnabled) {
+          addDebugMaterial(APP.world, nav);
+        } else {
+          removeDebugMaterial(APP.world, nav);
+        }
+      }
+    });
+  });
+
+  isEnabled = APP.store.state.preferences.showAudioDebugPanel;
+});
+
+const sourcePos = new THREE.Vector3();
+const sourceDir = new THREE.Vector3();
+const audioEmittersQuery = defineQuery([AudioEmitter]);
+const navMeshQuery = defineQuery([NavMesh]);
+const navMeshEnterQuery = enterQuery(navMeshQuery);
+const navMeshExitQuery = exitQuery(navMeshQuery);
+export function audioDebugSystem(world: HubsWorld) {
+  navMeshEnterQuery(world).forEach(nav => {
+    isEnabled && !unsupported && addDebugMaterial(world, nav);
+  });
+  navMeshExitQuery(world).forEach(nav => {
+    removeDebugMaterial(world, nav);
+  });
+  let idx = 0;
+  if (isEnabled && !unsupported) {
+    audioEmittersQuery(world).forEach(emitter => {
+      if (APP.isAudioPaused.has(emitter)) return;
+      if (idx >= maxDebugSources) return;
+
+      const audio = APP.audios.get(emitter)!;
+
+      audio.getWorldPosition(sourcePos);
+      audio.getWorldDirection(sourceDir);
+
+      const panner = isPositionalAudio(audio) ? audio.panner : fakePanner;
+
+      nav2uni.forEach((uniforms: DebugUniforms, nav: number) => {
+        const navMesh = world.eid2obj.get(nav)! as Mesh;
+        uniforms.sourcePositions[idx] = navMesh.worldToLocal(sourcePos).clone(); // TODO: Use Vector3 pool
+        uniforms.sourceOrientations[idx] = navMesh.worldToLocal(sourceDir).clone();
+        uniforms.distanceModels[idx] = 0;
+        if (panner.distanceModel === DistanceModelType.Linear) {
+          uniforms.distanceModels[idx] = 0;
+        } else if (panner.distanceModel === DistanceModelType.Inverse) {
+          uniforms.distanceModels[idx] = 1;
+        } else if (panner.distanceModel === DistanceModelType.Exponential) {
+          uniforms.distanceModels[idx] = 2;
+        }
+        uniforms.maxDistances[idx] = panner.maxDistance;
+        uniforms.refDistances[idx] = panner.refDistance;
+        uniforms.rolloffFactors[idx] = panner.rolloffFactor;
+        uniforms.coneInnerAngles[idx] = panner.coneInnerAngle;
+        uniforms.coneOuterAngles[idx] = panner.coneOuterAngle;
+        uniforms.gains[idx] = audio.gain.gain.value;
+        uniforms.clipped[idx] = APP.clippingState.has(emitter) ? 1 : 0;
+      });
+      idx++;
+    });
+    nav2uni.forEach((uniforms: DebugUniforms, nav: number) => {
+      const navMesh = world.eid2obj.get(nav)! as Mesh;
+      const debugMaterial = navMesh.material as ShaderMaterial;
+      debugMaterial.uniforms.time.value = world.time.elapsed;
+      debugMaterial.uniforms.distanceModel.value = uniforms.distanceModels;
+      debugMaterial.uniforms.maxDistance.value = uniforms.maxDistances;
+      debugMaterial.uniforms.refDistance.value = uniforms.refDistances;
+      debugMaterial.uniforms.rolloffFactor.value = uniforms.rolloffFactors;
+      debugMaterial.uniforms.sourcePosition.value = uniforms.sourcePositions;
+      debugMaterial.uniforms.sourceOrientation.value = uniforms.sourceOrientations;
+      debugMaterial.uniforms.count.value = idx;
+      debugMaterial.uniforms.coneInnerAngle.value = uniforms.coneInnerAngles;
+      debugMaterial.uniforms.coneOuterAngle.value = uniforms.coneOuterAngles;
+      debugMaterial.uniforms.gain.value = uniforms.gains;
+      debugMaterial.uniforms.clipped.value = uniforms.clipped;
+      debugMaterial.uniformsNeedUpdate = true;
+    });
+  }
+}

--- a/src/bit-systems/audio-emitter-system.ts
+++ b/src/bit-systems/audio-emitter-system.ts
@@ -14,6 +14,16 @@ function isPositionalAudio(node: AudioObject3D): node is PositionalAudio {
   return (node as any).panner !== undefined;
 }
 
+export function cleanupAudio(audio: AudioObject3D) {
+  const eid = audio.eid!;
+  audio.disconnect();
+  const audioSystem = APP.scene?.systems["hubs-systems"].audioSystem;
+  APP.audios.delete(eid);
+  APP.supplementaryAttenuation.delete(eid);
+  APP.isAudioPaused.delete(eid);
+  audioSystem.removeAudio({ node: audio });
+}
+
 function swapAudioType<T extends AudioObject3D>(
   world: HubsWorld,
   audioSystem: AudioSystem,
@@ -22,6 +32,10 @@ function swapAudioType<T extends AudioObject3D>(
 ) {
   const audio = world.eid2obj.get(eid)! as AudioObject3D;
   audio.disconnect();
+  APP.gainMultipliers.delete(eid);
+  APP.sourceType.set(eid, SourceType.MEDIA_VIDEO);
+  APP.supplementaryAttenuation.delete(eid);
+  APP.audios.delete(eid);
   audioSystem.removeAudio({ node: audio });
 
   const newAudio = new NewType(APP.audioListener);

--- a/src/bit-systems/audio-emitter-system.ts
+++ b/src/bit-systems/audio-emitter-system.ts
@@ -10,7 +10,7 @@ import { addObject3DComponent, swapObject3DComponent } from "../utils/jsx-entity
 type AudioObject3D = StereoAudio | PositionalAudio;
 type AudioConstructor<T> = new (listener: ThreeAudioListener) => T;
 
-function isPositionalAudio(node: AudioObject3D): node is PositionalAudio {
+export function isPositionalAudio(node: AudioObject3D): node is PositionalAudio {
   return (node as any).panner !== undefined;
 }
 

--- a/src/bit-systems/audio-emitter-system.ts
+++ b/src/bit-systems/audio-emitter-system.ts
@@ -7,8 +7,11 @@ import { AudioSystem } from "../systems/audio-system";
 import { applySettings, getCurrentAudioSettings, updateAudioSettings } from "../update-audio-settings";
 import { addObject3DComponent, swapObject3DComponent } from "../utils/jsx-entity";
 
-type AudioObject3D = StereoAudio | PositionalAudio;
+export type AudioObject3D = StereoAudio | PositionalAudio;
 type AudioConstructor<T> = new (listener: ThreeAudioListener) => T;
+
+export const Emitter2Audio = (AudioEmitter as any).audios as Map<number, number>;
+export const Emitter2Params = (AudioEmitter as any).params as Map<number, number>;
 
 export const EMITTER_FLAGS = {
   MUTED: 1 << 0,
@@ -26,6 +29,7 @@ export function cleanupAudio(audio: AudioObject3D) {
   const audioSystem = APP.scene?.systems["hubs-systems"].audioSystem;
   APP.audios.delete(eid);
   APP.supplementaryAttenuation.delete(eid);
+  APP.audioOverrides.delete(eid);
   audioSystem.removeAudio({ node: audio });
 }
 
@@ -40,6 +44,7 @@ function swapAudioType<T extends AudioObject3D>(
   APP.gainMultipliers.delete(eid);
   APP.sourceType.set(eid, SourceType.MEDIA_VIDEO);
   APP.supplementaryAttenuation.delete(eid);
+  APP.audioOverrides.delete(eid);
   APP.audios.delete(eid);
   audioSystem.removeAudio({ node: audio });
 

--- a/src/bit-systems/audio-emitter-system.ts
+++ b/src/bit-systems/audio-emitter-system.ts
@@ -41,10 +41,8 @@ function swapAudioType<T extends AudioObject3D>(
 ) {
   const audio = world.eid2obj.get(eid)! as AudioObject3D;
   audio.disconnect();
-  APP.gainMultipliers.delete(eid);
   APP.sourceType.set(eid, SourceType.MEDIA_VIDEO);
   APP.supplementaryAttenuation.delete(eid);
-  APP.audioOverrides.delete(eid);
   APP.audios.delete(eid);
   audioSystem.removeAudio({ node: audio });
 

--- a/src/bit-systems/audio-emitter-system.ts
+++ b/src/bit-systems/audio-emitter-system.ts
@@ -1,0 +1,89 @@
+import { addComponent, addEntity, defineQuery, removeComponent } from "bitecs";
+import { PositionalAudio, Audio as StereoAudio, AudioListener as ThreeAudioListener } from "three";
+import { HubsWorld } from "../app";
+import { AudioEmitter, AudioSettingsChanged } from "../bit-components";
+import { AudioType, SourceType } from "../components/audio-params";
+import { AudioSystem } from "../systems/audio-system";
+import { applySettings, getCurrentAudioSettings, updateAudioSettings } from "../update-audio-settings";
+import { addObject3DComponent, swapObject3DComponent } from "../utils/jsx-entity";
+
+type AudioObject3D = StereoAudio | PositionalAudio;
+type AudioConstructor<T> = new (listener: ThreeAudioListener) => T;
+
+function isPositionalAudio(node: AudioObject3D): node is PositionalAudio {
+  return (node as any).panner !== undefined;
+}
+
+function swapAudioType<T extends AudioObject3D>(
+  world: HubsWorld,
+  audioSystem: AudioSystem,
+  eid: number,
+  NewType: AudioConstructor<T>
+) {
+  const audio = world.eid2obj.get(eid)! as AudioObject3D;
+  audio.disconnect();
+  audioSystem.removeAudio({ node: audio });
+
+  const newAudio = new NewType(APP.audioListener);
+  newAudio.setNodeSource(audio.source!);
+  audioSystem.addAudio({ sourceType: SourceType.MEDIA_VIDEO, node: newAudio });
+  APP.audios.set(eid, newAudio);
+
+  audio.parent!.add(newAudio);
+  audio.removeFromParent();
+
+  swapObject3DComponent(world, eid, newAudio);
+}
+
+export function makeAudioSourceEntity(world: HubsWorld, video: HTMLVideoElement, audioSystem: AudioSystem) {
+  const eid = addEntity(world);
+  APP.sourceType.set(eid, SourceType.MEDIA_VIDEO);
+  if (video.paused) {
+    APP.isAudioPaused.add(eid);
+  } else {
+    APP.isAudioPaused.delete(eid);
+  }
+
+  let audio;
+  const { audioType } = getCurrentAudioSettings(eid);
+  const audioListener = APP.audioListener;
+  if (audioType === AudioType.PannerNode) {
+    audio = new PositionalAudio(audioListener);
+  } else {
+    audio = new StereoAudio(audioListener);
+  }
+  addComponent(world, AudioEmitter, eid);
+  addObject3DComponent(world, eid, audio);
+
+  audio.gain.gain.value = 0;
+  audioSystem.addAudio({ sourceType: SourceType.MEDIA_VIDEO, node: audio });
+
+  const audioSrcEl = video;
+  audio.setMediaElementSource(audioSrcEl);
+
+  APP.audios.set(eid, audio);
+  updateAudioSettings(eid, audio);
+
+  // Original audio source volume can now be restored as audio systems will take over
+  audioSrcEl.volume = 1;
+  return eid;
+}
+
+const staleAudioEmittersQuery = defineQuery([AudioEmitter, AudioSettingsChanged]);
+export function audioEmitterSystem(world: HubsWorld, audioSystem: AudioSystem) {
+  staleAudioEmittersQuery(world).forEach(function (eid) {
+    const audio = world.eid2obj.get(eid)! as PositionalAudio | StereoAudio;
+    const settings = getCurrentAudioSettings(eid);
+    const isPannerNode = isPositionalAudio(audio);
+
+    // TODO this needs more testing
+    if (!isPannerNode && settings.audioType === AudioType.PannerNode) {
+      swapAudioType(world, audioSystem, eid, PositionalAudio);
+    } else if (isPannerNode && settings.audioType === AudioType.Stereo) {
+      swapAudioType(world, audioSystem, eid, StereoAudio);
+    }
+
+    applySettings(audio, settings);
+    removeComponent(world, AudioSettingsChanged, eid);
+  });
+}

--- a/src/bit-systems/audio-emitter-system.ts
+++ b/src/bit-systems/audio-emitter-system.ts
@@ -10,6 +10,12 @@ import { addObject3DComponent, swapObject3DComponent } from "../utils/jsx-entity
 type AudioObject3D = StereoAudio | PositionalAudio;
 type AudioConstructor<T> = new (listener: ThreeAudioListener) => T;
 
+export const EMITTER_FLAGS = {
+  MUTED: 1 << 0,
+  PAUSED: 1 << 1,
+  CLIPPED: 1 << 2
+};
+
 export function isPositionalAudio(node: AudioObject3D): node is PositionalAudio {
   return (node as any).panner !== undefined;
 }
@@ -20,7 +26,6 @@ export function cleanupAudio(audio: AudioObject3D) {
   const audioSystem = APP.scene?.systems["hubs-systems"].audioSystem;
   APP.audios.delete(eid);
   APP.supplementaryAttenuation.delete(eid);
-  APP.isAudioPaused.delete(eid);
   audioSystem.removeAudio({ node: audio });
 }
 
@@ -53,9 +58,9 @@ export function makeAudioSourceEntity(world: HubsWorld, video: HTMLVideoElement,
   const eid = addEntity(world);
   APP.sourceType.set(eid, SourceType.MEDIA_VIDEO);
   if (video.paused) {
-    APP.isAudioPaused.add(eid);
+    AudioEmitter.flags[eid] |= EMITTER_FLAGS.PAUSED;
   } else {
-    APP.isAudioPaused.delete(eid);
+    AudioEmitter.flags[eid] &= ~EMITTER_FLAGS.PAUSED;
   }
 
   let audio;

--- a/src/bit-systems/audio-zone-system.ts
+++ b/src/bit-systems/audio-zone-system.ts
@@ -114,17 +114,13 @@ const getEmitterPosition = (() => {
 const applyEmitterParams = (emitterEid: number, params: AudioSettings) => {
   APP.zoneOverrides.set(emitterEid, params);
   const audio = APP.audios.get(emitterEid);
-  if (audio) {
-    updateAudioSettings(emitterEid, audio);
-  }
+  updateAudioSettings(emitterEid, audio);
 };
 
 const restoreEmitterParams = (emitterEid: number) => {
   APP.zoneOverrides.delete(emitterEid);
   const audio = APP.audios.get(emitterEid);
-  if (audio) {
-    updateAudioSettings(emitterEid, audio);
-  }
+  updateAudioSettings(emitterEid, audio);
 };
 
 const setRay = (() => {

--- a/src/bit-systems/audio-zone-system.ts
+++ b/src/bit-systems/audio-zone-system.ts
@@ -261,9 +261,6 @@ const audioZoneListenerEnterQuery = enterQuery(audioZoneListenerQuery);
 const audioZoneListenerExitQuery = exitQuery(audioZoneListenerQuery);
 
 export function audioZoneSystem(world: HubsWorld) {
-  const zones = audioZoneQuery(world);
-  if (!zones.length) return;
-
   [...audioEmitterEnterQuery(world), ...audioZoneListenerEnterQuery(world)].forEach(entityEid => {
     currZones.set(entityEid, new Set());
     prevZones.set(entityEid, new Set());
@@ -289,6 +286,9 @@ export function audioZoneSystem(world: HubsWorld) {
     const isDebugEnabled = APP.store.state.preferences.showAudioDebugPanel;
     isDebugEnabled && debugObjects.has(zoneEid) && releaseZoneDebugObject(APP.world, zoneEid);
   });
+
+  const zones = audioZoneQuery(world);
+  if (!zones.length) return;
 
   const listener = APP.audioListener.eid!;
   const listenersQuery = audioZoneListenerQuery(world);

--- a/src/bit-systems/audio-zone-system.ts
+++ b/src/bit-systems/audio-zone-system.ts
@@ -1,0 +1,291 @@
+import { defineQuery, enterQuery, exitQuery } from "bitecs";
+import { HubsWorld } from "../app";
+import { AudioEmitter, AudioZone, AudioListenerTag } from "../bit-components";
+import { Box3, BoxGeometry, DoubleSide, MeshBasicMaterial, Object3D, Ray, Vector3, Mesh, BoxHelper } from "three";
+import { AUDIO_ZONE_FLAGS } from "../inflators/audio-zone";
+import { disposeNode } from "../utils/three-utils";
+import { AudioSettings } from "../components/audio-params";
+import { updateAudioSettings } from "../update-audio-settings";
+
+const debugObjects = new Map<number, Object3D>();
+
+const DEBUG_BBAA_COLOR = 0x49ef4;
+
+const debugMaterial = new MeshBasicMaterial({
+  color: DEBUG_BBAA_COLOR,
+  transparent: true,
+  opacity: 0.25,
+  side: DoubleSide
+});
+
+const addZoneDebugObject = (world: HubsWorld, zone: number) => {
+  const geometry = new BoxGeometry();
+  const obj = new Mesh(geometry, debugMaterial);
+  const aabb = new BoxHelper(obj, DEBUG_BBAA_COLOR);
+
+  const parent = APP.world.eid2obj.get(zone) as Object3D;
+  parent.add(aabb);
+  parent.updateMatrixWorld(true);
+
+  debugObjects.set(zone, obj);
+};
+
+const releaseZoneDebugObject = (world: HubsWorld, zone: number) => {
+  const obj = debugObjects.get(zone)!;
+  obj?.removeFromParent();
+  disposeNode(obj);
+};
+
+const isZoneEnabled = (zone: number): boolean => {
+  return Boolean(AudioZone.flags[zone] & AUDIO_ZONE_FLAGS.ENABLED);
+};
+
+const getZoneBoundingBox = (zone: number) => {
+  if (AudioZone.flags[zone] & AUDIO_ZONE_FLAGS.DYNAMIC) {
+    const obj = APP.world.eid2obj.get(zone)!;
+    return aabbs.get(zone)!.setFromObject(obj);
+  } else {
+    return aabbs.get(zone)!;
+  }
+};
+
+const zoneContains = (zone: number, position: Vector3) => {
+  return getZoneBoundingBox(zone).containsPoint(position);
+};
+
+const getZoneAudioParams = (zone: number) => {
+  return APP.audioOverrides.get(zone);
+};
+
+type AnyPredicate = (zone: number) => boolean;
+const any = (set: Set<number>, predicate: AnyPredicate) => {
+  for (const item of set) {
+    if (predicate(item)) return true;
+  }
+  return false;
+};
+
+const isUpdated = (currZones: Set<number>, prevZones: Set<Number>) => {
+  return currZones && prevZones && (currZones.size !== prevZones.size || any(currZones, zone => !prevZones.has(zone)));
+};
+
+const getSourcePosition = (() => {
+  const pos = new Vector3();
+  return (source: number) => {
+    const audio = APP.audios.get(source);
+    if (audio) {
+      audio.getWorldPosition(pos);
+    } else {
+      pos.set(0, 0, 0);
+    }
+    return pos;
+  };
+})();
+
+const applySourceParams = (source: number, params: AudioSettings) => {
+  APP.zoneOverrides.set(source, params);
+  const audio = APP.audios.get(source);
+  if (audio) {
+    updateAudioSettings(source, audio);
+  }
+};
+
+const restoreSourceParams = (source: number) => {
+  APP.zoneOverrides.delete(source);
+  const audio = APP.audios.get(source);
+  if (audio) {
+    updateAudioSettings(source, audio);
+  }
+};
+
+const setRay = (() => {
+  const direction = new Vector3();
+  return (ray: Ray, from: Vector3, to: Vector3) => {
+    ray.set(from, direction.subVectors(to, from).normalize());
+  };
+})();
+
+const exclude = (zones: Set<number>) => {
+  return (zone: number) => {
+    return !zones.has(zone);
+  };
+};
+
+const hasIntersection = (ray: Ray) => {
+  const intersectTarget = new Vector3();
+  return (zone: number) => {
+    ray.intersectBox(getZoneBoundingBox(zone), intersectTarget);
+    return intersectTarget !== null;
+  };
+};
+
+const updateSource = (() => {
+  const ray = new Ray();
+  return (
+    source: number,
+    sourcePosition: Vector3,
+    sourceZones: Set<number>,
+    listenerPosition: Vector3,
+    listenerZones: Set<number>
+  ) => {
+    setRay(ray, listenerPosition, sourcePosition);
+
+    // TODO: Reimplement the desired sorting of zones
+    const inOutParams = Array.from(sourceZones)
+      .filter(zone => AudioZone.flags[zone] & AUDIO_ZONE_FLAGS.IN_OUT)
+      .filter(exclude(listenerZones))
+      .filter(hasIntersection(ray))
+      .map(zone => getZoneAudioParams(zone))
+      .reduce(paramsReducer, null);
+
+    // TODO: Reimplement the desired sorting of zones
+    const outInParams = Array.from(listenerZones)
+      .filter(zone => AudioZone.flags[zone] & AUDIO_ZONE_FLAGS.OUT_IN)
+      .filter(exclude(sourceZones))
+      .filter(hasIntersection(ray))
+      .map(zone => getZoneAudioParams(zone))
+      .reduce(paramsReducer, null);
+
+    if (!outInParams && !inOutParams) {
+      restoreSourceParams(source);
+    } else if (outInParams && !inOutParams) {
+      applySourceParams(source, outInParams);
+    } else if (!outInParams && inOutParams) {
+      applySourceParams(source, inOutParams);
+    } else {
+      // In this case two zones ar acting over the same source simultaneously.
+      // We apply the closest zone params with the lowest gain
+      applySourceParams(
+        source,
+        Object.assign(
+          {},
+          inOutParams,
+          outInParams,
+          paramsReducer(
+            {
+              gain: outInParams?.gain
+            },
+            {
+              gain: inOutParams?.gain
+            }
+          )
+        )
+      );
+    }
+  };
+})();
+
+const REDUCED_KEYS = [
+  "gain",
+  "maxDistance",
+  "refDistance",
+  "rolloffFactor",
+  "coneInnerAngle",
+  "coneOuterAngle",
+  "coneOuterGain"
+] as const;
+type ReducedAudioSettingsKeys = typeof REDUCED_KEYS[number];
+type ReducedAudioSettings = Pick<AudioSettings, ReducedAudioSettingsKeys>;
+
+// We apply the most restrictive audio parameters
+const paramsReducer = (acc: AudioSettings, curr: AudioSettings): AudioSettings => {
+  if (!curr && !acc) return {} as AudioSettings;
+  else if (curr && !acc) return curr;
+  else if (!curr && acc) return acc;
+  else
+    return REDUCED_KEYS.reduce((result: ReducedAudioSettings, key: ReducedAudioSettingsKeys): AudioSettings => {
+      if (curr[key] !== undefined && acc[key] !== undefined) {
+        result[key] = Math.min(acc[key]!, curr[key]!);
+      } else if (curr[key] !== undefined && acc[key] === undefined) {
+        result[key] = curr[key];
+      } else if (curr[key] === undefined && acc[key] !== undefined) {
+        result[key] = acc[key];
+      }
+      return result;
+    }, {});
+};
+
+const addOrRemoveZone = (zones: Set<number>, zone: number, position: Vector3) => {
+  if (!zones) return;
+  const isInZone = isZoneEnabled(zone) && zoneContains(zone, position);
+  const wasInZone = zones.has(zone);
+  if (isInZone && !wasInZone) {
+    zones.add(zone);
+  } else if (!isInZone && wasInZone) {
+    zones.delete(zone);
+  }
+};
+
+const currZones = new Map<number, Set<number>>();
+const prevZones = new Map<number, Set<number>>();
+const aabbs = new Map<number, Box3>();
+
+const listenerPos = new Vector3();
+const audioZoneQuery = defineQuery([AudioZone]);
+const audioZoneEnterQuery = enterQuery(audioZoneQuery);
+const audioZoneExitQuery = exitQuery(audioZoneQuery);
+const audioZoneSourceQuery = defineQuery([AudioEmitter]);
+const audioZoneSourceEnterQuery = enterQuery(audioZoneSourceQuery);
+const audioZoneSourceExitQuery = exitQuery(audioZoneSourceQuery);
+const audioZoneListenerQuery = defineQuery([AudioListenerTag]);
+const audioZoneListenerEnterQuery = enterQuery(audioZoneListenerQuery);
+const audioZoneListenerExitQuery = exitQuery(audioZoneListenerQuery);
+
+export function audioZoneSystem(world: HubsWorld) {
+  [...audioZoneSourceEnterQuery(world), ...audioZoneListenerEnterQuery(world)].forEach(entity => {
+    currZones.set(entity, new Set());
+    prevZones.set(entity, new Set());
+  });
+  [...audioZoneSourceExitQuery(world), ...audioZoneListenerExitQuery(world)].forEach(entity => {
+    currZones.delete(entity);
+    prevZones.delete(entity);
+  });
+
+  audioZoneEnterQuery(world).forEach(zone => {
+    const obj = APP.world.eid2obj.get(zone)!;
+    const aabb = new Box3();
+    aabb.setFromObject(obj);
+    aabbs.set(zone, aabb);
+  });
+  audioZoneExitQuery(world).forEach(zone => {
+    aabbs.delete(zone);
+    debugObjects.delete(zone);
+  });
+
+  const listener = APP.audioListener.eid!;
+  const zones = audioZoneQuery(world);
+  const listenersQuery = audioZoneListenerQuery(world);
+  const sourcesQuery = audioZoneSourceQuery(world);
+
+  zones.forEach(zone => {
+    const shouldShowDebug =
+      (AudioZone.flags[zone] & AUDIO_ZONE_FLAGS.DEBUG && APP.store.state.preferences.showAudioDebugPanel) || true;
+    if (shouldShowDebug) {
+      !debugObjects.has(zone) && addZoneDebugObject(world, zone);
+    } else {
+      debugObjects.has(zone) && releaseZoneDebugObject(world, zone);
+    }
+
+    APP.audioListener.getWorldPosition(listenerPos);
+    addOrRemoveZone(currZones.get(listener)!, zone, listenerPos);
+    sourcesQuery.forEach((source: number) => {
+      addOrRemoveZone(currZones.get(source)!, zone, getSourcePosition(source));
+    });
+  });
+
+  sourcesQuery.forEach(source => {
+    const isListenerUpdated = isUpdated(currZones.get(listener)!, prevZones.get(listener)!);
+    const isSourceUpdated = isUpdated(currZones.get(source)!, prevZones.get(source)!);
+    if (isListenerUpdated || isSourceUpdated) {
+      updateSource(source, getSourcePosition(source), currZones.get(source)!, listenerPos, currZones.get(listener)!);
+    }
+  });
+
+  [...sourcesQuery, ...listenersQuery].forEach(entity => {
+    const zones = prevZones.get(entity);
+    if (zones) {
+      zones.clear();
+      currZones.get(entity)?.forEach(zone => zones.add(zone));
+    }
+  });
+}

--- a/src/bit-systems/audio-zone-system.ts
+++ b/src/bit-systems/audio-zone-system.ts
@@ -291,19 +291,19 @@ export function audioZoneSystem(world: HubsWorld) {
   if (!zones.length) return;
 
   const listener = APP.audioListener.eid!;
-  const listenersQuery = audioZoneListenerQuery(world);
-  const emittersQuery = audioEmitterQuery(world);
+  const listeners = audioZoneListenerQuery(world);
+  const emitters = audioEmitterQuery(world);
 
+  APP.audioListener.getWorldPosition(listenerPos);
   zones.forEach(zoneEid => {
-    APP.audioListener.getWorldPosition(listenerPos);
     addOrRemoveZone(currZones.get(listener)!, zoneEid, listenerPos);
-    emittersQuery.forEach((emitterEid: number) => {
+    emitters.forEach((emitterEid: number) => {
       addOrRemoveZone(currZones.get(emitterEid)!, zoneEid, getEmitterPosition(emitterEid));
     });
   });
 
-  emittersQuery.forEach(emitterEid => {
-    const isListenerUpdated = isUpdated(currZones.get(listener)!, prevZones.get(listener)!);
+  const isListenerUpdated = isUpdated(currZones.get(listener)!, prevZones.get(listener)!);
+  emitters.forEach(emitterEid => {
     const isEmitterUpdated = isUpdated(currZones.get(emitterEid)!, prevZones.get(emitterEid)!);
     if (isListenerUpdated || isEmitterUpdated) {
       updateEmitter(
@@ -316,7 +316,7 @@ export function audioZoneSystem(world: HubsWorld) {
     }
   });
 
-  [...emittersQuery, ...listenersQuery].forEach(entityEid => {
+  [...emitters, ...listeners].forEach(entityEid => {
     const zones = prevZones.get(entityEid);
     if (zones) {
       zones.clear();

--- a/src/bit-systems/audio-zone-system.ts
+++ b/src/bit-systems/audio-zone-system.ts
@@ -243,6 +243,9 @@ const audioZoneListenerExitQuery = exitQuery(audioZoneListenerQuery);
 const audioZoneDebugQuery = defineQuery([AudioZone, AudioDebugChanged]);
 
 export function audioZoneSystem(world: HubsWorld) {
+  const zones = audioZoneQuery(world);
+  if (!zones.length) return;
+
   [...audioZoneSourceEnterQuery(world), ...audioZoneListenerEnterQuery(world)].forEach(entity => {
     currZones.set(entity, new Set());
     prevZones.set(entity, new Set());
@@ -264,7 +267,6 @@ export function audioZoneSystem(world: HubsWorld) {
   });
 
   const listener = APP.audioListener.eid!;
-  const zones = audioZoneQuery(world);
   const listenersQuery = audioZoneListenerQuery(world);
   const sourcesQuery = audioZoneSourceQuery(world);
 

--- a/src/bit-systems/audio-zone-system.ts
+++ b/src/bit-systems/audio-zone-system.ts
@@ -20,20 +20,21 @@ const debugMaterial = new MeshBasicMaterial({
 
 const addZoneDebugObject = (world: HubsWorld, zone: number) => {
   const geometry = new BoxGeometry();
-  const obj = new Mesh(geometry, debugMaterial);
-  const aabb = new BoxHelper(obj, DEBUG_BBAA_COLOR);
+  const mesh = new Mesh(geometry, debugMaterial);
+  const helper = new BoxHelper(mesh, DEBUG_BBAA_COLOR);
 
-  const parent = APP.world.eid2obj.get(zone) as Object3D;
-  parent.add(aabb);
+  const parent = world.eid2obj.get(zone) as Object3D;
+  parent.add(helper);
   parent.updateMatrixWorld(true);
 
-  debugObjects.set(zone, obj);
+  debugObjects.set(zone, helper);
 };
 
 const releaseZoneDebugObject = (world: HubsWorld, zone: number) => {
-  const obj = debugObjects.get(zone)!;
-  obj?.removeFromParent();
-  disposeNode(obj);
+  const helper = debugObjects.get(zone)!;
+  helper?.removeFromParent();
+  disposeNode(helper);
+  debugObjects.delete(zone);
 };
 
 const isZoneEnabled = (zone: number): boolean => {

--- a/src/bit-systems/media-loading.ts
+++ b/src/bit-systems/media-loading.ts
@@ -1,7 +1,7 @@
 import { addComponent, defineQuery, enterQuery, exitQuery, hasComponent, removeComponent, removeEntity } from "bitecs";
 import { Vector3 } from "three";
 import { HubsWorld } from "../app";
-import { GLTFModel, MediaLoader, Networked, ObjectMenuTarget } from "../bit-components";
+import { GLTFModel, MediaLoaded, MediaLoader, Networked, ObjectMenuTarget } from "../bit-components";
 import { ErrorObject } from "../prefabs/error-object";
 import { LoadingObject } from "../prefabs/loading-object";
 import { animate } from "../utils/animate";
@@ -145,6 +145,8 @@ function* loadMedia(world: HubsWorld, eid: EntityID) {
       throw new UnsupportedMediaTypeError(eid, urlData.mediaType);
     }
     media = yield* loader(world, urlData);
+    addComponent(world, MediaLoaded, media);
+    MediaLoaded.rootRef[media] = eid;
   } catch (e) {
     console.error(e);
     media = renderAsEntity(world, ErrorObject());

--- a/src/bit-systems/media-loading.ts
+++ b/src/bit-systems/media-loading.ts
@@ -146,7 +146,6 @@ function* loadMedia(world: HubsWorld, eid: EntityID) {
     }
     media = yield* loader(world, urlData);
     addComponent(world, MediaLoaded, media);
-    MediaLoaded.rootRef[media] = eid;
   } catch (e) {
     console.error(e);
     media = renderAsEntity(world, ErrorObject());

--- a/src/bit-systems/video-menu-system.ts
+++ b/src/bit-systems/video-menu-system.ts
@@ -10,6 +10,7 @@ import {
   HeldRemoteRight,
   HoveredRemoteRight,
   MediaVideo,
+  MediaVideoPlaybackChanged,
   NetworkedVideo,
   VideoMenu,
   VideoMenuItem
@@ -103,6 +104,7 @@ export function videoMenuSystem(world: HubsWorld, userinput: any) {
         pauseIndicatorObj.visible = true;
         rightMenuIndicatorCoroutine = coroutine(animateIndicator(world, VideoMenu.pauseIndicatorRef[eid]));
       }
+      addComponent(world, MediaVideoPlaybackChanged, videoEid);
     }
 
     const videoIsFacingCamera = isFacingCamera(world.eid2obj.get(videoEid)!);

--- a/src/bit-systems/video-menu-system.ts
+++ b/src/bit-systems/video-menu-system.ts
@@ -22,8 +22,7 @@ import { animate } from "../utils/animate";
 import { coroutine } from "../utils/coroutine";
 import { easeOutQuadratic } from "../utils/easing";
 import { isFacingCamera } from "../utils/three-utils";
-import { MediaVideo2Audio } from "./video-system";
-import { EMITTER_FLAGS } from "./audio-emitter-system";
+import { Emitter2Audio, EMITTER_FLAGS } from "./audio-emitter-system";
 
 const videoMenuQuery = defineQuery([VideoMenu]);
 const hoverRightVideoQuery = defineQuery([HoveredRemoteRight, MediaVideo]);
@@ -95,7 +94,7 @@ export function videoMenuSystem(world: HubsWorld, userinput: any) {
       const playIndicatorObj = world.eid2obj.get(VideoMenu.playIndicatorRef[eid])!;
       const pauseIndicatorObj = world.eid2obj.get(VideoMenu.pauseIndicatorRef[eid])!;
 
-      const audioEid = MediaVideo2Audio.get(videoEid)!;
+      const audioEid = Emitter2Audio.get(videoEid)!;
       if (video.paused) {
         video.play();
         AudioEmitter.flags[audioEid] &= ~EMITTER_FLAGS.PAUSED;

--- a/src/bit-systems/video-menu-system.ts
+++ b/src/bit-systems/video-menu-system.ts
@@ -4,13 +4,13 @@ import { clamp, mapLinear } from "three/src/math/MathUtils";
 import { Text as TroikaText } from "troika-three-text";
 import { HubsWorld } from "../app";
 import {
+  AudioEmitter,
   CursorRaycastable,
   EntityStateDirty,
   Held,
   HeldRemoteRight,
   HoveredRemoteRight,
   MediaVideo,
-  MediaVideoPlaybackChanged,
   NetworkedVideo,
   VideoMenu,
   VideoMenuItem
@@ -22,6 +22,8 @@ import { animate } from "../utils/animate";
 import { coroutine } from "../utils/coroutine";
 import { easeOutQuadratic } from "../utils/easing";
 import { isFacingCamera } from "../utils/three-utils";
+import { MediaVideo2Audio } from "./video-system";
+import { EMITTER_FLAGS } from "./audio-emitter-system";
 
 const videoMenuQuery = defineQuery([VideoMenu]);
 const hoverRightVideoQuery = defineQuery([HoveredRemoteRight, MediaVideo]);
@@ -93,18 +95,20 @@ export function videoMenuSystem(world: HubsWorld, userinput: any) {
       const playIndicatorObj = world.eid2obj.get(VideoMenu.playIndicatorRef[eid])!;
       const pauseIndicatorObj = world.eid2obj.get(VideoMenu.pauseIndicatorRef[eid])!;
 
+      const audioEid = MediaVideo2Audio.get(videoEid)!;
       if (video.paused) {
         video.play();
+        AudioEmitter.flags[audioEid] &= ~EMITTER_FLAGS.PAUSED;
         playIndicatorObj.visible = true;
         pauseIndicatorObj.visible = false;
         rightMenuIndicatorCoroutine = coroutine(animateIndicator(world, VideoMenu.playIndicatorRef[eid]));
       } else {
         video.pause();
+        AudioEmitter.flags[audioEid] |= EMITTER_FLAGS.PAUSED;
         playIndicatorObj.visible = false;
         pauseIndicatorObj.visible = true;
         rightMenuIndicatorCoroutine = coroutine(animateIndicator(world, VideoMenu.pauseIndicatorRef[eid]));
       }
-      addComponent(world, MediaVideoPlaybackChanged, videoEid);
     }
 
     const videoIsFacingCamera = isFacingCamera(world.eid2obj.get(videoEid)!);

--- a/src/bit-systems/video-system.ts
+++ b/src/bit-systems/video-system.ts
@@ -1,102 +1,12 @@
-import { addComponent, addEntity, defineQuery, enterQuery, exitQuery, hasComponent, removeComponent } from "bitecs";
-import {
-  PositionalAudio,
-  Audio as StereoAudio,
-  Mesh,
-  MeshStandardMaterial,
-  AudioListener as ThreeAudioListener
-} from "three";
+import { defineQuery, enterQuery, hasComponent } from "bitecs";
+import { Mesh, MeshStandardMaterial } from "three";
 import { HubsWorld } from "../app";
-import { AudioEmitter, AudioSettingsChanged, MediaVideo, NetworkedVideo, Owned } from "../bit-components";
-import { AudioType, SourceType } from "../components/audio-params";
+import { MediaVideo, NetworkedVideo, Owned } from "../bit-components";
 import { AudioSystem } from "../systems/audio-system";
-import { applySettings, getCurrentAudioSettings, updateAudioSettings } from "../update-audio-settings";
-import { addObject3DComponent, swapObject3DComponent } from "../utils/jsx-entity";
-
-type AudioObject3D = StereoAudio | PositionalAudio;
-type AudioConstructor<T> = new (listener: ThreeAudioListener) => T;
+import { makeAudioSourceEntity } from "./audio-emitter-system";
 
 enum Flags {
   PAUSED = 1 << 0
-}
-
-function makeAudioSourceEntity(world: HubsWorld, video: HTMLVideoElement, audioSystem: AudioSystem) {
-  const eid = addEntity(world);
-  APP.sourceType.set(eid, SourceType.MEDIA_VIDEO);
-  if (video.paused) {
-    APP.isAudioPaused.add(eid);
-  } else {
-    APP.isAudioPaused.delete(eid);
-  }
-
-  let audio;
-  const { audioType } = getCurrentAudioSettings(eid);
-  const audioListener = APP.audioListener;
-  if (audioType === AudioType.PannerNode) {
-    audio = new PositionalAudio(audioListener);
-  } else {
-    audio = new StereoAudio(audioListener);
-  }
-  addComponent(world, AudioEmitter, eid);
-  addObject3DComponent(world, eid, audio);
-
-  audio.gain.gain.value = 0;
-  audioSystem.addAudio({ sourceType: SourceType.MEDIA_VIDEO, node: audio });
-
-  const audioSrcEl = video;
-  audio.setMediaElementSource(audioSrcEl);
-
-  APP.audios.set(eid, audio);
-  updateAudioSettings(eid, audio);
-
-  // Original audio source volume can now be restored as audio systems will take over
-  audioSrcEl.volume = 1;
-  return eid;
-}
-
-function isPositionalAudio(node: AudioObject3D): node is PositionalAudio {
-  return (node as any).panner !== undefined;
-}
-
-function swapAudioType<T extends AudioObject3D>(
-  world: HubsWorld,
-  audioSystem: AudioSystem,
-  eid: number,
-  NewType: AudioConstructor<T>
-) {
-  const audio = world.eid2obj.get(eid)! as AudioObject3D;
-  audio.disconnect();
-  audioSystem.removeAudio({ node: audio });
-
-  const newAudio = new NewType(APP.audioListener);
-  newAudio.setNodeSource(audio.source!);
-  audioSystem.addAudio({ sourceType: SourceType.MEDIA_VIDEO, node: newAudio });
-  APP.audios.set(eid, newAudio);
-
-  audio.parent!.add(newAudio);
-  audio.removeFromParent();
-
-  swapObject3DComponent(world, eid, newAudio);
-}
-
-// TODO this can live outside of video system
-const staleAudioEmittersQuery = defineQuery([AudioEmitter, AudioSettingsChanged]);
-function audioEmitterSystem(world: HubsWorld, audioSystem: AudioSystem) {
-  staleAudioEmittersQuery(world).forEach(function (eid) {
-    const audio = world.eid2obj.get(eid)! as PositionalAudio | StereoAudio;
-    const settings = getCurrentAudioSettings(eid);
-    const isPannerNode = isPositionalAudio(audio);
-
-    // TODO this needs more testing
-    if (!isPannerNode && settings.audioType === AudioType.PannerNode) {
-      swapAudioType(world, audioSystem, eid, PositionalAudio);
-    } else if (isPannerNode && settings.audioType === AudioType.Stereo) {
-      swapAudioType(world, audioSystem, eid, StereoAudio);
-    }
-
-    applySettings(audio, settings);
-    removeComponent(world, AudioSettingsChanged, eid);
-  });
 }
 
 const OUT_OF_SYNC_SEC = 5;
@@ -118,8 +28,6 @@ export function videoSystem(world: HubsWorld, audioSystem: AudioSystem) {
     // Note in media-video we call updateMatrixWorld here to force PositionalAudio's updateMatrixWorld to run even
     // if it has an invisible parent. We don't want to have invisible parents now.
   });
-
-  audioEmitterSystem(world, audioSystem);
 
   networkedVideoQuery(world).forEach(function (eid) {
     const video = (world.eid2obj.get(eid) as any).material.map.image as HTMLVideoElement;

--- a/src/bit-systems/video-system.ts
+++ b/src/bit-systems/video-system.ts
@@ -1,7 +1,7 @@
-import { defineQuery, enterQuery, hasComponent } from "bitecs";
+import { defineQuery, enterQuery, exitQuery, hasComponent, removeComponent } from "bitecs";
 import { Mesh, MeshStandardMaterial } from "three";
 import { HubsWorld } from "../app";
-import { MediaVideo, NetworkedVideo, Owned } from "../bit-components";
+import { MediaVideo, MediaVideoPlaybackChanged, NetworkedVideo, Owned } from "../bit-components";
 import { AudioSystem } from "../systems/audio-system";
 import { makeAudioSourceEntity } from "./audio-emitter-system";
 
@@ -9,26 +9,44 @@ enum Flags {
   PAUSED = 1 << 0
 }
 
+const video2audio = new Map<number, number>();
+
 const OUT_OF_SYNC_SEC = 5;
 const networkedVideoQuery = defineQuery([NetworkedVideo]);
 const mediaVideoQuery = defineQuery([MediaVideo]);
 const mediaVideoEnterQuery = enterQuery(mediaVideoQuery);
+const mediaVideoExitQuery = exitQuery(mediaVideoQuery);
+const mediaPlaybackUpdated = defineQuery([MediaVideo, MediaVideoPlaybackChanged]);
 export function videoSystem(world: HubsWorld, audioSystem: AudioSystem) {
-  mediaVideoEnterQuery(world).forEach(function (eid) {
-    const videoObj = world.eid2obj.get(eid) as Mesh;
+  mediaVideoEnterQuery(world).forEach(function (videoEid) {
+    const videoObj = world.eid2obj.get(videoEid) as Mesh;
     const video = (videoObj.material as MeshStandardMaterial).map!.image as HTMLVideoElement;
-    if (MediaVideo.autoPlay[eid]) {
+    if (MediaVideo.autoPlay[videoEid]) {
       video.play().catch(() => {
         // Need to deal with the fact play() may fail if user has not interacted with browser yet.
         console.error("Error auto-playing video.");
       });
     }
-    const audio = world.eid2obj.get(makeAudioSourceEntity(world, video, audioSystem))!;
+    const audioEid = makeAudioSourceEntity(world, video, audioSystem);
+    video2audio.set(videoEid, audioEid);
+    const audio = world.eid2obj.get(audioEid)!;
     videoObj.add(audio);
     // Note in media-video we call updateMatrixWorld here to force PositionalAudio's updateMatrixWorld to run even
     // if it has an invisible parent. We don't want to have invisible parents now.
   });
-
+  mediaVideoExitQuery(world).forEach(videoEid => {
+    video2audio.delete(videoEid);
+  });
+  mediaPlaybackUpdated(world).forEach(videoEid => {
+    const audio = video2audio.get(videoEid)!;
+    const videoEl = (world.eid2obj.get(videoEid) as any).material.map.image as HTMLVideoElement;
+    if (videoEl.paused) {
+      APP.isAudioPaused.add(audio);
+    } else {
+      APP.isAudioPaused.delete(audio);
+    }
+    removeComponent(world, MediaVideoPlaybackChanged, videoEid);
+  });
   networkedVideoQuery(world).forEach(function (eid) {
     const video = (world.eid2obj.get(eid) as any).material.map.image as HTMLVideoElement;
     if (hasComponent(world, Owned, eid)) {

--- a/src/bit-systems/video-system.ts
+++ b/src/bit-systems/video-system.ts
@@ -55,12 +55,12 @@ export function videoSystem(world: HubsWorld, audioSystem: AudioSystem) {
     video2audio.delete(videoEid);
   });
   mediaPlaybackUpdated(world).forEach(videoEid => {
-    const audio = video2audio.get(videoEid)!;
+    const audioEid = video2audio.get(videoEid)!;
     const videoEl = (world.eid2obj.get(videoEid) as any).material.map.image as HTMLVideoElement;
     if (videoEl.paused) {
-      APP.isAudioPaused.add(audio);
+      APP.isAudioPaused.add(audioEid);
     } else {
-      APP.isAudioPaused.delete(audio);
+      APP.isAudioPaused.delete(audioEid);
     }
     removeComponent(world, MediaVideoPlaybackChanged, videoEid);
   });

--- a/src/components/audio-params.ts
+++ b/src/components/audio-params.ts
@@ -28,16 +28,16 @@ export enum PanningModelType {
 }
 
 export interface AudioSettings {
-  audioType?: AudioType;
-  distanceModel?: DistanceModelType;
-  panningModel?: PanningModelType;
-  rolloffFactor?: number;
-  refDistance?: number;
-  maxDistance?: number;
-  coneInnerAngle?: number;
-  coneOuterAngle?: number;
-  coneOuterGain?: number;
-  gain?: number;
+  audioType: AudioType;
+  distanceModel: DistanceModelType;
+  panningModel: PanningModelType;
+  rolloffFactor: number;
+  refDistance: number;
+  maxDistance: number;
+  coneInnerAngle: number;
+  coneOuterAngle: number;
+  coneOuterGain: number;
+  gain: number;
 }
 
 export const AvatarAudioDefaults: AudioSettings = {

--- a/src/components/audio-params.ts
+++ b/src/components/audio-params.ts
@@ -28,16 +28,16 @@ export enum PanningModelType {
 }
 
 export interface AudioSettings {
-  audioType: AudioType;
-  distanceModel: DistanceModelType;
-  panningModel: PanningModelType;
-  rolloffFactor: number;
-  refDistance: number;
-  maxDistance: number;
-  coneInnerAngle: number;
-  coneOuterAngle: number;
-  coneOuterGain: number;
-  gain: number;
+  audioType?: AudioType;
+  distanceModel?: DistanceModelType;
+  panningModel?: PanningModelType;
+  rolloffFactor?: number;
+  refDistance?: number;
+  maxDistance?: number;
+  coneInnerAngle?: number;
+  coneOuterAngle?: number;
+  coneOuterGain?: number;
+  gain?: number;
 }
 
 export const AvatarAudioDefaults: AudioSettings = {

--- a/src/inflators/audio-params.ts
+++ b/src/inflators/audio-params.ts
@@ -1,0 +1,11 @@
+import { HubsWorld } from "../app";
+import { AudioSettings } from "../components/audio-params";
+import { updateAudioSettings } from "../update-audio-settings";
+
+export function inflateAudioParams(world: HubsWorld, eid: number, params: AudioSettings) {
+  APP.audioOverrides.set(eid, params);
+  const audio = APP.audios.get(eid);
+  if (audio) {
+    updateAudioSettings(eid, audio);
+  }
+}

--- a/src/inflators/audio-params.ts
+++ b/src/inflators/audio-params.ts
@@ -1,6 +1,5 @@
 import { HubsWorld } from "../app";
 import { AudioSettings } from "../components/audio-params";
-import { updateAudioSettings } from "../update-audio-settings";
 
 export function inflateAudioParams(world: HubsWorld, eid: number, params: AudioSettings) {
   APP.audioOverrides.set(eid, params);

--- a/src/inflators/audio-params.ts
+++ b/src/inflators/audio-params.ts
@@ -4,8 +4,4 @@ import { updateAudioSettings } from "../update-audio-settings";
 
 export function inflateAudioParams(world: HubsWorld, eid: number, params: AudioSettings) {
   APP.audioOverrides.set(eid, params);
-  const audio = APP.audios.get(eid);
-  if (audio) {
-    updateAudioSettings(eid, audio);
-  }
 }

--- a/src/inflators/audio-params.ts
+++ b/src/inflators/audio-params.ts
@@ -1,6 +1,9 @@
+import { addComponent } from "bitecs";
 import { HubsWorld } from "../app";
+import { AudioParams } from "../bit-components";
 import { AudioSettings } from "../components/audio-params";
 
 export function inflateAudioParams(world: HubsWorld, eid: number, params: AudioSettings) {
+  addComponent(world, AudioParams, eid);
   APP.audioOverrides.set(eid, params);
 }

--- a/src/inflators/audio-zone.ts
+++ b/src/inflators/audio-zone.ts
@@ -1,0 +1,39 @@
+import { addComponent } from "bitecs";
+import { HubsWorld } from "../app";
+import { AudioZone } from "../bit-components";
+
+export const AUDIO_ZONE_FLAGS = {
+  ENABLED: 1 << 0,
+  IN_OUT: 1 << 1,
+  OUT_IN: 1 << 2,
+  DEBUG: 1 << 3,
+  DYNAMIC: 1 << 4
+};
+
+export type AudioZoneParams = {
+  enabled: boolean;
+  inOut: boolean;
+  outIn: boolean;
+  debuggable: boolean;
+  dynamic: boolean;
+};
+
+const DEFAULTS = {
+  enabled: true,
+  inOut: true,
+  outIn: true,
+  debuggable: true,
+  dynamic: false // This will make the zone to update it's world matrix every frame. Only use for movable zones
+};
+
+export function inflateAudioZone(world: HubsWorld, eid: number, params: AudioZoneParams) {
+  params = Object.assign({}, DEFAULTS, params);
+
+  addComponent(world, AudioZone, eid);
+
+  params.enabled && (AudioZone.flags[eid] |= AUDIO_ZONE_FLAGS.ENABLED);
+  params.inOut && (AudioZone.flags[eid] |= AUDIO_ZONE_FLAGS.IN_OUT);
+  params.outIn && (AudioZone.flags[eid] |= AUDIO_ZONE_FLAGS.OUT_IN);
+  params.debuggable && (AudioZone.flags[eid] |= AUDIO_ZONE_FLAGS.DEBUG);
+  params.dynamic && (AudioZone.flags[eid] |= AUDIO_ZONE_FLAGS.DYNAMIC);
+}

--- a/src/systems/audio-debug-system.js
+++ b/src/systems/audio-debug-system.js
@@ -119,8 +119,8 @@ AFRAME.registerSystem("audio-debug", {
 
         audio.getWorldPosition(sourcePos);
         audio.getWorldDirection(sourceDir);
-        this.sourcePositions[sourceNum] = this.navMeshObject.worldToLocal(sourcePos).clone(); // TODO: Use Vector3 pool
-        this.sourceOrientations[sourceNum] = this.navMeshObject.worldToLocal(sourceDir).clone();
+        this.sourcePositions[sourceNum] = sourcePos; // TODO: Use Vector3 pool
+        this.sourceOrientations[sourceNum] = sourceDir;
 
         const panner = audio.panner || fakePanner;
 

--- a/src/systems/audio-debug.vert
+++ b/src/systems/audio-debug.vert
@@ -5,7 +5,7 @@ varying vec2 vUv;
 varying vec3 vNormal;
 void main()
 {
-  vNormal = normalize(normal);
-  gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-  vUv = position.xz;
+  vNormal=normalize(normal);
+  gl_Position=projectionMatrix*modelViewMatrix*vec4(position,1.);
+  vUv=(modelMatrix*vec4(position,1.)).xz;
 }

--- a/src/systems/hubs-systems.ts
+++ b/src/systems/hubs-systems.ts
@@ -70,6 +70,7 @@ import { pdfSystem } from "../bit-systems/pdf-system";
 import { particleEmitterSystem } from "../bit-systems/particle-emitter";
 import { audioEmitterSystem } from "../bit-systems/audio-emitter-system";
 import { audioZoneSystem } from "../bit-systems/audio-zone-system";
+import { audioDebugSystem } from "../bit-systems/audio-debug-system";
 
 declare global {
   interface Window {
@@ -251,6 +252,7 @@ export function mainTick(xrFrame: XRFrame, renderer: WebGLRenderer, scene: Scene
   simpleWaterSystem(world);
 
   videoTextureSystem(world);
+  audioDebugSystem(world);
 
   deleteEntitySystem(world, aframeSystems.userinput);
   destroyAtExtremeDistanceSystem(world);

--- a/src/systems/hubs-systems.ts
+++ b/src/systems/hubs-systems.ts
@@ -69,6 +69,7 @@ import { simpleWaterSystem } from "../bit-systems/simple-water";
 import { pdfSystem } from "../bit-systems/pdf-system";
 import { particleEmitterSystem } from "../bit-systems/particle-emitter";
 import { audioEmitterSystem } from "../bit-systems/audio-emitter-system";
+import { audioZoneSystem } from "../bit-systems/audio-zone-system";
 
 declare global {
   interface Window {
@@ -243,12 +244,13 @@ export function mainTick(xrFrame: XRFrame, renderer: WebGLRenderer, scene: Scene
   pdfSystem(world);
   mediaFramesSystem(world);
   hubsSystems.audioZonesSystem.tick(hubsSystems.el);
+  audioZoneSystem(world);
+  audioEmitterSystem(world, hubsSystems.audioSystem);
   hubsSystems.gainSystem.tick();
   hubsSystems.nameTagSystem.tick();
   simpleWaterSystem(world);
 
   videoTextureSystem(world);
-  audioEmitterSystem(world, hubsSystems.audioSystem);
 
   deleteEntitySystem(world, aframeSystems.userinput);
   destroyAtExtremeDistanceSystem(world);

--- a/src/systems/hubs-systems.ts
+++ b/src/systems/hubs-systems.ts
@@ -68,6 +68,7 @@ import { uvScrollSystem } from "../bit-systems/uv-scroll";
 import { simpleWaterSystem } from "../bit-systems/simple-water";
 import { pdfSystem } from "../bit-systems/pdf-system";
 import { particleEmitterSystem } from "../bit-systems/particle-emitter";
+import { audioEmitterSystem } from "../bit-systems/audio-emitter-system";
 
 declare global {
   interface Window {
@@ -247,6 +248,7 @@ export function mainTick(xrFrame: XRFrame, renderer: WebGLRenderer, scene: Scene
   simpleWaterSystem(world);
 
   videoTextureSystem(world);
+  audioEmitterSystem(world, hubsSystems.audioSystem);
 
   deleteEntitySystem(world, aframeSystems.userinput);
   destroyAtExtremeDistanceSystem(world);

--- a/src/systems/remove-object3D-system.js
+++ b/src/systems/remove-object3D-system.js
@@ -21,6 +21,7 @@ import { gltfCache } from "../components/gltf-model-plus";
 import { releaseTextureByKey } from "../utils/load-texture";
 import { disposeMaterial, traverseSome, disposeNode } from "../utils/three-utils";
 import { forEachMaterial } from "../utils/material-utils";
+import { cleanupAudio } from "../bit-systems/audio-emitter-system";
 
 function cleanupObjOnExit(Component, f) {
   const query = exitQuery(defineQuery([Component]));
@@ -49,11 +50,7 @@ const cleanupGLTFs = cleanupObjOnExit(GLTFModel, obj => {
 const cleanupLights = cleanupObjOnExit(LightTag, obj => obj.dispose());
 const cleanupTexts = cleanupObjOnExit(Text, obj => obj.dispose());
 const cleanupMediaFrames = cleanupObjOnExit(MediaFrame, obj => obj.geometry.dispose());
-const cleanupAudioEmitters = cleanupObjOnExit(AudioEmitter, obj => {
-  obj.disconnect();
-  const audioSystem = AFRAME.scenes[0].systems["hubs-systems"].audioSystem;
-  audioSystem.removeAudio({ node: obj });
-});
+const cleanupAudioEmitters = cleanupObjOnExit(AudioEmitter, obj => cleanupAudio(obj));
 const cleanupImages = cleanupObjOnExit(MediaImage, obj => {
   releaseTextureByKey(APP.getString(MediaImage.cacheKey[obj.eid]));
   obj.geometry.dispose();

--- a/src/systems/remove-object3D-system.js
+++ b/src/systems/remove-object3D-system.js
@@ -74,7 +74,7 @@ const cleanupSimpleWaters = cleanupObjOnExit(SimpleWater, obj => {
 });
 const cleanupMirrors = cleanupObjOnExit(Mirror, obj => obj.dispose());
 const cleanupParticleSystem = cleanupObjOnExit(ParticleEmitterTag, obj => disposeNode(obj));
-const cleanupAudioDebugSystems = cleanupOnExit(NavMesh, eid => cleanupAudioDebugNavMesh(eid));
+const cleanupAudioDebugSystem = cleanupOnExit(NavMesh, eid => cleanupAudioDebugNavMesh(eid));
 
 // TODO This feels messy and brittle
 //
@@ -138,7 +138,7 @@ export function removeObject3DSystem(world) {
   cleanupSimpleWaters(world);
   cleanupMirrors(world);
   cleanupParticleSystem(world);
-  cleanupAudioDebugSystems(world);
+  cleanupAudioDebugSystem(world);
 
   // Finally remove all the entities we just removed from the eid2obj map
   entities.forEach(removeObjFromMap);

--- a/src/systems/remove-object3D-system.js
+++ b/src/systems/remove-object3D-system.js
@@ -15,13 +15,15 @@ import {
   Slice9,
   Text,
   VideoMenu,
-  ParticleEmitterTag
+  ParticleEmitterTag,
+  NavMesh
 } from "../bit-components";
 import { gltfCache } from "../components/gltf-model-plus";
 import { releaseTextureByKey } from "../utils/load-texture";
 import { disposeMaterial, traverseSome, disposeNode } from "../utils/three-utils";
 import { forEachMaterial } from "../utils/material-utils";
 import { cleanupAudio } from "../bit-systems/audio-emitter-system";
+import { cleanupAudioDebugNavMesh } from "../bit-systems/audio-debug-system";
 
 function cleanupObjOnExit(Component, f) {
   const query = exitQuery(defineQuery([Component]));
@@ -72,6 +74,7 @@ const cleanupSimpleWaters = cleanupObjOnExit(SimpleWater, obj => {
 });
 const cleanupMirrors = cleanupObjOnExit(Mirror, obj => obj.dispose());
 const cleanupParticleSystem = cleanupObjOnExit(ParticleEmitterTag, obj => disposeNode(obj));
+const cleanupAudioDebugSystems = cleanupOnExit(NavMesh, eid => cleanupAudioDebugNavMesh(eid));
 
 // TODO This feels messy and brittle
 //
@@ -135,6 +138,7 @@ export function removeObject3DSystem(world) {
   cleanupSimpleWaters(world);
   cleanupMirrors(world);
   cleanupParticleSystem(world);
+  cleanupAudioDebugSystems(world);
 
   // Finally remove all the entities we just removed from the eid2obj map
   entities.forEach(removeObjFromMap);

--- a/src/utils/jsx-entity.ts
+++ b/src/utils/jsx-entity.ts
@@ -77,6 +77,9 @@ import { SimpleWaterParams, inflateSimpleWater } from "../inflators/simple-water
 import { inflatePDF, PDFParams } from "../inflators/pdf";
 import { MirrorParams, inflateMirror } from "../inflators/mirror";
 import { inflateParticleEmitter, ParticleEmitterParams } from "../inflators/particle-emitter";
+import { AudioZoneParams, inflateAudioZone } from "../inflators/audio-zone";
+import { AudioSettings } from "../components/audio-params";
+import { inflateAudioParams } from "../inflators/audio-params";
 
 preload(
   new Promise(resolve => {
@@ -230,6 +233,8 @@ export interface ComponentData {
   grabbable?: GrabbableParams;
   billboard?: { onlyY: boolean };
   mirror?: MirrorParams;
+  audioZone?: AudioZoneParams;
+  audioParams?: AudioSettings;
 }
 
 export interface JSXComponentData extends ComponentData {
@@ -374,7 +379,9 @@ export const commonInflators: Required<{ [K in keyof ComponentData]: InflatorFn 
   // inflators that create Object3Ds
   ambientLight: inflateAmbientLight,
   directionalLight: inflateDirectionalLight,
-  mirror: inflateMirror
+  mirror: inflateMirror,
+  audioZone: inflateAudioZone,
+  audioParams: inflateAudioParams
 };
 
 const jsxInflators: Required<{ [K in keyof JSXComponentData]: InflatorFn }> = {

--- a/types/glsl.d.ts
+++ b/types/glsl.d.ts
@@ -1,0 +1,14 @@
+declare module "*.glsl" {
+  const value: string;
+  export default value;
+}
+
+declare module "*.vert" {
+  const value: string;
+  export default value;
+}
+
+declare module "*.frag" {
+  const value: string;
+  export default value;
+}


### PR DESCRIPTION
This PR migrates the audio zones and audio debug systems (mainly because having the debugger is handy to test the audio zones).

- Audio emitter is now a separate system that only handles `media-video` emitters for now (will handle all the audio emitter sources at a later stage)
- The new audio zones and audio debugger only work with `media-video` emitters yet. I prefer to migrate the rest of the audio related components first (`audio-target`, `zone-audio-source`) in other separater PRs before consolidating them in the audio emitters system.
- I've added a `MediaVideoPlaybackChanged` component to handle media-video playback state changes.
- There is a new `AudioListenerTag` component and that makes the `audio-zone-system` to handle the audio zone entities in two different groups: emitters and listeners. Another option would have been to have a specific `AudioZoneEntity` tag but in most cases that would require to double tag most of the entities so I opted for reusing existing tags.
- I'm using `getScene` as the init point for the service, not sure if this is what we want or we prefer a direct init method call in `hubs-systems` init as we currently do for the previous systems.
- I've updated the audio debug shader to work in world space instead of local space. That removed the need to transforming the emitters to local object space and also allows reusing that material for any object that wants to show audio debug info (ie. in case we support multiple nav meshes in the future)
- New audio zones dynamic parameter to avoid world matrix updates unless the audio zone is marked as movable. Requires: https://github.com/MozillaReality/hubs-blender-exporter/pull/198

Next steps on audio migration:
- Migrate `audio-target` and `audio-zone-source`
- Migrate `audio-gain-system`
- Migrate `audio-settings-system`
- Integrate avatar audio related systems (`avatar-audio-source` and `avatar-volume-controls`) in the new bitecs audio systems.
- Integrate `linked-media` in the new bitecs audio systems.
- Look into bypassing the ThreeJS Audio nodes and handle them by just using the WebAudio API.
- As I make progress in the above tasks I'll be separating the previous APP audio stores into a separated set of stores hanging from `AudioEmitter`: `AudioEmitter.sourceType`, `AudioEmitter.audioOverrides`, etc to keep both AFrame and BitECS systems separated.