### PR TITLE
Add Dash video play support to bitecs

### DIFF
--- a/src/bit-systems/media-loading.ts
+++ b/src/bit-systems/media-loading.ts
@@ -28,8 +28,10 @@ const loaderForMediaType = {
     world: HubsWorld,
     { accessibleUrl, contentType }: { accessibleUrl: string; contentType: string }
   ) => loadImage(world, accessibleUrl, contentType),
-  [MediaType.VIDEO]: (world: HubsWorld, { accessibleUrl }: { accessibleUrl: string }) =>
-    loadVideo(world, accessibleUrl),
+  [MediaType.VIDEO]: (
+    world: HubsWorld,
+	{ accessibleUrl, contentType }: { accessibleUrl: string, contentType: string }
+  ) => loadVideo(world, accessibleUrl, contentType),
   [MediaType.MODEL]: (
     world: HubsWorld,
     { accessibleUrl, contentType }: { accessibleUrl: string; contentType: string }

--- a/src/textures/DashVideoTexture.ts
+++ b/src/textures/DashVideoTexture.ts
@@ -34,18 +34,14 @@ export class DashVideoTexture extends VideoTexture {
   ) { 
     super(video, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy);
     this.isDashVideoTexture = true;
-    this.player = null; // Set via setPlayer()
-  }
-
-  setPlayer(player: MediaPlayer) : DashVideoTexture {
-    this.player = player;
-    return this;
+    this.player = null; // Set by user later
   }
 
   dispose() {
     super.dispose();
     if (this.player !== null) {
       this.player.reset();
+      this.player = null;
     }
   }
 }

--- a/src/textures/DashVideoTexture.ts
+++ b/src/textures/DashVideoTexture.ts
@@ -1,0 +1,51 @@
+import {
+  Mapping,
+  TextureDataType,
+  TextureFilter,
+  PixelFormat,
+  VideoTexture,
+  Wrapping
+} from "three";
+
+interface MediaPlayer {
+  reset: () => {};
+};
+
+// DashVideoTexture class holds dash MediaPlayer
+// and disposes it when texture is disposed.
+// Note: Assumes that player is not shared among
+//       other textures. If we want to allow shared
+//       player we may need refcount.
+
+export class DashVideoTexture extends VideoTexture {
+  isDashVideoTexture: boolean;
+  player: MediaPlayer | null;
+
+  constructor(
+    video: HTMLVideoElement,
+    mapping?: Mapping,
+    wrapS?: Wrapping,
+    wrapT?: Wrapping,
+    magFilter?: TextureFilter,
+    minFilter?: TextureFilter,
+    format?: PixelFormat,
+    type?: TextureDataType,
+    anisotropy?: number
+  ) { 
+    super(video, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy);
+    this.isDashVideoTexture = true;
+    this.player = null; // Set via setPlayer()
+  }
+
+  setPlayer(player: MediaPlayer) : DashVideoTexture {
+    this.player = player;
+    return this;
+  }
+
+  dispose() {
+    super.dispose();
+    if (this.player !== null) {
+      this.player.reset();
+    }
+  }
+}

--- a/src/utils/load-video-texture.js
+++ b/src/utils/load-video-texture.js
@@ -21,7 +21,7 @@ export async function loadVideoTexture(src, contentType) {
 
     if (contentType.startsWith("application/dash")) {
       texture = new DashVideoTexture(videoEl);
-      texture.setPlayer(createDashPlayer(src, videoEl, failLoad));
+      texture.player = createDashPlayer(src, videoEl, failLoad);
     } else {
       texture = new VideoTexture(videoEl);
       videoEl.src = src;

--- a/src/utils/load-video-texture.js
+++ b/src/utils/load-video-texture.js
@@ -1,9 +1,10 @@
-import { createVideoOrAudioEl } from "../utils/media-utils";
-export async function loadVideoTexture(src) {
+import { LinearFilter, VideoTexture, sRGBEncoding } from "three";
+import { DashVideoTexture } from "../textures/DashVideoTexture";
+import { createDashPlayer, createVideoOrAudioEl } from "./media-utils";
+
+export async function loadVideoTexture(src, contentType) {
   const videoEl = createVideoOrAudioEl("video");
-  const texture = new THREE.VideoTexture(videoEl);
-  texture.minFilter = THREE.LinearFilter;
-  texture.encoding = THREE.sRGBEncoding;
+  let texture;
 
   const isReady = () => {
     return (texture.image.videoHeight || texture.image.height) && (texture.image.videoWidth || texture.image.width);
@@ -11,14 +12,24 @@ export async function loadVideoTexture(src) {
 
   return new Promise((resolve, reject) => {
     let pollTimeout;
+
     const failLoad = function (e) {
       videoEl.onerror = null;
       clearTimeout(pollTimeout);
       reject(e);
     };
 
-    videoEl.src = src;
-    videoEl.onerror = failLoad;
+    if (contentType.startsWith("application/dash")) {
+      texture = new DashVideoTexture(videoEl);
+      texture.setPlayer(createDashPlayer(src, videoEl, failLoad));
+    } else {
+      texture = new VideoTexture(videoEl);
+      videoEl.src = src;
+      videoEl.onerror = failLoad;
+    }
+
+    texture.minFilter = LinearFilter;
+    texture.encoding = sRGBEncoding;
 
     // NOTE: We used to use the canplay event here to yield the texture, but that fails to fire on iOS Safari
     // and also sometimes in Chrome it seems.

--- a/src/utils/load-video.tsx
+++ b/src/utils/load-video.tsx
@@ -6,8 +6,8 @@ import { renderAsEntity } from "../utils/jsx-entity";
 import { loadVideoTexture } from "../utils/load-video-texture";
 import { HubsWorld } from "../app";
 
-export function* loadVideo(world: HubsWorld, url: string) {
-  const { texture, ratio }: { texture: VideoTexture; ratio: number } = yield loadVideoTexture(url);
+export function* loadVideo(world: HubsWorld, url: string, contentType: string) {
+  const { texture, ratio }: { texture: VideoTexture; ratio: number } = yield loadVideoTexture(url, contentType);
 
   return renderAsEntity(
     world,


### PR DESCRIPTION
This PR adds Dash video play support to bitecs.

The main changes are
* Make `createDashPlayer()` util function
* Add `DashVideoTexture` which holds Dash video player and dispose it when the texture is disposed
  * Currently player is saved as `texture.dash` but I don't think polluting texture is good. Making a new class may be cleaner
* `loadVideoTexture()` creates `VideoTexture` or `DashVideoTexture` depending on contentType