### PR TITLE
Add HLS video play support to bitecs

### DIFF
--- a/src/components/media-video.js
+++ b/src/components/media-video.js
@@ -1,9 +1,14 @@
 import audioIcon from "../assets/images/audio.png";
 import { paths } from "../systems/userinput/paths";
 import HLS from "hls.js";
-import { addAndArrangeMedia, createVideoOrAudioEl, createDashPlayer, createHLSPlayer, hasAudioTracks } from "../utils/media-utils";
+import {
+  addAndArrangeMedia,
+  createVideoOrAudioEl,
+  createDashPlayer,
+  createHLSPlayer,
+  hasAudioTracks
+} from "../utils/media-utils";
 import { disposeTexture } from "../utils/material-utils";
-import { proxiedUrlFor } from "../utils/media-url-utils";
 import { SOUND_CAMERA_TOOL_TOOK_SNAPSHOT } from "../systems/sound-effects-system";
 import { applyPersistentSync } from "../utils/permissions-utils";
 import { refreshMediaMirror, getCurrentMirroredMedia } from "../utils/mirror-utils";

--- a/src/textures/HLSVideoTexture.ts
+++ b/src/textures/HLSVideoTexture.ts
@@ -29,12 +29,7 @@ export class HLSVideoTexture extends VideoTexture {
   ) {
     super(video, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy);
     this.isHLSVideoTexture = true;
-    this.player = null; // Set via setPlayer()
-  }
-
-  setPlayer(player: HLSPlayer): HLSVideoTexture {
-    this.player = player;
-    return this;
+    this.player = null; // Set by user later
   }
 
   dispose() {
@@ -43,6 +38,7 @@ export class HLSVideoTexture extends VideoTexture {
       this.player.stopLoad();
       this.player.detachMedia();
       this.player.destroy();
+      this.player = null;
     }
   }
 }

--- a/src/textures/HLSVideoTexture.ts
+++ b/src/textures/HLSVideoTexture.ts
@@ -1,0 +1,48 @@
+import { Mapping, TextureDataType, TextureFilter, PixelFormat, VideoTexture, Wrapping } from "three";
+
+interface HLSPlayer {
+  stopLoad: () => {};
+  detachMedia: () => {};
+  destroy: () => {};
+}
+
+// HLSVideoTexture class holds HLS Player
+// and disposes it when texture is disposed.
+// Note: Assumes that player is not shared among
+//       other textures. If we want to allow shared
+//       player we may need refcount.
+
+export class HLSVideoTexture extends VideoTexture {
+  isHLSVideoTexture: boolean;
+  player: HLSPlayer | null;
+
+  constructor(
+    video: HTMLVideoElement,
+    mapping?: Mapping,
+    wrapS?: Wrapping,
+    wrapT?: Wrapping,
+    magFilter?: TextureFilter,
+    minFilter?: TextureFilter,
+    format?: PixelFormat,
+    type?: TextureDataType,
+    anisotropy?: number
+  ) {
+    super(video, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy);
+    this.isHLSVideoTexture = true;
+    this.player = null; // Set via setPlayer()
+  }
+
+  setPlayer(player: HLSPlayer): HLSVideoTexture {
+    this.player = player;
+    return this;
+  }
+
+  dispose() {
+    super.dispose();
+    if (this.player !== null) {
+      this.player.stopLoad();
+      this.player.detachMedia();
+      this.player.destroy();
+    }
+  }
+}

--- a/src/utils/load-video-texture.js
+++ b/src/utils/load-video-texture.js
@@ -33,11 +33,11 @@ export async function loadVideoTexture(src, contentType) {
     if (contentType.startsWith("application/dash")) {
       texture = new DashVideoTexture(videoEl);
       texture.player = createDashPlayer(src, videoEl, failLoad);
-    // TODO: Remove the dependency with AFRAME
+      // TODO: Remove the dependency with AFRAME
     } else if (AFRAME.utils.material.isHLS(src, contentType)) {
       texture = new HLSVideoTexture(videoEl);
       if (HLS.isSupported()) {
-        texture.setPlayer(createHLSPlayer(src, videoEl, failLoad));
+        texture.player = createHLSPlayer(src, videoEl, failLoad);
       } else if (!videoEl.canPlayType(contentType)) {
         failLoad("HLS unsupported");
       }

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -11,6 +11,10 @@ import Linkify from "linkify-it";
 import tlds from "tlds";
 import { mediaTypeFor } from "./media-type";
 import { MediaPlayer } from "dashjs";
+import { buildAbsoluteURL } from "url-toolkit";
+import HLS from "hls.js";
+import configs from "../utils/configs";
+import qsTruthy from "../utils/qs_truthy";
 
 import anime from "animejs";
 
@@ -672,4 +676,47 @@ export function createDashPlayer(url, videoEl, failLoad) {
   // We can also use our own HEAD request method like we use to sync NAF
   // dashPlayer.addUTCTimingSource("urn:mpeg:dash:utc:http-head:2014", location.href);
   return player;
+}
+
+export function createHLSPlayer(url, videoEl, failLoad) {
+  const corsProxyPrefix = `https://${configs.CORS_PROXY_SERVER}/`;
+  const baseUrl = url.startsWith(corsProxyPrefix) ? url.substring(corsProxyPrefix.length) : url;
+  const hls = new HLS({
+    debug: qsTruthy("hlsDebug"),
+    xhrSetup: (xhr, u) => {
+      if (u.startsWith(corsProxyPrefix)) {
+        u = u.substring(corsProxyPrefix.length);
+      }
+
+      // HACK HLS.js resolves relative urls internally, but our CORS proxying screws it up. Resolve relative to the original unproxied url.
+      // TODO extend HLS.js to allow overriding of its internal resolving instead
+      if (!u.startsWith("http")) {
+        u = buildAbsoluteURL(baseUrl, u.startsWith("/") ? u : `/${u}`);
+      }
+
+      xhr.open("GET", proxiedUrlFor(u), true);
+    }
+  });
+
+  hls.loadSource(url);
+  hls.attachMedia(videoEl);
+
+  hls.on(HLS.Events.ERROR, function (event, data) {
+    if (data.fatal) {
+      switch (data.type) {
+        case HLS.ErrorTypes.NETWORK_ERROR:
+          // try to recover network error
+          hls.startLoad();
+          break;
+        case HLS.ErrorTypes.MEDIA_ERROR:
+          hls.recoverMediaError();
+          break;
+        default:
+          failLoad(event);
+          return;
+      }
+    }
+  });
+
+  return hls;
 }


### PR DESCRIPTION
This PR adds HLS video play support to bitecs.

The main changes are

* Make `createHLSPlayer()` util function
* Add `HLSVideoTexture` which holds HLS video player and cleans up it when the texture is disposed
* `loadVideoTexture()` creates `HLSVideoTexture` if video is HLS