### PR TITLE
Correctly handle scene physics in BitECS

### DIFF
--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -346,3 +346,5 @@ export const LinearScale = defineComponent({
   targetZ: Types.f32
 });
 export const Quack = defineComponent();
+export const TrimeshTag = defineComponent();
+export const HeightFieldTag = defineComponent();

--- a/src/bit-systems/scene-loading.ts
+++ b/src/bit-systems/scene-loading.ts
@@ -4,13 +4,15 @@ import { Mesh } from "three";
 import { HubsWorld } from "../app";
 import {
   EnvironmentSettings,
+  HeightFieldTag,
   NavMesh,
   Networked,
   PhysicsShape,
   SceneLoader,
   ScenePreviewCamera,
   SceneRoot,
-  Skybox
+  Skybox,
+  TrimeshTag
 } from "../bit-components";
 import Sky from "../components/skybox";
 import { Fit, inflatePhysicsShape, Shape } from "../inflators/physics-shape";
@@ -104,7 +106,9 @@ function* loadScene(
       }
     });
 
-    if (!findChildWithComponent(world, PhysicsShape, scene)) {
+    if (findChildWithComponent(world, TrimeshTag, scene) || findChildWithComponent(world, HeightFieldTag, scene)) {
+      console.log("heightfield or trimesh found on scene");
+    } else {
       let navMeshEid;
       if (isHighDensity) {
         navMeshEid = findChildWithComponent(world, NavMesh, scene);

--- a/src/inflators/heightfield.ts
+++ b/src/inflators/heightfield.ts
@@ -1,5 +1,7 @@
+import { addComponent } from "bitecs";
 import { HubsWorld } from "../app";
 import { Fit, inflatePhysicsShape, Shape } from "./physics-shape";
+import { HeightFieldTag } from "../bit-components";
 
 export type HeightFieldParams = {
   distance: number;
@@ -16,4 +18,5 @@ export function inflateHeightField(world: HubsWorld, eid: number, params: Height
     heightfieldDistance: params.distance,
     heightfieldData: params.data
   });
+  addComponent(world, HeightFieldTag, eid);
 }

--- a/src/inflators/trimesh.ts
+++ b/src/inflators/trimesh.ts
@@ -1,5 +1,7 @@
+import { addComponent } from "bitecs";
 import { HubsWorld } from "../app";
 import { Fit, inflatePhysicsShape, Shape } from "./physics-shape";
+import { TrimeshTag } from "../bit-components";
 
 export function inflateTrimesh(world: HubsWorld, eid: number) {
   inflatePhysicsShape(world, eid, {
@@ -8,4 +10,5 @@ export function inflateTrimesh(world: HubsWorld, eid: number) {
     includeInvisible: true,
     margin: 0.01
   });
+  addComponent(world, TrimeshTag, eid);
 }


### PR DESCRIPTION
Scene physics were not being correctly handled in bitecs. We were looking for an existing physics shape assuming that that would be a heightfield or trimesh (Spoke) or otherwise we would create a default physics floor based on a heuristic.

This fails anytime the scene contains a physics shape already as all components have already been inflated at this point so I added specific tag components for trimesh and heightfields so we can correctly handle that case which is a common case for Spoke generated scenes. For Blender scenes (as there is no trimesh/heightfield automatic generation there) we will use the heurstic.

This correctly mimics our previous AFrame behaviour and ensure retro compat.