### PR TITLE
Bit media frames physics

### DIFF
--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -157,7 +157,9 @@ export const MediaLoader = defineComponent({
 });
 MediaLoader.src[$isStringType] = true;
 export const MediaLoaded = defineComponent();
-MediaLoaded.contentBounds = new Map();
+export const MediaContentBounds = defineComponent({
+  bounds: [Types.f32, 3]
+});
 
 export const SceneRoot = defineComponent();
 export const NavMesh = defineComponent();

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -30,6 +30,7 @@ export const MediaFrame = defineComponent({
   scale: [Types.f32, 3],
   mediaType: Types.ui8,
   bounds: [Types.f32, 3],
+  guide: Types.eid,
   preview: Types.eid,
   previewingNid: Types.eid
 });
@@ -156,6 +157,7 @@ export const MediaLoader = defineComponent({
 });
 MediaLoader.src[$isStringType] = true;
 export const MediaLoaded = defineComponent();
+MediaLoaded.contentBounds = new Map();
 
 export const SceneRoot = defineComponent();
 export const NavMesh = defineComponent();
@@ -176,7 +178,8 @@ export const MediaPDF = defineComponent({
 MediaPDF.map = new Map();
 
 export const MediaVideo = defineComponent({
-  autoPlay: Types.ui8
+  autoPlay: Types.ui8,
+  ratio: Types.f32
 });
 export const AnimationMixer = defineComponent();
 export const NetworkedVideo = defineComponent({
@@ -199,6 +202,7 @@ AudioEmitter.audios = new Map();
 AudioEmitter.params = new Map();
 export const AudioSettingsChanged = defineComponent();
 export const Deletable = defineComponent();
+export const Deleting = defineComponent();
 export const EnvironmentSettings = defineComponent();
 EnvironmentSettings.map = new Map();
 

--- a/src/bit-systems/camera-tool.js
+++ b/src/bit-systems/camera-tool.js
@@ -9,7 +9,6 @@ import {
   HoveredRemoteRight,
   Interacted,
   RemoteRight,
-  Rigidbody,
   TextButton
 } from "../bit-components";
 import { addMedia } from "../utils/media-utils";
@@ -212,7 +211,7 @@ function rotateWithRightClick(world, camera) {
     userinput.get(paths.device.mouse.buttonRight)
   ) {
     const rightCursor = anyEntityWith(world, RemoteRight);
-    physicsSystem.updateBodyOptions(Rigidbody.bodyId[camera], { type: "kinematic" });
+    physicsSystem.updateRigidBodyOptions(camera, { type: "kinematic" });
     transformSystem.startTransform(world.eid2obj.get(camera), world.eid2obj.get(rightCursor), {
       mode: "cursor"
     });

--- a/src/bit-systems/delete-entity-system.ts
+++ b/src/bit-systems/delete-entity-system.ts
@@ -1,7 +1,7 @@
-import { defineQuery, exitQuery, hasComponent, removeEntity } from "bitecs";
+import { addComponent, defineQuery, exitQuery, hasComponent, removeEntity } from "bitecs";
 import { Vector3 } from "three";
 import { HubsWorld } from "../app";
-import { Deletable, HoveredRemoteLeft, HoveredRemoteRight } from "../bit-components";
+import { Deletable, Deleting, HoveredRemoteLeft, HoveredRemoteRight } from "../bit-components";
 import { paths } from "../systems/userinput/paths";
 import { animate } from "../utils/animate";
 import { findAncestorEntity } from "../utils/bit-utils";
@@ -18,6 +18,7 @@ function* animateThenRemoveEntity(world: HubsWorld, eid: number): Coroutine {
   if (hasSavedEntityState(world, eid)) {
     deleteEntityState(APP.hubChannel!, world, eid);
   }
+  addComponent(world, Deleting, eid);
   const obj = world.eid2obj.get(eid)!;
   yield* animate({
     properties: [[obj.scale.clone(), END_SCALE]],

--- a/src/bit-systems/media-loading.ts
+++ b/src/bit-systems/media-loading.ts
@@ -1,12 +1,13 @@
 import { addComponent, defineQuery, enterQuery, exitQuery, hasComponent, removeComponent, removeEntity } from "bitecs";
 import { Vector3 } from "three";
 import { HubsWorld } from "../app";
-import { GLTFModel, MediaLoaded, MediaLoader, Networked, ObjectMenuTarget } from "../bit-components";
+import { GLTFModel, MediaLoaded, MediaLoader, Networked, ObjectMenuTarget, PhysicsShape } from "../bit-components";
 import { inflatePhysicsShape, Shape } from "../inflators/physics-shape";
 import { ErrorObject } from "../prefabs/error-object";
 import { LoadingObject } from "../prefabs/loading-object";
 import { animate } from "../utils/animate";
 import { setNetworkedDataWithoutRoot } from "../utils/assign-network-ids";
+import { computeObjectAABB } from "../utils/auto-box-collider";
 import { crClearTimeout, crNextFrame, crTimeout } from "../utils/coroutine";
 import { ClearFunction, JobRunner, withRollback } from "../utils/coroutine-utils";
 import { easeOutQuadratic } from "../utils/easing";
@@ -18,6 +19,39 @@ import { loadVideo } from "../utils/load-video";
 import { loadAudio } from "../utils/load-audio";
 import { MediaType, mediaTypeName, resolveMediaInfo } from "../utils/media-utils";
 import { EntityID } from "../utils/networking-types";
+
+export const MediaContentBounds = (MediaLoaded as any).contentBounds as Map<EntityID, Vector3>;
+
+const getBox = (() => {
+  const rotation = new THREE.Euler();
+  return (world: HubsWorld, eid: EntityID, rootEid: EntityID, worldSpace?: boolean) => {
+    const box = new THREE.Box3();
+    const obj = world.eid2obj.get(eid)!;
+    const rootObj = world.eid2obj.get(rootEid)!;
+
+    rotation.copy(obj.rotation);
+    obj.rotation.set(0, 0, 0);
+    obj.updateMatrices(true, true);
+    rootObj.updateMatrices(true, true);
+    rootObj.updateMatrixWorld(true);
+
+    computeObjectAABB(rootObj, box, false);
+
+    if (!box.isEmpty()) {
+      if (!worldSpace) {
+        obj.worldToLocal(box.min);
+        obj.worldToLocal(box.max);
+      }
+      obj.rotation.copy(rotation);
+      obj.matrixNeedsUpdate = true;
+    }
+
+    rootObj.matrixWorldNeedsUpdate = true;
+    rootObj.updateMatrices();
+
+    return box;
+  };
+})();
 
 export function* waitForMediaLoaded(world: HubsWorld, eid: EntityID) {
   while (hasComponent(world, MediaLoader, eid)) {
@@ -176,8 +210,11 @@ function* loadAndAnimateMedia(world: HubsWorld, eid: EntityID, clearRollbacks: C
   removeComponent(world, MediaLoader, eid);
 
   if (media) {
+    const box = getBox(world, eid, media);
+    MediaContentBounds.set(media, box.getSize(new Vector3()));
     // TODO update scale?
-    inflatePhysicsShape(world, media, {
+    removeComponent(world, PhysicsShape, eid);
+    inflatePhysicsShape(world, eid, {
       type: hasComponent(world, GLTFModel, media) ? Shape.HULL : Shape.BOX,
       minHalfExtent: 0.04
     });
@@ -188,6 +225,8 @@ const jobs = new JobRunner();
 const mediaLoaderQuery = defineQuery([MediaLoader]);
 const mediaLoaderEnterQuery = enterQuery(mediaLoaderQuery);
 const mediaLoaderExitQuery = exitQuery(mediaLoaderQuery);
+const mediaLoadedQuery = defineQuery([MediaLoaded]);
+const mediaLoadedExitQuery = exitQuery(mediaLoadedQuery);
 export function mediaLoadingSystem(world: HubsWorld) {
   mediaLoaderEnterQuery(world).forEach(function (eid) {
     jobs.add(eid, clearRollbacks => loadAndAnimateMedia(world, eid, clearRollbacks));
@@ -196,6 +235,8 @@ export function mediaLoadingSystem(world: HubsWorld) {
   mediaLoaderExitQuery(world).forEach(function (eid) {
     jobs.stop(eid);
   });
+
+  mediaLoadedExitQuery(world).forEach(eid => MediaContentBounds.delete(eid));
 
   jobs.tick();
 }

--- a/src/bit-systems/media-loading.ts
+++ b/src/bit-systems/media-loading.ts
@@ -1,5 +1,5 @@
 import { addComponent, defineQuery, enterQuery, exitQuery, hasComponent, removeComponent, removeEntity } from "bitecs";
-import { Vector3 } from "three";
+import { Box3, Euler, Vector3 } from "three";
 import { HubsWorld } from "../app";
 import {
   GLTFModel,
@@ -7,8 +7,7 @@ import {
   MediaLoaded,
   MediaLoader,
   Networked,
-  ObjectMenuTarget,
-  PhysicsShape
+  ObjectMenuTarget
 } from "../bit-components";
 import { inflatePhysicsShape, Shape } from "../inflators/physics-shape";
 import { ErrorObject } from "../prefabs/error-object";
@@ -29,9 +28,9 @@ import { MediaType, mediaTypeName, resolveMediaInfo } from "../utils/media-utils
 import { EntityID } from "../utils/networking-types";
 
 const getBox = (() => {
-  const rotation = new THREE.Euler();
+  const rotation = new Euler();
   return (world: HubsWorld, eid: EntityID, rootEid: EntityID, worldSpace?: boolean) => {
-    const box = new THREE.Box3();
+    const box = new Box3();
     const obj = world.eid2obj.get(eid)!;
     const rootObj = world.eid2obj.get(rootEid)!;
 
@@ -95,12 +94,12 @@ function resizeAndRecenter(world: HubsWorld, media: EntityID, eid: EntityID) {
   if (!resize && !recenter) return;
 
   const mediaObj = world.eid2obj.get(media)!;
-  const box = new THREE.Box3();
+  const box = new Box3();
   box.setFromObject(mediaObj);
 
   let scalar = 1;
   if (resize) {
-    const size = new THREE.Vector3();
+    const size = new Vector3();
     box.getSize(size);
     scalar = 1 / Math.max(size.x, size.y, size.z);
     if (hasComponent(world, GLTFModel, media)) scalar = scalar * 0.5;
@@ -109,7 +108,7 @@ function resizeAndRecenter(world: HubsWorld, media: EntityID, eid: EntityID) {
   }
 
   if (recenter) {
-    const center = new THREE.Vector3();
+    const center = new Vector3();
     box.getCenter(center);
     mediaObj.position.copy(center).multiplyScalar(-1 * scalar);
     mediaObj.matrixNeedsUpdate = true;

--- a/src/bit-systems/media-loading.ts
+++ b/src/bit-systems/media-loading.ts
@@ -217,10 +217,12 @@ function* loadAndAnimateMedia(world: HubsWorld, eid: EntityID, clearRollbacks: C
   removeComponent(world, MediaLoader, eid);
 
   if (media) {
-    const box = getBox(world, eid, media);
-    addComponent(world, MediaContentBounds, media);
-    box.getSize(tmpVector);
-    MediaContentBounds.bounds[media].set(tmpVector.toArray());
+    if (hasComponent(world, MediaLoaded, media)) {
+      const box = getBox(world, eid, media);
+      addComponent(world, MediaContentBounds, media);
+      box.getSize(tmpVector);
+      MediaContentBounds.bounds[media].set(tmpVector.toArray());
+    }
     // TODO update scale?
     removeComponent(world, PhysicsShape, eid);
     inflatePhysicsShape(world, eid, {
@@ -234,8 +236,6 @@ const jobs = new JobRunner();
 const mediaLoaderQuery = defineQuery([MediaLoader]);
 const mediaLoaderEnterQuery = enterQuery(mediaLoaderQuery);
 const mediaLoaderExitQuery = exitQuery(mediaLoaderQuery);
-const mediaLoadedQuery = defineQuery([MediaLoaded]);
-const mediaLoadedExitQuery = exitQuery(mediaLoadedQuery);
 export function mediaLoadingSystem(world: HubsWorld) {
   mediaLoaderEnterQuery(world).forEach(function (eid) {
     jobs.add(eid, clearRollbacks => loadAndAnimateMedia(world, eid, clearRollbacks));
@@ -244,8 +244,6 @@ export function mediaLoadingSystem(world: HubsWorld) {
   mediaLoaderExitQuery(world).forEach(function (eid) {
     jobs.stop(eid);
   });
-
-  mediaLoadedExitQuery(world).forEach(eid => removeComponent(world, MediaContentBounds, eid));
 
   jobs.tick();
 }

--- a/src/bit-systems/media-loading.ts
+++ b/src/bit-systems/media-loading.ts
@@ -218,9 +218,9 @@ function* loadAndAnimateMedia(world: HubsWorld, eid: EntityID, clearRollbacks: C
   if (media) {
     if (hasComponent(world, MediaLoaded, media)) {
       const box = getBox(world, eid, media);
-      addComponent(world, MediaContentBounds, media);
+      addComponent(world, MediaContentBounds, eid);
       box.getSize(tmpVector);
-      MediaContentBounds.bounds[media].set(tmpVector.toArray());
+      MediaContentBounds.bounds[eid].set(tmpVector.toArray());
     }
     // TODO update scale?
     inflatePhysicsShape(world, eid, {

--- a/src/bit-systems/media-loading.ts
+++ b/src/bit-systems/media-loading.ts
@@ -224,7 +224,6 @@ function* loadAndAnimateMedia(world: HubsWorld, eid: EntityID, clearRollbacks: C
       MediaContentBounds.bounds[media].set(tmpVector.toArray());
     }
     // TODO update scale?
-    removeComponent(world, PhysicsShape, eid);
     inflatePhysicsShape(world, eid, {
       type: hasComponent(world, GLTFModel, media) ? Shape.HULL : Shape.BOX,
       minHalfExtent: 0.04

--- a/src/components/body-helper.js
+++ b/src/components/body-helper.js
@@ -46,7 +46,8 @@ AFRAME.registerComponent("body-helper", {
 
   update: function (prevData) {
     if (prevData) {
-      this.system.updateBody(this.uuid, this.data);
+      const eid = this.el.object3D.eid;
+      this.system.updateRigidBody(eid, this.data);
     }
   },
 

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -25,7 +25,7 @@ import { waitForDOMContentLoaded } from "../utils/async-utils";
 
 import { SHAPE } from "three-ammo/constants";
 import { addComponent, entityExists, removeComponent } from "bitecs";
-import { MediaLoading } from "../bit-components";
+import { MediaContentBounds, MediaLoading } from "../bit-components";
 
 let loadingObject;
 
@@ -279,7 +279,9 @@ AFRAME.registerComponent("media-loader", {
       }
 
       // TODO this does duplicate work in some cases, but finish() is the only consistent place to do it
-      this.contentBounds = getBox(this.el, this.el.getObject3D("mesh")).getSize(new THREE.Vector3());
+      const contentBounds = getBox(this.el, this.el.getObject3D("mesh")).getSize(new THREE.Vector3());
+      addComponent(APP.world, MediaContentBounds, el.eid);
+      MediaContentBounds.bounds[el.eid].set(contentBounds.toArray());
 
       el.emit("media-loaded");
       if (el.eid && entityExists(APP.world, el.eid)) {

--- a/src/inflators/media-frame.js
+++ b/src/inflators/media-frame.js
@@ -1,12 +1,12 @@
 import { addObject3DComponent } from "../utils/jsx-entity";
 import { NetworkedMediaFrame, MediaFrame, Networked } from "../bit-components";
-import { addComponent, hasComponent } from "bitecs";
+import { addComponent, addEntity, hasComponent } from "bitecs";
 import { MediaType } from "../utils/media-utils";
 import { COLLISION_LAYERS } from "../constants";
 import { Layers } from "../camera-layers";
 import { inflateRigidBody, Type } from "./rigid-body";
 import { Fit, inflatePhysicsShape, Shape } from "./physics-shape";
-import { Mesh, BoxBufferGeometry, ShaderMaterial, Color, DoubleSide, Group } from "three";
+import { Mesh, BoxBufferGeometry, ShaderMaterial, Color, DoubleSide } from "three";
 
 const DEFAULTS = {
   bounds: { x: 1, y: 1, z: 1 },
@@ -51,9 +51,8 @@ export function inflateMediaFrame(world, eid, componentProps) {
     })
   );
   guide.layers.set(Layers.CAMERA_LAYER_UI);
-  // TODO: This is a hack around the physics system addBody call requiring its body to have parent
-  guide.parent = new Group();
-  addObject3DComponent(world, eid, guide);
+  const guideEid = addEntity(world);
+  addObject3DComponent(world, guideEid, guide);
   addComponent(world, MediaFrame, eid, true);
   addComponent(world, NetworkedMediaFrame, eid, true);
 
@@ -68,6 +67,7 @@ export function inflateMediaFrame(world, eid, componentProps) {
     pdf: MediaType.PDF
   }[componentProps.mediaType];
   MediaFrame.bounds[eid].set([componentProps.bounds.x, componentProps.bounds.y, componentProps.bounds.z]);
+  MediaFrame.guide[eid] = guideEid;
 
   inflateRigidBody(world, eid, {
     type: Type.KINEMATIC,

--- a/src/inflators/rigid-body.ts
+++ b/src/inflators/rigid-body.ts
@@ -17,7 +17,7 @@ export enum ActivationState {
   DISABLE_SIMULATION = 4
 }
 
-export type RigiBodyParams = {
+export type RigidBodyParams = {
   type: Type;
   mass: number;
   gravity: [number, number, number];
@@ -88,25 +88,34 @@ export const getBodyFromRigidBody = (eid: number) => {
   };
 };
 
-export function inflateRigidBody(world: HubsWorld, eid: number, params: Partial<RigiBodyParams>) {
+const updateRigidBody = (eid: number, params: RigidBodyParams) => {
+  Rigidbody.type[eid] = params.type;
+  Rigidbody.mass[eid] = params.mass;
+  Rigidbody.gravity[eid].set(params.gravity);
+  Rigidbody.linearDamping[eid] = params.linearDamping;
+  Rigidbody.angularDamping[eid] = params.angularDamping;
+  Rigidbody.linearSleepingThreshold[eid] = params.linearSleepingThreshold;
+  Rigidbody.angularSleepingThreshold[eid] = params.angularSleepingThreshold;
+  Rigidbody.angularFactor[eid].set(params.angularFactor);
+  Rigidbody.activationState[eid] = params.activationState;
+  params.emitCollisionEvents && (Rigidbody.flags[eid] |= RIGID_BODY_FLAGS.EMIT_COLLISION_EVENTS);
+  params.disableCollision && (Rigidbody.flags[eid] |= RIGID_BODY_FLAGS.DISABLE_COLLISION);
+  Rigidbody.collisionFilterGroup[eid] = params.collisionGroup;
+  Rigidbody.collisionFilterMask[eid] = params.collisionMask;
+  params.scaleAutoUpdate && (Rigidbody.flags[eid] |= RIGID_BODY_FLAGS.SCALE_AUTO_UPDATE);
+};
+
+export const updateRigiBodyParams = (eid: number, params: Partial<RigidBodyParams>) => {
+  const currentParams = getBodyFromRigidBody(eid);
+  const bodyParams = Object.assign({}, currentParams, params);
+  updateRigidBody(eid, bodyParams);
+};
+
+export function inflateRigidBody(world: HubsWorld, eid: number, params: Partial<RigidBodyParams>) {
   const bodyParams = Object.assign({}, DEFAULTS, params);
 
   addComponent(world, Rigidbody, eid);
-
-  Rigidbody.type[eid] = bodyParams.type;
-  Rigidbody.mass[eid] = bodyParams.mass;
-  Rigidbody.gravity[eid].set(bodyParams.gravity);
-  Rigidbody.linearDamping[eid] = bodyParams.linearDamping;
-  Rigidbody.angularDamping[eid] = bodyParams.angularDamping;
-  Rigidbody.linearSleepingThreshold[eid] = bodyParams.linearSleepingThreshold;
-  Rigidbody.angularSleepingThreshold[eid] = bodyParams.angularSleepingThreshold;
-  Rigidbody.angularFactor[eid].set(bodyParams.angularFactor);
-  Rigidbody.activationState[eid] = bodyParams.activationState;
-  params.emitCollisionEvents && (Rigidbody.flags[eid] |= RIGID_BODY_FLAGS.EMIT_COLLISION_EVENTS);
-  params.disableCollision && (Rigidbody.flags[eid] |= RIGID_BODY_FLAGS.DISABLE_COLLISION);
-  Rigidbody.collisionFilterGroup[eid] = bodyParams.collisionGroup;
-  Rigidbody.collisionFilterMask[eid] = bodyParams.collisionMask;
-  bodyParams.scaleAutoUpdate && (Rigidbody.flags[eid] |= RIGID_BODY_FLAGS.SCALE_AUTO_UPDATE);
+  updateRigidBody(eid, bodyParams);
 
   return eid;
 }

--- a/src/inflators/video.js
+++ b/src/inflators/video.js
@@ -12,5 +12,6 @@ export function inflateVideo(world, eid, { texture, ratio, projection, autoPlay 
   addObject3DComponent(world, eid, mesh);
   addComponent(world, MediaVideo, eid);
   MediaVideo.autoPlay[eid] = autoPlay ? 1 : 0;
+  MediaVideo.ratio[eid] = ratio;
   return eid;
 }

--- a/src/systems/bit-constraints-system.js
+++ b/src/systems/bit-constraints-system.js
@@ -46,7 +46,7 @@ function add(world, physicsSystem, interactor, constraintComponent, entities) {
   for (let i = 0; i < entities.length; i++) {
     const eid = findAncestorEntity(world, entities[i], ancestor => hasComponent(world, Rigidbody, ancestor));
     takeOwnership(world, eid);
-    physicsSystem.updateBodyOptions(Rigidbody.bodyId[eid], grabBodyOptions);
+    physicsSystem.updateRigidBodyOptions(eid, grabBodyOptions);
     physicsSystem.addConstraint(interactor, Rigidbody.bodyId[eid], Rigidbody.bodyId[interactor], {});
     addComponent(world, Constraint, eid);
     addComponent(world, constraintComponent, eid);
@@ -58,7 +58,7 @@ function remove(world, offersConstraint, constraintComponent, physicsSystem, int
     const eid = findAncestorEntity(world, entities[i], ancestor => hasComponent(world, Rigidbody, ancestor));
     if (!entityExists(world, eid)) continue;
     if (hasComponent(world, offersConstraint, entities[i]) && hasComponent(world, Rigidbody, eid)) {
-      physicsSystem.updateBodyOptions(Rigidbody.bodyId[eid], releaseBodyOptions);
+      physicsSystem.updateRigidBodyOptions(eid, releaseBodyOptions);
       physicsSystem.removeConstraint(interactor);
       removeComponent(world, constraintComponent, eid);
       if (

--- a/src/systems/bit-media-frames.js
+++ b/src/systems/bit-media-frames.js
@@ -245,7 +245,7 @@ function createPreviewMesh(world, capturable) {
   cloneObj.add(previewMesh);
   world.scene.add(cloneObj);
 
-  hasComponent(world, AEntity, capturable) && (cloneObj.el = el); // We rely on media-loader component for bounds
+  hasComponent(world, AEntity, capturable) && (cloneObj.el = el);
 
   return cloneObj;
 }

--- a/src/systems/bit-media-frames.js
+++ b/src/systems/bit-media-frames.js
@@ -8,6 +8,7 @@ import {
   Deleting,
   GLTFModel,
   Held,
+  MediaContentBounds,
   MediaFrame,
   MediaImage,
   MediaLoaded,
@@ -24,7 +25,6 @@ import { cloneObject3D, createPlaneBufferGeometry, disposeNode, setMatrixWorld }
 import { takeOwnership } from "../utils/take-ownership";
 import { takeSoftOwnership } from "../utils/take-soft-ownership";
 import { findAncestorWithComponent, findChildWithComponent } from "../utils/bit-utils";
-import { MediaContentBounds } from "../bit-systems/media-loading";
 import { TEXTURES_FLIP_Y } from "../loaders/HubsTextureLoader";
 import { addObject3DComponent } from "../utils/jsx-entity";
 import { updateMaterials } from "../utils/material-utils";
@@ -137,7 +137,7 @@ function getEntityBounds(world, target) {
     contentBounds = targetObj.el.components["media-loader"].contentBounds;
   } else {
     const mediaEid = findChildWithComponent(world, MediaLoaded, target);
-    contentBounds = MediaContentBounds.get(mediaEid);
+    contentBounds = new Vector3().fromArray(MediaContentBounds.bounds[mediaEid]);
   }
 
   return contentBounds;

--- a/src/systems/bit-media-frames.js
+++ b/src/systems/bit-media-frames.js
@@ -178,6 +178,11 @@ const setMatrixScale = (() => {
   };
 })();
 
+const videoGeometry = createPlaneBufferGeometry(1, 1, 1, 1, TEXTURES_FLIP_Y);
+const previewMaterial = new MeshBasicMaterial();
+previewMaterial.side = DoubleSide;
+previewMaterial.transparent = true;
+previewMaterial.opacity = 0.5;
 function createPreviewMesh(world, capturable) {
   let srcMesh;
   let el;
@@ -205,13 +210,7 @@ function createPreviewMesh(world, capturable) {
 
   // Audios can't be cloned so we take a different path for them
   if (isVideo) {
-    const previewMaterial = new MeshBasicMaterial();
-    previewMaterial.side = DoubleSide;
-    previewMaterial.transparent = true;
-    previewMaterial.opacity = 0.5;
-
-    const geometry = createPlaneBufferGeometry(1, 1, 1, 1, TEXTURES_FLIP_Y);
-    previewMesh = new Mesh(geometry, previewMaterial);
+    previewMesh = new Mesh(videoGeometry, previewMaterial);
     previewMesh.material.map = srcMesh.material.map;
     previewMesh.material.needsUpdate = true;
     // Preview mesh UVs are set to accommodate textureLoader default, but video textures don't match this

--- a/src/systems/bit-media-frames.js
+++ b/src/systems/bit-media-frames.js
@@ -127,18 +127,8 @@ function isColliding(world, physicsSystem, eidA, eidB) {
 }
 
 // TODO we only allow capturing media-loader so rely on its bounds calculations for now
-function getEntityBounds(world, target) {
-  const targetObj = world.eid2obj.get(target);
-
-  let contentBounds;
-  if (hasComponent(world, AEntity, target)) {
-    contentBounds = targetObj.el.components["media-loader"].contentBounds;
-  } else {
-    const mediaEid = findChildWithComponent(world, MediaLoaded, target);
-    contentBounds = new Vector3().fromArray(MediaContentBounds.bounds[mediaEid]);
-  }
-
-  return contentBounds;
+function getEntityBounds(target) {
+  return new Vector3().fromArray(MediaContentBounds.bounds[target]);
 }
 
 function scaleForAspectFit(containerSize, itemSize) {
@@ -262,7 +252,7 @@ function showPreview(world, frame, capturable) {
 
   MediaFrame.preview[frame] = eid;
   MediaFrame.previewingNid[frame] = Networked.id[capturable];
-  snapToFrame(world, frame, eid, getEntityBounds(world, capturable));
+  snapToFrame(world, frame, eid, getEntityBounds(capturable));
 }
 
 function hidePreview(world, frame) {
@@ -364,7 +354,7 @@ export function mediaFramesSystem(world, physicsSystem) {
     const isFrameOwned = hasComponent(world, Owned, frame);
 
     if (captured && isCapturedOwned && !isCapturedHeld && !isFrameDeleting && colliding) {
-      snapToFrame(world, frame, captured, getEntityBounds(world, captured));
+      snapToFrame(world, frame, captured, getEntityBounds(captured));
       physicsSystem.updateRigidBodyOptions(captured, { type: "kinematic" });
     } else if (
       (isFrameOwned && MediaFrame.capturedNid[frame] && world.deletedNids.has(MediaFrame.capturedNid[frame])) ||
@@ -395,7 +385,7 @@ export function mediaFramesSystem(world, physicsSystem) {
         const obj = world.eid2obj.get(capturable);
         obj.updateMatrices();
         tmpVec3.setFromMatrixScale(obj.matrixWorld).toArray(NetworkedMediaFrame.scale[frame]);
-        snapToFrame(world, frame, capturable, getEntityBounds(world, capturable));
+        snapToFrame(world, frame, capturable, getEntityBounds(capturable));
         physicsSystem.updateRigidBodyOptions(capturable, { type: "kinematic" });
       }
     }

--- a/src/systems/bit-media-frames.js
+++ b/src/systems/bit-media-frames.js
@@ -1,23 +1,32 @@
 // https://dev.reticulum.io/scenes/7vGnzkM/outdoor-meetup
 // A scene with media-frames
 
-import { addEntity, defineQuery, enterQuery, exitQuery, entityExists, hasComponent, removeEntity } from "bitecs";
+import { defineQuery, enterQuery, exitQuery, entityExists, hasComponent, addEntity, removeEntity } from "bitecs";
 import {
   AEntity,
+  Deleting,
+  GLTFModel,
   Held,
   MediaFrame,
+  MediaImage,
+  MediaLoaded,
   MediaLoading,
+  MediaPDF,
+  MediaVideo,
   Networked,
   NetworkedMediaFrame,
   Owned,
   Rigidbody
 } from "../bit-components";
-import { addObject3DComponent } from "../utils/jsx-entity";
-import { updateMaterials } from "../utils/material-utils";
 import { MediaType } from "../utils/media-utils";
-import { cloneObject3D, setMatrixWorld } from "../utils/three-utils";
+import { cloneObject3D, createPlaneBufferGeometry, disposeNode, setMatrixWorld } from "../utils/three-utils";
 import { takeOwnership } from "../utils/take-ownership";
 import { takeSoftOwnership } from "../utils/take-soft-ownership";
+import { findAncestorWithComponent, findChildWithComponent } from "../utils/bit-utils";
+import { MediaContentBounds } from "../bit-systems/media-loading";
+import { TEXTURES_FLIP_Y } from "../loaders/HubsTextureLoader";
+import { addObject3DComponent } from "../utils/jsx-entity";
+import { updateMaterials } from "../utils/material-utils";
 
 const EMPTY_COLOR = 0x6fc0fd;
 const HOVER_COLOR = 0x2f80ed;
@@ -27,16 +36,21 @@ const mediaFramesQuery = defineQuery([MediaFrame]);
 const enteredMediaFramesQuery = enterQuery(mediaFramesQuery);
 const exitedMediaFramesQuery = exitQuery(mediaFramesQuery);
 
-// TODO currently only aframe entiteis can be placed in media frames
 function mediaTypeMaskFor(world, eid) {
-  if (!hasComponent(world, AEntity, eid)) return 0;
-
-  const el = world.eid2obj.get(eid).el;
   let mediaTypeMask = 0;
-  mediaTypeMask |= el.components["gltf-model-plus"] && MediaType.MODEL;
-  mediaTypeMask |= el.components["media-video"] && MediaType.VIDEO;
-  mediaTypeMask |= el.components["media-image"] && MediaType.IMAGE;
-  mediaTypeMask |= el.components["media-pdf"] && MediaType.PDF;
+  if (hasComponent(world, AEntity, eid)) {
+    const el = world.eid2obj.get(eid).el;
+    mediaTypeMask |= el.components["gltf-model-plus"] && MediaType.MODEL;
+    mediaTypeMask |= el.components["media-video"] && MediaType.VIDEO;
+    mediaTypeMask |= el.components["media-image"] && MediaType.IMAGE;
+    mediaTypeMask |= el.components["media-pdf"] && MediaType.PDF;
+  } else {
+    const mediaEid = findChildWithComponent(world, MediaLoaded, eid);
+    mediaTypeMask |= hasComponent(world, GLTFModel, mediaEid) && MediaType.MODEL;
+    mediaTypeMask |= hasComponent(world, MediaVideo, mediaEid) && MediaType.VIDEO;
+    mediaTypeMask |= hasComponent(world, MediaImage, mediaEid) && MediaType.IMAGE;
+    mediaTypeMask |= hasComponent(world, MediaPDF, mediaEid) && MediaType.PDF;
+  }
   return mediaTypeMask;
 }
 
@@ -70,8 +84,7 @@ function inOtherFrame(world, ignoredFrame, eid) {
   return false;
 }
 
-function getCapturableEntity(world, frame) {
-  const physicsSystem = AFRAME.scenes[0].systems["hubs-systems"].physicsSystem;
+function getCapturableEntity(world, physicsSystem, frame) {
   const collisions = physicsSystem.getCollisions(Rigidbody.bodyId[frame]);
   const frameObj = world.eid2obj.get(frame);
   for (let i = 0; i < collisions.length; i++) {
@@ -89,8 +102,7 @@ function getCapturableEntity(world, frame) {
   return null;
 }
 
-function isColliding(world, eidA, eidB) {
-  const physicsSystem = AFRAME.scenes[0].systems["hubs-systems"].physicsSystem;
+function isColliding(world, physicsSystem, eidA, eidB) {
   const collisions = physicsSystem.getCollisions(Rigidbody.bodyId[eidA]);
   for (let i = 0; i < collisions.length; i++) {
     const bodyData = physicsSystem.bodyUuidToData.get(collisions[i]);
@@ -102,25 +114,37 @@ function isColliding(world, eidA, eidB) {
   return false;
 }
 
+// TODO we only allow capturing media-loader so rely on its bounds calculations for now
+function getEntityBounds(world, target) {
+  const targetObj = world.eid2obj.get(target);
+
+  let contentBounds;
+  if (hasComponent(world, AEntity, target)) {
+    contentBounds = targetObj.el.components["media-loader"].contentBounds;
+  } else {
+    const mediaEid = findChildWithComponent(world, MediaLoaded, target);
+    contentBounds = MediaContentBounds.get(mediaEid);
+  }
+
+  return contentBounds;
+}
+
+function scaleForAspectFit(containerSize, itemSize) {
+  return Math.min(containerSize[0] / itemSize.x, containerSize[1] / itemSize.y, containerSize[2] / itemSize.z);
+}
+
 const snapToFrame = (() => {
   const framePos = new THREE.Vector3();
   const frameQuat = new THREE.Quaternion();
   const frameScale = new THREE.Vector3();
   const m4 = new THREE.Matrix4();
 
-  function scaleForAspectFit(containerSize, itemSize) {
-    return Math.min(containerSize[0] / itemSize.x, containerSize[1] / itemSize.y, containerSize[2] / itemSize.z);
-  }
-
-  return function snapToFrame(world, frame, target) {
+  return (world, frame, target, contentBounds) => {
     const frameObj = world.eid2obj.get(frame);
     const targetObj = world.eid2obj.get(target);
 
     frameObj.updateMatrices();
     frameObj.matrixWorld.decompose(framePos, frameQuat, frameScale);
-
-    // TODO we only allow capturing media-loader so rely on its bounds calculations for now
-    const contentBounds = targetObj.el.components["media-loader"].contentBounds;
 
     setMatrixWorld(
       targetObj,
@@ -133,89 +157,152 @@ const snapToFrame = (() => {
   };
 })();
 
-function setMatrixScale(obj, scaleArray) {
+const setMatrixScale = (() => {
   const position = new THREE.Vector3();
   const quaternion = new THREE.Quaternion();
   const scale = new THREE.Vector3();
   const m4 = new THREE.Matrix4();
-  obj.updateMatrices();
-  obj.matrixWorld.decompose(position, quaternion, scale);
-  setMatrixWorld(obj, m4.compose(position, quaternion, scale.fromArray(scaleArray)));
-}
 
-function cloneForPreview(world, eid) {
-  // TODO We assume capturable object is an AFRAME entity
-  const el = world.eid2obj.get(eid).el;
-  const mesh = el.getObject3D("mesh");
-  const meshClone = cloneObject3D(mesh, false);
-  meshClone.traverse(node => {
-    updateMaterials(node, function (srcMat) {
-      const mat = srcMat.clone();
-      mat.transparent = true;
-      mat.opacity = 0.5;
-      mat.format = THREE.RGBAFormat;
-      mat.blending = THREE.NormalBlending;
-      node.material = mat;
-      return mat;
+  return (obj, scaleArray) => {
+    obj.updateMatrices();
+    obj.matrixWorld.decompose(position, quaternion, scale);
+    setMatrixWorld(obj, m4.compose(position, quaternion, scale.fromArray(scaleArray)));
+  };
+})();
+
+const frame2mixer = new Map();
+function createPreviewMesh(world, frame, capturable) {
+  let srcMesh;
+  let el;
+  let previewMesh;
+  let isVideo = false;
+  let ratio = 1;
+  if (hasComponent(world, AEntity, capturable)) {
+    el = world.eid2obj.get(capturable).el;
+    const video = el.components["media-video"];
+    isVideo = !!video;
+    if (isVideo) {
+      ratio =
+        (video.videoTexture.image.videoHeight || video.videoTexture.image.height) /
+        (video.videoTexture.image.videoWidth || video.videoTexture.image.width);
+    }
+    srcMesh = el.getObject3D("mesh");
+  } else {
+    const mediaEid = findChildWithComponent(world, MediaLoaded, capturable);
+    isVideo = hasComponent(world, MediaVideo, mediaEid);
+    if (isVideo) {
+      ratio = MediaVideo.ratio[mediaEid];
+    }
+    srcMesh = APP.world.eid2obj.get(mediaEid);
+  }
+
+  // Audios can't be cloned so we take a different path for them
+  if (isVideo) {
+    const previewMaterial = new THREE.MeshBasicMaterial();
+    previewMaterial.side = THREE.DoubleSide;
+    previewMaterial.transparent = true;
+    previewMaterial.opacity = 0.5;
+
+    const geometry = createPlaneBufferGeometry(1, 1, 1, 1, TEXTURES_FLIP_Y);
+    previewMesh = new THREE.Mesh(geometry, previewMaterial);
+    previewMesh.material.map = srcMesh.material.map;
+    previewMesh.material.needsUpdate = true;
+    // Preview mesh UVs are set to accommodate textureLoader default, but video textures don't match this
+    previewMesh.scale.y *= TEXTURES_FLIP_Y !== previewMesh.material.map.flipY ? -ratio : ratio;
+  } else {
+    previewMesh = cloneObject3D(srcMesh, false);
+    previewMesh.traverse(node => {
+      updateMaterials(node, function (srcMat) {
+        const mat = srcMat.clone();
+        mat.transparent = true;
+        mat.opacity = 0.5;
+        mat.format = THREE.RGBAFormat;
+        mat.blending = THREE.NormalBlending;
+        node.material = mat;
+        return mat;
+      });
     });
-  });
 
-  // TODO play animations on previews
+    if (hasComponent(world, AEntity, capturable)) {
+      const loopAnimation = el.components["loop-animation"];
+      if (loopAnimation && loopAnimation.isPlaying) {
+        const originalAnimation = loopAnimation.currentActions[loopAnimation.data.activeClipIndex];
+        const animation = previewMesh.animations[loopAnimation.data.activeClipIndex];
+        const mixer = new THREE.AnimationMixer(previewMesh);
+        const action = mixer.clipAction(animation);
+        action.syncWith(originalAnimation);
+        action.setLoop(THREE.LoopRepeat, Infinity).play();
+        frame2mixer.set(frame, mixer);
+      }
+    }
+  }
 
   // TODO HACK We add this mesh to a group whose position is centered
   //      so that putting this in the middle of a media frame is easy,
   //      but we should just do this math when putting an object into a frame
   //      and not assume an object's root is in the center of its geometry.
-  meshClone.position.setScalar(0);
-  meshClone.quaternion.identity();
-  meshClone.matrixNeedsUpdate = true;
-  const aabb = new THREE.Box3().setFromObject(meshClone);
-  aabb.getCenter(meshClone.position).multiplyScalar(-1);
-  meshClone.matrixNeedsUpdate = true;
+  previewMesh.position.setScalar(0);
+  previewMesh.quaternion.identity();
+  previewMesh.matrixNeedsUpdate = true;
+  const aabb = new THREE.Box3().setFromObject(previewMesh);
+  aabb.getCenter(previewMesh.position).multiplyScalar(-1);
+  previewMesh.matrixNeedsUpdate = true;
 
   const cloneObj = new THREE.Group();
-  cloneObj.el = el; // We rely on media-loader component for bounds
-  cloneObj.add(meshClone);
-  AFRAME.scenes[0].object3D.add(cloneObj);
+  cloneObj.add(previewMesh);
+  APP.world.scene.add(cloneObj);
 
-  return addObject3DComponent(world, addEntity(world), cloneObj);
+  hasComponent(world, AEntity, capturable) && (cloneObj.el = el); // We rely on media-loader component for bounds
+
+  return cloneObj;
 }
 
 function showPreview(world, frame, capturable) {
-  const clone = cloneForPreview(world, capturable);
-  MediaFrame.preview[frame] = clone;
+  const previewObj = createPreviewMesh(world, frame, capturable);
+  const eid = addEntity(world);
+  addObject3DComponent(world, eid, previewObj);
+
+  MediaFrame.preview[frame] = eid;
   MediaFrame.previewingNid[frame] = Networked.id[capturable];
-  snapToFrame(world, frame, clone);
+  snapToFrame(world, frame, eid, getEntityBounds(world, capturable));
 }
 
 function hidePreview(world, frame) {
   // NOTE we intentionally do not dispose of geometries or textures since they are all shared with the original object
-  removeEntity(world, MediaFrame.preview[frame]);
+  const eid = MediaFrame.preview[frame];
+  removeEntity(world, eid);
+
   MediaFrame.preview[frame] = 0;
   MediaFrame.previewingNid[frame] = 0;
+
+  frame2mixer.delete(frame);
 }
 
 const zero = [0, 0, 0];
 const tmpVec3 = new THREE.Vector3();
 
-export function display(world, frame, heldMediaTypes) {
-  const capturable = !MediaFrame.capturedNid[frame] && getCapturableEntity(world, frame);
-  const shouldPreviewBeVisible = capturable && hasComponent(world, Held, capturable);
+export function display(world, physicsSystem, frame, captured, heldMediaTypes) {
+  const capturable = !MediaFrame.capturedNid[frame] && getCapturableEntity(world, physicsSystem, frame);
+  const shouldPreviewBeVisible =
+    (capturable && findChildWithComponent(world, Held, capturable)) ||
+    (captured && findChildWithComponent(world, Held, captured));
   if (shouldPreviewBeVisible && !MediaFrame.preview[frame]) {
-    showPreview(world, frame, capturable);
+    showPreview(world, frame, capturable ? capturable : captured);
   } else if (!shouldPreviewBeVisible && MediaFrame.preview[frame]) {
     hidePreview(world, frame);
   }
 
-  const frameObj = world.eid2obj.get(frame);
-  frameObj.visible = !!(MediaFrame.mediaType[frame] & heldMediaTypes);
+  const guideEid = MediaFrame.guide[frame];
+  const guideObj = world.eid2obj.get(guideEid);
+  guideObj.visible = !!(MediaFrame.mediaType[frame] & heldMediaTypes);
 
-  if (frameObj.visible) {
+  if (guideObj.visible) {
     const captured = world.nid2eid.get(MediaFrame.capturedNid[frame]) || 0;
     const isHoldingObjectOfInterest =
-      (captured && hasComponent(world, Held, captured)) || (capturable && hasComponent(world, Held, capturable));
+      (captured && findChildWithComponent(world, Held, captured)) ||
+      (capturable && findChildWithComponent(world, Held, capturable));
 
-    frameObj.material.uniforms.color.value.set(
+    guideObj.material.uniforms.color.value.set(
       isHoldingObjectOfInterest ? HOVER_COLOR : MediaFrame.capturedNid[frame] ? FULL_COLOR : EMPTY_COLOR
     );
   }
@@ -229,10 +316,16 @@ function mediaTypesOf(world, entities) {
   return mask;
 }
 
+export function cleanupMediaFrame(obj) {
+  obj.traverse(child => {
+    disposeNode(child);
+  });
+}
+
 const takeOwnershipOnTimeout = new Map();
 const heldQuery = defineQuery([Held]);
 // const droppedQuery = exitQuery(heldQuery);
-export function mediaFramesSystem(world) {
+export function mediaFramesSystem(world, physicsSystem) {
   enteredMediaFramesQuery(world).forEach(eid => {
     if (Networked.owner[eid] === APP.getSid("reticulum")) {
       takeOwnershipOnTimeout.set(
@@ -245,6 +338,11 @@ export function mediaFramesSystem(world) {
         }, 10000)
       );
     }
+
+    const guideEid = MediaFrame.guide[eid];
+    const guide = world.eid2obj.get(guideEid);
+    const frameObj = world.eid2obj.get(eid);
+    frameObj.add(guide);
   });
 
   exitedMediaFramesQuery(world).forEach(eid => {
@@ -255,7 +353,6 @@ export function mediaFramesSystem(world) {
     }
   });
 
-  const physicsSystem = AFRAME.scenes[0].systems["hubs-systems"].physicsSystem;
   const heldMediaTypes = mediaTypesOf(world, heldQuery(world));
   // const droppedEntities = droppedQuery(world).filter(eid => entityExists(world, eid));
   const mediaFrames = mediaFramesQuery(world);
@@ -264,16 +361,19 @@ export function mediaFramesSystem(world) {
     const frame = mediaFrames[i];
 
     const captured = world.nid2eid.get(MediaFrame.capturedNid[frame]) || 0;
-    const colliding = captured && isColliding(world, frame, captured);
+    const isCapturedOwned = hasComponent(world, Owned, captured);
+    const isCapturedHeld = findChildWithComponent(world, Held, captured);
+    const colliding = captured && isColliding(world, physicsSystem, frame, captured);
+    const isFrameDeleting = findAncestorWithComponent(world, Deleting, frame);
+    const isFrameOwned = hasComponent(world, Owned, frame);
 
-    if (captured && hasComponent(world, Owned, captured) && !hasComponent(world, Held, captured) && colliding) {
-      snapToFrame(world, frame, captured);
-      physicsSystem.updateBodyOptions(Rigidbody.bodyId[captured], { type: "kinematic" });
+    if (captured && isCapturedOwned && !isCapturedHeld && !isFrameDeleting && colliding) {
+      snapToFrame(world, frame, captured, getEntityBounds(world, captured));
+      physicsSystem.updateRigidBodyOptions(captured, { type: "kinematic" });
     } else if (
-      (hasComponent(world, Owned, frame) &&
-        MediaFrame.capturedNid[frame] &&
-        world.deletedNids.has(MediaFrame.capturedNid[frame])) ||
-      (captured && hasComponent(world, Owned, captured) && !colliding)
+      (isFrameOwned && MediaFrame.capturedNid[frame] && world.deletedNids.has(MediaFrame.capturedNid[frame])) ||
+      (captured && isCapturedOwned && !colliding) ||
+      isFrameDeleting
     ) {
       takeOwnership(world, frame);
       NetworkedMediaFrame.capturedNid[frame] = 0;
@@ -282,13 +382,15 @@ export function mediaFramesSystem(world) {
       //           and then I take ownership of the entity (by grabbing it),
       //           the physics system does not immediately notice the entity colliding with the frame,
       //           so I immediately think the frame should be emptied.
+    } else if (isFrameOwned && MediaFrame.capturedNid[frame] && !captured) {
+      NetworkedMediaFrame.capturedNid[frame] = 0;
+      NetworkedMediaFrame.scale[frame].set(zero);
     } else if (!NetworkedMediaFrame.capturedNid[frame]) {
-      const capturable = getCapturableEntity(world, frame);
+      const capturable = getCapturableEntity(world, physicsSystem, frame);
       if (
         capturable &&
-        (hasComponent(world, Owned, capturable) ||
-          (isOwnedByRet(world, capturable) && hasComponent(world, Owned, frame))) &&
-        !hasComponent(world, Held, capturable) &&
+        (hasComponent(world, Owned, capturable) || (isOwnedByRet(world, capturable) && isFrameOwned)) &&
+        !findChildWithComponent(world, Held, capturable) &&
         !inOtherFrame(world, frame, capturable)
       ) {
         takeOwnership(world, frame);
@@ -297,8 +399,8 @@ export function mediaFramesSystem(world) {
         const obj = world.eid2obj.get(capturable);
         obj.updateMatrices();
         tmpVec3.setFromMatrixScale(obj.matrixWorld).toArray(NetworkedMediaFrame.scale[frame]);
-        snapToFrame(world, frame, capturable);
-        physicsSystem.updateBodyOptions(Rigidbody.bodyId[capturable], { type: "kinematic" });
+        snapToFrame(world, frame, capturable, getEntityBounds(world, capturable));
+        physicsSystem.updateRigidBodyOptions(capturable, { type: "kinematic" });
       }
     }
 
@@ -306,17 +408,21 @@ export function mediaFramesSystem(world) {
       NetworkedMediaFrame.capturedNid[frame] !== MediaFrame.capturedNid[frame] &&
       captured &&
       entityExists(world, captured) &&
-      hasComponent(world, Owned, captured)
+      isCapturedOwned
     ) {
       // TODO: If you are resetting scale because you lost a race for the frame,
       //       you should probably also move the object away from the frame.
       setMatrixScale(world.eid2obj.get(captured), MediaFrame.scale[frame]);
-      physicsSystem.updateBodyOptions(Rigidbody.bodyId[captured], { type: "dynamic" });
+      physicsSystem.updateBodyOptions(captured, { type: "dynamic" });
     }
 
     MediaFrame.capturedNid[frame] = NetworkedMediaFrame.capturedNid[frame];
     MediaFrame.scale[frame].set(NetworkedMediaFrame.scale[frame]);
 
-    display(world, frame, heldMediaTypes);
+    frame2mixer.forEach(mixer => {
+      mixer.update(APP.world.time.delta / 1000);
+    });
+
+    display(world, physicsSystem, frame, captured, heldMediaTypes);
   }
 }

--- a/src/systems/bit-media-frames.js
+++ b/src/systems/bit-media-frames.js
@@ -324,10 +324,9 @@ export function mediaFramesSystem(world, physicsSystem) {
       );
     }
 
-    const guideEid = MediaFrame.guide[eid];
-    const guide = world.eid2obj.get(guideEid);
+    const guideObj = world.eid2obj.get(MediaFrame.guide[eid]);
     const frameObj = world.eid2obj.get(eid);
-    frameObj.add(guide);
+    frameObj.add(guideObj);
   });
 
   exitedMediaFramesQuery(world).forEach(eid => {

--- a/src/systems/bit-media-frames.js
+++ b/src/systems/bit-media-frames.js
@@ -409,7 +409,7 @@ export function mediaFramesSystem(world, physicsSystem) {
       // TODO: If you are resetting scale because you lost a race for the frame,
       //       you should probably also move the object away from the frame.
       setMatrixScale(world.eid2obj.get(captured), MediaFrame.scale[frame]);
-      physicsSystem.updateBodyOptions(captured, { type: "dynamic" });
+      physicsSystem.updateRigidBodyOptions(captured, { type: "dynamic" });
     }
 
     MediaFrame.capturedNid[frame] = NetworkedMediaFrame.capturedNid[frame];

--- a/src/systems/bit-media-frames.js
+++ b/src/systems/bit-media-frames.js
@@ -126,7 +126,6 @@ function isColliding(world, physicsSystem, eidA, eidB) {
   return false;
 }
 
-// TODO we only allow capturing media-loader so rely on its bounds calculations for now
 function getEntityBounds(target) {
   return new Vector3().fromArray(MediaContentBounds.bounds[target]);
 }

--- a/src/systems/bit-media-frames.js
+++ b/src/systems/bit-media-frames.js
@@ -207,7 +207,7 @@ function createPreviewMesh(world, frame, capturable) {
     if (isVideo) {
       ratio = MediaVideo.ratio[mediaEid];
     }
-    srcMesh = APP.world.eid2obj.get(mediaEid);
+    srcMesh = world.eid2obj.get(mediaEid);
   }
 
   // Audios can't be cloned so we take a different path for them
@@ -264,7 +264,7 @@ function createPreviewMesh(world, frame, capturable) {
 
   const cloneObj = new Group();
   cloneObj.add(previewMesh);
-  APP.world.scene.add(cloneObj);
+  world.scene.add(cloneObj);
 
   hasComponent(world, AEntity, capturable) && (cloneObj.el = el); // We rely on media-loader component for bounds
 
@@ -434,7 +434,7 @@ export function mediaFramesSystem(world, physicsSystem) {
     MediaFrame.scale[frame].set(NetworkedMediaFrame.scale[frame]);
 
     frame2mixer.forEach(mixer => {
-      mixer.update(APP.world.time.delta / 1000);
+      mixer.update(world.time.delta / 1000);
     });
 
     display(world, physicsSystem, frame, captured, heldMediaTypes);

--- a/src/systems/bit-media-frames.js
+++ b/src/systems/bit-media-frames.js
@@ -4,7 +4,6 @@
 import { defineQuery, enterQuery, exitQuery, entityExists, hasComponent, addEntity, removeEntity } from "bitecs";
 import {
   AEntity,
-  AnimationMixer,
   Deleting,
   GLTFModel,
   Held,
@@ -32,7 +31,6 @@ import {
   Box3,
   DoubleSide,
   Group,
-  LoopRepeat,
   Matrix4,
   Mesh,
   MeshBasicMaterial,
@@ -184,7 +182,6 @@ const setMatrixScale = (() => {
   };
 })();
 
-const frame2mixer = new Map();
 function createPreviewMesh(world, frame, capturable) {
   let srcMesh;
   let el;
@@ -236,19 +233,6 @@ function createPreviewMesh(world, frame, capturable) {
         return mat;
       });
     });
-
-    if (hasComponent(world, AEntity, capturable)) {
-      const loopAnimation = el.components["loop-animation"];
-      if (loopAnimation && loopAnimation.isPlaying) {
-        const originalAnimation = loopAnimation.currentActions[loopAnimation.data.activeClipIndex];
-        const animation = previewMesh.animations[loopAnimation.data.activeClipIndex];
-        const mixer = new AnimationMixer(previewMesh);
-        const action = mixer.clipAction(animation);
-        action.syncWith(originalAnimation);
-        action.setLoop(LoopRepeat, Infinity).play();
-        frame2mixer.set(frame, mixer);
-      }
-    }
   }
 
   // TODO HACK We add this mesh to a group whose position is centered
@@ -288,8 +272,6 @@ function hidePreview(world, frame) {
 
   MediaFrame.preview[frame] = 0;
   MediaFrame.previewingNid[frame] = 0;
-
-  frame2mixer.delete(frame);
 }
 
 const zero = [0, 0, 0];
@@ -432,10 +414,6 @@ export function mediaFramesSystem(world, physicsSystem) {
 
     MediaFrame.capturedNid[frame] = NetworkedMediaFrame.capturedNid[frame];
     MediaFrame.scale[frame].set(NetworkedMediaFrame.scale[frame]);
-
-    frame2mixer.forEach(mixer => {
-      mixer.update(world.time.delta / 1000);
-    });
 
     display(world, physicsSystem, frame, captured, heldMediaTypes);
   }

--- a/src/systems/floaty-object-system.js
+++ b/src/systems/floaty-object-system.js
@@ -42,7 +42,7 @@ function makeStaticAtRest(world) {
       Object.assign(bodyData.options, {
         type: "kinematic"
       });
-      physicsSystem.updateBody(bodyId, bodyData.options);
+      physicsSystem.updateRigidBody(eid, bodyData.options);
       removeComponent(world, MakeStaticWhenAtRest, eid);
     }
   });
@@ -53,7 +53,7 @@ function makeKinematicOnRelease(world) {
   const physicsSystem = AFRAME.scenes[0].systems["hubs-systems"].physicsSystem;
   makeKinematicOnReleaseExitQuery(world).forEach(eid => {
     if (!entityExists(world, eid) || !hasComponent(world, Owned, eid)) return;
-    physicsSystem.updateBodyOptions(Rigidbody.bodyId[eid], { type: "kinematic" });
+    physicsSystem.updateRigidBodyOptions(eid, { type: "kinematic" });
   });
 }
 
@@ -72,14 +72,14 @@ export const floatyObjectSystem = world => {
   const physicsSystem = AFRAME.scenes[0].systems["hubs-systems"].physicsSystem;
 
   enteredFloatyObjectsQuery(world).forEach(eid => {
-    physicsSystem.updateBodyOptions(Rigidbody.bodyId[eid], {
+    physicsSystem.updateRigidBodyOptions(eid, {
       type: "kinematic",
       gravity: { x: 0, y: 0, z: 0 }
     });
   });
 
   enterHeldFloatyObjectsQuery(world).forEach(eid => {
-    physicsSystem.updateBodyOptions(Rigidbody.bodyId[eid], {
+    physicsSystem.updateRigidBodyOptions(eid, {
       gravity: { x: 0, y: 0, z: 0 },
       type: "dynamic",
       collisionFilterMask: COLLISION_LAYERS.HANDS | COLLISION_LAYERS.MEDIA_FRAMES
@@ -94,7 +94,7 @@ export const floatyObjectSystem = world => {
     const bodyData = physicsSystem.bodyUuidToData.get(bodyId);
     if (FloatyObject.flags[eid] & FLOATY_OBJECT_FLAGS.MODIFY_GRAVITY_ON_RELEASE) {
       if (bodyData.linearVelocity < 1.85) {
-        physicsSystem.updateBodyOptions(bodyId, {
+        physicsSystem.updateRigidBodyOptions(eid, {
           gravity: { x: 0, y: 0, z: 0 },
           angularDamping: FloatyObject.flags[eid] & FLOATY_OBJECT_FLAGS.REDUCE_ANGULAR_FLOAT ? 0.89 : 0.5,
           linearDamping: 0.95,
@@ -104,7 +104,7 @@ export const floatyObjectSystem = world => {
         });
         addComponent(world, MakeStaticWhenAtRest, eid);
       } else {
-        physicsSystem.updateBodyOptions(bodyId, {
+        physicsSystem.updateRigidBodyOptions(eid, {
           gravity: { x: 0, y: FloatyObject.releaseGravity[eid], z: 0 },
           angularDamping: 0.01,
           linearDamping: 0.01,
@@ -115,7 +115,7 @@ export const floatyObjectSystem = world => {
         removeComponent(world, MakeStaticWhenAtRest, eid);
       }
     } else {
-      physicsSystem.updateBodyOptions(bodyId, {
+      physicsSystem.updateRigidBodyOptions(eid, {
         collisionFilterMask: COLLISION_LAYERS.DEFAULT_INTERACTABLE,
         gravity: { x: 0, y: -9.8, z: 0 }
       });

--- a/src/systems/hubs-systems.ts
+++ b/src/systems/hubs-systems.ts
@@ -248,7 +248,7 @@ export function mainTick(xrFrame: XRFrame, renderer: WebGLRenderer, scene: Scene
   pdfMenuSystem(world, sceneEl.is("frozen"));
   linkHoverMenuSystem(world);
   pdfSystem(world);
-  mediaFramesSystem(world);
+  mediaFramesSystem(world, hubsSystems.physicsSystem);
   hubsSystems.audioZonesSystem.tick(hubsSystems.el);
   audioZoneSystem(world);
   audioEmitterSystem(world, hubsSystems.audioSystem);

--- a/src/systems/on-ownership-lost.js
+++ b/src/systems/on-ownership-lost.js
@@ -27,7 +27,7 @@ export function onOwnershipLost(world) {
     }
 
     if (hasComponent(world, Rigidbody, eid)) {
-      physicsSystem.updateBodyOptions(Rigidbody.bodyId[eid], kinematicOptions);
+      physicsSystem.updateRigidBodyOptions(eid, kinematicOptions);
     }
   }
 }

--- a/src/systems/physics-system.js
+++ b/src/systems/physics-system.js
@@ -2,6 +2,8 @@ import { AmmoWorker, WorkerHelpers, CONSTANTS } from "three-ammo";
 import { AmmoDebugConstants, DefaultBufferSize } from "ammo-debug-drawer";
 import configs from "../utils/configs";
 import ammoWasmUrl from "ammo.js/builds/ammo.wasm.wasm";
+import { Rigidbody } from "../bit-components";
+import { updateRigiBodyParams } from "../inflators/rigid-body";
 
 const MESSAGE_TYPES = CONSTANTS.MESSAGE_TYPES,
   TYPE = CONSTANTS.TYPE,
@@ -241,6 +243,12 @@ export class PhysicsSystem {
     return bodyId;
   }
 
+  updateRigidBody(eid, options) {
+    const bodyId = Rigidbody.bodyId[eid];
+    updateRigiBodyParams(eid, options);
+    this.updateBody(bodyId, options);
+  }
+
   updateBody(uuid, options) {
     if (this.bodyUuidToData.has(uuid)) {
       this.bodyUuidToData.get(uuid).options = options;
@@ -248,6 +256,12 @@ export class PhysicsSystem {
     } else {
       console.warn(`updateBody called for uuid: ${uuid} but body missing.`);
     }
+  }
+
+  updateRigidBodyOptions(eid, options) {
+    const bodyId = Rigidbody.bodyId[eid];
+    updateRigiBodyParams(eid, options);
+    this.updateBodyOptions(bodyId, options);
   }
 
   // TODO inline updateBody

--- a/src/systems/physics-system.js
+++ b/src/systems/physics-system.js
@@ -246,26 +246,17 @@ export class PhysicsSystem {
   updateRigidBody(eid, options) {
     const bodyId = Rigidbody.bodyId[eid];
     updateRigiBodyParams(eid, options);
-    this.updateBody(bodyId, options);
-  }
-
-  updateBody(uuid, options) {
-    if (this.bodyUuidToData.has(uuid)) {
-      this.bodyUuidToData.get(uuid).options = options;
-      this.workerHelpers.updateBody(uuid, options);
+    if (this.bodyUuidToData.has(bodyId)) {
+      this.bodyUuidToData.get(bodyId).options = options;
+      this.workerHelpers.updateBody(bodyId, options);
     } else {
-      console.warn(`updateBody called for uuid: ${uuid} but body missing.`);
+      console.warn(`updateBody called for uuid: ${bodyId} but body missing.`);
     }
   }
 
   updateRigidBodyOptions(eid, options) {
     const bodyId = Rigidbody.bodyId[eid];
     updateRigiBodyParams(eid, options);
-    this.updateBodyOptions(bodyId, options);
-  }
-
-  // TODO inline updateBody
-  updateBodyOptions(bodyId, options) {
     const bodyData = this.bodyUuidToData.get(bodyId);
     if (!bodyData) {
       // TODO: Fix me.

--- a/src/systems/remove-object3D-system.js
+++ b/src/systems/remove-object3D-system.js
@@ -24,6 +24,7 @@ import { disposeMaterial, traverseSome, disposeNode } from "../utils/three-utils
 import { forEachMaterial } from "../utils/material-utils";
 import { cleanupAudio } from "../bit-systems/audio-emitter-system";
 import { cleanupAudioDebugNavMesh } from "../bit-systems/audio-debug-system";
+import { cleanupMediaFrame } from "./bit-media-frames";
 
 function cleanupObjOnExit(Component, f) {
   const query = exitQuery(defineQuery([Component]));
@@ -51,8 +52,8 @@ const cleanupGLTFs = cleanupObjOnExit(GLTFModel, obj => {
 });
 const cleanupLights = cleanupObjOnExit(LightTag, obj => obj.dispose());
 const cleanupTexts = cleanupObjOnExit(TextTag, obj => obj.dispose());
-const cleanupMediaFrames = cleanupObjOnExit(MediaFrame, obj => obj.geometry.dispose());
-const cleanupAudioEmitters = cleanupObjOnExit(AudioEmitter, obj => cleanupAudio(obj));
+const cleanupMediaFrames = cleanupObjOnExit(MediaFrame, cleanupMediaFrame);
+const cleanupAudioEmitters = cleanupObjOnExit(AudioEmitter, cleanupAudio);
 const cleanupImages = cleanupObjOnExit(MediaImage, obj => {
   releaseTextureByKey(APP.getString(MediaImage.cacheKey[obj.eid]));
   obj.geometry.dispose();

--- a/src/utils/jsx-entity.ts
+++ b/src/utils/jsx-entity.ts
@@ -86,7 +86,7 @@ import { AudioZoneParams, inflateAudioZone } from "../inflators/audio-zone";
 import { AudioSettings } from "../components/audio-params";
 import { inflateAudioParams } from "../inflators/audio-params";
 import { PhysicsShapeParams, inflatePhysicsShape } from "../inflators/physics-shape";
-import { inflateRigidBody, RigiBodyParams } from "../inflators/rigid-body";
+import { inflateRigidBody, RigidBodyParams } from "../inflators/rigid-body";
 import { AmmoShapeParams, inflateAmmoShape } from "../inflators/ammo-shape";
 import { BoxColliderParams, inflateBoxCollider } from "../inflators/box-collider";
 import { inflateTrimesh } from "../inflators/trimesh";
@@ -250,6 +250,7 @@ export interface ComponentData {
   mirror?: MirrorParams;
   audioZone?: AudioZoneParams;
   audioParams?: AudioSettings;
+  mediaFrame?: any;
 }
 
 type OptionalParams<T> = Partial<T> | true;
@@ -299,7 +300,7 @@ export interface JSXComponentData extends ComponentData {
   networked?: any;
   textButton?: any;
   hoverButton?: any;
-  rigidbody?: OptionalParams<RigiBodyParams>;
+  rigidbody?: OptionalParams<RigidBodyParams>;
   physicsShape?: OptionalParams<PhysicsShapeParams>;
   floatyObject?: any;
   networkedFloatyObject?: any;
@@ -347,7 +348,6 @@ export interface JSXComponentData extends ComponentData {
   mediaLoader?: MediaLoaderParams;
   sceneRoot?: boolean;
   sceneLoader?: { src: string };
-  mediaFrame?: any;
   object3D?: any;
   text?: TextParams;
   model?: ModelParams;
@@ -412,7 +412,8 @@ export const commonInflators: Required<{ [K in keyof ComponentData]: InflatorFn 
   spotLight: inflateSpotLight,
   mirror: inflateMirror,
   audioZone: inflateAudioZone,
-  audioParams: inflateAudioParams
+  audioParams: inflateAudioParams,
+  mediaFrame: inflateMediaFrame
 };
 
 const jsxInflators: Required<{ [K in keyof JSXComponentData]: InflatorFn }> = {
@@ -454,7 +455,6 @@ const jsxInflators: Required<{ [K in keyof JSXComponentData]: InflatorFn }> = {
   mediaLoader: inflateMediaLoader,
 
   // inflators that create Object3Ds
-  mediaFrame: inflateMediaFrame,
   object3D: addObject3DComponent,
   slice9: inflateSlice9,
   text: inflateText,


### PR DESCRIPTION
Built on top of https://github.com/mozilla/hubs/pull/5978. Only the last commit applies.

As commented in a previous PR, 

> It's a bit unfortunate that we have to go back and forth between bitECS and Ammo to keep everything in sync. As the
entry point for the physics life cycle is the physics system, I wonder it would be better to encapsulate all the > component life cycle there and let that system manage it all. Instead of going through the hops of adding a component and have that intermediate bit-physics-system to map that to the physics system, just call the physics system and it will add/update the component under the hood and keep everything in sync.
