### PR TITLE
Add config for automatic room switching near links

### DIFF
--- a/src/components/change-hub-when-near.ts
+++ b/src/components/change-hub-when-near.ts
@@ -1,0 +1,111 @@
+import { AElement } from "aframe";
+import { Object3D, Vector3 } from "three";
+import { changeHub } from "../change-hub";
+import configs from "../utils/configs";
+import { isHubsRoomUrl } from "../utils/media-url-utils";
+
+function getSrcFromMediaLoader(el: AElement): string | null {
+  if (!el.parentNode) return null;
+  const src = el.components["media-loader"]?.data?.src as string;
+  if (src) return src;
+  const href = el.components["media-loader"]?.data?.mediaOptions?.href as string;
+  if (href) return href;
+  return null;
+}
+
+async function tryGetSrc(el: AElement): Promise<string | null> {
+  const networkedEl = await NAF.utils.getNetworkedEntity(el);
+  const url = getSrcFromMediaLoader(networkedEl);
+  if (url) return url;
+
+  return new Promise(resolve => {
+    const onMediaResolved = () => {
+      resolve(getSrcFromMediaLoader(networkedEl));
+    };
+    networkedEl.addEventListener("media_resolved", onMediaResolved, { once: true });
+  });
+}
+
+async function tryGetHubId(el: AElement): Promise<string | null> {
+  const src = await tryGetSrc(el);
+  return (src && (await isHubsRoomUrl(src))) || null;
+}
+
+const isNearby = (() => {
+  const NEAR = 1.5;
+  const NEAR_SQUARED = NEAR * NEAR;
+  const positionA = new Vector3();
+  const positionB = new Vector3();
+  return function isNearby(a: Object3D, b: Object3D) {
+    a.updateMatrices();
+    b.updateMatrices();
+    positionA.setFromMatrixPosition(a.matrixWorld);
+    positionB.setFromMatrixPosition(b.matrixWorld);
+
+    return positionA.distanceToSquared(positionB) < NEAR_SQUARED;
+  };
+})();
+
+const DELAY_MS = 2000;
+
+enum State {
+  notReady,
+  idle,
+  nearby,
+  traveling
+}
+
+// change-hub-when-near
+//
+// Add this component to a child of media loader.
+// If the media loader's src points to a room link,
+// This component acts as a portal that will call
+// changeHub when the player is nearby.
+//
+// This was requested for an upcoming event.
+// We expect to remove it it soon.
+//
+if (configs.feature("change_hub_near_room_links")) {
+  console.log("Enabling automatic fast room switching when near room links.");
+  AFRAME.registerComponent("change-hub-when-near", {
+    init() {
+      this.state = State.notReady;
+
+      tryGetHubId(this.el).then(hubId => {
+        if (!hubId) {
+          console.error("Failed to find target hub id for portal.");
+          return;
+        }
+
+        this.targetHubId = hubId;
+        this.avatarPov = (document.getElementById("avatar-pov-node") as AElement)?.object3D;
+        this.timer = 0;
+        this.state = State.idle;
+      });
+    },
+
+    tick(now) {
+      if (this.state === State.notReady || this.state === State.traveling) return;
+
+      if (this.state === State.idle) {
+        if (isNearby(this.el.object3D, this.avatarPov)) {
+          this.state = State.nearby;
+          this.timer = now + DELAY_MS;
+        }
+      } else if (this.state === State.nearby) {
+        if (now > this.timer) {
+          if (isNearby(this.el.object3D, this.avatarPov)) {
+            this.state = State.traveling;
+            changeHub(this.targetHubId).finally(() => {
+              this.state = State.idle;
+            });
+          } else {
+            this.state = State.idle;
+          }
+        }
+      }
+    }
+  });
+}
+
+export {};

--- a/src/hub.html
+++ b/src/hub.html
@@ -754,7 +754,7 @@
 
             <template id="hubs-destination-hover-menu">
                 <a-entity class="ui interactable-ui hover-container" visible="false">
-                    <a-entity mixin="rounded-text-action-button ui" is-remote-hover-target tags="singleActionButton: true; isHoverMenuChild: true;" open-media-button position="0 -0.125 0.001">
+                    <a-entity mixin="rounded-text-action-button ui" is-remote-hover-target tags="singleActionButton: true; isHoverMenuChild: true;" open-media-button position="0 -0.125 0.001" change-hub-when-near>
                         <a-entity text="value:value; textAlign:center;" text-raycast-hack position="0 0 0.02"></a-entity>
                     </a-entity>
                 </a-entity>

--- a/src/hub.js
+++ b/src/hub.js
@@ -116,6 +116,7 @@ import "./components/emit-scene-event-on-remove";
 import "./components/follow-in-fov";
 import "./components/clone-media-button";
 import "./components/open-media-button";
+import "./components/change-hub-when-near";
 import "./components/refresh-media-button";
 import "./components/tweet-media-button";
 import "./components/remix-avatar-button";

--- a/src/schema.toml
+++ b/src/schema.toml
@@ -46,6 +46,7 @@ features.show_feedback_ui = { category = "features", type = "boolean", internal 
 features.show_issue_report_dialog = { category = "features", type = "boolean", internal = "true" }
 features.show_cloud = { category = "features", type = "boolean", internal = "true" }
 features.show_newsletter_signup = { category = "features", type = "boolean", internal = "true" }
+features.change_hub_near_room_links = { category = "features", type = "boolean", internal = "true" }
 
 images.logo = { category = "images", type = "file", name = "App Logo", description = "Logo used across the app." }
 images.logo_dark = { category = "images", type = "file", name = "App Logo Dark", description = "Logo used across the app in dark mode." }

--- a/types/aframe.d.ts
+++ b/types/aframe.d.ts
@@ -22,6 +22,7 @@ declare module "aframe" {
   }
 
   interface AComponent {
+    data: any;
     init();
     tick: FnTick;
     tock: FnTick;
@@ -127,6 +128,7 @@ declare module "aframe" {
   declare global {
     const AFRAME: {
       registerSystem(name: string, def: Partial<ASystem>);
+      registerComponent(name: string, def: Partial<AComponent>);
       scenes: AScene[];
       utils: Util;
     };

--- a/types/networked-aframe.d.ts
+++ b/types/networked-aframe.d.ts
@@ -6,6 +6,7 @@ declare global {
       isMine: (el: AElement) => boolean;
       takeOwnership: (el: AElement) => boolean;
       createNetworkId: () => string;
+      getNetworkedEntity: (el: AElement) => Promise<AElement>;
     };
     connection: {
       getServerTime: () => number;


### PR DESCRIPTION
Add an app config to enable automatic room switching when near room links.

The app config is hidden/internal because it should not be used. It's meant for internal testing and should be removed shortly.