### PR TITLE
fix: dark mode logo now shows when specified

### DIFF
--- a/admin/webpack.config.js
+++ b/admin/webpack.config.js
@@ -80,7 +80,7 @@ module.exports = (env, argv) => {
       RETICULUM_SERVER: "hubs.local:4000",
       POSTGREST_SERVER: "",
       ITA_SERVER: "turkey",
-      TIER: "p0"
+      TIER: "p1"
     });
   }
 

--- a/src/react-components/misc/AppLogo.tsx
+++ b/src/react-components/misc/AppLogo.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import configs from "../../utils/configs";
-import HmcLogo from "../icons/HmcLogo.svg";
+import { ReactComponent as HmcLogo } from "../icons/HmcLogo.svg";
 import { isHmc } from "../../utils/isHmc";
 import { useLogo } from "../styles/theme";
 

--- a/src/react-components/styles/theme.js
+++ b/src/react-components/styles/theme.js
@@ -57,7 +57,7 @@ export function useTheme(themeId) {
 
 function getAppLogo(darkMode) {
   const theme = getCurrentTheme();
-  const shouldUseDarkLogo = theme ? theme.darkModeDefault : darkMode;
+  const shouldUseDarkLogo = theme ? (theme.darkModeDefault || theme.id.includes("dark-mode")) : darkMode;
   return (shouldUseDarkLogo && configs.image("logo_dark")) || configs.image("logo");
 }
 

--- a/src/react-components/styles/theme.js
+++ b/src/react-components/styles/theme.js
@@ -57,7 +57,7 @@ export function useTheme(themeId) {
 
 function getAppLogo(darkMode) {
   const theme = getCurrentTheme();
-  const shouldUseDarkLogo = theme ? (theme.darkModeDefault || theme.id.includes("dark-mode")) : darkMode;
+  const shouldUseDarkLogo = theme ? theme.darkModeDefault || theme.id.includes("dark-mode") : darkMode;
   return (shouldUseDarkLogo && configs.image("logo_dark")) || configs.image("logo");
 }
 

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -1,4 +1,6 @@
 declare module "*.svg" {
-  const content: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
-  export default content;
+  import React = require("react");
+  export const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>;
+  const src: string;
+  export default src;
 }


### PR DESCRIPTION
- Dark mode logo was not showing for some accounts since the HMC logo fix. Discovered that users had to manually add "darkModeDefault: true" to their theme in the admin panel. This is not obvious, so I added a check for the inclusion of "dark-mode" in the theme id.
- Minor fix for the import of svgs in TS included in this PR
- This PR also changes the local env TIER variable to paid tier "p1".

NOTE: I'm not sure I agree with the darkModeDefault property - when we tidy up custom theming, I'll look into alternatives.