### PR TITLE
Add interpolation to bitECS network transform.

### DIFF
--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -285,3 +285,22 @@ export const ScenePreviewCamera = defineComponent({
   duration: Types.f32,
   positionOnly: Types.ui8
 });
+export const LinearTranslate = defineComponent({
+  duration: Types.f32,
+  targetX: Types.f32,
+  targetY: Types.f32,
+  targetZ: Types.f32
+});
+export const LinearRotate = defineComponent({
+  duration: Types.f32,
+  targetX: Types.f32,
+  targetY: Types.f32,
+  targetZ: Types.f32,
+  targetW: Types.f32
+});
+export const LinearScale = defineComponent({
+  duration: Types.f32,
+  targetX: Types.f32,
+  targetY: Types.f32,
+  targetZ: Types.f32
+});

--- a/src/bit-systems/linear-transform.ts
+++ b/src/bit-systems/linear-transform.ts
@@ -1,0 +1,72 @@
+import { defineQuery, removeComponent } from "bitecs";
+import { Quaternion, Vector3 } from "three";
+import { LinearRotate, LinearScale, LinearTranslate, Object3DTag } from "../bit-components";
+import { HubsWorld } from "../app";
+
+// Working variables
+const _vec3 = new Vector3();
+const _quat = new Quaternion();
+
+const linearTranslateQuery = defineQuery([LinearTranslate, Object3DTag]);
+const linearRotateQuery = defineQuery([LinearRotate, Object3DTag]);
+const linearScaleQuery = defineQuery([LinearScale, Object3DTag]);
+
+export function linearTransformSystem(world: HubsWorld) {
+  linearTranslateQuery(world).forEach(eid => {
+    const duration = LinearTranslate.duration[eid];
+    const targetX = LinearTranslate.targetX[eid];
+    const targetY = LinearTranslate.targetY[eid];
+    const targetZ = LinearTranslate.targetZ[eid];
+
+    const deltaTime = world.time.delta;
+    const obj = world.eid2obj.get(eid)!;
+
+    if (deltaTime >= duration) {
+      obj.position.set(targetX, targetY, targetZ);
+      removeComponent(world, LinearTranslate, eid);
+    } else {
+      obj.position.lerp(_vec3.set(targetX, targetY, targetZ), deltaTime / duration);
+      LinearTranslate.duration[eid] = duration - deltaTime;
+    }
+    obj.matrixNeedsUpdate = true;
+  });
+
+  linearRotateQuery(world).forEach(eid => {
+    const duration = LinearRotate.duration[eid];
+    const targetX = LinearRotate.targetX[eid];
+    const targetY = LinearRotate.targetY[eid];
+    const targetZ = LinearRotate.targetZ[eid];
+    const targetW = LinearRotate.targetW[eid];
+
+    const deltaTime = world.time.delta;
+    const obj = world.eid2obj.get(eid)!;
+
+    if (deltaTime >= duration) {
+      obj.quaternion.set(targetX, targetY, targetZ, targetW);
+      removeComponent(world, LinearRotate, eid);
+    } else {
+      obj.quaternion.slerp(_quat.set(targetX, targetY, targetZ, targetW), deltaTime / duration);
+      LinearRotate.duration[eid] = duration - deltaTime;
+    }
+    obj.matrixNeedsUpdate = true;
+  });
+
+  linearScaleQuery(world).forEach(eid => {
+    const duration = LinearScale.duration[eid];
+    const targetX = LinearScale.targetX[eid];
+    const targetY = LinearScale.targetY[eid];
+    const targetZ = LinearScale.targetZ[eid];
+
+    const deltaTime = world.time.delta;
+    const obj = world.eid2obj.get(eid)!;
+
+    if (deltaTime >= duration) {
+      obj.scale.set(targetX, targetY, targetZ);
+      removeComponent(world, LinearScale, eid);
+    } else {
+      obj.scale.lerp(_vec3.set(targetX, targetY, targetZ), deltaTime / duration);
+      LinearScale.duration[eid] = duration - deltaTime;
+    }
+    obj.matrixNeedsUpdate = true;
+  });
+}

--- a/src/bit-systems/network-send-system.ts
+++ b/src/bit-systems/network-send-system.ts
@@ -8,13 +8,12 @@ import {
   isCreatedByMe,
   isNetworkInstantiated,
   localClientID,
+  millisecondsBetweenTicks,
   networkedQuery,
   pendingJoins,
   softRemovedEntities
 } from "./networking";
 
