### PR TITLE
Check permissions for CreateMessages

### DIFF
--- a/src/prefabs/prefabs.ts
+++ b/src/prefabs/prefabs.ts
@@ -8,8 +8,22 @@ type CameraPrefabT = () => EntityDef;
 type CubeMediaPrefabT = () => EntityDef;
 type MediaPrefabT = (params: MediaLoaderParams) => EntityDef;
 
+type Permission =
+  | "spawn_camera"
+  | "spawn_and_move_media"
+  | "update_hub"
+  | "pin_objects"
+  | "spawn_emoji"
+  | "amplify_audio"
+  | "fly"
+  | "voice_chat"
+  | "spawn_drawing"
+  | "tweet"
+  | "kick_users"
+  | "mute_users";
+
 export type PrefabDefinition = {
-  permission?: "spawn_camera";
+  permission: Permission;
   template: CameraPrefabT | CubeMediaPrefabT | MediaPrefabT;
 };
 
@@ -17,6 +31,6 @@ export type PrefabName = "camera" | "cube" | "media" | "duck";
 
 export const prefabs = new Map<PrefabName, PrefabDefinition>();
 prefabs.set("camera", { permission: "spawn_camera", template: CameraPrefab });
-prefabs.set("cube", { template: CubeMediaFramePrefab });
-prefabs.set("media", { template: MediaPrefab });
-prefabs.set("duck", { template: DuckPrefab });
+prefabs.set("cube", { permission: "spawn_and_move_media", template: CubeMediaFramePrefab });
+prefabs.set("media", { permission: "spawn_and_move_media", template: MediaPrefab });
+prefabs.set("duck", { permission: "spawn_and_move_media", template: DuckPrefab });

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -4,5 +4,5 @@ import type { ClientID } from "./networking-types";
 export function hasPermissionToSpawn(creator: ClientID, prefabName: PrefabName) {
   if (creator === "reticulum") return true;
   const perm = prefabs.get(prefabName)!.permission;
-  return !perm || APP.hubChannel!.userCan(creator, perm);
+  return APP.hubChannel!.userCan(creator, perm);
 }


### PR DESCRIPTION
When clients receive a `CreateMessage`, they should check whether the sender has the appropriate `Permission` to be spawning from that prefab.

Since all prefabs currently need a permission, and we'd like to try not to forget them, I've made the `permission` field of `PrefabDefinition` non-optional. 