### PR TITLE
fixes error in chat commmad permission checking

### DIFF
--- a/src/message-dispatch.js
+++ b/src/message-dispatch.js
@@ -270,7 +270,7 @@ export default class MessageDispatch extends EventTarget {
       case "clear":
         {
           if (this.hubChannel.can("pin_objects")) {
-            clearState(this.hubChannel, APP.world);
+            clearState(APP.world);
           }
         }
         break;

--- a/src/utils/entity-state-utils.ts
+++ b/src/utils/entity-state-utils.ts
@@ -239,10 +239,10 @@ const TEST_ASSET_STATE =
   "https://raw.githubusercontent.com/mozilla/hubs-sample-assets/main/Hubs%20Components/test_json/__NAME__";
 
 export async function loadState(hubChannel: HubChannel, world: HubsWorld, state: string) {
-  clearState(world, hubChannel);
+  clearState(world);
 
   const stateUrl = TEST_ASSET_STATE.replace("__NAME__", state);
-  console.log(stateUrl);
+
   const resp = await fetch(stateUrl);
   const entityStates: EntityStateList = await resp.json();
   entityStates.data.forEach(entityState => {
@@ -251,7 +251,7 @@ export async function loadState(hubChannel: HubChannel, world: HubsWorld, state:
   });
 }
 
-export function clearState(world: HubsWorld, hubChannel: HubChannel) {
+export function clearState(world: HubsWorld) {
   networkedQuery(world).forEach(eid => {
     if (isNetworkInstantiated(eid) && isPinned(eid)) {
       deleteTheDeletableAncestor(world, eid);


### PR DESCRIPTION
Removes `this.hubChannel.signIn` due to improper function use. 

The function will always return true in the if statement, which doesn't validate user sign-in permission. 