### PR TITLE
Override media gain when loading the scene

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -576,21 +576,13 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data)
 
   // Mute media until the scene has been fully loaded.
   // We intentionally want voice to be unmuted.
-  const { globalMediaVolume } = APP.store.state.preferences;
-  APP.store.update({
-    preferences: {
-      globalMediaVolume: 0
-    }
-  });
+  const audioSystem = scene.systems["hubs-systems"].audioSystem;
+  audioSystem.setMediaGainOverride(0);
   remountUI({
     messageDispatch: messageDispatch,
     onSendMessage: messageDispatch.dispatch,
     onLoaded: () => {
-      APP.store.update({
-        preferences: {
-          globalMediaVolume
-        }
-      });
+      audioSystem.setMediaGainOverride(1);
       store.executeOnLoadActions(scene);
     },
     onMediaSearchResultEntrySelected: (entry, selectAction) =>

--- a/src/systems/audio-system.js
+++ b/src/systems/audio-system.js
@@ -136,6 +136,7 @@ export class AudioSystem {
     this.outboundGainNode.connect(this.outboundAnalyser);
     this.outboundAnalyser.connect(this.mediaStreamDestinationNode);
     this.audioContextNeedsToBeResumed = false;
+    this.mediaGainOverride = 1;
 
     this.mediaGain = this.audioContext.createGain();
     this.mixer = {
@@ -163,6 +164,11 @@ export class AudioSystem {
 
     this.onPrefsUpdated = this.updatePrefs.bind(this);
     window.APP.store.addEventListener("statechanged", this.onPrefsUpdated);
+  }
+
+  setMediaGainOverride(gain) {
+    this.mediaGainOverride = gain;
+    this.updatePrefs();
   }
 
   addStreamToOutboundAudio(id, mediaStream) {
@@ -205,7 +211,7 @@ export class AudioSystem {
 
   updatePrefs() {
     const { globalVoiceVolume, globalMediaVolume, globalSFXVolume } = window.APP.store.state.preferences;
-    let newGain = globalMediaVolume / 100;
+    let newGain = this.mediaGainOverride * (globalMediaVolume / 100);
     this.mixer[SourceType.MEDIA_VIDEO].gain.setTargetAtTime(newGain, this.audioContext.currentTime, GAIN_TIME_CONST);
 
     newGain = globalSFXVolume / 100;


### PR DESCRIPTION
The media gain preference can be set to 0 if the page is reloaded while the gain is temporarily set to 0. Instead of that override the media gain to avoid touching the prefs.