### PR TITLE
Ensure entry room logo is the same ratio as loading screen logo

### DIFF
--- a/src/react-components/room/RoomEntryModal.scss
+++ b/src/react-components/room/RoomEntryModal.scss
@@ -20,8 +20,8 @@
 
 :local(.logo) {
   height: auto;
-  max-height: 250px;
-  height: 100%;
+  max-width: 260px;
+  max-height: 140px;
   object-fit: contain;
   object-position: center;
   min-width: 172px;

--- a/src/react-components/room/RoomEntryModal.scss
+++ b/src/react-components/room/RoomEntryModal.scss
@@ -24,7 +24,6 @@
   max-height: 140px;
   object-fit: contain;
   object-position: center;
-  min-width: 172px;
 }
 
 :local(.room-name) {


### PR DESCRIPTION
The logo image size on the entry modal was inconsistent with the loading screen logo. This PR ensures they are equal in size.