### PR TITLE
Upgrade Lilypad to v1.8.2

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -2244,11 +2244,11 @@
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "node_modules/@mozilla/lilypad-ui": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@mozilla/lilypad-ui/-/lilypad-ui-1.7.7.tgz",
-      "integrity": "sha512-Ubhw29bwotBg+yR6eg4C0CJH+54pDgxOBtPAjcT9jo9eG8IgsCLAGdI8su9mFYdgl+M562ovV/3XBqy5SHC9bw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@mozilla/lilypad-ui/-/lilypad-ui-1.8.2.tgz",
+      "integrity": "sha512-fwHNoPLrV2dXV5WYz5IEO6whRDvARx4/4d8/5sqfScLnRo43Feffn+CpnNBpbvt9P5bS6ZLsr6ppoDZYNmhK9A==",
       "peerDependencies": {
-        "react": "^18.1.0"
+        "react": ">=16.13.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -11615,9 +11615,10 @@
       }
     },
     "@mozilla/lilypad-ui": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@mozilla/lilypad-ui/-/lilypad-ui-1.7.7.tgz",
-      "integrity": "sha512-Ubhw29bwotBg+yR6eg4C0CJH+54pDgxOBtPAjcT9jo9eG8IgsCLAGdI8su9mFYdgl+M562ovV/3XBqy5SHC9bw=="
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@mozilla/lilypad-ui/-/lilypad-ui-1.8.2.tgz",
+      "integrity": "sha512-fwHNoPLrV2dXV5WYz5IEO6whRDvARx4/4d8/5sqfScLnRo43Feffn+CpnNBpbvt9P5bS6ZLsr6ppoDZYNmhK9A==",
+      "requires": {}
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -12055,7 +12056,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
       "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/info": {
       "version": "1.5.0",
@@ -12070,7 +12072,8 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
       "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -12104,13 +12107,15 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "aframe": {
       "version": "git+ssh://git@github.com/mozillareality/aframe.git#3155ad3df9632ee84d93d3cd8250a4c44767e70e",
@@ -12178,7 +12183,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-html-community": {
       "version": "0.0.8",
@@ -13481,7 +13487,8 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "7.1.1",
@@ -14540,7 +14547,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ieee754": {
       "version": "1.2.1",
@@ -15073,12 +15081,14 @@
     "jss-default-unit": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
-      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg=="
+      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg==",
+      "requires": {}
     },
     "jss-expand": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/jss-expand/-/jss-expand-5.3.0.tgz",
-      "integrity": "sha512-NiM4TbDVE0ykXSAw6dfFmB1LIqXP/jdd0ZMnlvlGgEMkMt+weJIl8Ynq1DsuBY9WwkNyzWktdqcEW2VN0RAtQg=="
+      "integrity": "sha512-NiM4TbDVE0ykXSAw6dfFmB1LIqXP/jdd0ZMnlvlGgEMkMt+weJIl8Ynq1DsuBY9WwkNyzWktdqcEW2VN0RAtQg==",
+      "requires": {}
     },
     "jss-extend": {
       "version": "6.2.0",
@@ -15101,7 +15111,8 @@
     "jss-global": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
-      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q=="
+      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q==",
+      "requires": {}
     },
     "jss-nested": {
       "version": "6.0.1",
@@ -15141,7 +15152,8 @@
     "jss-props-sort": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
-      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g=="
+      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g==",
+      "requires": {}
     },
     "jss-template": {
       "version": "1.0.1",
@@ -15835,7 +15847,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -17060,7 +17073,8 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
       "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "super-animejs": {
       "version": "3.1.0",
@@ -17770,7 +17784,8 @@
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
       "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml": {
       "version": "1.0.1",

--- a/admin/package.json
+++ b/admin/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@iarna/toml": "^2.2.3",
-    "@mozilla/lilypad-ui": "^1.7.7",
+    "@mozilla/lilypad-ui": "^1.8.2",
     "aframe": "github:mozillareality/aframe#hubs/master",
     "bitecs": "github:mozilla/bitECS#hubs-patches",
     "classnames": "^2.2.5",


### PR DESCRIPTION
Why
---
This removes the need for `--legacy-peer-deps` or `--force` during dependency installation