### PR TITLE
tidying up security issues for locked down demo

### DIFF
--- a/src/systems/inspect-yourself-system.js
+++ b/src/systems/inspect-yourself-system.js
@@ -1,8 +1,9 @@
+import { isLockedDownDemoRoom } from "../utils/hub-utils";
 import { paths } from "./userinput/paths";
 export class InspectYourselfSystem {
   tick(scene, userinput, cameraSystem) {
     if (!scene.is("entered")) return;
-    if (userinput.get(paths.actions.startInspectingSelf)) {
+    if (userinput.get(paths.actions.startInspectingSelf) && !isLockedDownDemoRoom()) {
       const rig = document.getElementById("avatar-rig");
       cameraSystem.inspect(rig, 1.5);
     }

--- a/src/utils/hub-utils.js
+++ b/src/utils/hub-utils.js
@@ -55,7 +55,7 @@ export function isRoomOwner(clientId) {
 }
 
 export function isLockedDownDemoRoom() {
-  if (window.APP?.hubChannel?.canOrWillIfCreator("update_hub")) return;
+  if (APP.hubChannel?.canOrWillIfCreator("update_hub")) return;
   const hubId = getCurrentHubId();
   if (configs.feature("is_locked_down_demo_room")) {
     const idArr = configs.feature("is_locked_down_demo_room").replace(/\s/g, "").split(",");

--- a/src/utils/hub-utils.js
+++ b/src/utils/hub-utils.js
@@ -55,6 +55,7 @@ export function isRoomOwner(clientId) {
 }
 
 export function isLockedDownDemoRoom() {
+  if (window.APP?.hubChannel?.canOrWillIfCreator("update_hub")) return;
   const hubId = getCurrentHubId();
   if (configs.feature("is_locked_down_demo_room")) {
     const idArr = configs.feature("is_locked_down_demo_room").replace(/\s/g, "").split(",");


### PR DESCRIPTION
This PR locks down the "i" key shortcut in locked down demo rooms and allows promoted users to have full access to room features. The desire is for promoted users to be able to moderate demo rooms.