### PR TITLE
Update room entry buttons label from "options" to "room settings"

### DIFF
--- a/src/assets/locales/de.json
+++ b/src/assets/locales/de.json
@@ -436,7 +436,7 @@
   "revoke-token-modal.title": "Token widerrufen",
   "room-entry-modal.enter-on-device-button": "In VR betreten",
   "room-entry-modal.join-room-button": "Raum betreten",
-  "room-entry-modal.options-button": "Optionen",
+  "room-entry-modal.room-settings-button": "Raumeinstellungen",
   "room-entry-modal.room-name-label": "Raumname",
   "room-entry-modal.spectate-button": "Zuschauen",
   "room-settings-sidebar.access-invite": "Nur mit Einladung",

--- a/src/assets/locales/fr.json
+++ b/src/assets/locales/fr.json
@@ -452,7 +452,7 @@
   "revoke-token-modal.title": "Révoquer jeton",
   "room-entry-modal.enter-on-device-button": "Entrer avec l'appareil",
   "room-entry-modal.join-room-button": "Rejoindre la salle",
-  "room-entry-modal.options-button": "Options",
+  "room-entry-modal.room-settings-button": "Paramètres de la salle",
   "room-entry-modal.room-name-label": "Nom de la salle",
   "room-entry-modal.spectate-button": "Observer",
   "room-settings-sidebar.access-invite": "Invitation seulement",

--- a/src/assets/locales/ja.json
+++ b/src/assets/locales/ja.json
@@ -513,7 +513,7 @@
   "revoke-token-modal.title": "トークンの取り消し",
   "room-entry-modal.enter-on-device-button": "デバイスで入室",
   "room-entry-modal.join-room-button": "入室",
-  "room-entry-modal.options-button": "オプション",
+  "room-entry-modal.room-settings-button": "部屋の設定",
   "room-entry-modal.room-name-label": "ルーム名",
   "room-entry-modal.spectate-button": "観客モードで入室",
   "room-settings-sidebar.access-invite": "招待者のみ",

--- a/src/assets/locales/ja.json
+++ b/src/assets/locales/ja.json
@@ -513,7 +513,7 @@
   "revoke-token-modal.title": "トークンの取り消し",
   "room-entry-modal.enter-on-device-button": "デバイスで入室",
   "room-entry-modal.join-room-button": "入室",
-  "room-entry-modal.room-settings-button": "部屋の設定",
+  "room-entry-modal.room-settings-button": "ルームの設定",
   "room-entry-modal.room-name-label": "ルーム名",
   "room-entry-modal.spectate-button": "観客モードで入室",
   "room-settings-sidebar.access-invite": "招待者のみ",

--- a/src/assets/locales/ko.json
+++ b/src/assets/locales/ko.json
@@ -112,7 +112,7 @@
   "room-entry-modal.join-room-button": "입장하기",
   "room-entry-modal.enter-on-device-button": "다른 장치를 이용하기",
   "room-entry-modal.spectate-button": "관전하기",
-  "room-entry-modal.options-button": "설정",
+  "room-entry-modal.room-settings-button": "방 설정",
   "content-menu.objects-menu-button": "Objects",
   "content-menu.people-menu-button": "참가자 ({presenceCount})",
   "back-button": "뒤로가기",

--- a/src/assets/locales/pt.json
+++ b/src/assets/locales/pt.json
@@ -459,7 +459,7 @@
   "revoke-token-modal.title": "Revogar token",
   "room-entry-modal.enter-on-device-button": "Entrar remoto",
   "room-entry-modal.join-room-button": "Entrar",
-  "room-entry-modal.options-button": "Opções",
+  "room-entry-modal.room-settings-button": "Configurações do quarto",
   "room-entry-modal.room-name-label": "Sala",
   "room-entry-modal.spectate-button": "Espiar",
   "room-settings-sidebar.access-invite": "Apenas convite",

--- a/src/assets/locales/zh-tw.json
+++ b/src/assets/locales/zh-tw.json
@@ -461,7 +461,7 @@
 	"revoke-token-modal.title": "撤銷代幣",
 	"room-entry-modal.enter-on-device-button": "在裝置上輸入",
 	"room-entry-modal.join-room-button": "加入房間",
