### PR TITLE
Move loop-animation component to each object instead of scene

### DIFF
--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -201,7 +201,7 @@ export const LoopAnimationInitialize = defineComponent({});
  *          paused: boolean,
  *          startOffset: number,
  *          timeScale: number
- *        }[]>}
+ *        }>}
  */
 export const LoopAnimationInitializeData = new Map();
 export const LoopAnimation = defineComponent();

--- a/src/inflators/loop-animation.ts
+++ b/src/inflators/loop-animation.ts
@@ -2,10 +2,10 @@ import { addComponent } from "bitecs";
 import { LoopAnimationInitialize, LoopAnimationInitializeData } from "../bit-components";
 import { HubsWorld } from "../app";
 
-type ElementParams = {
+export type LoopAnimationParams = {
   activeClipIndex?: number;
   // TODO: Do we need to keep supporting the following two params?
-  //       Perhaps we should detemine which one should be the
+  //       Perhaps we should determine which one should be the
   //       the canonical presentation and then handle converting
   //       the others to that.
   // DEPRECATED: Use activeClipIndex instead since animation
@@ -18,9 +18,7 @@ type ElementParams = {
   timeScale?: number;
 };
 
-export type LoopAnimationParams = ElementParams[];
-
-const ELEMENT_DEFAULTS: Required<ElementParams> = {
+const DEFAULTS: Required<LoopAnimationParams> = {
   activeClipIndex: 0,
   clip: "",
   activeClipIndices: [],
@@ -29,32 +27,17 @@ const ELEMENT_DEFAULTS: Required<ElementParams> = {
   timeScale: 1.0
 };
 
-const DEFAULTS: Required<LoopAnimationParams> = [ELEMENT_DEFAULTS];
-
-export function inflateLoopAnimationInitialize(
-  world: HubsWorld,
-  eid: number,
-  params: LoopAnimationParams = []
-): number {
-  if (params.length === 0) {
-    params = DEFAULTS;
-  }
-
-  const componentParams = [];
-  for (let i = 0; i < params.length; i++) {
-    const requiredParams = Object.assign({}, ELEMENT_DEFAULTS, params[i]) as Required<ElementParams>;
-    const activeClipIndices =
-      requiredParams.activeClipIndices.length > 0 ? requiredParams.activeClipIndices : [requiredParams.activeClipIndex];
-    componentParams.push({
-      activeClipIndices,
-      clip: APP.getSid(requiredParams.clip),
-      paused: requiredParams.paused,
-      startOffset: requiredParams.startOffset,
-      timeScale: requiredParams.timeScale
-    });
-  }
-
+export function inflateLoopAnimationInitialize(world: HubsWorld, eid: number, params: LoopAnimationParams): number {
+  const requiredParams = Object.assign({}, DEFAULTS, params) as Required<LoopAnimationParams>;
+  const activeClipIndices =
+    requiredParams.activeClipIndices.length > 0 ? requiredParams.activeClipIndices : [requiredParams.activeClipIndex];
   addComponent(world, LoopAnimationInitialize, eid);
-  LoopAnimationInitializeData.set(eid, componentParams);
+  LoopAnimationInitializeData.set(eid, {
+    activeClipIndices,
+    clip: APP.getSid(requiredParams.clip),
+    paused: requiredParams.paused,
+    startOffset: requiredParams.startOffset,
+    timeScale: requiredParams.timeScale
+  });
   return eid;
 }

--- a/src/inflators/model.tsx
+++ b/src/inflators/model.tsx
@@ -5,7 +5,6 @@ import { GLTFModel, MaterialTag, MixerAnimatableInitialize } from "../bit-compon
 import { addMaterialComponent, addObject3DComponent, gltfInflatorExists, gltfInflators } from "../utils/jsx-entity";
 import { mapMaterials } from "../utils/material-utils";
 import { EntityID } from "../utils/networking-types";
-import { inflateLoopAnimationInitialize, LoopAnimationParams } from "./loop-animation";
 
 function camelCase(s: string) {
   return s.replace(/-(\w)/g, (_, m) => m.toUpperCase());
@@ -14,15 +13,7 @@ function camelCase(s: string) {
 export type ModelParams = { model: Object3D };
 
 // These components are all handled in some special way, not through inflators
-const ignoredComponents = [
-  "visible",
-  "frustum",
-  "frustrum",
-  "shadow",
-  "networked",
-  "animation-mixer",
-  "loop-animation"
-];
+const ignoredComponents = ["visible", "frustum", "frustrum", "shadow", "networked", "animation-mixer"];
 
 function inflateComponents(
   world: HubsWorld,
@@ -122,7 +113,6 @@ export function inflateModel(world: HubsWorld, rootEid: number, { model }: Model
   // These components are special because we want to do a one-off action
   // that we can't do in a regular inflator (because they depend on the object3D).
   // If more things need to run at this point, we may need to expand the api here.
-  const loopAnimationParams: LoopAnimationParams = [];
   model.traverse(obj => {
     const components = obj.userData.gltfExtensions?.MOZ_hubs_components || {};
     if (components.visible) {
@@ -136,10 +126,6 @@ export function inflateModel(world: HubsWorld, rootEid: number, { model }: Model
         o.castShadow = cast;
         o.receiveShadow = receive;
       });
-    }
-
-    if (components["loop-animation"]) {
-      loopAnimationParams.push(components["loop-animation"]);
     }
 
     // We have had both spellings at different times.
@@ -163,7 +149,6 @@ export function inflateModel(world: HubsWorld, rootEid: number, { model }: Model
   // See https://github.com/mozilla/hubs/pull/5938#discussion_r1163410185
   if (model.animations !== undefined && model.animations.length > 0) {
     addComponent(world, MixerAnimatableInitialize, rootEid);
-    inflateLoopAnimationInitialize(world, rootEid, loopAnimationParams);
   }
 
   addComponent(world, GLTFModel, rootEid);

--- a/src/utils/jsx-entity.ts
+++ b/src/utils/jsx-entity.ts
@@ -258,6 +258,7 @@ export interface ComponentData {
   audioParams?: AudioSettings;
   mediaFrame?: any;
   text?: TextParams;
+  loopAnimation?: LoopAnimationParams;
 }
 
 type OptionalParams<T> = Partial<T> | true;
@@ -363,7 +364,6 @@ export interface JSXComponentData extends ComponentData {
   networkDebug?: boolean;
   waypointPreview?: boolean;
   pdf?: PDFParams;
-  loopAnimation?: LoopAnimationParams;
 }
 
 export interface GLTFComponentData extends ComponentData {
@@ -427,7 +427,8 @@ export const commonInflators: Required<{ [K in keyof ComponentData]: InflatorFn 
   audioZone: inflateAudioZone,
   audioParams: inflateAudioParams,
   mediaFrame: inflateMediaFrame,
-  text: inflateText
+  text: inflateText,
+  loopAnimation: inflateLoopAnimationInitialize
 };
 
 const jsxInflators: Required<{ [K in keyof JSXComponentData]: InflatorFn }> = {


### PR DESCRIPTION
When two animation clips with the same name are targeted to different objects we are playing always the first one and the second one is never played.

This used to work fine in AFrame because we used to re-targe animations based on the object where `loop-component` was attached but with the bitECS migration we ignore the objects components and we attach one `loop-animation` component to the scene root so we can't re-target anymore as we have lost the reference of which objects play animations.

**Note**: This works fine in most cases but it fails when several objects are using the same animation name which seems to be pretty common (as I've seen this in different assets lately)

This PR addresses this issue keeping the`loop-animation` component attached to the original object so the animations can be correctly re-targeted.

As it's widely commented in the code, it makes sense to have only one `loop-animation` at the scene level that handles all the animations in the scene but that would require quite some refactoring to move the component to the scene level. What we could easily do is updating the Blender component to use the glTF animation index instead of the clip name as that one it's unique so we can at least do the component transform that we are doing and each clip would be correctly played in its related object. I'll open an issue to update the Blender component and start using that instead of the clip name.

Use this model for testing.
[Frustum.glb.zip](https://github.com/mozilla/hubs/files/11958098/Frustum.glb.zip)
[Frustum.blend.zip](https://github.com/mozilla/hubs/files/11958102/Frustum.blend.zip)
