### PR TITLE
Webaudio-migration

### DIFF
--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -222,7 +222,6 @@ export const VideoMenu = defineComponent({
 export const AudioEmitter = defineComponent({
   flags: Types.ui8
 });
-AudioEmitter.audios = new Map();
 AudioEmitter.params = new Map();
 export const AudioSettingsChanged = defineComponent();
 export const Deletable = defineComponent();

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -341,3 +341,4 @@ export const LinearScale = defineComponent({
   targetY: Types.f32,
   targetZ: Types.f32
 });
+export const AudioListenerTag = defineComponent();

--- a/src/bit-systems/audio-emitter-system.ts
+++ b/src/bit-systems/audio-emitter-system.ts
@@ -78,18 +78,10 @@ export const updatePannerNode = (() => {
 
 export const updateAudio = (elOrEid: ElOrEid, obj: Object3D) => {
   const audio = APP.audios.get(elOrEid)!;
-  // const gain = APP.gains.get(elOrEid)!;
   const muted = !!APP.mutedState.has(elOrEid);
   const clipped = !!APP.clippingState.has(elOrEid);
   const isAudioPaused = !!APP.isAudioPaused.has(elOrEid);
-  if (
-    isPositionalAudio(audio) &&
-    // (!gain || gain.gain.value > 0.00001) &&
-    !muted &&
-    !clipped &&
-    !isAudioPaused &&
-    obj.matrixIsModified
-  ) {
+  if (isPositionalAudio(audio) && !muted && !clipped && !isAudioPaused && obj.matrixIsModified) {
     updatePannerNode(audio, obj);
   }
 };

--- a/src/bit-systems/audio-emitter-system.ts
+++ b/src/bit-systems/audio-emitter-system.ts
@@ -1,4 +1,4 @@
-import { addComponent, addEntity, defineQuery, exitQuery, removeComponent } from "bitecs";
+import { addComponent, defineQuery, exitQuery, removeComponent } from "bitecs";
 import { MeshStandardMaterial, Mesh, Vector3, Object3D, Quaternion } from "three";
 import { HubsWorld } from "../app";
 import { AudioEmitter, AudioSettingsChanged } from "../bit-components";
@@ -152,8 +152,6 @@ export function makeAudioEntity(
   addComponent(world, AudioEmitter, eid);
   audioSystem.addAudio({ sourceType, node: gain });
   updateAudioSettings(eid, audio);
-
-  return eid;
 }
 
 const staleAudioEmittersQuery = defineQuery([AudioEmitter, AudioSettingsChanged]);

--- a/src/bit-systems/audio-emitter-system.ts
+++ b/src/bit-systems/audio-emitter-system.ts
@@ -1,74 +1,141 @@
-import { addComponent, addEntity, defineQuery, removeComponent } from "bitecs";
-import {
-  PositionalAudio,
-  Audio as StereoAudio,
-  AudioListener as ThreeAudioListener,
-  MeshStandardMaterial,
-  Mesh
-} from "three";
+import { addComponent, addEntity, defineQuery, enterQuery, exitQuery, removeComponent } from "bitecs";
+import { MeshStandardMaterial, Mesh, Vector3, Object3D, Quaternion } from "three";
 import { HubsWorld } from "../app";
 import { AudioEmitter, AudioSettingsChanged } from "../bit-components";
 import { AudioType, SourceType } from "../components/audio-params";
 import { AudioSystem } from "../systems/audio-system";
 import { applySettings, getCurrentAudioSettings, updateAudioSettings } from "../update-audio-settings";
-import { addObject3DComponent, swapObject3DComponent } from "../utils/jsx-entity";
+import { EntityID } from "../utils/networking-types";
+import { ElOrEid } from "../utils/bit-utils";
 
-export type AudioObject3D = StereoAudio | PositionalAudio;
-type AudioConstructor<T> = new (listener: ThreeAudioListener) => T;
+export type AudioNode = PannerNode | StereoPannerNode;
 
 export const Emitter2Audio = (AudioEmitter as any).audios as Map<number, number>;
 export const Emitter2Params = (AudioEmitter as any).params as Map<number, number>;
 
-export function isPositionalAudio(node: AudioObject3D): node is PositionalAudio {
-  return (node as any).panner !== undefined;
+export function isPositionalAudio(node: AudioNode): node is PannerNode {
+  return node instanceof PannerNode;
 }
 
-export function cleanupAudio(audio: AudioObject3D) {
-  const eid = audio.eid!;
+export const getAudioPosition = (() => {
+  const _position = new Vector3();
+  const _quaternion = new Quaternion();
+  const _scale = new Vector3();
+  return (eid: ElOrEid, position: Vector3) => {
+    const node = APP.audios.get(eid)!;
+    if (node instanceof PannerNode) {
+      const panner = node as PannerNode;
+      return position.set(panner.positionX.value, panner.positionY.value, panner.positionZ.value);
+    } else {
+      if (typeof eid !== "number") {
+        eid = eid.eid;
+      }
+      const obj = APP.world.eid2obj.get(eid)!;
+      obj.matrixWorld.decompose(_position, _quaternion, _scale);
+      position.copy(_position);
+    }
+  };
+})();
+
+export const getAudioOrientation = (() => {
+  const _position = new Vector3();
+  const _quaternion = new Quaternion();
+  const _scale = new Vector3();
+  return (eid: ElOrEid, orientation: Vector3) => {
+    const node = APP.audios.get(eid)!;
+    if (node instanceof PannerNode) {
+      const panner = node as PannerNode;
+      return orientation.set(panner.orientationX.value, panner.orientationY.value, panner.orientationZ.value);
+    } else {
+      if (typeof eid !== "number") {
+        eid = eid.eid;
+      }
+      const obj = APP.world.eid2obj.get(eid)!;
+      obj.matrixWorld.decompose(_position, _quaternion, _scale);
+      orientation.set(0, 0, -1).applyQuaternion(_quaternion);
+    }
+  };
+})();
+
+export const updatePannerNode = (() => {
+  const _position = new Vector3();
+  const _quaternion = new Quaternion();
+  const _scale = new Vector3();
+  const _orientation = new Vector3();
+  return (audio: PannerNode, obj: Object3D) => {
+    obj.updateMatrices();
+    obj.matrixWorld.decompose(_position, _quaternion, _scale);
+    _orientation.set(0, 0, -1).applyQuaternion(_quaternion);
+    const timeDelta = APP.world.time.delta / 1000;
+    const endTime = APP.audioCtx.currentTime + timeDelta;
+    audio.positionX.linearRampToValueAtTime(_position.x, endTime);
+    audio.positionY.linearRampToValueAtTime(_position.y, endTime);
+    audio.positionZ.linearRampToValueAtTime(_position.z, endTime);
+    audio.orientationX.linearRampToValueAtTime(_orientation.x, endTime);
+    audio.orientationY.linearRampToValueAtTime(_orientation.y, endTime);
+    audio.orientationZ.linearRampToValueAtTime(_orientation.z, endTime);
+  };
+})();
+
+export const updateAudio = (elOrEid: ElOrEid, obj: Object3D) => {
+  const audio = APP.audios.get(elOrEid)!;
+  // const gain = APP.gains.get(elOrEid)!;
+  const muted = !!APP.mutedState.has(elOrEid);
+  const clipped = !!APP.clippingState.has(elOrEid);
+  const isAudioPaused = !!APP.isAudioPaused.has(elOrEid);
+  if (
+    isPositionalAudio(audio) &&
+    // (!gain || gain.gain.value > 0.00001) &&
+    !muted &&
+    !clipped &&
+    !isAudioPaused &&
+    obj.matrixIsModified
+  ) {
+    updatePannerNode(audio, obj);
+  }
+};
+
+export function cleanupAudio(eid: EntityID, audioSystem: AudioSystem) {
+  const audio = APP.audios.get(eid)!;
+  const gain = APP.gains.get(eid)!;
+  gain.disconnect();
   audio.disconnect();
-  const audioSystem = APP.scene?.systems["hubs-systems"].audioSystem;
   APP.audios.delete(eid);
+  APP.gains.delete(eid);
   APP.supplementaryAttenuation.delete(eid);
   APP.audioOverrides.delete(eid);
   audioSystem.removeAudio({ node: audio });
 }
 
-function swapAudioType<T extends AudioObject3D>(
-  world: HubsWorld,
-  audioSystem: AudioSystem,
-  eid: number,
-  NewType: AudioConstructor<T>
-) {
-  const audio = world.eid2obj.get(eid)! as AudioObject3D;
-  audio.disconnect();
-  APP.sourceType.set(eid, SourceType.MEDIA_VIDEO);
-  APP.supplementaryAttenuation.delete(eid);
-  APP.audios.delete(eid);
-  audioSystem.removeAudio({ node: audio });
-
-  const newAudio = new NewType(APP.audioListener);
-  newAudio.setNodeSource(audio.source!);
-  audioSystem.addAudio({ sourceType: SourceType.MEDIA_VIDEO, node: newAudio });
-  APP.audios.set(eid, newAudio);
-
-  audio.parent!.add(newAudio);
-  audio.removeFromParent();
-
-  swapObject3DComponent(world, eid, newAudio);
+function swapAudioType(world: HubsWorld, audioSystem: AudioSystem, eid: number, type: AudioType) {
+  cleanupAudio(eid, audioSystem);
+  APP.audios;
+  makeAudioEntity(world, eid, APP.sourceType.get(eid)!, audioSystem, type);
 }
 
-export function makeAudioEntity(world: HubsWorld, source: number, sourceType: SourceType, audioSystem: AudioSystem) {
+export function makeAudioEntity(
+  world: HubsWorld,
+  source: number,
+  sourceType: SourceType,
+  audioSystem: AudioSystem,
+  overrideAudioType?: AudioType
+) {
   const eid = addEntity(world);
   APP.sourceType.set(eid, sourceType);
 
+  let { audioType } = getCurrentAudioSettings(eid);
+  overrideAudioType && (audioType = overrideAudioType);
   let audio;
-  const { audioType } = getCurrentAudioSettings(eid);
-  const audioListener = APP.audioListener;
-  if (audioType === AudioType.PannerNode) {
-    audio = new PositionalAudio(audioListener);
+  if (audioType === PannerNode) {
+    audio = APP.audioCtx.createPanner();
   } else {
-    audio = new StereoAudio(audioListener);
+    audio = APP.audioCtx.createStereoPanner();
   }
+  const gain = APP.audioCtx.createGain();
+  gain.gain.value = 0;
+  audio.connect(gain);
+  APP.audios.set(eid, audio);
+  APP.gains.set(eid, gain);
 
   if (sourceType === SourceType.MEDIA_VIDEO) {
     const videoObj = world.eid2obj.get(source) as Mesh;
@@ -79,38 +146,45 @@ export function makeAudioEntity(world: HubsWorld, source: number, sourceType: So
       APP.isAudioPaused.delete(eid);
     }
     const audioSrcEl = video;
-    audio.setMediaElementSource(audioSrcEl);
+    const mediaElement = APP.audioCtx.createMediaElementSource(audioSrcEl);
+    mediaElement.connect(audio);
     // Original audio source volume can now be restored as audio systems will take over
     audioSrcEl.volume = 1;
-    audio.gain.gain.value = 0;
   }
 
   addComponent(world, AudioEmitter, eid);
-  addObject3DComponent(world, eid, audio);
-
-  audioSystem.addAudio({ sourceType, node: audio });
-
-  APP.audios.set(eid, audio);
+  audioSystem.addAudio({ sourceType, node: gain });
   updateAudioSettings(eid, audio);
 
   return eid;
 }
 
 const staleAudioEmittersQuery = defineQuery([AudioEmitter, AudioSettingsChanged]);
+const audioEmitterQuery = defineQuery([AudioEmitter]);
+const audioEmitterEnter = enterQuery(audioEmitterQuery);
+const audioEmitterExit = exitQuery(audioEmitterQuery);
 export function audioEmitterSystem(world: HubsWorld, audioSystem: AudioSystem) {
   staleAudioEmittersQuery(world).forEach(function (eid) {
-    const audio = world.eid2obj.get(eid)! as PositionalAudio | StereoAudio;
+    const audio = APP.audios.get(eid)!;
     const settings = getCurrentAudioSettings(eid);
     const isPannerNode = isPositionalAudio(audio);
 
     // TODO this needs more testing
     if (!isPannerNode && settings.audioType === AudioType.PannerNode) {
-      swapAudioType(world, audioSystem, eid, PositionalAudio);
+      swapAudioType(world, audioSystem, eid, AudioType.PannerNode);
     } else if (isPannerNode && settings.audioType === AudioType.Stereo) {
-      swapAudioType(world, audioSystem, eid, StereoAudio);
+      swapAudioType(world, audioSystem, eid, AudioType.Stereo);
     }
 
-    applySettings(audio, settings);
+    applySettings(eid, settings);
     removeComponent(world, AudioSettingsChanged, eid);
+  });
+  audioEmitterExit(world).forEach(eid => {
+    const audioSystem = APP.scene?.systems["hubs-systems"].audioSystem;
+    cleanupAudio(eid, audioSystem);
+  });
+  audioEmitterEnter(world).forEach(eid => {
+    const obj = APP.world.eid2obj.get(eid)!;
+    updateAudio(eid, obj);
   });
 }

--- a/src/bit-systems/audio-listener-system.ts
+++ b/src/bit-systems/audio-listener-system.ts
@@ -1,0 +1,43 @@
+import { Quaternion, Vector3 } from "three";
+import { HubsWorld } from "../app";
+import { defineQuery } from "bitecs";
+import { AudioListenerTag } from "../bit-components";
+
+const _position = new Vector3();
+const _quaternion = new Quaternion();
+const _scale = new Vector3();
+const _orientation = new Vector3();
+
+const audioListenerQuery = defineQuery([AudioListenerTag]);
+export function audioListenerSystem(world: HubsWorld) {
+  audioListenerQuery(world).forEach(eid => {
+    const obj = APP.world.eid2obj.get(eid)!;
+    const listener = APP.audioCtx.listener;
+
+    const up = obj.up;
+
+    const timeDelta = world.time.delta / 1000;
+
+    obj.matrixWorld.decompose(_position, _quaternion, _scale);
+
+    _orientation.set(0, 0, -1).applyQuaternion(_quaternion);
+
+    if (listener.positionX) {
+      // code path for Chrome (see #14393)
+      const endTime = APP.audioCtx.currentTime + timeDelta;
+      listener.positionX.linearRampToValueAtTime(_position.x, endTime);
+      listener.positionY.linearRampToValueAtTime(_position.y, endTime);
+      listener.positionZ.linearRampToValueAtTime(_position.z, endTime);
+      listener.forwardX.linearRampToValueAtTime(_orientation.x, endTime);
+      listener.forwardY.linearRampToValueAtTime(_orientation.y, endTime);
+      listener.forwardZ.linearRampToValueAtTime(_orientation.z, endTime);
+      listener.upX.linearRampToValueAtTime(up.x, endTime);
+      listener.upY.linearRampToValueAtTime(up.y, endTime);
+      listener.upZ.linearRampToValueAtTime(up.z, endTime);
+    } else {
+      // Although these methods are deprecated they are currently the only way to set the orientation and position in Firefox.
+      listener.setPosition(_position.x, _position.y, _position.z);
+      listener.setOrientation(_orientation.x, _orientation.y, _orientation.z, up.x, up.y, up.z);
+    }
+  });
+}

--- a/src/bit-systems/camera-tool.js
+++ b/src/bit-systems/camera-tool.js
@@ -96,11 +96,11 @@ function createRecorder(captureAudio) {
   // if no audio comes through on the listener source. (Eg the room is otherwise silent.)
   // So for now, if we don't have a track, just disable audio capture.
   if (captureAudio && APP.dialog._micProducer?.track) {
-    const context = THREE.AudioContext.getContext();
+    const context = APP.audioCtx;
     const destination = context.createMediaStreamDestination();
-    if (APP.audioListener) {
+    if (APP.audioCtx.listener) {
       // NOTE audio is not captured from camera vantage point for now.
-      APP.audioListener.getInput().connect(destination);
+      APP.audioCtx.listener.connect(destination);
     }
     context.createMediaStreamSource(new MediaStream([APP.dialog._micProducer?.track])).connect(destination);
     srcAudioTrack = destination.stream.getAudioTracks()[0];

--- a/src/bit-systems/video-menu-system.ts
+++ b/src/bit-systems/video-menu-system.ts
@@ -21,7 +21,6 @@ import { animate } from "../utils/animate";
 import { coroutine } from "../utils/coroutine";
 import { easeOutQuadratic } from "../utils/easing";
 import { isFacingCamera } from "../utils/three-utils";
-import { Emitter2Audio } from "./audio-emitter-system";
 
 const videoMenuQuery = defineQuery([VideoMenu]);
 const hoverRightVideoQuery = defineQuery([HoveredRemoteRight, MediaVideo]);
@@ -93,16 +92,15 @@ export function videoMenuSystem(world: HubsWorld, userinput: any) {
       const playIndicatorObj = world.eid2obj.get(VideoMenu.playIndicatorRef[eid])!;
       const pauseIndicatorObj = world.eid2obj.get(VideoMenu.pauseIndicatorRef[eid])!;
 
-      const audioEid = Emitter2Audio.get(videoEid)!;
       if (video.paused) {
         video.play();
-        APP.isAudioPaused.delete(audioEid);
+        APP.isAudioPaused.delete(videoEid);
         playIndicatorObj.visible = true;
         pauseIndicatorObj.visible = false;
         rightMenuIndicatorCoroutine = coroutine(animateIndicator(world, VideoMenu.playIndicatorRef[eid]));
       } else {
         video.pause();
-        APP.isAudioPaused.add(audioEid);
+        APP.isAudioPaused.add(videoEid);
         playIndicatorObj.visible = false;
         pauseIndicatorObj.visible = true;
         rightMenuIndicatorCoroutine = coroutine(animateIndicator(world, VideoMenu.pauseIndicatorRef[eid]));

--- a/src/bit-systems/video-system.ts
+++ b/src/bit-systems/video-system.ts
@@ -13,7 +13,7 @@ import {
 import { SourceType } from "../components/audio-params";
 import { AudioSystem } from "../systems/audio-system";
 import { findAncestorWithComponent } from "../utils/bit-utils";
-import { Emitter2Audio, Emitter2Params, makeAudioEntity } from "./audio-emitter-system";
+import { Emitter2Params, makeAudioEntity } from "./audio-emitter-system";
 import { takeSoftOwnership } from "../utils/take-soft-ownership";
 
 enum Flags {
@@ -38,26 +38,23 @@ export function videoSystem(world: HubsWorld, audioSystem: AudioSystem) {
         console.error("Error auto-playing video.");
       });
     }
-    const audioEid = makeAudioEntity(world, videoEid, SourceType.MEDIA_VIDEO, audioSystem);
-    Emitter2Audio.set(videoEid, audioEid);
-    const audio = world.eid2obj.get(audioEid)!;
+    makeAudioEntity(world, videoEid, SourceType.MEDIA_VIDEO, audioSystem);
+    const audio = world.eid2obj.get(videoEid)!;
     videoObj.add(audio);
   });
   mediaLoadedQuery(world).forEach(videoEid => {
     const audioParamsEid = findAncestorWithComponent(world, AudioParams, videoEid);
     if (audioParamsEid) {
       const audioSettings = APP.audioOverrides.get(audioParamsEid)!;
-      const audioEid = Emitter2Audio.get(videoEid)!;
-      APP.audioOverrides.set(audioEid, audioSettings);
+      APP.audioOverrides.set(videoEid, audioSettings);
       Emitter2Params.set(videoEid, audioParamsEid);
-      addComponent(world, AudioSettingsChanged, audioEid);
+      addComponent(world, AudioSettingsChanged, videoEid);
     }
   });
   mediaVideoExitQuery(world).forEach(videoEid => {
     const audioParamsEid = Emitter2Params.get(videoEid);
     audioParamsEid && APP.audioOverrides.delete(audioParamsEid);
     Emitter2Params.delete(videoEid);
-    Emitter2Audio.delete(videoEid);
   });
 
   networkedVideoEnterQuery(world).forEach(function (eid) {

--- a/src/bit-systems/video-system.ts
+++ b/src/bit-systems/video-system.ts
@@ -1,4 +1,4 @@
-import { addComponent, defineQuery, enterQuery, exitQuery, hasComponent } from "bitecs";
+import { addComponent, defineQuery, enterQuery, exitQuery, hasComponent, removeComponent } from "bitecs";
 import { Mesh, MeshStandardMaterial } from "three";
 import { HubsWorld } from "../app";
 import {
@@ -39,8 +39,6 @@ export function videoSystem(world: HubsWorld, audioSystem: AudioSystem) {
       });
     }
     makeAudioEntity(world, videoEid, SourceType.MEDIA_VIDEO, audioSystem);
-    const audio = world.eid2obj.get(videoEid)!;
-    videoObj.add(audio);
   });
   mediaLoadedQuery(world).forEach(videoEid => {
     const audioParamsEid = findAncestorWithComponent(world, AudioParams, videoEid);

--- a/src/bit-systems/video-system.ts
+++ b/src/bit-systems/video-system.ts
@@ -42,8 +42,6 @@ export function videoSystem(world: HubsWorld, audioSystem: AudioSystem) {
     Emitter2Audio.set(videoEid, audioEid);
     const audio = world.eid2obj.get(audioEid)!;
     videoObj.add(audio);
-    // Note in media-video we call updateMatrixWorld here to force PositionalAudio's updateMatrixWorld to run even
-    // if it has an invisible parent. We don't want to have invisible parents now.
   });
   mediaLoadedQuery(world).forEach(videoEid => {
     const audioParamsEid = findAncestorWithComponent(world, AudioParams, videoEid);

--- a/src/components/audio-feedback.js
+++ b/src/components/audio-feedback.js
@@ -55,7 +55,7 @@ AFRAME.registerComponent("networked-audio-analyser", {
     this.el.addEventListener(
       "sound-source-set",
       event => {
-        const ctx = THREE.AudioContext.getContext();
+        const ctx = APP.audioCtx;
         this.analyser = ctx.createAnalyser();
         this.analyser.fftSize = 32;
         this.levels = new Uint8Array(this.analyser.fftSize);

--- a/src/components/audio-zone-source.js
+++ b/src/components/audio-zone-source.js
@@ -1,3 +1,4 @@
+import { getAudioPosition } from "../bit-systems/audio-emitter-system";
 import { updateAudioSettings } from "../update-audio-settings";
 
 AFRAME.registerComponent("audio-zone-source", {
@@ -14,12 +15,7 @@ AFRAME.registerComponent("audio-zone-source", {
   getPosition: (() => {
     const sourcePos = new THREE.Vector3();
     return function () {
-      const audio = APP.audios.get(this.el);
-      if (audio) {
-        audio.getWorldPosition(sourcePos);
-      } else {
-        sourcePos.set(0, 0, 0);
-      }
+      getAudioPosition(this.el, sourcePos);
       return sourcePos;
     };
   })(),

--- a/src/gltf-component-mappings.js
+++ b/src/gltf-component-mappings.js
@@ -224,7 +224,7 @@ async function mediaInflator(el, componentName, componentData, components, fitTo
       // The way we are handling it is wrong. If a user created a scene with this old version
       // of the component, all of these parameters will be present whether the user explicitly set
       // the values for them or not. But really, they should only count as "overrides" if the user
-      // meant for them to take precendence over the app and scene defaults.
+      // meant for them to take precedence over the app and scene defaults.
       // TODO: Fix this issue. One option is to just ignore this component data, which might break old scenes
       //       but simplifying the handling. Another option is to compare the component data here with
       //       the "defaults" and only save the values that are different from the defaults. However,

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -544,7 +544,7 @@ export default class SceneEntryManager {
       if (isNaN(audioVolume)) {
         audioVolume = 1.0;
       }
-      const audioContext = THREE.AudioContext.getContext();
+      const audioContext = APP.audioCtx;
       const audioSource = audioContext.createMediaStreamSource(audioStream);
       const audioDestination = audioContext.createMediaStreamDestination();
       const gainNode = audioContext.createGain();

--- a/src/systems/capture-system.js
+++ b/src/systems/capture-system.js
@@ -39,11 +39,10 @@ AFRAME.registerSystem("capture-system", {
   },
 
   _tryAddingAudioTrack() {
-    if (this._gotAudioTrack || !this.el.audioListener) return;
+    if (this._gotAudioTrack) return;
 
-    const listener = this.el.audioListener;
-    const destination = listener.context.createMediaStreamDestination();
-    listener.getInput().connect(destination);
+    const destination = APP.audioCtx.createMediaStreamDestination();
+    APP.audioCtx.listener.connect(destination);
     const audio = destination.stream.getAudioTracks()[0];
 
     this._stream.addTrack(audio);

--- a/src/systems/hubs-systems.ts
+++ b/src/systems/hubs-systems.ts
@@ -78,6 +78,7 @@ import { scenePreviewCameraSystem } from "../bit-systems/scene-preview-camera-sy
 import { linearTransformSystem } from "../bit-systems/linear-transform";
 import { mixerAnimatableSystem } from "../bit-systems/mixer-animatable";
 import { loopAnimationSystem } from "../bit-systems/loop-animation";
+import { audioListenerSystem } from "../bit-systems/audio-listener-system";
 
 declare global {
   interface Window {
@@ -256,6 +257,7 @@ export function mainTick(xrFrame: XRFrame, renderer: WebGLRenderer, scene: Scene
   hubsSystems.audioZonesSystem.tick(hubsSystems.el);
   audioZoneSystem(world);
   audioEmitterSystem(world, hubsSystems.audioSystem);
+  audioListenerSystem(world);
   audioTargetSystem(world, hubsSystems.audioSystem);
   hubsSystems.gainSystem.tick();
   hubsSystems.nameTagSystem.tick();

--- a/src/systems/physics-system.js
+++ b/src/systems/physics-system.js
@@ -171,7 +171,14 @@ export class PhysicsSystem {
               object3D.matrixNeedsUpdate = true;
             }
 
+            // const activationState = this.workerHelpers.getBodyOptions(uuid).activationState;
+            // if (activationState === "active" || activationState === "disableDeactivation") {
+            //   object3D.updateMatrices();
+            // } else {
+            //   object3D.matrixIsModified = false;
+            // }
             object3D.updateMatrices();
+
             this.objectMatricesFloatArray.set(
               object3D.matrixWorld.elements,
               index * BUFFER_CONFIG.BODY_DATA_SIZE + BUFFER_CONFIG.MATRIX_OFFSET

--- a/src/systems/remove-object3D-system.js
+++ b/src/systems/remove-object3D-system.js
@@ -1,6 +1,5 @@
 import { defineQuery, exitQuery, hasComponent, removeEntity } from "bitecs";
 import {
-  AudioEmitter,
   EnvironmentSettings,
   GLTFModel,
   LightTag,
@@ -22,7 +21,6 @@ import { gltfCache } from "../components/gltf-model-plus";
 import { releaseTextureByKey } from "../utils/load-texture";
 import { disposeMaterial, traverseSome, disposeNode } from "../utils/three-utils";
 import { forEachMaterial } from "../utils/material-utils";
-import { cleanupAudio } from "../bit-systems/audio-emitter-system";
 import { cleanupAudioDebugNavMesh } from "../bit-systems/audio-debug-system";
 import { cleanupMediaFrame } from "./bit-media-frames";
 
@@ -53,7 +51,6 @@ const cleanupGLTFs = cleanupObjOnExit(GLTFModel, obj => {
 const cleanupLights = cleanupObjOnExit(LightTag, obj => obj.dispose());
 const cleanupTexts = cleanupObjOnExit(TextTag, obj => obj.dispose());
 const cleanupMediaFrames = cleanupObjOnExit(MediaFrame, cleanupMediaFrame);
-const cleanupAudioEmitters = cleanupObjOnExit(AudioEmitter, cleanupAudio);
 const cleanupImages = cleanupObjOnExit(MediaImage, obj => {
   releaseTextureByKey(APP.getString(MediaImage.cacheKey[obj.eid]));
   obj.geometry.dispose();
@@ -134,7 +131,6 @@ export function removeObject3DSystem(world) {
   cleanupImages(world);
   cleanupVideos(world);
   cleanupEnvironmentSettings(world);
-  cleanupAudioEmitters(world);
   cleanupSkyboxes(world);
   cleanupSimpleWaters(world);
   cleanupMirrors(world);

--- a/src/utils/render-target-recorder.js
+++ b/src/utils/render-target-recorder.js
@@ -23,7 +23,7 @@ function blitFramebuffer(renderer, src, srcX0, srcY0, srcX1, srcY1, dest, dstX0,
   }
 }
 const createBlankAudioTrack = () => {
-  const context = THREE.AudioContext.getContext();
+  const context = APP.audioCtx;
   const oscillator = context.createOscillator();
   const gain = context.createGain();
   const destination = context.createMediaStreamDestination();

--- a/types/three.d.ts
+++ b/types/three.d.ts
@@ -4,6 +4,7 @@ import { Object3D, Mesh, WebGLRenderer, Scene, Camera } from "three";
 declare module "three" {
   interface Object3D {
     matrixNeedsUpdate: boolean;
+    matrixIsModified: boolean;
     childrenNeedMatrixWorldUpdate: boolean;
     eid?: number;
     el?: AElement;


### PR DESCRIPTION
This PR migrates the client code from ThreeJS Audio to use the WebAudio API directly and introduces some optiomizations to avoid audio transform updates when the audio emitter is muted, clipped, paused or it's matrix is not modified.

`matrixIsModified` is currently not really used as it'll be true if the object matrix has been updated at least once. I'd like to try to avoid some more audio matrix updates for objects that are not actually moving, maybe using the physics body `activationState` but that's going to require updates on `three-ammo` so I'll leave it for a follow-aup PR.