### PR TITLE
Decouple branding sections from external details

### DIFF
--- a/admin/src/react-components/admin-menu.js
+++ b/admin/src/react-components/admin-menu.js
@@ -18,7 +18,7 @@ import SettingsIcon from "@material-ui/icons/Settings";
 import Collapse from "@material-ui/core/Collapse";
 import { getServiceDisplayName } from "../utils/ita";
 import configs from "../utils/configs";
-import { hasPaidFeature } from "../utils/feature_flags";
+import { hasPaidFeature, isBrandingDisabled } from "../utils/feature_flags";
 import HubsLogo from "../assets/images/hubs_logo.png";
 
 const mapStateToProps = state => ({
@@ -187,7 +187,7 @@ class Menu extends Component {
                 <ListItemText className={this.props.classes.text} primary="App Settings" />
               </ListItem>
 
-              {hasPaidFeature() && (
+              {hasPaidFeature() && !isBrandingDisabled() && (
                 <>
                   {/* IMAGE SETTING  */}
                   <ListItem

--- a/admin/src/react-components/pages/system-editor.tsx
+++ b/admin/src/react-components/pages/system-editor.tsx
@@ -10,7 +10,7 @@ import CardSection from "../shared/CardSection";
 import { Icon } from "@mozilla/lilypad-ui";
 import { DiscordIcon, BookIcon, QuestionIcon, GithubIcon } from "../shared/icons";
 import Card from "../shared/Card";
-import { hasPaidFeature } from "../../utils/feature_flags";
+import { hasPaidFeature, isBrandingDisabled } from "../../utils/feature_flags";
 
 const styles = withCommonStyles(() => ({}));
 
@@ -108,7 +108,7 @@ const SystemEditorComponent = ({ classes }) => {
         <section className="mb-40">
           <h3 className="heading-sm mb-28">Customize the look of your hub</h3>
 
-          {hasPaidFeature() && (
+          {hasPaidFeature() && !isBrandingDisabled() && (
             <CardSection
               className="mb-20"
               ctaCallback={() => {

--- a/admin/src/utils/configs.js
+++ b/admin/src/utils/configs.js
@@ -1,12 +1,18 @@
 // Read configs from global variable if available, otherwise use the process.env injected from build.
 const configs = {};
 
-["RETICULUM_SERVER", "POSTGREST_SERVER", "ITA_SERVER", "TIER", "CONFIGURABLE_SERVICES", "CORS_PROXY_SERVER"].forEach(
-  x => {
-    const el = document.querySelector(`meta[name='env:${x.toLowerCase()}']`);
-    configs[x] = el ? el.getAttribute("content") : process.env[x];
-  }
-);
+[
+  "CONFIGURABLE_SERVICES",
+  "CORS_PROXY_SERVER",
+  "DISABLE_BRANDING",
+  "ITA_SERVER",
+  "POSTGREST_SERVER",
+  "RETICULUM_SERVER",
+  "TIER"
+].forEach(x => {
+  const el = document.querySelector(`meta[name='env:${x.toLowerCase()}']`);
+  configs[x] = el ? el.getAttribute("content") : process.env[x];
+});
 
 // Custom clients do not use <meta> tags for passing data, so if reticulum_server meta tag exists, it is not a custom client
 const hasReticulumServerMetaTag = !!document.querySelector("meta[name='env:reticulum_server']");

--- a/admin/src/utils/feature_flags.ts
+++ b/admin/src/utils/feature_flags.ts
@@ -1,10 +1,15 @@
 import configs from "../utils/configs";
 import { PaidTiers } from "../../types";
 
+// TODO: Remove this function once Orch sets DISABLE_BRANDING
 export function hasPaidFeature(): boolean {
   // If the user is not a turkey user then no need to check.
   if (configs.ITA_SERVER != "turkey") return true;
 
   const authorizedTiers: PaidTiers[] = ["p1", "b1"];
   return authorizedTiers.includes(configs.TIER);
+}
+
+export function isBrandingDisabled(): boolean {
+  return configs.DISABLE_BRANDING === "true"
 }

--- a/admin/webpack.config.js
+++ b/admin/webpack.config.js
@@ -295,6 +295,7 @@ module.exports = (env, argv) => {
       new webpack.DefinePlugin({
         "process.browser": true,
         "process.env": JSON.stringify({
+          DISABLE_BRANDING: process.env.DISABLE_BRANDING,
           NODE_ENV: argv.mode,
           BUILD_VERSION: process.env.BUILD_VERSION,
           CONFIGURABLE_SERVICES: process.env.CONFIGURABLE_SERVICES,


### PR DESCRIPTION
Why
---
Admin is an instance service.  We don’t want it coupled to orchestration details or the Hubs managed service plans.

What
----
* Hide branding sections based on `DISABLE_BRANDING` rather than `ITA_SERVER` and `TIER`