### PR TITLE
Fix debugLocalScene when using newLoader

### DIFF
--- a/src/load-media-on-paste-or-drop.ts
+++ b/src/load-media-on-paste-or-drop.ts
@@ -96,6 +96,8 @@ async function onPaste(e: ClipboardEvent) {
 
 let lastDebugScene: string;
 function onDrop(e: DragEvent) {
+  e.preventDefault();
+
   if (!(AFRAME as any).scenes[0].is("entered")) {
     return;
   }
@@ -111,12 +113,10 @@ function onDrop(e: DragEvent) {
 
   const files = e.dataTransfer?.files;
   if (files && files.length) {
-    e.preventDefault();
     return spawnFromFileList(files);
   }
   const url = e.dataTransfer?.getData("url") || e.dataTransfer?.getData("text");
   if (url) {
-    e.preventDefault();
     return spawnFromUrl(url);
   }
 }


### PR DESCRIPTION
When newLoader was enabled debugLocalScene would just download the dragged in file. We were failing to call preventDefault on the event. We actually never want the default behavior, so this PR changes the handler to always call preventDefault.