-const ticksPerSecond = 12;
-const millisecondsBetweenTicks = 1000 / ticksPerSecond;
 let nextTick = 0;
 
 const ownedNetworkedQuery = defineQuery([Owned, Networked]);

--- a/src/bit-systems/networking.ts
+++ b/src/bit-systems/networking.ts
@@ -26,3 +26,6 @@ export function isPinned(eid: EntityID) {
 export function isCreatedByMe(eid: EntityID) {
   return Networked.creator[eid] === APP.getSid(NAF.clientId);
 }
+
+const ticksPerSecond = 12;
+export const millisecondsBetweenTicks = 1000 / ticksPerSecond;

--- a/src/systems/hubs-systems.ts
+++ b/src/systems/hubs-systems.ts
@@ -74,6 +74,7 @@ import { audioZoneSystem } from "../bit-systems/audio-zone-system";
 import { audioDebugSystem } from "../bit-systems/audio-debug-system";
 import { textSystem } from "../bit-systems/text";
 import { scenePreviewCameraSystem } from "../bit-systems/scene-preview-camera-system";
+import { linearTransformSystem } from "../bit-systems/linear-transform";
 
 declare global {
   interface Window {
@@ -255,6 +256,7 @@ export function mainTick(xrFrame: XRFrame, renderer: WebGLRenderer, scene: Scene
   hubsSystems.gainSystem.tick();
   hubsSystems.nameTagSystem.tick();
   simpleWaterSystem(world);
+  linearTransformSystem(world);
 
   // All systems that update text properties should run before this
   textSystem(world);

--- a/src/systems/networked-transform.js
+++ b/src/systems/networked-transform.js
@@ -1,5 +1,6 @@
-import { defineQuery, hasComponent } from "bitecs";
-import { NetworkedTransform, Owned } from "../bit-components";
+import { addComponent, defineQuery, hasComponent } from "bitecs";
+import { LinearRotate, LinearScale, LinearTranslate, NetworkedTransform, Owned } from "../bit-components";
+import { millisecondsBetweenTicks } from "../bit-systems/networking";
 
 const query = defineQuery([NetworkedTransform]);
 
@@ -27,23 +28,31 @@ export function networkedTransformSystem(world) {
     } else {
       tmpVec.fromArray(NetworkedTransform.position[eid]);
       if (!tmpVec.near(obj.position)) {
-        obj.position.copy(tmpVec);
-        obj.matrixNeedsUpdate = true;
+        addComponent(world, LinearTranslate, eid);
+        LinearTranslate.duration[eid] = millisecondsBetweenTicks;
+        LinearTranslate.targetX[eid] = tmpVec.x;
+        LinearTranslate.targetY[eid] = tmpVec.y;
+        LinearTranslate.targetZ[eid] = tmpVec.z;
       }
 
       tmpQuat.fromArray(NetworkedTransform.rotation[eid]);
       if (!tmpQuat.near(obj.quaternion)) {
-        obj.quaternion.copy(tmpQuat);
-        obj.matrixNeedsUpdate = true;
+        addComponent(world, LinearRotate, eid);
+        LinearRotate.duration[eid] = millisecondsBetweenTicks;
+        LinearRotate.targetX[eid] = tmpQuat.x;
+        LinearRotate.targetY[eid] = tmpQuat.y;
+        LinearRotate.targetZ[eid] = tmpQuat.z;
+        LinearRotate.targetW[eid] = tmpQuat.w;
       }
 
       tmpVec.fromArray(NetworkedTransform.scale[eid]);
       if (!tmpVec.near(obj.scale)) {
-        obj.scale.copy(tmpVec);
-        obj.matrixNeedsUpdate = true;
+        addComponent(world, LinearScale, eid);
+        LinearScale.duration[eid] = millisecondsBetweenTicks;
+        LinearScale.targetX[eid] = tmpVec.x;
+        LinearScale.targetY[eid] = tmpVec.y;
+        LinearScale.targetZ[eid] = tmpVec.z;
       }
     }
   }
 }
-
-// TODO lerping


### PR DESCRIPTION
This PR adds easy linear interpolation to bitECS network transform.

Changes
* Add LinearTranslate/Rotate/Scale components
* Add linearTransform system to handle the added components
* network-transform sets the component when receiving data from remote
* Move millisecondsBetweenTicks from network-send-system to networking because it is referred from two places