### PR TITLE
BitECS media loading fixes

### DIFF
--- a/src/bit-systems/media-loading.ts
+++ b/src/bit-systems/media-loading.ts
@@ -79,8 +79,9 @@ const loaderForMediaType = {
     { accessibleUrl, contentType }: { accessibleUrl: string; contentType: string }
   ) => loadModel(world, accessibleUrl, contentType, true),
   [MediaType.PDF]: (world: HubsWorld, { accessibleUrl }: { accessibleUrl: string }) => loadPDF(world, accessibleUrl),
-  [MediaType.AUDIO]: (world: HubsWorld, { accessibleUrl }: { accessibleUrl: string }) => loadAudio(world, accessibleUrl),
-  [MediaType.HTML]: (world: HubsWorld, { canonicalUrl, thumbnail }: { canonicalUrl: string, thumbnail: string }) =>
+  [MediaType.AUDIO]: (world: HubsWorld, { accessibleUrl }: { accessibleUrl: string }) =>
+    loadAudio(world, accessibleUrl),
+  [MediaType.HTML]: (world: HubsWorld, { canonicalUrl, thumbnail }: { canonicalUrl: string; thumbnail: string }) =>
     loadHtml(world, canonicalUrl, thumbnail)
 };
 
@@ -99,6 +100,10 @@ function resizeAndRecenter(world: HubsWorld, media: EntityID, eid: EntityID) {
   const mediaObj = world.eid2obj.get(media)!;
   const box = new Box3();
   box.setFromObject(mediaObj);
+
+  // The AABB can be empty here for interactables that fetch  media (ie. gltf with an empty that has a video component).
+  // If we don't return the interactable would be wrongly positioned at the (0,0,0).
+  if (box.isEmpty()) return;
 
   let scalar = 1;
   if (resize) {


### PR DESCRIPTION
This PR addresses some media issues an refactors some code:
- Media with no mesh that triggers media loading is incorrectly positioned in the origin. This PR set a default AABB for positioning the empty root.

https://github.com/mozilla/hubs/assets/837184/75c737dd-d2fb-467e-8235-42d1fb602f3a

(You can test this using a glTF file that has an empty root and triggers a media loading. ie. a video loading [media-video-flat.glb.zip](https://github.com/mozilla/hubs/files/11724425/media-video-flat.glb.zip))

- Refactor to use `MediaLoaded` instead of `MediaLoading` to know when a media is loaded.
- Handles the loading entity removal in the next tick to avoid other systems relaying on the entity (`mixerAnimatableSystem`) crash if the loading cube is inmmediatly removed after adding it.
