### PR TITLE
Fix: EnvironmentMap not updating after changing scene

### DIFF
--- a/src/components/skybox.js
+++ b/src/components/skybox.js
@@ -475,8 +475,7 @@ AFRAME.registerComponent("skybox", {
       this.el.setObject3D("light-probe", this.sky.generateLightProbe(this.el.sceneEl.renderer));
     }
 
-    // TODO if we care about dynamic skybox changes we should also update the enviornment map here
-    //
+    this.el.sceneEl.object3D.environment = this.sky.generateEnvironmentMap(this.el.sceneEl.renderer);
   },
 
   remove() {


### PR DESCRIPTION
Original Scene Lighting/Colors:
![image](https://user-images.githubusercontent.com/73490994/232857255-1ec7c657-03f6-4f86-831d-d5718625b43b.png)

Scene colors and lights when coming from a dark scene:
![image](https://user-images.githubusercontent.com/73490994/232857972-25036b68-dc02-48d7-9a95-e00056b5835d.png)

I found that this happens because the environment of the scene is not updating correctly when changing the scene.
I also found this comment:
 `// TODO if we care about dynamic skybox changes we should also update the environment map here`
 
What is just the solution to the problem I was having