### PR TITLE
Implement rotate and scale button functions with bitecs

### DIFF
--- a/src/bit-systems/object-menu.ts
+++ b/src/bit-systems/object-menu.ts
@@ -1,7 +1,15 @@
-import { defineQuery, entityExists, hasComponent } from "bitecs";
-import { Matrix4, Vector3 } from "three";
+import { defineQuery, enterQuery, entityExists, exitQuery, hasComponent } from "bitecs";
+import { Matrix4, Quaternion, Vector3 } from "three";
 import type { HubsWorld } from "../app";
-import { HoveredRemoteRight, Interacted, ObjectMenu, ObjectMenuTarget } from "../bit-components";
+import {
+  HeldRemoteRight,
+  HoveredRemoteRight,
+  Interacted,
+  ObjectMenu,
+  ObjectMenuTarget,
+  RemoteRight,
+  Rigidbody
+} from "../bit-components";
 import { anyEntityWith, findAncestorWithComponent } from "../utils/bit-utils";
 import { createNetworkedEntity } from "../utils/create-networked-entity";
 import { createEntityState, deleteEntityState } from "../utils/entity-state-utils";
@@ -10,11 +18,16 @@ import type { EntityID } from "../utils/networking-types";
 import { setMatrixWorld } from "../utils/three-utils";
 import { deleteTheDeletableAncestor } from "./delete-entity-system";
 import { createMessageDatas, isPinned } from "./networking";
+import { TRANSFORM_MODE } from "../components/transform-object-button";
+import { ScalingHandler } from "../components/scale-button";
 
 // Working variables.
-const _vec1 = new Vector3();
-const _vec2 = new Vector3();
+const _vec3_1 = new Vector3();
+const _vec3_2 = new Vector3();
+const _quat = new Quaternion();
 const _mat4 = new Matrix4();
