### PR TITLE
Do not resize model loaded as part of the scene using the model component

### DIFF
--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -183,7 +183,7 @@ AFRAME.GLTFModelPlus.registerComponent("media", "media", (el, componentName, com
   }
 });
 
-async function mediaInflator(el, componentName, componentData, components) {
+async function mediaInflator(el, componentName, componentData, components, fitToBox = true) {
   let isControlled = true;
 
   if (componentName === "link" && (components.video || components.image)) {
@@ -266,7 +266,7 @@ async function mediaInflator(el, componentName, componentData, components) {
 
   el.setAttribute("media-loader", {
     src: sanitizeUrl(src),
-    fitToBox: true,
+    fitToBox,
     resolve: true,
     fileIsOwned: true,
     animate: false,
@@ -275,23 +275,26 @@ async function mediaInflator(el, componentName, componentData, components) {
   });
 }
 
-AFRAME.GLTFModelPlus.registerComponent("model", "model", mediaInflator);
-AFRAME.GLTFModelPlus.registerComponent("image", "image", mediaInflator);
-AFRAME.GLTFModelPlus.registerComponent("audio", "audio", mediaInflator, (name, property, value) => {
+const mediaInflatorNoResize = (el, componentName, componentData, components) =>
+  mediaInflator(el, componentName, componentData, components, false);
+
+AFRAME.GLTFModelPlus.registerComponent("model", "model", mediaInflatorNoResize);
+AFRAME.GLTFModelPlus.registerComponent("image", "image", mediaInflatorNoResize);
+AFRAME.GLTFModelPlus.registerComponent("audio", "audio", mediaInflatorNoResize, (name, property, value) => {
   if (property === "paused") {
     return { name: "video-pause-state", property, value };
   } else {
     return null;
   }
 });
-AFRAME.GLTFModelPlus.registerComponent("video", "video", mediaInflator, (name, property, value) => {
+AFRAME.GLTFModelPlus.registerComponent("video", "video", mediaInflatorNoResize, (name, property, value) => {
   if (property === "paused") {
     return { name: "video-pause-state", property, value };
   } else {
     return null;
   }
 });
-AFRAME.GLTFModelPlus.registerComponent("link", "link", mediaInflator);
+AFRAME.GLTFModelPlus.registerComponent("link", "link", mediaInflatorNoResize);
 
 AFRAME.GLTFModelPlus.registerComponent("hoverable", "is-remote-hover-target", el => {
   el.setAttribute("is-remote-hover-target", "");

--- a/src/inflators/model-loader.ts
+++ b/src/inflators/model-loader.ts
@@ -3,13 +3,13 @@ import { inflateMediaLoader } from "./media-loader";
 
 export type ModelLoaderParams = {
   src: string;
-}
+};
 
 export function inflateModelLoader(world: HubsWorld, eid: number, params: ModelLoaderParams) {
   inflateMediaLoader(world, eid, {
     src: params.src,
     recenter: true,
-    resize: true,
+    resize: false,
     animateLoad: false,
     isObjectMenuTarget: false
   });


### PR DESCRIPTION
We are resizing objects that have a media component attached (image/video(model) and that causes issues as scene designers expect those objects to stay untouched.

Resizing makes sense for dynamically spawned objects but not so much for scene objects.

We were already not resizing image/video component in bitECS but model was still being resized, I've changed that. I've also updated the related AFrame components to behave the same.

Closes https://github.com/MozillaReality/hubs-blender-exporter/issues/104