### PR TITLE
feat: Move raised hands to top of guestlist

### DIFF
--- a/src/react-components/room/PeopleSidebar.js
+++ b/src/react-components/room/PeopleSidebar.js
@@ -105,6 +105,7 @@ export function PeopleSidebar({
   const me = people.find(person => !!person.isMe);
   const filteredPeople = people
     .filter(person => !person.isMe)
+    // eslint-disable-next-line no-unused-vars
     .sort((a, _b) => {
       return a.hand_raised ? -1 : 1;
     });

--- a/src/react-components/room/PeopleSidebar.js
+++ b/src/react-components/room/PeopleSidebar.js
@@ -105,7 +105,7 @@ export function PeopleSidebar({
   const me = people.find(person => !!person.isMe);
   const filteredPeople = people
     .filter(person => !person.isMe)
-    .sort((a, b) => {
+    .sort((a, _b) => {
       return a.hand_raised ? -1 : 1;
     });
   me && filteredPeople.unshift(me);

--- a/src/react-components/room/PeopleSidebar.js
+++ b/src/react-components/room/PeopleSidebar.js
@@ -103,7 +103,11 @@ export function PeopleSidebar({
 }) {
   const intl = useIntl();
   const me = people.find(person => !!person.isMe);
-  const filteredPeople = people.filter(person => !person.isMe);
+  const filteredPeople = people
+    .filter(person => !person.isMe)
+    .sort((a, b) => {
+      return a.hand_raised ? -1 : 1;
+    });
   me && filteredPeople.unshift(me);
 
   return (

--- a/src/react-components/room/PeopleSidebar.js
+++ b/src/react-components/room/PeopleSidebar.js
@@ -105,8 +105,7 @@ export function PeopleSidebar({
   const me = people.find(person => !!person.isMe);
   const filteredPeople = people
     .filter(person => !person.isMe)
-    // eslint-disable-next-line no-unused-vars
-    .sort((a, _b) => {
+    .sort(a => {
       return a.hand_raised ? -1 : 1;
     });
   me && filteredPeople.unshift(me);


### PR DESCRIPTION
Why?
- value add for Q&A sessions (eg. education, conferences, etc) - speaker is easily able to view those who have hands raised for questions
<img width="278" alt="Screenshot 2023-06-12 at 3 25 52 PM" src="https://github.com/mozilla/hubs/assets/42850541/ff5ae69f-f3aa-477d-9881-5e7068857fe1">
