### PR TITLE
Chat command to add media with options

### DIFF
--- a/src/message-dispatch.js
+++ b/src/message-dispatch.js
@@ -9,6 +9,7 @@ import { ExitReason } from "./react-components/room/ExitedRoomScreen";
 import { LogMessageType } from "./react-components/room/ChatSidebar";
 import { createNetworkedEntity } from "./utils/create-networked-entity";
 import qsTruthy from "./utils/qs_truthy";
+import { add } from "./utils/chat-commands";
 
 let uiRoot;
 // Handles user-entered messages
@@ -235,6 +236,10 @@ export default class MessageDispatch extends EventTarget {
             this.log(LogMessageType.invalidAudioNormalizationRange);
           }
         }
+        break;
+      case "add":
+        const avatarPov = document.querySelector("#avatar-pov-node").object3D;
+        add(APP.world, avatarPov, args);
         break;
     }
   };

--- a/src/message-dispatch.js
+++ b/src/message-dispatch.js
@@ -238,8 +238,10 @@ export default class MessageDispatch extends EventTarget {
         }
         break;
       case "add":
-        const avatarPov = document.querySelector("#avatar-pov-node").object3D;
-        add(APP.world, avatarPov, args);
+        {
+          const avatarPov = document.querySelector("#avatar-pov-node").object3D;
+          add(APP.world, avatarPov, args);
+        }
         break;
     }
   };

--- a/src/utils/chat-commands.ts
+++ b/src/utils/chat-commands.ts
@@ -1,0 +1,56 @@
+import { Object3D } from "three";
+import { HubsWorld } from "../app";
+import { createNetworkedEntity } from "./create-networked-entity";
+
+function checkFlag(args: string[], flag: string) {
+  return !!args.find(s => s === flag);
+}
+
+function usage(
+  commandName: string,
+  flags: string[] | null,
+  options: Map<string, string[]> | null,
+  rest: string[] | null
+) {
+  let str = [];
+  str.push(`/${commandName}`);
+  if (flags) {
+    flags.forEach(flag => {
+      str.push(`[${flag}]`);
+    });
+  }
+  if (options) {
+    options.forEach((values, key) => {
+      str.push(`[${key}=(${values.join(" | ")})]`);
+    });
+  }
+  if (rest) {
+    rest.forEach(s => str.push(`<${s}>`));
+  }
+  return str.join(" ");
+}
+
+const FLAG_NO_RESIZE = "--no-resize";
+const FLAG_NO_RECENTER = "--no-recenter";
+const FLAG_NO_ANIMATE_LOAD = "--no-animate";
+const FLAG_NO_OBJECT_MENU = "--no-menu";
+const ADD_FLAGS = [FLAG_NO_RESIZE, FLAG_NO_RECENTER, FLAG_NO_ANIMATE_LOAD, FLAG_NO_OBJECT_MENU];
+export function add(world: HubsWorld, avatarPov: Object3D, args: string[]) {
+  args = args.filter(arg => arg);
+  if (args.length) {
+    const initialData = {
+      src: args[args.length - 1],
+      resize: !checkFlag(args, FLAG_NO_RESIZE),
+      recenter: !checkFlag(args, FLAG_NO_RECENTER),
+      animateLoad: !checkFlag(args, FLAG_NO_ANIMATE_LOAD),
+      isObjectMenuTarget: !checkFlag(args, FLAG_NO_OBJECT_MENU)
+    };
+    console.log("Adding media", initialData);
+    const eid = createNetworkedEntity(world, "media", initialData);
+    const obj = APP.world.eid2obj.get(eid)!;
+    obj.position.copy(avatarPov.localToWorld(new THREE.Vector3(0, 0, -1.5)));
+    obj.lookAt(avatarPov.getWorldPosition(new THREE.Vector3()));
+  } else {
+    console.log(usage("add", ADD_FLAGS, null, ["url"]));
+  }
+}

--- a/src/utils/chat-commands.ts
+++ b/src/utils/chat-commands.ts
@@ -31,18 +31,18 @@ function usage(
 }
 
 const FLAG_RESIZE = "--resize";
-const FLAG_NO_RECENTER = "--no-recenter";
-const FLAG_NO_ANIMATE_LOAD = "--no-animate";
+const FLAG_RECENTER = "--recenter";
+const FLAG_ANIMATE_LOAD = "--animate";
 const FLAG_NO_OBJECT_MENU = "--no-menu";
-const ADD_FLAGS = [FLAG_RESIZE, FLAG_NO_RECENTER, FLAG_NO_ANIMATE_LOAD, FLAG_NO_OBJECT_MENU];
+const ADD_FLAGS = [FLAG_RESIZE, FLAG_RECENTER, FLAG_ANIMATE_LOAD, FLAG_NO_OBJECT_MENU];
 export function add(world: HubsWorld, avatarPov: Object3D, args: string[]) {
   args = args.filter(arg => arg);
   if (args.length) {
     const initialData = {
       src: args[args.length - 1],
       resize: checkFlag(args, FLAG_RESIZE),
-      recenter: !checkFlag(args, FLAG_NO_RECENTER),
-      animateLoad: !checkFlag(args, FLAG_NO_ANIMATE_LOAD),
+      recenter: checkFlag(args, FLAG_RECENTER),
+      animateLoad: checkFlag(args, FLAG_ANIMATE_LOAD),
       isObjectMenuTarget: !checkFlag(args, FLAG_NO_OBJECT_MENU)
     };
     console.log("Adding media", initialData);

--- a/src/utils/chat-commands.ts
+++ b/src/utils/chat-commands.ts
@@ -30,17 +30,17 @@ function usage(
   return str.join(" ");
 }
 
-const FLAG_NO_RESIZE = "--no-resize";
+const FLAG_RESIZE = "--resize";
 const FLAG_NO_RECENTER = "--no-recenter";
 const FLAG_NO_ANIMATE_LOAD = "--no-animate";
 const FLAG_NO_OBJECT_MENU = "--no-menu";
-const ADD_FLAGS = [FLAG_NO_RESIZE, FLAG_NO_RECENTER, FLAG_NO_ANIMATE_LOAD, FLAG_NO_OBJECT_MENU];
+const ADD_FLAGS = [FLAG_RESIZE, FLAG_NO_RECENTER, FLAG_NO_ANIMATE_LOAD, FLAG_NO_OBJECT_MENU];
 export function add(world: HubsWorld, avatarPov: Object3D, args: string[]) {
   args = args.filter(arg => arg);
   if (args.length) {
     const initialData = {
       src: args[args.length - 1],
-      resize: !checkFlag(args, FLAG_NO_RESIZE),
+      resize: checkFlag(args, FLAG_RESIZE),
       recenter: !checkFlag(args, FLAG_NO_RECENTER),
       animateLoad: !checkFlag(args, FLAG_NO_ANIMATE_LOAD),
       isObjectMenuTarget: !checkFlag(args, FLAG_NO_OBJECT_MENU)


### PR DESCRIPTION
This chat command was requested by the art team, who wants to load assets without the media loading system resizing, recentering, or animating them in. These features can be enabled with optional flags.

Usage: 
```
/add [--resize] [--recenter] [--animate] [--no-menu] <url>
```