### PR TITLE
Fix type issues for simple-water and particle-emitter

### DIFF
--- a/src/inflators/particle-emitter.ts
+++ b/src/inflators/particle-emitter.ts
@@ -24,8 +24,16 @@ export type ParticleEmitterParams = {
   lifetime: number;
   lifetimeRandomness: number;
   particleCount: number;
-  startVelocity: [number, number];
-  endVelocity: [number, number, number];
+  startVelocity: {
+    x: number;
+    y: number;
+    z: number;
+  };
+  endVelocity: {
+    x: number;
+    y: number;
+    z: number;
+  };
   velocityCurve: string;
   angularVelocity: number;
 };
@@ -47,8 +55,8 @@ const DEFAULTS = {
   lifetime: 5,
   lifetimeRandomness: 5,
   particleCount: 100,
-  startVelocity: [0, 0, 0.5],
-  endVelocity: [0, 0, 0],
+  startVelocity: { x: 0, y: 0, z: 0.5 },
+  endVelocity: { x: 0, y: 0, z: 0 },
   velocityCurve: "linear",
   angularVelocity: 0
 };
@@ -79,8 +87,8 @@ export function inflateParticleEmitter(world: HubsWorld, eid: number, params: Pa
   particleEmitter.lifetime = params.lifetime;
   particleEmitter.lifetimeRandomness = params.lifetimeRandomness;
   particleEmitter.particleCount = params.particleCount;
-  particleEmitter.startVelocity.fromArray(params.startVelocity);
-  particleEmitter.endVelocity.fromArray(params.endVelocity);
+  particleEmitter.startVelocity.set(params.startVelocity.x, params.startVelocity.y, params.startVelocity.z);
+  particleEmitter.endVelocity.set(params.endVelocity.x, params.endVelocity.y, params.endVelocity.z);
   particleEmitter.velocityCurve = params.velocityCurve;
   particleEmitter.angularVelocity = params.angularVelocity;
 

--- a/src/inflators/simple-water.ts
+++ b/src/inflators/simple-water.ts
@@ -8,11 +8,23 @@ export type SimpleWaterParams = {
   opacity: number;
   color: string;
   tideHeight: number;
-  tideScale: [number, number];
-  tideSpeed: [number, number];
+  tideScale: {
+    x: number;
+    y: number;
+  };
+  tideSpeed: {
+    x: number;
+    y: number;
+  };
   waveHeight: number;
-  waveScale: [number, number];
-  waveSpeed: [number, number];
+  waveScale: {
+    x: number;
+    y: number;
+  };
+  waveSpeed: {
+    x: number;
+    y: number;
+  };
   ripplesScale: number;
   ripplesSpeed: number;
 };
@@ -21,11 +33,11 @@ const DEFAULTS = {
   opacity: 1,
   color: "#0054df",
   tideHeight: 0.01,
-  tideScale: [1, 1],
-  tideSpeed: [0.5, 0.5],
+  tideScale: { x: 1, y: 1 },
+  tideSpeed: { x: 0.5, y: 0.5 },
   waveHeight: 0.1,
-  waveScale: [1, 20],
-  waveSpeed: [0.05, 6],
+  waveScale: { x: 1, y: 20 },
+  waveSpeed: { x: 0.05, y: 6 },
   ripplesScale: 1,
   ripplesSpeed: 0.25
 };
@@ -37,11 +49,11 @@ export function inflateSimpleWater(world: HubsWorld, eid: number, params: Simple
   simpleWater.opacity = params.opacity;
   simpleWater.color.set(params.color);
   simpleWater.tideHeight = params.tideHeight;
-  simpleWater.tideScale.fromArray(params.tideScale);
-  simpleWater.tideSpeed.fromArray(params.tideSpeed);
+  simpleWater.tideScale.set(params.tideScale.x, params.tideScale.y);
+  simpleWater.tideSpeed.set(params.tideSpeed.x, params.tideSpeed.y);
   simpleWater.waveHeight = params.waveHeight;
-  simpleWater.waveScale.fromArray(params.waveScale);
-  simpleWater.waveSpeed.fromArray(params.waveSpeed);
+  simpleWater.waveScale.set(params.waveScale.x, params.waveScale.y);
+  simpleWater.waveSpeed.set(params.waveSpeed.x, params.waveSpeed.y);
   simpleWater.ripplesScale = params.ripplesScale;
   simpleWater.ripplesSpeed = params.ripplesSpeed;
 

--- a/src/utils/jsx-entity.ts
+++ b/src/utils/jsx-entity.ts
@@ -229,9 +229,7 @@ export interface ComponentData {
   directionalLight?: DirectionalLightParams;
   grabbable?: GrabbableParams;
   billboard?: { onlyY: boolean };
-  simpleWater?: SimpleWaterParams;
   mirror?: MirrorParams;
-  particleEmitter?: ParticleEmitterParams;
 }
 
 export interface JSXComponentData extends ComponentData {
@@ -350,6 +348,8 @@ export interface GLTFComponentData extends ComponentData {
   skybox: SkyboxParams;
   fog: FogParams;
   background: BackgroundParams;
+  simpleWater?: SimpleWaterParams;
+  particleEmitter?: ParticleEmitterParams;
 }
 
 declare global {
@@ -374,9 +374,7 @@ export const commonInflators: Required<{ [K in keyof ComponentData]: InflatorFn 
   // inflators that create Object3Ds
   ambientLight: inflateAmbientLight,
   directionalLight: inflateDirectionalLight,
-  simpleWater: inflateSimpleWater,
-  mirror: inflateMirror,
-  particleEmitter: inflateParticleEmitter
+  mirror: inflateMirror
 };
 
 const jsxInflators: Required<{ [K in keyof JSXComponentData]: InflatorFn }> = {
@@ -441,7 +439,9 @@ export const gltfInflators: Required<{ [K in keyof GLTFComponentData]: InflatorF
   spawner: inflateSpawner,
   videoTextureTarget: inflateVideoTextureTarget,
   videoTextureSource: createDefaultInflator(VideoTextureSource),
-  uvScroll: inflateUVScroll
+  uvScroll: inflateUVScroll,
+  simpleWater: inflateSimpleWater,
+  particleEmitter: inflateParticleEmitter
 };
 
 function jsxInflatorExists(name: string): name is keyof JSXComponentData {


### PR DESCRIPTION
This fixes a bug that I've seen in earlier code of mine. I think the reason the bug was introduced was that after adding support for the glTF inflator I wanted the component to also work for JSX entities and I changed the component parameters data to array obviously breaking the glTF support. I've fixed that.

I've also limited the `simple-water` and `particle-emitter` inflators support only to glTF as I've seen that for this type of components we are not really adding support for JSX (see `UVScroll` component) and adding support for JSX would require adding another inflator which I'm not sure if it's worth i. Is this assumption correct or we want parity?