### PR TITLE
Add chat command to respawn

### DIFF
--- a/src/message-dispatch.js
+++ b/src/message-dispatch.js
@@ -9,7 +9,7 @@ import { ExitReason } from "./react-components/room/ExitedRoomScreen";
 import { LogMessageType } from "./react-components/room/ChatSidebar";
 import { createNetworkedEntity } from "./utils/create-networked-entity";
 import qsTruthy from "./utils/qs_truthy";
-import { add } from "./utils/chat-commands";
+import { add, respawn } from "./utils/chat-commands";
 
 let uiRoot;
 // Handles user-entered messages
@@ -241,6 +241,13 @@ export default class MessageDispatch extends EventTarget {
         {
           const avatarPov = document.querySelector("#avatar-pov-node").object3D;
           add(APP.world, avatarPov, args);
+        }
+        break;
+      case "respawn":
+        {
+          const sceneEl = AFRAME.scenes[0];
+          const characterController = this.scene.systems["hubs-systems"].characterController;
+          respawn(APP.world, sceneEl, characterController);
         }
         break;
     }

--- a/src/utils/chat-commands.ts
+++ b/src/utils/chat-commands.ts
@@ -4,6 +4,7 @@ import { HubsWorld } from "../app";
 import { moveToSpawnPoint } from "../bit-systems/waypoint";
 import { CharacterControllerSystem } from "../systems/character-controller-system";
 import { createNetworkedEntity } from "./create-networked-entity";
+import qsTruthy from "./qs_truthy";
 
 function checkFlag(args: string[], flag: string) {
   return !!args.find(s => s === flag);
@@ -59,9 +60,15 @@ export function add(world: HubsWorld, avatarPov: Object3D, args: string[]) {
 }
 
 export function respawn(world: HubsWorld, scene: AScene, characterController: CharacterControllerSystem) {
-  if (scene.is("entered")) {
-    moveToSpawnPoint(world, characterController);
-  } else {
+  if (!scene.is("entered")) {
     console.error("Cannot respawn until you have entered the room.");
+    return;
   }
+
+  if (!qsTruthy("newLoader")) {
+    console.error("This command only works with the newLoader query string parameter.");
+    return;
+  }
+
+  moveToSpawnPoint(world, characterController);
 }

--- a/src/utils/chat-commands.ts
+++ b/src/utils/chat-commands.ts
@@ -1,5 +1,8 @@
+import { AScene } from "aframe";
 import { Object3D } from "three";
 import { HubsWorld } from "../app";
+import { moveToSpawnPoint } from "../bit-systems/waypoint";
+import { CharacterControllerSystem } from "../systems/character-controller-system";
 import { createNetworkedEntity } from "./create-networked-entity";
 
 function checkFlag(args: string[], flag: string) {
@@ -52,5 +55,13 @@ export function add(world: HubsWorld, avatarPov: Object3D, args: string[]) {
     obj.lookAt(avatarPov.getWorldPosition(new THREE.Vector3()));
   } else {
     console.log(usage("add", ADD_FLAGS, null, ["url"]));
+  }
+}
+
+export function respawn(world: HubsWorld, scene: AScene, characterController: CharacterControllerSystem) {
+  if (scene.is("entered")) {
+    moveToSpawnPoint(world, characterController);
+  } else {
+    console.error("Cannot respawn until you have entered the room.");
   }
 }


### PR DESCRIPTION
This chat command was requested by the art team, who wants to quickly reset back to the spawn point(s) to test whether they are configured as expected.

Usage:
```
/respawn
```