### PR TITLE
fix: displayName regex

### DIFF
--- a/src/components/name-tag.js
+++ b/src/components/name-tag.js
@@ -250,7 +250,7 @@ AFRAME.registerComponent("name-tag", {
       this.pronounsText.el.addEventListener("text-updated", () => this.updateNametagWidth(), {
         once: true
       });
-      if (this.pronouns.length > DISPLAY_NAME_LENGTH) {
+      if (this.pronouns && this.pronouns.length > DISPLAY_NAME_LENGTH) {
         this.pronouns = this.pronouns.slice(0, DISPLAY_NAME_LENGTH).concat("...");
       }
       this.pronounsText.el.setAttribute("text", {

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -63,9 +63,9 @@ export const SCHEMA = {
       type: "object",
       additionalProperties: false,
       properties: {
-        displayName: { type: "string", pattern: "^(?:[A-Z]|[a-z]|[0-9]|[_~\\-]|\\s){3,32}$" },
+        displayName: { type: "string", pattern: "^[A-Za-z0-9_~\\s\\-]{3,32}$" },
         avatarId: { type: "string" },
-        pronouns: { type: "string", pattern: "^[a-zA-Z///a-zA-Z]{2,32}$" },
+        pronouns: { type: "string", pattern: "^([a-zA-Z]{1,32}\\/){0,4}[a-zA-Z]{1,32}$" },
         // personalAvatarId is obsolete, but we need it here for backwards compatibility.
         personalAvatarId: { type: "string" }
       }

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -63,7 +63,7 @@ export const SCHEMA = {
       type: "object",
       additionalProperties: false,
       properties: {
-        displayName: { type: "string", pattern: "^[A-Za-z0-9_~ -]{3,32}$" },
+        displayName: { type: "string", pattern: "^(?:[A-Z]|[a-z]|[0-9]|[_~\\-]|\\s){3,32}$" },
         avatarId: { type: "string" },
         pronouns: { type: "string", pattern: "^[a-zA-Z///a-zA-Z]{2,32}$" },
         // personalAvatarId is obsolete, but we need it here for backwards compatibility.


### PR DESCRIPTION
Solves this console error:
`Pattern attribute value ^[A-Za-z0-9_~ -]{3,32}$ is not a valid regular expression: Uncaught SyntaxError: Invalid regular expression: /^[A-Za-z0-9_~ -]{3,32}$/v: Invalid character in character class`