### PR TITLE
Add Media loading HTML support to bitecs

### DIFF
--- a/src/bit-systems/media-loading.ts
+++ b/src/bit-systems/media-loading.ts
@@ -24,6 +24,7 @@ import { loadModel } from "../utils/load-model";
 import { loadPDF } from "../utils/load-pdf";
 import { loadVideo } from "../utils/load-video";
 import { loadAudio } from "../utils/load-audio";
+import { loadHtml } from "../utils/load-html";
 import { MediaType, mediaTypeName, resolveMediaInfo } from "../utils/media-utils";
 import { EntityID } from "../utils/networking-types";
 
@@ -78,7 +79,9 @@ const loaderForMediaType = {
     { accessibleUrl, contentType }: { accessibleUrl: string; contentType: string }
   ) => loadModel(world, accessibleUrl, contentType, true),
   [MediaType.PDF]: (world: HubsWorld, { accessibleUrl }: { accessibleUrl: string }) => loadPDF(world, accessibleUrl),
-  [MediaType.AUDIO]: (world: HubsWorld, { accessibleUrl }: { accessibleUrl: string }) => loadAudio(world, accessibleUrl)
+  [MediaType.AUDIO]: (world: HubsWorld, { accessibleUrl }: { accessibleUrl: string }) => loadAudio(world, accessibleUrl),
+  [MediaType.HTML]: (world: HubsWorld, { canonicalUrl, thumbnail }: { canonicalUrl: string, thumbnail: string }) =>
+    loadHtml(world, canonicalUrl, thumbnail)
 };
 
 export const MEDIA_LOADER_FLAGS = {

--- a/src/utils/load-html.tsx
+++ b/src/utils/load-html.tsx
@@ -1,0 +1,22 @@
+/** @jsx createElementEntity */
+import { createElementEntity, renderAsEntity } from "../utils/jsx-entity";
+import { HubsWorld } from "../app";
+import { guessContentType } from "./media-url-utils";
+import { createImageDef } from "./load-image";
+
+export function* loadHtml(world: HubsWorld, url: string, thumbnailUrl: string) {
+  const imageDef = yield* createImageDef(world, thumbnailUrl, guessContentType(thumbnailUrl) || "image/png");
+  return renderAsEntity(
+    world,
+    <entity
+      name="HTML"
+      image={imageDef}
+      // TODO: Comment out for hover link menu
+      //       Currently if commenting out the object
+      //       won't move. RemoteHoverTarget component
+      //       seems to be the cause. Investigate and
+      //       fix the root issue.
+      //link={{ href:url }}
+    />
+  );
+}

--- a/src/utils/load-image.tsx
+++ b/src/utils/load-image.tsx
@@ -9,7 +9,8 @@ import { AlphaMode } from "./create-image-mesh";
 
 // TODO AlphaMode is written in JS and should be a ts enum
 type AlphaModeType = typeof AlphaMode.Opaque | typeof AlphaMode.Mask | typeof AlphaMode.Blend;
-export function* loadImage(world: HubsWorld, url: string, contentType: string) {
+
+export function* createImageDef(world: HubsWorld, url: string, contentType: string) {
   const { texture, ratio, cacheKey }: { texture: Texture; ratio: number; cacheKey: string } =
     yield loadTextureCancellable(url, 1, contentType);
 
@@ -23,17 +24,23 @@ export function* loadImage(world: HubsWorld, url: string, contentType: string) {
     alphaMode = AlphaMode.Opaque;
   }
 
+  return {
+    texture,
+    ratio,
+    projection: ProjectionMode.FLAT,
+    alphaMode,
+    cacheKey
+  };
+}
+
+export function* loadImage(world: HubsWorld, url: string, contentType: string) {
+  const imageDef = yield* createImageDef(world, url, contentType);
+
   return renderAsEntity(
     world,
     <entity
       name="Image"
-      image={{
-        texture,
-        ratio,
-        projection: ProjectionMode.FLAT,
-        alphaMode,
-        cacheKey
-      }}
+      image={imageDef}
     />
   );
 }


### PR DESCRIPTION
This PR adds media loading HTML support to bitecs.

"Open Link" support requires #5976 so draft now.

![image](https://user-images.githubusercontent.com/7637832/222636321-17286d31-cbd6-4e5a-8997-167811e3d1c4.png)
