### PR TITLE
bitECS object list support

### DIFF
--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -161,6 +161,12 @@ export const LoadedByMediaLoader = defineComponent();
 export const MediaContentBounds = defineComponent({
   bounds: [Types.f32, 3]
 });
+export const MediaInfo = defineComponent({
+  accessibleUrl: Types.ui32,
+  contentType: Types.ui32
+});
+MediaInfo.accessibleUrl[$isStringType] = true;
+MediaInfo.contentType[$isStringType] = true;
 
 // MediaImageLoaderData and MediaVideoLoaderData are
 // for parameters that are set at glTF inflators

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -111,7 +111,7 @@ AFRAME.registerComponent("media-loader", {
         setMatrixWorld(mesh, originalMeshMatrix);
       } else {
         // Move the mesh such that the center of its bounding box is in the same position as the parent matrix position
-        const box = getBox(this.el, mesh);
+        const box = getBox(this.el.object3D, mesh);
         const scaleCoefficient = fitToBox ? getScaleCoefficient(0.5, box) : 1;
         const { min, max } = box;
         center.addVectors(min, max).multiplyScalar(0.5 * scaleCoefficient);
@@ -283,7 +283,7 @@ AFRAME.registerComponent("media-loader", {
       }
 
       // TODO this does duplicate work in some cases, but finish() is the only consistent place to do it
-      const contentBounds = getBox(this.el, this.el.getObject3D("mesh")).getSize(new THREE.Vector3());
+      const contentBounds = getBox(this.el.object3D, this.el.getObject3D("mesh")).getSize(new THREE.Vector3());
       addComponent(APP.world, MediaContentBounds, el.eid);
       MediaContentBounds.bounds[el.eid].set(contentBounds.toArray());
 

--- a/src/components/super-spawner.js
+++ b/src/components/super-spawner.js
@@ -111,7 +111,7 @@ AFRAME.registerComponent("super-spawner", {
         ? 1
         : 0.5;
 
-    const scaleCoefficient = getScaleCoefficient(boxSize, getBox(spawnedEntity, spawnedEntity.object3D));
+    const scaleCoefficient = getScaleCoefficient(boxSize, getBox(spawnedEntity.object3D, spawnedEntity.object3D));
     this.spawnedMediaScale.divideScalar(scaleCoefficient);
   },
 

--- a/src/prefabs/media.tsx
+++ b/src/prefabs/media.tsx
@@ -28,6 +28,7 @@ export function MediaPrefab(params: MediaLoaderParams): EntityDef {
         collisionMask: COLLISION_LAYERS.HANDS
       }}
       scale={[1, 1, 1]}
+      inspectable
     />
   );
 }

--- a/src/react-components/room/object-hooks.js
+++ b/src/react-components/room/object-hooks.js
@@ -1,24 +1,36 @@
 import { useEffect, useState, useCallback, useMemo } from "react";
 import { removeNetworkedObject } from "../../utils/removeNetworkedObject";
+import { shouldUseNewLoader } from "../../utils/bit-utils";
 import { rotateInPlaceAroundWorldUp, affixToWorldUp } from "../../utils/three-utils";
 import { getPromotionTokenForFile } from "../../utils/media-utils";
 import { hasComponent } from "bitecs";
-import { Static } from "../../bit-components";
 import { isPinned as getPinnedState } from "../../bit-systems/networking";
+import { MediaInfo, Static } from "../../bit-components";
+import { deleteTheDeletableAncestor } from "../../bit-systems/delete-entity-system";
 
 export function isMe(object) {
-  return object.el.id === "avatar-rig";
+  return object.id === "avatar-rig";
 }
 
 export function isPlayer(object) {
-  return !!object.el.components["networked-avatar"];
+  if (shouldUseNewLoader()) {
+    // TODO Add when networked avatar is migrated
+    return false;
+  } else {
+    return !!object.el.components["networked-avatar"];
+  }
 }
 
 export function getObjectUrl(object) {
-  const mediaLoader = object.el.components["media-loader"];
-
-  const url =
-    mediaLoader && ((mediaLoader.data.mediaOptions && mediaLoader.data.mediaOptions.href) || mediaLoader.data.src);
+  let url;
+  if (shouldUseNewLoader()) {
+    const urlSid = MediaInfo.accessibleUrl[object.eid];
+    url = APP.getString(urlSid);
+  } else {
+    const mediaLoader = object.el.components["media-loader"];
+    url =
+      mediaLoader && ((mediaLoader.data.mediaOptions && mediaLoader.data.mediaOptions.href) || mediaLoader.data.src);
+  }
 
   if (url && !url.startsWith("hubs://")) {
     return url;
@@ -28,7 +40,7 @@ export function getObjectUrl(object) {
 }
 
 export function usePinObject(hubChannel, scene, object) {
-  const [isPinned, setIsPinned] = useState(getPinnedState(object.el.eid));
+  const [isPinned, setIsPinned] = useState(getPinnedState(object.eid));
 
   const pinObject = useCallback(() => {
     const el = object.el;
@@ -51,6 +63,11 @@ export function usePinObject(hubChannel, scene, object) {
   }, [isPinned, pinObject, unpinObject]);
 
   useEffect(() => {
+    // TODO Add when pinning is migrated
+    if (shouldUseNewLoader()) {
+      return;
+    }
+
     const el = object.el;
 
     function onPinStateChanged() {
@@ -64,6 +81,11 @@ export function usePinObject(hubChannel, scene, object) {
       el.removeEventListener("unpinned", onPinStateChanged);
     };
   }, [object]);
+
+  if (shouldUseNewLoader()) {
+    // TODO Add when pinning is migrated
+    return false;
+  }
 
   const el = object.el;
 
@@ -114,16 +136,20 @@ export function useGoToSelectedObject(scene, object) {
 
 export function useRemoveObject(hubChannel, scene, object) {
   const removeObject = useCallback(() => {
-    removeNetworkedObject(scene, object.el);
+    if (shouldUseNewLoader()) {
+      deleteTheDeletableAncestor(APP.world, object.eid);
+    } else {
+      removeNetworkedObject(scene, object.el);
+    }
   }, [scene, object]);
 
-  const el = object.el;
+  const eid = object.eid;
 
   const canRemoveObject = !!(
     scene.is("entered") &&
     !isPlayer(object) &&
-    !getPinnedState(el.eid) &&
-    !hasComponent(APP.world, Static, el.eid) &&
+    !getPinnedState(eid) &&
+    !hasComponent(APP.world, Static, eid) &&
     hubChannel.can("spawn_and_move_media")
   );
 

--- a/src/systems/camera-system.js
+++ b/src/systems/camera-system.js
@@ -8,8 +8,19 @@ import { qsGet } from "../utils/qs_truthy";
 const customFOV = qsGet("fov");
 const enableThirdPersonMode = qsTruthy("thirdPerson");
 import { Layers } from "../camera-layers";
+import { Inspectable } from "../bit-components";
+import { findAncestorWithComponent, shouldUseNewLoader } from "../utils/bit-utils";
 
-function getInspectableInHierarchy(el) {
+function getInspectableInHierarchy(eid) {
+  let inspectable = findAncestorWithComponent(APP.world, Inspectable, eid);
+  if (!inspectable) {
+    console.warn("could not find inspectable in hierarchy");
+    inspectable = eid;
+  }
+  return APP.world.eid2obj.get(inspectable);
+}
+
+function getInspectableInHierarchyAframe(el) {
   let inspectable = el;
   while (inspectable) {
     if (isTagged(inspectable, "inspectable")) {
@@ -36,8 +47,14 @@ function pivotFor(el) {
   return child.object3D;
 }
 
-export function getInspectableAndPivot(el) {
-  const inspectable = getInspectableInHierarchy(el);
+function getInspectableAndPivot(eid) {
+  const inspectable = getInspectableInHierarchy(eid);
+  // TODO Add support for pivotFor (avatars only)
+  return { inspectable, pivot: inspectable };
+}
+
+function getInspectableAndPivotAframe(el) {
+  const inspectable = getInspectableInHierarchyAframe(el);
   const pivot = pivotFor(inspectable.el);
   return { inspectable, pivot };
 }
@@ -119,22 +136,16 @@ const moveRigSoCameraLooksAtPivot = (function () {
     decompose(camera.matrixWorld, cwp, cwq);
     rig.getWorldQuaternion(cwq);
 
-    const box = getBox(inspectable.el, inspectable.el.getObject3D("mesh") || inspectable, true);
+    const box = getBox(inspectable, inspectable, true);
     if (box.min.x === Infinity) {
       // fix edgecase where inspectable object has no mesh / dimensions
       box.min.subVectors(owp, defaultBoxMax);
       box.max.addVectors(owp, defaultBoxMax);
     }
     box.getCenter(center);
-    const vrMode = inspectable.el.sceneEl.is("vr-mode");
+    const vrMode = APP.scene.is("vr-mode");
     const dist =
-      calculateViewingDistance(
-        inspectable.el.sceneEl.camera.fov,
-        inspectable.el.sceneEl.camera.aspect,
-        box,
-        center,
-        vrMode
-      ) * distanceMod;
+      calculateViewingDistance(APP.scene.camera.fov, APP.scene.camera.aspect, box, center, vrMode) * distanceMod;
     target.position.addVectors(
       owp,
       oForw
@@ -252,15 +263,19 @@ export class CameraSystem {
     this.mode = NEXT_MODES[this.mode] || 0;
   }
 
-  inspect(el, distanceMod, fireChangeEvent = true) {
-    const { inspectable, pivot } = getInspectableAndPivot(el);
-
+  inspect(obj, distanceMod, fireChangeEvent = true) {
     this.verticalDelta = 0;
     this.horizontalDelta = 0;
     this.inspectZoom = 0;
+
     if (this.mode === CAMERA_MODE_INSPECT) {
       return;
     }
+
+    const { inspectable, pivot } = shouldUseNewLoader()
+      ? getInspectableAndPivot(obj.eid)
+      : getInspectableAndPivotAframe(obj.el);
+
     const scene = AFRAME.scenes[0];
     scene.object3D.traverse(ensureLightsAreSeenByCamera);
     scene.classList.add("hand-cursor");
@@ -282,7 +297,16 @@ export class CameraSystem {
     this.viewingCamera.updateMatrices();
     this.snapshot.matrixWorld.copy(this.viewingRig.object3D.matrixWorld);
 
-    this.snapshot.audio = !(inspectable.el && isTagged(inspectable.el, "preventAudioBoost")) && getAudio(inspectable);
+    let preventAudioBoost;
+
+    if (shouldUseNewLoader()) {
+      // TODO Add when avatar is migrated
+      preventAudioBoost = false;
+    } else {
+      preventAudioBoost = inspectable.el && isTagged(inspectable.el, "preventAudioBoost");
+    }
+
+    this.snapshot.audio = !preventAudioBoost && getAudio(inspectable);
     if (this.snapshot.audio) {
       this.snapshot.audio.updateMatrices();
       this.snapshot.audioTransform.copy(this.snapshot.audio.matrixWorld);
@@ -427,7 +451,7 @@ export class CameraSystem {
         const hoverEl = this.interaction.state.rightRemote.hovered || this.interaction.state.leftRemote.hovered;
 
         if (hoverEl) {
-          this.inspect(hoverEl, 1.5);
+          this.inspect(hoverEl.object3D, 1.5);
         }
       } else if (this.mode === CAMERA_MODE_INSPECT && this.userinput.get(paths.actions.stopInspecting)) {
         scene.emit("uninspect");

--- a/src/utils/auto-box-collider.js
+++ b/src/utils/auto-box-collider.js
@@ -90,13 +90,13 @@ export const computeObjectAABB = (function () {
 })();
 
 const rotation = new THREE.Euler();
-export function getBox(entity, boxRoot, worldSpace) {
+export function getBox(obj, boxRoot, worldSpace) {
   const box = new THREE.Box3();
 
-  rotation.copy(entity.object3D.rotation);
-  entity.object3D.rotation.set(0, 0, 0);
+  rotation.copy(obj.rotation);
+  obj.rotation.set(0, 0, 0);
 
-  entity.object3D.updateMatrices(true, true);
+  obj.updateMatrices(true, true);
   boxRoot.updateMatrices(true, true);
   boxRoot.updateMatrixWorld(true);
 
@@ -104,11 +104,11 @@ export function getBox(entity, boxRoot, worldSpace) {
 
   if (!box.isEmpty()) {
     if (!worldSpace) {
-      entity.object3D.worldToLocal(box.min);
-      entity.object3D.worldToLocal(box.max);
+      obj.worldToLocal(box.min);
+      obj.worldToLocal(box.max);
     }
-    entity.object3D.rotation.copy(rotation);
-    entity.object3D.matrixNeedsUpdate = true;
+    obj.rotation.copy(rotation);
+    obj.matrixNeedsUpdate = true;
   }
 
   boxRoot.matrixWorldNeedsUpdate = true;

--- a/src/utils/jsx-entity.ts
+++ b/src/utils/jsx-entity.ts
@@ -38,8 +38,8 @@ import {
   MaterialTag,
   VideoTextureSource,
   Quack,
-  Mirror,
-  MixerAnimatableInitialize
+  MixerAnimatableInitialize,
+  Inspectable
 } from "../bit-components";
 import { inflateMediaLoader } from "../inflators/media-loader";
 import { inflateMediaFrame } from "../inflators/media-frame";
@@ -359,6 +359,7 @@ export interface JSXComponentData extends ComponentData {
   waypointPreview?: boolean;
   pdf?: PDFParams;
   loopAnimation?: LoopAnimationParams;
+  inspectable?: boolean;
 }
 
 export interface GLTFComponentData extends ComponentData {
@@ -464,6 +465,7 @@ const jsxInflators: Required<{ [K in keyof JSXComponentData]: InflatorFn }> = {
   quack: createDefaultInflator(Quack),
   mixerAnimatable: createDefaultInflator(MixerAnimatableInitialize),
   loopAnimation: inflateLoopAnimationInitialize,
+  inspectable: createDefaultInflator(Inspectable),
   // inflators that create Object3Ds
   object3D: addObject3DComponent,
   slice9: inflateSlice9,

--- a/src/utils/media-sorting.js
+++ b/src/utils/media-sorting.js
@@ -1,9 +1,5 @@
-import { faVideo } from "@fortawesome/free-solid-svg-icons/faVideo";
-import { faMusic } from "@fortawesome/free-solid-svg-icons/faMusic";
-import { faImage } from "@fortawesome/free-solid-svg-icons/faImage";
-import { faNewspaper } from "@fortawesome/free-solid-svg-icons/faNewspaper";
-import { faQuestion } from "@fortawesome/free-solid-svg-icons/faQuestion";
-import { faCube } from "@fortawesome/free-solid-svg-icons/faCube";
+import { hasComponent } from "bitecs";
+import { GLTFModel, MediaImage, MediaInfo, MediaPDF, MediaVideo } from "../bit-components";
 
 export const SORT_ORDER_VIDEO = 0;
 export const SORT_ORDER_AUDIO = 1;
@@ -12,7 +8,24 @@ export const SORT_ORDER_PDF = 3;
 export const SORT_ORDER_MODEL = 4;
 export const SORT_ORDER_UNIDENTIFIED = 5;
 
-export function mediaSortOrder(el) {
+function mediaSortOrder(eid) {
+  if (hasComponent(APP.world, MediaVideo, eid)) {
+    if (hasComponent(APP.world, MediaInfo, eid)) {
+      const contentTypeSid = MediaInfo.contentType[eid];
+      const contentType = APP.getString(contentTypeSid);
+      if (contentType.startsWith("audio/")) {
+        return SORT_ORDER_AUDIO;
+      }
+    }
+    return SORT_ORDER_VIDEO;
+  }
+  if (hasComponent(APP.world, MediaImage, eid)) return SORT_ORDER_IMAGE;
+  if (hasComponent(APP.world, MediaPDF, eid)) return SORT_ORDER_PDF;
+  if (hasComponent(APP.world, GLTFModel, eid)) return SORT_ORDER_MODEL;
+  return SORT_ORDER_UNIDENTIFIED;
+}
+
+function mediaSortOrderAframe(el) {
   if (el.components["media-video"] && el.components["media-video"].data.contentType.startsWith("audio/")) {
     return SORT_ORDER_AUDIO;
   }
@@ -23,18 +36,13 @@ export function mediaSortOrder(el) {
   return SORT_ORDER_UNIDENTIFIED;
 }
 
-export function mediaSort(el1, el2) {
-  return mediaSortOrder(el1) - mediaSortOrder(el2);
+export function mediaSort(eid1, eid2) {
+  return mediaSortOrder(eid1) - mediaSortOrder(eid2);
 }
 
-export const DISPLAY_IMAGE = new Map([
-  [SORT_ORDER_VIDEO, faVideo],
-  [SORT_ORDER_AUDIO, faMusic],
-  [SORT_ORDER_IMAGE, faImage],
-  [SORT_ORDER_PDF, faNewspaper],
-  [SORT_ORDER_UNIDENTIFIED, faQuestion],
-  [SORT_ORDER_MODEL, faCube]
-]);
+export function mediaSortAframe(el1, el2) {
+  return mediaSortOrderAframe(el1) - mediaSortOrderAframe(el2);
+}
 
 const SORT_ORDER_TO_TYPE = {
   [SORT_ORDER_VIDEO]: "video",
@@ -44,7 +52,12 @@ const SORT_ORDER_TO_TYPE = {
   [SORT_ORDER_MODEL]: "model"
 };
 
-export function getMediaType(el) {
-  const order = mediaSortOrder(el);
+export function getMediaType(eid) {
+  const order = mediaSortOrder(eid);
+  return SORT_ORDER_TO_TYPE[order];
+}
+
+export function getMediaTypeAframe(el) {
+  const order = mediaSortOrderAframe(el);
   return SORT_ORDER_TO_TYPE[order];
 }


### PR DESCRIPTION
This commit adds bitECS object list support.

**Basic Strategy**

Reuse the existing A-Frame based code as much as possible for now.

In the related functions that take A-Frame element, take `Object3D` instead. `Object3D` has a reference to A-Frame element in the A-Frame based implementation and has a reference to Entity ID in the bitECS. The functions process with A-Frame element or Entity ID depending on whether new loader enabled.

Explicitly use `shouldUseNewLoader()` and/or make two functions, one for A-Frame based and another one for bitECS based implementation, if different logics are needed between A-Frame based and bitECS based implementations. Duplicated codes may not be perfectly removed but it would be simpler to follow the code rather than the new loader pretends the old one. And it would be easier to edit
the code when we will get rid of A-Frame.

**Changes**

- Introduce `MediaInfo` component and save url and content type into it when loading media in media-loader. The info is used in the object list
- Fire `listed_media_changed` event when media is loaded via media-loader and when the loaded media entity is removed
- Take `Object3D` instead of A-Frame element in the related functions
- Use `shouldUseNewLoader()` and/or make two separated functions
  for A-Frame and bitECS where the different logics are needed

**Future TODOs**

- Support avatars

Authors @keianhzo and @takahirox 
