### PR TITLE
Resize the nametag to fit the pronoun text

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -113,11 +113,11 @@
                             <a-entity class="nametag-status-border" visible="false"
                                 slice9="width: 0.45; height: 0.2; left: 64; top: 64; right: 66; bottom: 66; transparent: false; alphaTest: 0.1; src: nametag-border;"></a-entity>
                             <a-entity class="nametag-text"
-                                text="side: double; textAlign: center; color: #ddd; fontSize: 0.1;" text-raycast-hack
-                                position="0 0.025 0.001"></a-entity>
+                                text="side: double; textAlign: center; color: #ddd; fontSize: 0.1; anchorY: center"
+                                text-raycast-hack position="0 0.125 0.001"></a-entity>
                             <a-entity class="pronouns-text"
-                                text="side: double; textAlign: center; color: #ddd; fontSize: 0.06;" text-raycast-hack
-                                position="0 -0.06 0.001"></a-entity>
+                                text="side: double; textAlign: center; color: #ddd; fontSize: 0.06; anchorY: center"
+                                text-raycast-hack position="0 0 0.001"></a-entity>
                         </a-entity>
                         <a-entity is-not-remote-hover-target class="recordingBadge" sprite="name: recording-badge.png"
                             scale="0.10 0.10 0.10" position="0 0.25 0.001" visible="false"></a-entity>


### PR DESCRIPTION
Currently the nametag pronoun overlaps with the volume bar. This PR makes the nametag to dynamically resize when there is a pronoun text to correctly show it. 
Now:
<img width="371" alt="Screenshot 2023-06-23 at 10 49 43" src="https://github.com/mozilla/hubs/assets/837184/8f809449-654d-477e-a6fa-b26e3b709fa8"><img width="317" alt="Screenshot 2023-06-23 at 10 49 11" src="https://github.com/mozilla/hubs/assets/837184/24ef08ee-3eee-468c-9f1b-45c89a551c5c">
Before:
<img width="386" alt="Screenshot 2023-06-23 at 10 53 48" src="https://github.com/mozilla/hubs/assets/837184/3b02b0ed-e1c4-4f9b-ae95-f3c47452951b">


