### PR TITLE
Use ref callback for render callback in React 18

### DIFF
--- a/src/react-components/chat-message.js
+++ b/src/react-components/chat-message.js
@@ -59,9 +59,7 @@ function renderChatMessage(body, from, allowEmojiRender) {
 
   const EntryDom = ({ callback }) => (
     <div
-      // callback is passed in here as part of React 18 createRoot method.
-      // eslint-disable-next-line react/no-unknown-property
-      callback={callback}
+      ref={callback}
       className={classNames({
         [styles.presenceLogEntry]: !isEmoji,
         [styles.presenceLogEntryOneLine]: !isEmoji && !multiline,


### PR DESCRIPTION
As we moved to using Reeact 18 rendering it seems that we need to user a ref callback.

Fixes https://github.com/mozilla/hubs/issues/6134