### PR TITLE
fix: Toolbar buttons should all be transparent on click

### DIFF
--- a/src/react-components/room/components/ChatToolbarButton/ChatToolbarButton.tsx
+++ b/src/react-components/room/components/ChatToolbarButton/ChatToolbarButton.tsx
@@ -14,9 +14,10 @@ const chatTooltipDescription = defineMessage({
 
 type ChatToolbarButtonProps = {
   onClick: () => void;
+  selected: boolean
 };
 
-const ChatToolbarButton = ({ onClick }: ChatToolbarButtonProps) => {
+const ChatToolbarButton = ({ onClick, selected }: ChatToolbarButtonProps) => {
   const { unreadMessages } = useContext(ChatContext);
   const intl = useIntl();
   const description = intl.formatMessage(chatTooltipDescription);
@@ -31,6 +32,7 @@ const ChatToolbarButton = ({ onClick }: ChatToolbarButtonProps) => {
         icon={<ChatIcon />}
         preset="accent4"
         label={<FormattedMessage id="chat-toolbar-button" defaultMessage="Chat" />}
+        selected={selected}
       />
     </ToolTip>
   );

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1646,6 +1646,7 @@ class UIRoot extends Component {
                     {!isLockedDownDemo && (
                       <ChatToolbarButton
                         onClick={() => this.toggleSidebar("chat", { chatPrefix: "", chatAutofocus: false })}
+                        selected={this.state.sidebarId === "chat"}
                       />
                     )}
                     {entered && isMobileVR && (

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -177,6 +177,7 @@ class UIRoot extends Component {
     enterInVR: false,
     entered: false,
     entering: false,
+    leaving: false,
     dialog: null,
     showShareDialog: false,
     linkCode: null,
@@ -1166,7 +1167,7 @@ class UIRoot extends Component {
             onClick: () =>
               this.showNonHistoriedDialog(LeaveRoomModal, {
                 destinationUrl: "/",
-                reason: LeaveReason.createRoom
+                reason: LeaveReason.createRoom,
               })
           },
           !isLockedDownDemo && {
@@ -1253,7 +1254,7 @@ class UIRoot extends Component {
               onClick: () => {
                 this.showNonHistoriedDialog(LeaveRoomModal, {
                   destinationUrl: "/",
-                  reason: LeaveReason.leaveRoom
+                  reason: LeaveReason.leaveRoom,
                 });
               }
             },
@@ -1675,10 +1676,16 @@ class UIRoot extends Component {
                         icon={<LeaveIcon />}
                         label={<FormattedMessage id="toolbar.leave-room-button" defaultMessage="Leave" />}
                         preset="cancel"
+                        selected={!!this.state.leaving}
                         onClick={() => {
+                          this.setState({leaving: true})
                           this.showNonHistoriedDialog(LeaveRoomModal, {
                             destinationUrl: "/",
-                            reason: LeaveReason.leaveRoom
+                            reason: LeaveReason.leaveRoom,
+                            onClose: () => {
+                              this.setState({leaving: false})
+                              this.closeDialog()
+                            }
                           });
                         }}
                       />


### PR DESCRIPTION
Currently all buttons except for "Leave" and "Chat" turn transparent upon opening. This PR rectifies this so that the toolbar buttons all behave uniformly.
<img width="519" alt="Screenshot 2023-07-20 at 2 26 35 PM" src="https://github.com/mozilla/hubs/assets/42850541/9a4b6bff-6da6-494e-8f0a-f08db367e076">
<img width="689" alt="Screenshot 2023-07-20 at 2 26 23 PM" src="https://github.com/mozilla/hubs/assets/42850541/ad521e4d-bb94-4d3c-8b53-28a9619e2128">
