### PR TITLE
Allow folks to close the full-screen Preferences modal by pressing the Escape key

### DIFF
--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -898,6 +898,12 @@ class PreferencesScreen extends Component {
     };
   }
 
+  onKeyDown = (e) => {
+    if (e.key === "Escape") {
+      this.props.onClose();
+    }
+  }
+
   onMediaDevicesUpdated = () => {
     const currentSpeakers = this.mediaDevicesManager.selectedSpeakersDeviceId;
     if (this.props.store.state.preferences.preferredSpeakers !== currentSpeakers) {
@@ -971,18 +977,20 @@ class PreferencesScreen extends Component {
     this.props.store.addEventListener("statechanged", this.storeUpdated);
     this.mediaDevicesManager.on(MediaDevicesEvents.DEVICE_CHANGE, this.onMediaDevicesUpdated);
     APP.hubChannel.addEventListener("permissions_updated", this.permissionsUpdated);
-
+    window.addEventListener("keydown", this.onKeyDown);
+    
     if (this.state.canVoiceChat) {
       this.mediaDevicesManager.startMicShare({ updatePrefs: false }).then(this.updateMediaDevices);
     } else {
       this.updateMediaDevices();
     }
   }
-
+  
   componentWillUnmount() {
     this.props.store.removeEventListener("statechanged", this.storeUpdated);
     this.mediaDevicesManager.off(MediaDevicesEvents.DEVICE_CHANGE, this.onMediaDevicesUpdated);
     APP.hubChannel.removeEventListener("permissions_updated", this.permissionsUpdated);
+    window.removeEventListener("keydown", this.onKeyDown);
   }
 
   permissionsUpdated() {


### PR DESCRIPTION
Hello! When I was playing with Hubs' great new demo room recently, I went into Preferences to boost the room's media volume. I noticed that I couldn't close the full-screen Preferences window with an Escape keypress, though I felt like I should be able to (both from a "UX patterns" perspective and because other elements within the UI are closeable with Esc).

This PR lets people close the Preferences window with Escape and get right back to the action without leaving their keyboard.

-----

Also, I noticed that when I ran `npm run test` as per the Contributing guidelines, I got this error:
![image](https://user-images.githubusercontent.com/3409031/230785703-3a2e2a9e-560f-46bf-b102-f483f8cee998.png)

I'm not sure if this is worth opening a new issue.