-	"room-entry-modal.options-button": "可選的",
+	"room-entry-modal.room-settings-button": "房间设置",
 	"room-entry-modal.room-name-label": "房間名稱",
 	"room-entry-modal.spectate-button": "觀看",
 	"room-settings-sidebar.access-invite": "僅限邀請",

--- a/src/react-components/room/RoomEntryModal.js
+++ b/src/react-components/room/RoomEntryModal.js
@@ -23,7 +23,7 @@ export function RoomEntryModal({
   onEnterOnDevice,
   showSpectate,
   onSpectate,
-  showOptions,
+  showRoomSettings,
   onRoomSettings,
   ...rest
 }) {
@@ -67,7 +67,7 @@ export function RoomEntryModal({
               </span>
             </Button>
           )}
-          {showOptions && breakpoint !== "sm" && (
+          {showRoomSettings && breakpoint !== "sm" && (
             <>
               <hr className={styleUtils.showLg} />
               <Button preset="transparent" className={styleUtils.showLg} onClick={onRoomSettings}>
@@ -93,7 +93,7 @@ RoomEntryModal.propTypes = {
   onEnterOnDevice: PropTypes.func,
   showSpectate: PropTypes.bool,
   onSpectate: PropTypes.func,
-  showOptions: PropTypes.bool,
+  showRoomSettings: PropTypes.bool,
   onRoomSettings: PropTypes.func
 };
 
@@ -101,5 +101,5 @@ RoomEntryModal.defaultProps = {
   showJoinRoom: true,
   showEnterOnDevice: true,
   showSpectate: true,
-  showOptions: true
+  showRoomSettings: true
 };

--- a/src/react-components/room/RoomEntryModal.js
+++ b/src/react-components/room/RoomEntryModal.js
@@ -24,7 +24,7 @@ export function RoomEntryModal({
   showSpectate,
   onSpectate,
   showOptions,
-  onOptions,
+  onRoomSettings,
   ...rest
 }) {
   const breakpoint = useCssBreakpoints();
@@ -70,10 +70,10 @@ export function RoomEntryModal({
           {showOptions && breakpoint !== "sm" && (
             <>
               <hr className={styleUtils.showLg} />
-              <Button preset="transparent" className={styleUtils.showLg} onClick={onOptions}>
+              <Button preset="transparent" className={styleUtils.showLg} onClick={onRoomSettings}>
                 <SettingsIcon />
                 <span>
-                  <FormattedMessage id="room-entry-modal.options-button" defaultMessage="Options" />
+                  <FormattedMessage id="room-entry-modal.room-settings-button" defaultMessage="Room Settings" />
                 </span>
               </Button>
             </>
@@ -94,7 +94,7 @@ RoomEntryModal.propTypes = {
   showSpectate: PropTypes.bool,
   onSpectate: PropTypes.func,
   showOptions: PropTypes.bool,
-  onOptions: PropTypes.func
+  onRoomSettings: PropTypes.func
 };
 
 RoomEntryModal.defaultProps = {

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -845,7 +845,7 @@ class UIRoot extends Component {
           showSpectate={!this.state.waitingOnAudio}
           onSpectate={() => this.setState({ watching: true })}
           showOptions={this.props.hubChannel.canOrWillIfCreator("update_hub")}
-          onOptions={() => {
+          onRoomSettings={() => {
             this.props.performConditionalSignIn(
               () => this.props.hubChannel.can("update_hub"),
               () => this.setSidebar("room-settings"),

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -844,7 +844,7 @@ class UIRoot extends Component {
           onEnterOnDevice={() => this.attemptLink()}
           showSpectate={!this.state.waitingOnAudio}
           onSpectate={() => this.setState({ watching: true })}
-          showOptions={this.props.hubChannel.canOrWillIfCreator("update_hub")}
+          showRoomSettings={this.props.hubChannel.canOrWillIfCreator("update_hub")}
           onRoomSettings={() => {
             this.props.performConditionalSignIn(
               () => this.props.hubChannel.can("update_hub"),


### PR DESCRIPTION
- For consistency across client, this PR changes the "options" label on room entry to read "room settings"
- Translations have been updated but require a second set of eyes to confirm accuracy
<img width="397" alt="Screenshot 2023-04-12 at 11 08 16 AM" src="https://user-images.githubusercontent.com/42850541/231503916-2cd66bb0-356d-4e40-aad5-ff897238e3fc.png">
