### PR TITLE
Move AudioLoader to bitecs

### DIFF
--- a/src/bit-systems/media-loading.ts
+++ b/src/bit-systems/media-loading.ts
@@ -14,6 +14,7 @@ import { loadImage } from "../utils/load-image";
 import { loadModel } from "../utils/load-model";
 import { loadPDF } from "../utils/load-pdf";
 import { loadVideo } from "../utils/load-video";
+import { loadAudio } from "../utils/load-audio";
 import { MediaType, mediaTypeName, resolveMediaInfo } from "../utils/media-utils";
 import { EntityID } from "../utils/networking-types";
 
@@ -36,7 +37,9 @@ const loaderForMediaType = {
     world: HubsWorld,
     { accessibleUrl, contentType }: { accessibleUrl: string; contentType: string }
   ) => loadModel(world, accessibleUrl, contentType, true),
-  [MediaType.PDF]: (world: HubsWorld, { accessibleUrl }: { accessibleUrl: string }) => loadPDF(world, accessibleUrl)
+  [MediaType.PDF]: (world: HubsWorld, { accessibleUrl }: { accessibleUrl: string }) => loadPDF(world, accessibleUrl),
+  [MediaType.AUDIO]: (world: HubsWorld, { accessibleUrl }: { accessibleUrl: string }) =>
+    loadAudio(world, accessibleUrl),
 };
 
 export const MEDIA_LOADER_FLAGS = {

--- a/src/utils/jsx-entity.ts
+++ b/src/utils/jsx-entity.ts
@@ -344,6 +344,7 @@ export interface JSXComponentData extends ComponentData {
 
 export interface GLTFComponentData extends ComponentData {
   pdf?: PDFLoaderParams;
+  audio?: VideoLoaderParams;
   video?: VideoLoaderParams;
   image?: ImageLoaderParams;
   model?: ModelLoaderParams;
@@ -444,6 +445,11 @@ const jsxInflators: Required<{ [K in keyof JSXComponentData]: InflatorFn }> = {
 export const gltfInflators: Required<{ [K in keyof GLTFComponentData]: InflatorFn }> = {
   ...commonInflators,
   pdf: inflatePDFLoader,
+  // Temporarily reuse video loader for audio because of
+  // their processings are similar.
+  // TODO: Write separated audio loader properly because
+  //       their processings are not perfectly indentical.
+  audio: inflateVideoLoader,
   video: inflateVideoLoader,
   image: inflateImageLoader,
   model: inflateModelLoader,

--- a/src/utils/load-audio-texture.ts
+++ b/src/utils/load-audio-texture.ts
@@ -1,0 +1,42 @@
+import { VideoTexture } from "three";
+import { createVideoOrAudioEl } from "../utils/media-utils";
+
+// TODO: Replace async with function*?
+// TODO: Integrate with loadVideoTexture in load-audio-texture?
+export async function loadAudioTexture(src: string) : Promise<{texture: VideoTexture, ratio: number}> {
+  const videoEl = createVideoOrAudioEl("video") as HTMLVideoElement;
+  const texture = new VideoTexture(videoEl);
+
+  const isReady = () => {
+    return videoEl.readyState > 0;
+  };
+
+  return new Promise((resolve, reject) => {
+    let pollTimeout: ReturnType<typeof setTimeout>;
+    const failLoad = function (e: Event) {
+      videoEl.onerror = null;
+      clearTimeout(pollTimeout);
+      reject(e);
+    };
+
+    videoEl.src = src;
+    videoEl.onerror = failLoad;
+
+    // NOTE: We used to use the canplay event here to yield the texture, but that fails to fire on iOS Safari
+    // and also sometimes in Chrome it seems.
+    // TODO: Check if this is still true
+    const poll = () => {
+      if (isReady()) {
+        videoEl.onerror = null;
+        // TODO: AudioIcon image must be used to render and
+	//       ratio must be of the AudioIcon. Fix this.
+	//       Also see the comment in utils/load-audio.
+        resolve({ texture, ratio: 3.0 / 4.0 });
+      } else {
+        pollTimeout = setTimeout(poll, 500);
+      }
+    };
+
+    poll();
+  });
+}

--- a/src/utils/load-audio.tsx
+++ b/src/utils/load-audio.tsx
@@ -1,0 +1,34 @@
+/** @jsx createElementEntity */
+import { createElementEntity } from "../utils/jsx-entity";
+import { ProjectionMode } from "./projection-mode";
+import { VideoTexture } from "three";
+import { renderAsEntity } from "../utils/jsx-entity";
+import { loadAudioTexture } from "../utils/load-audio-texture";
+import { HubsWorld } from "../app";
+
+export function* loadAudio(world: HubsWorld, url: string) {
+  const { texture, ratio }: { texture: VideoTexture; ratio: number } = yield loadAudioTexture(url);
+
+  // TODO: VideoTexture.image must be content that be played
+  //       in video-system. And it is also used to render.
+  //       It is audio here so the object will be rendered as
+  //       black. Audio icon must be rendered. Fix this.
+
+  return renderAsEntity(
+    world,
+    <entity
+      name="Audio"
+      networked
+      networkedVideo
+      grabbable={{ cursor: true, hand: false }}
+      // Audio and Video are handled very similarly in 3D scene
+      // so create as video
+      video={{
+        texture,
+        ratio,
+        autoPlay: true,
+        projection: ProjectionMode.FLAT
+      }}
+    ></entity>
+  );
+}


### PR DESCRIPTION
This PR adds AudioLoader to bitecs.

This PR focuses on just works with minimal change. It may need be rewritten elegantly later.

Rendering audio icon is not supported yet. It is rendered as black for now. Supporting it may require some refactoring and should be in another PR.