### PR TITLE
Allow attaching components that add Object3Ds to meshes

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -477,7 +477,11 @@ class GLTFHubsPlugin {
            * This was supported by the AFrame loader so this extension ensures backwards compatibility with all the existing scenes.
            * For more context about this see: https://github.com/mozilla/hubs/pull/6121
            */
-          if (node.mesh !== undefined || node.camera !== undefined) {
+          if (
+            node.mesh !== undefined ||
+            node.camera !== undefined ||
+            (node.extensions && node.extensions["KHR_lights_punctual"]?.light !== undefined)
+          ) {
             const exts = node.extensions?.MOZ_hubs_components;
             if (exts) {
               const children = [];

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -14,6 +14,7 @@ import { promisifyWorker } from "../utils/promisify-worker.js";
 import qsTruthy from "../utils/qs_truthy";
 import { cloneObject3D, disposeMaterial } from "../utils/three-utils";
 import SketchfabZipWorker from "../workers/sketchfab-zip.worker.js";
+import { shouldUseNewLoader } from "../utils/bit-utils";
 
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
 
@@ -469,7 +470,7 @@ class GLTFHubsPlugin {
 
         node.extras.gltfIndex = i;
 
-        if (qsTruthy("newLoader")) {
+        if (shouldUseNewLoader()) {
           /**
            * This guarantees that components that add Object3Ds (ie. through addObject3DComponent) are not attached to non-Object3D
            * entities as it's not supported in the BitECS loader.

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -482,6 +482,66 @@ class GLTFHubsPlugin {
   }
 }
 
+const OBJECT3D_EXT = [
+  "ambient-light",
+  "audio",
+  "directional-light",
+  "hemisphere-light",
+  "image",
+  "link",
+  "model",
+  "particle-emitter",
+  "pdf",
+  "point-light",
+  "reflection-probe",
+  "simple-water",
+  "skybox",
+  "spot-light",
+  "text",
+  "video"
+];
+
+/**
+ * This extension guarantees that components that add Object3Ds (ie. through addObject3DComponent) are not attached to non-Object3D
+ * entities as it's not supported in the BitECS loader.
+ * This was supported by the AFrame loader so this extension ensures backwards compatibility with all the existing scenes.
+ * For more context about this see: https://github.com/mozilla/hubs/pull/6121
+ */
+class GLTFHubsCompatExtension {
+  constructor(parser) {
+    this.parser = parser;
+  }
+
+  beforeRoot() {
+    const nodes = this.parser.json.nodes;
+    nodes.forEach(node => {
+      if (node.mesh !== undefined || node.camera !== undefined) {
+        const exts = node.extensions?.MOZ_hubs_components;
+        if (exts) {
+          const children = [];
+          for (const [key, value] of Object.entries(exts)) {
+            if (OBJECT3D_EXT.includes(key)) {
+              const newNode = {
+                name: `${node.name}_${key}`,
+                extensions: {
+                  MOZ_hubs_components: { [key]: value }
+                }
+              };
+              delete exts[key];
+              children.push(newNode);
+            }
+          }
+          node.children = node.children || [];
+          children.forEach(child => {
+            const idx = nodes.push(child) - 1;
+            node.children.push(idx);
+          });
+        }
+      }
+    });
+  }
+}
+
 class GLTFHubsComponentsExtension {
   constructor(parser) {
     this.parser = parser;
@@ -683,6 +743,9 @@ export async function loadGLTF(src, contentType, onProgress, jsonPreprocessor) {
   const loadingManager = new THREE.LoadingManager();
   loadingManager.setURLModifier(getCustomGLTFParserURLResolver(gltfUrl));
   const gltfLoader = new GLTFLoader(loadingManager);
+  if (qsTruthy("newLoader")) {
+    gltfLoader.register(parser => new GLTFHubsCompatExtension(parser));
+  }
   gltfLoader
     .register(parser => new GLTFHubsComponentsExtension(parser))
     .register(parser => new GLTFHubsPlugin(parser, jsonPreprocessor))

--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -395,7 +395,7 @@ const convertStandardMaterialsIfNeeded = object => {
 let ktxLoader;
 let dracoLoader;
 
-const OBJECT3D_EXT = [
+const OBJECT3D_EXT = new Set([
   "ambient-light",
   "audio",
   "directional-light",
@@ -412,7 +412,7 @@ const OBJECT3D_EXT = [
   "spot-light",
   "text",
   "video"
-];
+]);
 
 class GLTFHubsPlugin {
   constructor(parser, jsonPreprocessor) {
@@ -481,7 +481,7 @@ class GLTFHubsPlugin {
             if (exts) {
               const children = [];
               for (const [key, value] of Object.entries(exts)) {
-                if (OBJECT3D_EXT.includes(key)) {
+                if (OBJECT3D_EXT.has(key)) {
                   const newNode = {
                     name: `${node.name}_${key}`,
                     extensions: {

--- a/src/inflators/model.tsx
+++ b/src/inflators/model.tsx
@@ -88,10 +88,6 @@ export function inflateModel(world: HubsWorld, rootEid: number, { model }: Model
 
     const replacement = world.eid2obj.get(eid);
     if (replacement) {
-      if (obj.type !== "Object3D") {
-        console.error(obj, replacement);
-        throw new Error("Failed to inflate model. Unexpected object type found before swap.");
-      }
       if (obj === model) {
         throw new Error("Failed to inflate model. Can't inflate alternative object type on root scene.");
       }

--- a/src/inflators/model.tsx
+++ b/src/inflators/model.tsx
@@ -88,6 +88,10 @@ export function inflateModel(world: HubsWorld, rootEid: number, { model }: Model
 
     const replacement = world.eid2obj.get(eid);
     if (replacement) {
+      if (obj.type !== "Object3D") {
+        console.error(obj, replacement);
+        throw new Error("Failed to inflate model. Unexpected object type found before swap.");
+      }
       if (obj === model) {
         throw new Error("Failed to inflate model. Can't inflate alternative object type on root scene.");
       }


### PR DESCRIPTION
The loader crashes when a component that adds a mesh is attached to a mesh node (ie. particle system or water attached to a mesh). This works in the AFrame loader.

I'm not sure why we want to replace the object instead of just adding the new object to it, I seems to me that that would be more aligned with artists wishes as you might want to attach a particle system to an mesh for example but that seems to be how it worked in AFrame too so I focused on parity here.