### PR TITLE
Use canonical URL for local non-model assets

### DIFF
--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -615,8 +615,7 @@ export async function resolveMediaInfo(urlString) {
 
   // We want to resolve and proxy some hubs urls, like rooms and scene links,
   // but want to avoid proxying assets in order for this to work in dev environments
-  const isLocalModelAsset =
-    isNonCorsProxyDomain(url.hostname) && (guessContentType(url.href) || "").startsWith("model/gltf");
+  const isLocalModelAsset = isNonCorsProxyDomain(url.hostname);
 
   if (url.protocol != "data:" && url.protocol != "hubs:" && !isLocalModelAsset) {
     const response = await resolveUrl(url.href);


### PR DESCRIPTION
Not ready for merge.

Links for local files are broken when working locally behind `newLoader` flag.

This change causes the canconical URL to be retrieved for non-model local assets. This is tested locally and on my personal dev instance with *.jpg, *.glb, *.mp4, and *.mp3. It is possible that there is something that I am missing and that this is a regression so this should not be merged until I can confirm what the original intent was for limiting this behavior to model assets.

resolves #6081 