### PR TITLE
Add chat command ( /test ) to load sample assets

### DIFF
--- a/src/message-dispatch.js
+++ b/src/message-dispatch.js
@@ -181,7 +181,7 @@ export default class MessageDispatch extends EventTarget {
               this.log(LogMessageType.unauthorizedSceneChange);
             }
           } else {
-            this.log(LogMessageType.inalidSceneUrl);
+            this.log(LogMessageType.invalidSceneUrl);
           }
         } else if (this.hubChannel.canOrWillIfCreator("update_hub")) {
           this.mediaSearchStore.sourceNavigateWithNoNav("scenes", "use");

--- a/src/message-dispatch.js
+++ b/src/message-dispatch.js
@@ -9,7 +9,7 @@ import { ExitReason } from "./react-components/room/ExitedRoomScreen";
 import { LogMessageType } from "./react-components/room/ChatSidebar";
 import { createNetworkedEntity } from "./utils/create-networked-entity";
 import qsTruthy from "./utils/qs_truthy";
-import { add, respawn } from "./utils/chat-commands";
+import { add, testAsset, respawn } from "./utils/chat-commands";
 
 let uiRoot;
 // Handles user-entered messages
@@ -248,6 +248,12 @@ export default class MessageDispatch extends EventTarget {
           const sceneEl = AFRAME.scenes[0];
           const characterController = this.scene.systems["hubs-systems"].characterController;
           respawn(APP.world, sceneEl, characterController);
+        }
+        break;
+      case "test":
+        {
+          const avatarPov = document.querySelector("#avatar-pov-node").object3D;
+          testAsset(APP.world, avatarPov, args);
         }
         break;
     }

--- a/src/utils/chat-commands.ts
+++ b/src/utils/chat-commands.ts
@@ -59,6 +59,42 @@ export function add(world: HubsWorld, avatarPov: Object3D, args: string[]) {
   }
 }
 
+function changeScene(sceneUrl: string) {
+  console.log(`Changing scene to ${sceneUrl}`);
+  const error = APP.hubChannel!.updateScene(sceneUrl);
+  if (error) {
+    console.error(error);
+  }
+}
+
+function changeAvatar(avatarUrl: string) {
+  console.log(`Changing avatar to ${avatarUrl}`);
+  APP.store.update({ profile: { ...APP.store.state.profile, ...{ avatarId: avatarUrl } } });
+  AFRAME.scenes[0].emit("avatar_updated");
+}
+
+const TEST_ASSET_PREFIX =
+  "https://raw.githubusercontent.com/mozilla/hubs-sample-assets/main/Hubs%20Components/Exported%20GLB%20Models/";
+const FLAG_SCENE = "--scene";
+const FLAG_AVATAR = "--avatar";
+const TEST_ASSET_FLAGS = [FLAG_SCENE, FLAG_AVATAR, ...ADD_FLAGS];
+export function testAsset(world: HubsWorld, avatarPov: Object3D, args: string[]) {
+  args = args.filter(arg => arg);
+  if (!args.length) {
+    console.log(usage("test", TEST_ASSET_FLAGS, null, ["asset_name"]));
+    return;
+  }
+
+  args[args.length - 1] = `${TEST_ASSET_PREFIX}${args[args.length - 1]}`;
+  if (checkFlag(args, FLAG_SCENE)) {
+    changeScene(args[args.length - 1]);
+  } else if (checkFlag(args, FLAG_AVATAR)) {
+    changeAvatar(args[args.length - 1]);
+  } else {
+    add(world, avatarPov, args);
+  }
+}
+
 export function respawn(world: HubsWorld, scene: AScene, characterController: CharacterControllerSystem) {
   if (!scene.is("entered")) {
     console.error("Cannot respawn until you have entered the room.");

--- a/src/utils/chat-commands.ts
+++ b/src/utils/chat-commands.ts
@@ -75,17 +75,18 @@ function changeAvatar(avatarUrl: string) {
 
 const TEST_ASSET_PREFIX =
   "https://raw.githubusercontent.com/mozilla/hubs-sample-assets/main/Hubs%20Components/Exported%20GLB%20Models/";
+const TEST_ASSET_SUFFIX = ".glb";
 const FLAG_SCENE = "--scene";
 const FLAG_AVATAR = "--avatar";
 const TEST_ASSET_FLAGS = [FLAG_SCENE, FLAG_AVATAR, ...ADD_FLAGS];
 export function testAsset(world: HubsWorld, avatarPov: Object3D, args: string[]) {
   args = args.filter(arg => arg);
   if (!args.length) {
-    console.log(usage("test", TEST_ASSET_FLAGS, null, ["asset_name"]));
+    console.log(usage("test", TEST_ASSET_FLAGS, null, ["AssetName"]));
     return;
   }
 
-  args[args.length - 1] = `${TEST_ASSET_PREFIX}${args[args.length - 1]}`;
+  args[args.length - 1] = [TEST_ASSET_PREFIX, args[args.length - 1], TEST_ASSET_SUFFIX].join("");
   if (checkFlag(args, FLAG_SCENE)) {
     changeScene(args[args.length - 1]);
   } else if (checkFlag(args, FLAG_AVATAR)) {

--- a/types/aframe.d.ts
+++ b/types/aframe.d.ts
@@ -112,7 +112,7 @@ declare module "aframe" {
       interaction: InteractionSystem;
       nav: NavSystem;
     };
-    emit(string, any): void;
+    emit(string, any?): void;
     addState(string): void;
     is(string): boolean;
   }


### PR DESCRIPTION
This chat command enables loading [sample assets](https://github.com/mozilla/hubs-sample-assets/tree/main/Hubs%20Components/Exported%20GLB%20Models) by name. 

There are three types of assets: objects, scenes, and avatars.

- Objects are loaded with the same options as the [`/add` command](https://github.com/mozilla/hubs/pull/5945).
- The `--scene` flag changes the active scene.
- The `--avatar` flag changes the active avatar.

Usage:

```
/test [--scene] [--avatar] [--resize] [--recenter] [--animate] [--no-menu] <asset_name>
```

Examples:

Load a sample asset as a media object:
```
/test Billboard
```

Change the scene:
```
/test --scene EnvironmentSettings
```

Change your avatar:
```
/test --avatar MorphAudioFeedback
```

Warning: Typos in the `asset name` are not validated. Be careful not to change scenes to an nonexistent asset as doing so can create unrecoverable rooms.
