### PR TITLE
Handle dialog host change messages from reticulum.

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -1393,6 +1393,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     scene.emit("hub_updated", { hub });
   });
 
+  window.testChangeHost = () => {
+    hubPhxChannel.push("test_change_host", {});
+  };
+
   hubPhxChannel.on("host_changed", ({ host, port, turn }) => {
     console.log("Dialog host changed. Disconnecting from current host and connecting to the new one.", {
       hub_id: APP.hub.hub_id,

--- a/src/hub.js
+++ b/src/hub.js
@@ -1393,10 +1393,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     scene.emit("hub_updated", { hub });
   });
 
-  window.testChangeHost = () => {
-    hubPhxChannel.push("test_change_host", {});
-  };
-
   hubPhxChannel.on("host_changed", ({ host, port, turn }) => {
     console.log("Dialog host changed. Disconnecting from current host and connecting to the new one.", {
       hub_id: APP.hub.hub_id,


### PR DESCRIPTION
Reticulum may instruct us to change dialog hosts. Handle this message by disconnecting from the current dialog host and connecting to the new one.

https://github.com/mozilla/reticulum/pull/688