### PR TITLE
Remove unnecessary div around logo

### DIFF
--- a/src/react-components/room/RoomEntryModal.js
+++ b/src/react-components/room/RoomEntryModal.js
@@ -31,11 +31,7 @@ export function RoomEntryModal({
   return (
     <Modal className={classNames(styles.roomEntryModal, className)} disableFullscreen {...rest}>
       <Column center className={styles.content}>
-        {breakpoint !== "sm" && breakpoint !== "md" && (
-          <div className={styles.logoContainer}>
-            <AppLogo className={styles.logo} />
-          </div>
-        )}
+        {breakpoint !== "sm" && breakpoint !== "md" && <AppLogo className={styles.logo} />}
         <div className={styles.roomName}>
           <h5>
             <FormattedMessage id="room-entry-modal.room-name-label" defaultMessage="Room Name" />

--- a/src/react-components/room/RoomEntryModal.scss
+++ b/src/react-components/room/RoomEntryModal.scss
@@ -12,19 +12,13 @@
   }
 }
 
-:local(.logo-container) {
-  padding: 0 16px;
-  margin-top: 16px;
-  margin-bottom: 32px;
-}
-
 :local(.logo) {
   height: auto;
-  width: 260px;
   max-width: 260px;
   max-height: 140px;
   object-fit: contain;
   object-position: center;
+  margin: 16px 16px 32px;
 }
 
 :local(.room-name) {


### PR DESCRIPTION
- the div wrapping the entry room modal was causing an issue with the logo displaying in the room entry modal. Removing it fixes this. We shouldn't need to wrap components in unnecessary divs if we are able to pass a classname prop for styling.

<img width="486" alt="Screenshot 2023-05-30 at 11 56 12 AM" src="https://github.com/mozilla/hubs/assets/42850541/ac6d0719-fdc0-40d3-b406-8e9afb846c7f">