+
+let scalingHandler: ScalingHandler | null = null;
 
 function clicked(world: HubsWorld, eid: EntityID) {
   return hasComponent(world, Interacted, eid);
@@ -39,10 +52,65 @@ function moveToTarget(world: HubsWorld, menu: EntityID) {
   const targetObj = world.eid2obj.get(ObjectMenu.targetRef[menu])!;
   targetObj.updateMatrices();
 
-  const menuObj = world.eid2obj.get(menu)!;
-
   // TODO: position the menu more carefully...
-  setMatrixWorld(menuObj, targetObj.matrixWorld);
+  //       For example, if a menu object is just placed at a target
+  //       object's position the menu object can be hidden by a large
+  //       target object or the menu object looks too small for a far
+  //       target object.
+  _mat4.copy(targetObj.matrixWorld);
+
+  // Keeps world scale (1, 1, 1) because
+  // a menu object is a child of a target object
+  // and the target object's scale can be changed.
+  // Another option may be making the menu object
+  // a sibling of the target object.
+  _mat4.decompose(_vec3_1, _quat, _vec3_2);
+  _vec3_2.set(1.0, 1.0, 1.0);
+  _mat4.compose(_vec3_1, _quat, _vec3_2);
+
+  const menuObj = world.eid2obj.get(menu)!;
+  setMatrixWorld(menuObj, _mat4);
+
+  // TODO: Remove the dependency with AFRAME
+  const camera = AFRAME.scenes[0].systems["hubs-systems"].cameraSystem.viewingCamera;
+  camera.updateMatrices();
+  menuObj.lookAt(_vec3_1.setFromMatrixPosition(camera.matrixWorld));
+}
+
+// TODO: startRotation/Scaling() and stopRotation/Scaling() are
+//       temporary implementation that rely on the old systems.
+//       They should be rewritten more elegantly with bitecs.
+function startRotation(world: HubsWorld, targetEid: EntityID) {
+  const transformSystem = APP.scene!.systems["transform-selected-object"];
+  const physicsSystem = AFRAME.scenes[0].systems["hubs-systems"].physicsSystem;
+  physicsSystem.updateBodyOptions(Rigidbody.bodyId[targetEid], { type: "kinematic" });
+  const rightCursorEid = anyEntityWith(world, RemoteRight)!;
+  transformSystem.startTransform(world.eid2obj.get(targetEid)!, world.eid2obj.get(rightCursorEid)!, {
+    mode: TRANSFORM_MODE.CURSOR
+  });
+}
+
+function stopRotation() {
+  const transformSystem = APP.scene!.systems["transform-selected-object"];
+  transformSystem.stopTransform();
+}
+
+function startScaling(world: HubsWorld, targetEid: EntityID) {
+  // TODO: Don't use any
+  // TODO: Remove the dependency with AFRAME
+  const transformSystem = (AFRAME as any).scenes[0].systems["transform-selected-object"];
+  const physicsSystem = AFRAME.scenes[0].systems["hubs-systems"].physicsSystem;
+  physicsSystem.updateBodyOptions(Rigidbody.bodyId[targetEid], { type: "kinematic" });
+  const rightCursorEid = anyEntityWith(world, RemoteRight)!;
+  scalingHandler = new ScalingHandler(world.eid2obj.get(targetEid), transformSystem);
+  scalingHandler!.objectToScale = world.eid2obj.get(targetEid);
+  scalingHandler!.startScaling(world.eid2obj.get(rightCursorEid));
+}
+
+function stopScaling(world: HubsWorld) {
+  const rightCursorEid = anyEntityWith(world, RemoteRight)!;
+  scalingHandler!.endScaling(world.eid2obj.get(rightCursorEid));
+  scalingHandler = null;
 }
 
 function openLink(world: HubsWorld, eid: EntityID) {
@@ -71,8 +139,8 @@ function cloneObject(world: HubsWorld, sourceEid: EntityID) {
   const sourceObj = world.eid2obj.get(sourceEid)!;
   sourceObj.updateMatrices();
 
-  const objPos = _vec1.setFromMatrixPosition(sourceObj.matrixWorld);
-  const cameraPos = _vec2.setFromMatrixPosition(camera.matrixWorld);
+  const objPos = _vec3_1.setFromMatrixPosition(sourceObj.matrixWorld);
+  const cameraPos = _vec3_2.setFromMatrixPosition(camera.matrixWorld);
   objPos.add(cameraPos.sub(objPos).normalize().multiplyScalar(0.2));
   const clonedMatrixWorld = _mat4.copy(sourceObj.matrixWorld).setPosition(objPos);
   setMatrixWorld(clonedObj, clonedMatrixWorld);
@@ -101,12 +169,30 @@ function handleClicks(world: HubsWorld, menu: EntityID, hubChannel: HubChannel) 
     console.log("Clicked refresh");
   } else if (clicked(world, ObjectMenu.cloneButtonRef[menu])) {
     cloneObject(world, ObjectMenu.targetRef[menu]);
-  } else if (clicked(world, ObjectMenu.rotateButtonRef[menu])) {
-    console.log("Clicked rotate");
   } else if (clicked(world, ObjectMenu.mirrorButtonRef[menu])) {
     console.log("Clicked mirror");
-  } else if (clicked(world, ObjectMenu.scaleButtonRef[menu])) {
-    console.log("Clicked scale");
+  }
+}
+
+function handleHeldEnter(world: HubsWorld, eid: EntityID, menuEid: EntityID) {
+  switch (eid) {
+    case ObjectMenu.rotateButtonRef[menuEid]:
+      startRotation(world, ObjectMenu.targetRef[menuEid]);
+      break;
+    case ObjectMenu.scaleButtonRef[menuEid]:
+      startScaling(world, ObjectMenu.targetRef[menuEid]);
+      break;
+  }
+}
+
+function handleHeldExit(world: HubsWorld, eid: EntityID, menuEid: EntityID) {
+  switch (eid) {
+    case ObjectMenu.rotateButtonRef[menuEid]:
+      stopRotation();
+      break;
+    case ObjectMenu.scaleButtonRef[menuEid]:
+      stopScaling(world);
+      break;
   }
 }
 
@@ -142,13 +228,29 @@ function updateVisibility(world: HubsWorld, menu: EntityID, frozen: boolean) {
 }
 
 const hoveredQuery = defineQuery([HoveredRemoteRight]);
+const heldQuery = defineQuery([HeldRemoteRight]);
+const heldEnterQuery = enterQuery(heldQuery);
+const heldExitQuery = exitQuery(heldQuery);
 export function objectMenuSystem(world: HubsWorld, sceneIsFrozen: boolean, hubChannel: HubChannel) {
   const menu = anyEntityWith(world, ObjectMenu)!;
 
   ObjectMenu.targetRef[menu] = objectMenuTarget(world, menu, sceneIsFrozen);
   if (ObjectMenu.targetRef[menu]) {
-    moveToTarget(world, menu);
     handleClicks(world, menu, hubChannel);
+
+    heldExitQuery(world).forEach(eid => {
+      handleHeldExit(world, eid, menu);
+    });
+
+    heldEnterQuery(world).forEach(eid => {
+      handleHeldEnter(world, eid, menu);
+    });
+
+    if (scalingHandler !== null) {
+      scalingHandler.tick();
+    }
+
+    moveToTarget(world, menu);
   }
   updateVisibility(world, menu, sceneIsFrozen);
 }

--- a/src/prefabs/button3D.tsx
+++ b/src/prefabs/button3D.tsx
@@ -25,6 +25,8 @@ export interface Button3DParams extends Attrs {
   name?: string;
   type: ButtonType;
   labelRef?: Ref;
+  holdable?: true;
+  holdableButton?: true;
 }
 
 export function Button3D({

--- a/src/prefabs/object-menu.tsx
+++ b/src/prefabs/object-menu.tsx
@@ -4,7 +4,6 @@ import { Button3D, BUTTON_TYPES } from "./button3D";
 
 const buttonHeight = 0.2;
 const buttonScale: ArrayVec3 = [0.4, 0.4, 0.4];
-const smallButtonScale: ArrayVec3 = [0.2, 0.2, 0.2];
 const uiZ = 0.25;
 
 function PinButton(props: Attrs) {
@@ -170,6 +169,7 @@ function RotateButton(props: Attrs) {
       height={buttonHeight}
       type={BUTTON_TYPES.ACTION}
       text={"rotate"}
+      holdable
       {...props}
     />
   );
@@ -198,6 +198,7 @@ function ScaleButton(props: Attrs) {
       height={buttonHeight}
       type={BUTTON_TYPES.ACTION}
       text={"scale"}
+      holdable
       {...props}
     />
   );

--- a/types/aframe.d.ts
+++ b/types/aframe.d.ts
@@ -96,6 +96,11 @@ declare module "aframe" {
     invaders: PersonalSpaceInvader[];
   }
 
+  interface TransformSelectedObjectSystem extends ASystem {
+    startTransform(targetObj: Object3D, handObj: Object3D, data: object): void;
+    stopTransform(): void;
+  }
+
   interface AScene extends AElement {
     object3D: Scene;
     renderStarted: boolean;
@@ -109,6 +114,7 @@ declare module "aframe" {
     systems: {
       "hubs-systems": HubsSystems;
       "personal-space-bubble": PersonalSpaceBubbleSystem;
+      "transform-selected-object": TransformSelectedObjectSystem;
       userinput: UserInputSystem;
       /** @deprecated see bit-interaction-system */
       interaction: InteractionSystem;


### PR DESCRIPTION
This commit adds the implementations of Object menu rotate and scale button functions.

Note that this commit focuses on making them just functional with minimal change.

The implementation relys on the old systems to save development time. It should be rewritten more elegantly to fit more to bitECS.

The main logic of src/components/scale-button is exposed to be reused from the new and old systems.