### PR TITLE
Remove safari mic hack

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -41,6 +41,7 @@ patchWebGLRenderingContext();
 
 import "networked-aframe/src/index";
 import "webrtc-adapter";
+import { detectOS, detect } from "detect-browser";
 import {
   getReticulumFetchUrl,
   getReticulumMeta,
@@ -716,6 +717,19 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   if (platformUnsupported()) {
     return;
+  }
+
+  const detectedOS = detectOS(navigator.userAgent);
+  const browser = detect();
+  // HACK - it seems if we don't initialize the mic track up-front, voices can drop out on iOS
+  // safari when initializing it later.
+  if (["iOS", "Mac OS"].includes(detectedOS) && ["safari", "ios"].includes(browser.name) && browser.version < "16.4") {
+    try {
+      await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (e) {
+      remountUI({ showSafariMicDialog: true });
+      return;
+    }
   }
 
   const hubId = getCurrentHubId();

--- a/src/hub.js
+++ b/src/hub.js
@@ -41,7 +41,6 @@ patchWebGLRenderingContext();
 
 import "networked-aframe/src/index";
 import "webrtc-adapter";
-import { detectOS, detect } from "detect-browser";
 import {
   getReticulumFetchUrl,
   getReticulumMeta,
@@ -717,19 +716,6 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   if (platformUnsupported()) {
     return;
-  }
-
-  const detectedOS = detectOS(navigator.userAgent);
-  const browser = detect();
-  // HACK - it seems if we don't initialize the mic track up-front, voices can drop out on iOS
-  // safari when initializing it later.
-  if (["iOS", "Mac OS"].includes(detectedOS) && ["safari", "ios"].includes(browser.name)) {
-    try {
-      await navigator.mediaDevices.getUserMedia({ audio: true });
-    } catch (e) {
-      remountUI({ showSafariMicDialog: true });
-      return;
-    }
   }
 
   const hubId = getCurrentHubId();

--- a/src/hub.js
+++ b/src/hub.js
@@ -723,6 +723,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const browser = detect();
   // HACK - it seems if we don't initialize the mic track up-front, voices can drop out on iOS
   // safari when initializing it later.
+  // Seems to be working for Safari >= 16.4. We should revisit this in the future and remove it completely.
   if (["iOS", "Mac OS"].includes(detectedOS) && ["safari", "ios"].includes(browser.name) && browser.version < "16.4") {
     try {
       await navigator.mediaDevices.getUserMedia({ audio: true });


### PR DESCRIPTION
This hack is been there for a while but it seems to be fixed now. I have only tested in Safari 16.3 MacOS so it needs some more testing in iOS devices.

We might want to still leave it and remove it for only the latest current version or it's safe to assume that iOS/Mac devices are updated after a while after an update has been released?