### PR TITLE
fix:sets entry modal logo width

### DIFF
--- a/src/react-components/room/RoomEntryModal.scss
+++ b/src/react-components/room/RoomEntryModal.scss
@@ -19,8 +19,11 @@
 }
 
 :local(.logo) {
+  height: auto;
   max-height: 250px;
   height: 100%;
+  object-fit: cover;
+  min-width: 100px;
 }
 
 :local(.room-name) {

--- a/src/react-components/room/RoomEntryModal.scss
+++ b/src/react-components/room/RoomEntryModal.scss
@@ -22,8 +22,9 @@
   height: auto;
   max-height: 250px;
   height: 100%;
-  object-fit: cover;
-  min-width: 100px;
+  object-fit: contain;
+  object-position: center;
+  min-width: 172px;
 }
 
 :local(.room-name) {


### PR DESCRIPTION
- With custom logos now visible, this existing bug became apparent when some moz logos were not displaying. Setting a width resolves this.