### PR TITLE
feat: Add muted indicator to people list

### DIFF
--- a/src/components/avatar-volume-controls.js
+++ b/src/components/avatar-volume-controls.js
@@ -49,6 +49,10 @@ AFRAME.registerComponent("avatar-volume-controls", {
     this.el.emit("gain_multiplier_updated", { gainMultiplier });
     const isLocalMuted = APP.mutedState.has(this.audioEl);
     updatePref && updateAvatarVolumesPref(this.playerInfo.playerSessionId, gainMultiplier, isLocalMuted);
+    // If the gainMultiplier is lowered to 0, updated muted status in local storage
+    if (!gainMultiplier) {
+      this.updateLocalMuted(true, true);
+    }
   },
 
   updateLocalMuted(muted, updatePref = false) {
@@ -80,6 +84,10 @@ AFRAME.registerComponent("avatar-volume-controls", {
     const step = -calcGainStepDown(gainMultiplier);
     gainMultiplier = THREE.MathUtils.clamp(gainMultiplier + step, 0, MAX_GAIN_MULTIPLIER);
     this.updateGainMultiplier(gainMultiplier, true);
+    // If the gainMultiplier is lowered to 0, updated muted status in local storage
+    if (!gainMultiplier) {
+      this.updateLocalMuted(true, true);
+    }
   },
 
   updateVolumeLabel() {

--- a/src/components/avatar-volume-controls.js
+++ b/src/components/avatar-volume-controls.js
@@ -29,7 +29,7 @@ AFRAME.registerComponent("avatar-volume-controls", {
     this.onRemoteMuteUpdated = this.onRemoteMuteUpdated.bind(this);
     this.playerInfo.el.addEventListener("remote_mute_updated", this.onRemoteMuteUpdated);
     this.muteButton.object3D.visible = this.playerInfo.data.muted;
-    const volumePref = getAvatarVolumePref(this.playerInfo.displayName);
+    const volumePref = getAvatarVolumePref(this.playerInfo.playerSessionId);
     this.updateGainMultiplier(volumePref === undefined ? DEFAULT_VOLUME_BAR_MULTIPLIER : volumePref.gainMultiplier);
     this.updateLocalMuted(volumePref === undefined ? false : volumePref.muted);
   },
@@ -48,7 +48,7 @@ AFRAME.registerComponent("avatar-volume-controls", {
     this.updateVolumeLabel();
     this.el.emit("gain_multiplier_updated", { gainMultiplier });
     const isLocalMuted = APP.mutedState.has(this.audioEl);
-    updatePref && updateAvatarVolumesPref(this.playerInfo.displayName, gainMultiplier, isLocalMuted);
+    updatePref && updateAvatarVolumesPref(this.playerInfo.playerSessionId, gainMultiplier, isLocalMuted);
   },
 
   updateLocalMuted(muted, updatePref = false) {
@@ -65,7 +65,7 @@ AFRAME.registerComponent("avatar-volume-controls", {
     this.el.emit("local_muted_updated", { muted });
     const gainMultiplier = APP.gainMultipliers.get(this.audioEl);
     const isLocalMuted = APP.mutedState.has(this.audioEl);
-    updatePref && updateAvatarVolumesPref(this.playerInfo.displayName, gainMultiplier, isLocalMuted);
+    updatePref && updateAvatarVolumesPref(this.playerInfo.playerSessionId, gainMultiplier, isLocalMuted);
   },
 
   volumeUp() {

--- a/src/react-components/room/PeopleSidebar.js
+++ b/src/react-components/room/PeopleSidebar.js
@@ -110,6 +110,7 @@ export function PeopleSidebar({
       return a.hand_raised ? -1 : 1;
     });
   me && filteredPeople.unshift(me);
+  const store = window.APP.store;
 
   return (
     <Sidebar
@@ -155,6 +156,9 @@ export function PeopleSidebar({
                     width={12}
                     height={12}
                   />
+                )}
+                {store._preferences?.avatarVoiceLevels?.[person.id]?.muted && (
+                  <span className={styles.isMuted}>muted</span>
                 )}
                 <p className={styles.presence}>{getPresenceMessage(person.presence, intl)}</p>
               </ButtonListItem>

--- a/src/react-components/room/PeopleSidebar.scss
+++ b/src/react-components/room/PeopleSidebar.scss
@@ -22,3 +22,8 @@
   flex: 1;
   justify-content: flex-end;
 }
+
+:local(.isMuted) {
+  font-style: italic;
+  color: theme.$color-semantic-warning;
+}

--- a/src/react-components/room/UserProfileSidebar.js
+++ b/src/react-components/room/UserProfileSidebar.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect } from "react";
 import PropTypes from "prop-types";
 import { Sidebar } from "../sidebar/Sidebar";
 import { CloseButton } from "../input/CloseButton";
@@ -51,6 +51,7 @@ export function UserProfileSidebar({
     [updateMultiplier]
   );
   const newLevel = calcLevel(multiplier);
+
   return (
     <Sidebar
       beforeTitle={showBackButton ? <BackButton onClick={onBack} /> : <CloseButton onClick={onClose} />}

--- a/src/react-components/styles/theme.scss
+++ b/src/react-components/styles/theme.scss
@@ -10,60 +10,60 @@ $transparent: transparent;
 $transparent-hover: rgba(0, 0, 0, 0.08);
 $transparent-pressed: rgba(0, 0, 0, 0.12);
 
-$white: #FFFFFF;
-$white-hover: #E7E7E7;
-$white-pressed: #DBDBDB;
+$white: #ffffff;
+$white-hover: #e7e7e7;
+$white-pressed: #dbdbdb;
 
-$lightgrey: #E7E7E7;
-$lightgrey-hover: #F5F5F5;
-$lightgrey-pressed: #DBDBDB;
+$lightgrey: #e7e7e7;
+$lightgrey-hover: #f5f5f5;
+$lightgrey-pressed: #dbdbdb;
 
-$grey: #BBBBBB;
-$grey-hover: #C7C7C7;
-$grey-pressed: #ADADAD;
+$grey: #bbbbbb;
+$grey-hover: #c7c7c7;
+$grey-pressed: #adadad;
 
 $darkgrey: #868686;
 $darkgrey-hover: #949494;
-$darkgrey-pressed: #7A7A7A;
+$darkgrey-pressed: #7a7a7a;
 
 $black: #000000;
 $black-hover: #404040;
-$black-pressed: #7A7A7A;
+$black-pressed: #7a7a7a;
 
-$red: #F5325C;
-$red-hover: #F64B70;
-$red-pressed: #F41A49;
+$red: #f5325c;
+$red-hover: #f64b70;
+$red-pressed: #f41a49;
 
-$orange: #FF8500;
-$orange-hover: #FF911A;
-$orange-pressed: #E67800;
+$orange: #ff8500;
+$orange-hover: #ff911a;
+$orange-pressed: #e67800;
 
-$green: #7ED320;
-$green-hover: #8CDF2F;
-$green-pressed: #72BE1D;
+$green: #7ed320;
+$green-hover: #8cdf2f;
+$green-pressed: #72be1d;
 
-$blue: #007AB8;
-$blue-hover: #008BD1;
-$blue-pressed: #00699E;
+$blue: #007ab8;
+$blue-hover: #008bd1;
+$blue-pressed: #00699e;
 
-$purple: #7854F6;
-$purple-hover: #8C6EF7;
-$purple-pressed: #663DF5;
+$purple: #7854f6;
+$purple-hover: #8c6ef7;
+$purple-pressed: #663df5;
 
 $recessed-bg: #f9f9f9;
 
-$yellow: #FFC000;
+$yellow: #ffc000;
 
 // Brand Colors
-$spoke-primary-color: #2F80ED;
-$twitter-primary-color: #6FC0FD;
-$slack-primary-color: #611F69;
-$discord--primary-color: #7289DA;
+$spoke-primary-color: #2f80ed;
+$twitter-primary-color: #6fc0fd;
+$slack-primary-color: #611f69;
+$discord--primary-color: #7289da;
 
 // Discord Bot Page Colors
-$discord-bg-color: #2A2D32;
+$discord-bg-color: #2a2d32;
 $discord-text1-color: white;
-$discord-text2-color: #A3A3A3;
+$discord-text2-color: #a3a3a3;
 $discord-text3-color: rgb(127, 127, 127);
 $discord-text4-color: rgb(64, 64, 64);
 
@@ -272,3 +272,105 @@ $tile-button-bg-color-hover: var(--tile-button-bg-color-hover);
 $tile-button-bg-color-pressed: var(--tile-button-bg-color-pressed);
 $tile-button-border-color: var(--tile-button-border-color);
 
+// Lilypad compatible variables (to eventually replace the above)
+
+/**
+  PRIMARY INTERACTION
+  **/
+$color-interaction-primary: var(--color-interaction-primary);
+$color-interaction-primary-hover: var(--color-interaction-primary-hover);
+$color-interaction-primary-active: var(--color-interaction-primary-active);
+$color-interaction-primary-disabled: var(--color-interaction-primary-disabled);
+$color-interaction-primary-alt: var(--color-interaction-primary-alt);
+$color-interaction-primary-alt-hover: var(--color-interaction-primary-alt-hover);
+$color-interaction-primary-alt-active: var(--color-interaction-primary-alt-active);
+$color-interaction-primary-alt-disabled: var(--color-interaction-primary-alt-disabled);
+
+/**
+  SECONDARY INTERACTION
+  **/
+$color-interaction-secondary: var(--color-interaction-secondary);
+$color-interaction-secondary-hover: var(--color-interaction-secondary-hover);
+$color-interaction-secondary-active: var(--color-interaction-secondary-active);
+$color-interaction-secondary-disabled: var(--color-interaction-secondary-disabled);
+$color-interaction-secondary-alt: var(--color-interaction-secondary-alt);
+$color-interaction-secondary-alt-hover: var(--color-interaction-secondary-alt-hover);
+$color-interaction-secondary-alt-active: var(--color-interaction-secondary-alt-active);
+$color-interaction-secondary-alt-disabled: var(--color-interaction-secondary-alt-disabled);
+
+/**
+  SEMANTIC
+  **/
+$color-semantic-info: var(--color-semantic-info);
+$color-semantic-info-hover: var(--color-semantic-info-hover);
+$color-semantic-info-active: var(--color-semantic-info-active);
+$color-semantic-disabled: var(--color-semantic-disabled);
+$color-semantic-success: var(--color-semantic-success);
+$color-semantic-success-hover: var(--color-semantic-success-hover);
+$color-semantic--success-active: var(--color-semantic-success-active);
+$color-semantic-success-disabled: var(--color-semantic-success-disabled);
+$color-semantic-warning: var(--color-semantic-warning);
+$color-semantic-warning-hover: var(--color-semantic-warning-hover);
+$color-semantic-warning-active: var(--color-semantic-warning-active);
+$color-semantic-warning-disabled: var(--color-semantic-warning-disabled);
+$color-semantic-critical: var(--color-semantic-critical);
+$color-semantic-critical-hover: var(--color-semantic-critical-hover);
+$color-semantic-critical-active: var(--color-semantic-critical-active);
+$color-semantic-critical-disabled: var(--color-semantic-critical-disabled);
+$color-semantic-critical-bg-alt: var(--color-semantic-critical-bg-alt);
+$color-semantic-neutral: var(--color-semantic-neutral);
+$color-semantic-neutral-hover: var(--color-semantic-neutral-hover);
+$color-semantic-neutral-active: var(--color-semantic-neutral-active);
+$color-semantic-neutral-inactive: var(--color-semantic-neutral-inactive);
+
+/**
+  TEXT
+  **/
+$color-text-main: var(--color-text-main);
+$color-text-subtle: var(--color-text-subtle);
+$color-text-reverse: var(--color-text-reverse);
+$color-text-reverse-subtle: var(--color-text-reverse-subtle);
+$color-text-disabled: var(--color-text-disabled);
+$color-text-info: var(--color-text-info);
+$color-text-success: var(--color-text-success);
+$color-text-warning: var(--color-text-warning);
+$color-text-critical: var(--color-text-critical);
+
+/**
+  BORDER
+  **/
+$color-border-1: var(--color-border-1);
+$color-border-2: var(--color-border-2);
+$color-border-3: var(--color-border-3);
+
+/**
+  NEUTRALS
+  **/
+$color-neutral-0: var(--color-neutral-0);
+$color-neutral-0-reverse: var(--color-neutral-0-reverse);
+$color-neutral-1: var(--color-neutral-1);
+$color-neutral-2: var(--color-neutral-2);
+$color-neutral-3: var(--color-neutral-3);
+
+/**
+  STATUS
+  **/
+$color-status-ready: var(--color-status-ready);
+$color-status-offline: var(--color-status-offline);
+$color-status-busy: var(--color-status-busy);
+
+/**
+  BACKGROUNDS
+  **/
+$color-background-overlay: var(--color-background-overlay);
+$color-background-callout: var(--color-background-subtle-callout);
+$color-background-modal-overlay: var(--color-background-modal-overlay);
+$color-background-critical: var(--color-background-critical);
+$color-background-neutral-0: var(--color-background-neutral-0);
+
+/**
+  MENU
+  **/
+$color-interactions-menu: var(--color-interactions-menu);
+$color-interactions-menu-hover: var(--color-interactions-menu-hover);
+$color-interactions-menu-inactive: var(--color-interactions-menu-inactive);

--- a/src/utils/avatar-volume-utils.js
+++ b/src/utils/avatar-volume-utils.js
@@ -30,9 +30,9 @@ export function calcGainMultiplier(level) {
   );
 }
 
-export function updateAvatarVolumesPref(displayName, gainMultiplier, muted) {
+export function updateAvatarVolumesPref(playerSessionId, gainMultiplier, muted) {
   const avatarVoiceLevels = APP.store.state.preferences.avatarVoiceLevels || {};
-  avatarVoiceLevels[displayName] = {
+  avatarVoiceLevels[playerSessionId] = {
     gainMultiplier,
     muted
   };
@@ -43,6 +43,6 @@ export function updateAvatarVolumesPref(displayName, gainMultiplier, muted) {
   });
 }
 
-export function getAvatarVolumePref(displayName) {
-  return APP.store.state.preferences.avatarVoiceLevels?.[displayName];
+export function getAvatarVolumePref(playerSessionId) {
+  return APP.store.state.preferences.avatarVoiceLevels?.[playerSessionId];
 }


### PR DESCRIPTION
- adds "muted" indicator in the people list sidebar for guests the user has personally muted (as per the [UX Blast](https://docs.google.com/document/d/13K_N5eBXk0aTBlHVoPUPIxpSWFeY2rP2EafVqS30fg4/edit?skip_itp2_check=true#heading=h.3yjhrhxhk12i)
- As part of this work, I found that users' volumes were being stored under `displayName` `undefined` in `store._preferences`. Opted to store this under the users' session ids as these are accessible from the volume entities.
- Made lilypad color variable names accessible from `theme`
<img width="388" alt="Screenshot 2023-06-29 at 1 46 25 PM" src="https://github.com/mozilla/hubs/assets/42850541/6686cbda-e193-4515-bff1-0c6ad30a01c7">
<img width="388" alt="Screenshot 2023-06-29 at 1 46 39 PM" src="https://github.com/mozilla/hubs/assets/42850541/2910d9cf-4132-4608-a351-85bd023875fd">
<img width="384" alt="Screenshot 2023-06-29 at 1 47 05 PM" src="https://github.com/mozilla/hubs/assets/42850541/ca91206e-ee86-479e-9f80-e9b69bf6ae6f">
