### PR TITLE
Render 2d content in video-texture targets

### DIFF
--- a/src/bit-systems/video-texture.ts
+++ b/src/bit-systems/video-texture.ts
@@ -148,6 +148,7 @@ export function videoTextureSystem(world: HubsWorld) {
     }
 
     camera.layers.enable(Layers.CAMERA_LAYER_THIRD_PERSON_ONLY);
+    camera.layers.enable(Layers.CAMERA_LAYER_FX_MASK);
 
     const resolution = VideoTextureSource.resolution[eid];
     camera.aspect = resolution[0] / resolution[1];

--- a/src/components/video-texture-target.js
+++ b/src/components/video-texture-target.js
@@ -26,6 +26,7 @@ AFRAME.registerComponent("video-texture-source", {
     }
 
     this.camera.layers.enable(Layers.CAMERA_LAYER_THIRD_PERSON_ONLY);
+    this.camera.layers.enable(Layers.CAMERA_LAYER_FX_MASK);
 
     this.camera.aspect = this.data.resolution[0] / this.data.resolution[1];
 


### PR DESCRIPTION
We used to do this, we removed it as art of adding post effects. Restoring the old behavior for now as it has some uses. Ultimately this should probably be configured directly on the camera in the GLTF with the `layers` component.