### PR TITLE
Remove entity_state_api feature flag

### DIFF
--- a/src/utils/entity-state-utils.ts
+++ b/src/utils/entity-state-utils.ts
@@ -129,14 +129,9 @@ function push(hubChannel: HubChannel, command: HubChannelCommand, payload?: HubC
   if (!localClientID) {
     throw new Error("Cannot get/set entity states without a local client ID.");
   }
-  if (qsTruthy("entity_state_api")) {
-    return new Promise((resolve, reject) => {
-      hubChannel.channel.push(command, payload).receive("ok", resolve).receive("error", reject);
-    });
-  } else {
-    console.warn("Entity state API is inactive. Would have sent:", { command, payload });
-    return Promise.reject();
-  }
+  return new Promise((resolve, reject) => {
+    hubChannel.channel.push(command, payload).receive("ok", resolve).receive("error", reject);
+  });
 }
 
 function listEntityStates(hubChannel: HubChannel) {


### PR DESCRIPTION
Now that reticulum's entity state apis have stabilized, we can remove this feature flag. Note that the functionality is still behind the `newLoader` flag.