### PR TITLE
Adds new github action to deploy to a new smoke test instance 

### DIFF
--- a/.github/workflows/hubs-RetPageOrigin.yml
+++ b/.github/workflows/hubs-RetPageOrigin.yml
@@ -5,13 +5,12 @@ on:
     paths-ignore: ["README.md"]
   workflow_dispatch:
     inputs:
-      smoke-room:
+      smokeroom-choice:
         type: choice
         description: select smoke room
         options:
           - "smoke01"
           - "smoke02"
-
 jobs:
   turkeyGitops:
     uses: mozilla/hubs-ops/.github/workflows/turkeyGitops.yml@feature/smoke
@@ -21,7 +20,7 @@ jobs:
       personal_k8s_deployment: hubs
       personal_k8s_deployment_container: hubs
       bio_script_path: scripts/hab-wrap-and-push.sh
-      smoke-room: ${{inputs.smoke-room}}
+      smoke-room: ${{github.event.inputs.smokeroom-choice}}
     secrets:
       DOCKER_HUB_PWD: ${{ secrets.DOCKER_HUB_PWD }}
       GCP_TURKEYGITOPS_SA_JSON: ${{ secrets.GCP_TURKEYGITOPS_SA_JSON  }}

--- a/.github/workflows/hubs-RetPageOrigin.yml
+++ b/.github/workflows/hubs-RetPageOrigin.yml
@@ -11,6 +11,9 @@ on:
         options:
           - "smoke01"
           - "smoke02"
+          - "smoke03"
+          - "smoke04"
+          - "smoke05"
 jobs:
   turkeyGitops:
     uses: mozilla/hubs-ops/.github/workflows/turkeyGitops.yml@feature/smoke
@@ -20,7 +23,7 @@ jobs:
       personal_k8s_deployment: hubs
       personal_k8s_deployment_container: hubs
       bio_script_path: scripts/hab-wrap-and-push.sh
-      smoke-room: ${{github.event.inputs.smokeroom-choice}}
+      smoke-room: ${{inputs.smokeroom-choice}}
     secrets:
       DOCKER_HUB_PWD: ${{ secrets.DOCKER_HUB_PWD }}
       GCP_TURKEYGITOPS_SA_JSON: ${{ secrets.GCP_TURKEYGITOPS_SA_JSON  }}

--- a/.github/workflows/hubs-RetPageOrigin.yml
+++ b/.github/workflows/hubs-RetPageOrigin.yml
@@ -23,7 +23,7 @@ jobs:
       personal_k8s_deployment: hubs
       personal_k8s_deployment_container: hubs
       bio_script_path: scripts/hab-wrap-and-push.sh
-      smoke-room: ${{inputs.smokeroom-choice}}
+      smoke-instance: ${{inputs.smokeroom-choice}}
     secrets:
       DOCKER_HUB_PWD: ${{ secrets.DOCKER_HUB_PWD }}
       GCP_TURKEYGITOPS_SA_JSON: ${{ secrets.GCP_TURKEYGITOPS_SA_JSON  }}

--- a/.github/workflows/hubs-RetPageOrigin.yml
+++ b/.github/workflows/hubs-RetPageOrigin.yml
@@ -4,6 +4,14 @@ on:
     branches:
     paths-ignore: ["README.md"]
   workflow_dispatch:
+    inputs:
+      smoke-room:
+        type: choice
+        description: select smoke room
+        options:
+          - "smoke01"
+          - "smoke02"
+
 jobs:
   turkeyGitops:
     uses: mozilla/hubs-ops/.github/workflows/turkeyGitops.yml@feature/smoke
@@ -13,6 +21,7 @@ jobs:
       personal_k8s_deployment: hubs
       personal_k8s_deployment_container: hubs
       bio_script_path: scripts/hab-wrap-and-push.sh
+      smoke-room: ${{inputs.smoke-room}}
     secrets:
       DOCKER_HUB_PWD: ${{ secrets.DOCKER_HUB_PWD }}
       GCP_TURKEYGITOPS_SA_JSON: ${{ secrets.GCP_TURKEYGITOPS_SA_JSON  }}

--- a/.github/workflows/hubs-RetPageOrigin.yml
+++ b/.github/workflows/hubs-RetPageOrigin.yml
@@ -20,8 +20,8 @@ jobs:
     with:
       registry: mozillareality
       dockerfile: RetPageOriginDockerfile
-      personal_k8s_deployment: hubs
-      personal_k8s_deployment_container: hubs
+      k8s_deployment: hubs
+      k8s_deployment_container: hubs
       bio_script_path: scripts/hab-wrap-and-push.sh
       smoke-instance: ${{inputs.smokeroom-choice}}
     secrets:

--- a/.github/workflows/hubs-RetPageOrigin.yml
+++ b/.github/workflows/hubs-RetPageOrigin.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   turkeyGitops:
-    uses: mozilla/hubs-ops/.github/workflows/turkeyGitops.yml@master
+    uses: mozilla/hubs-ops/.github/workflows/turkeyGitops.yml@feature/smoke
     with:
       registry: mozillareality
       dockerfile: RetPageOriginDockerfile

--- a/.github/workflows/hubs-RetPageOrigin.yml
+++ b/.github/workflows/hubs-RetPageOrigin.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       smokeroom-choice:
         type: choice
-        description: select smoke room
+        description: Select smoke instance
         options:
           - "smoke01"
           - "smoke02"
@@ -16,7 +16,7 @@ on:
           - "smoke05"
 jobs:
   turkeyGitops:
-    uses: mozilla/hubs-ops/.github/workflows/turkeyGitops.yml@feature/smoke
+    uses: mozilla/hubs-ops/.github/workflows/turkeyGitops.yml@master
     with:
       registry: mozillareality
       dockerfile: RetPageOriginDockerfile


### PR DESCRIPTION
This will enable setting the docker image for any new smoke test instances configured in the dev cluster. 