### PR TITLE
Add noResize query string parameter

### DIFF
--- a/src/load-media-on-paste-or-drop.ts
+++ b/src/load-media-on-paste-or-drop.ts
@@ -26,7 +26,7 @@ export function spawnFromUrl(text: string) {
   const eid = createNetworkedEntity(APP.world, "media", {
     src: text,
     recenter: true,
-    resize: true,
+    resize: !qsTruthy("noResize"),
     animateLoad: true,
     isObjectMenuTarget: true
   });
@@ -49,7 +49,7 @@ export async function spawnFromFileList(files: FileList) {
         return {
           src: srcUrl.href,
           recenter: true,
-          resize: true,
+          resize: !qsTruthy("noResize"),
           animateLoad: true,
           isObjectMenuTarget: true
         };
@@ -59,7 +59,7 @@ export async function spawnFromFileList(files: FileList) {
         return {
           src: "error",
           recenter: true,
-          resize: true,
+          resize: !qsTruthy("noResize"),
           animateLoad: true,
           isObjectMenuTarget: true
         };


### PR DESCRIPTION
Adds `noResize` as a query string parameter that will disable resizing of media that is dragged into the window or pasted from a URL.

This feature was requested by the art team so that they could easily drag `glb` files from their file explorer into their browser window as they are working on them, and seeing their models at regular size. 