### PR TITLE
Add a way to move camera infinitely (add pointerlock)

### DIFF
--- a/src/react-components/preferences-screen.js
+++ b/src/react-components/preferences-screen.js
@@ -429,6 +429,14 @@ const preferenceLabels = defineMessages({
     id: "preferences-screen.preference.disable-strafing",
     defaultMessage: "Disable strafing"
   },
+  enablePointerlock: {
+    id: "preferences-screen.preference.enable-pointerlock",
+    defaultMessage: "Enable locking mouse, which allows you to move camera infinitely"
+  },
+  enablePointerlockRawInput: {
+    id: "preferences-screen.preference.enable-pointerlock-raw-input",
+    defaultMessage: "When locking mouse is enabled, disable acceleration"
+  },
   disableTeleporter: {
     id: "preferences-screen.preference.disable-teleporter",
     defaultMessage: "Disable teleporter"
@@ -1081,6 +1089,14 @@ class PreferencesScreen extends Component {
           },
           {
             key: "disableTeleporter",
+            prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX
+          },
+          {
+            key: "enablePointerlock",
+            prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX
+          },
+          {
+            key: "enablePointerlockRawInput",
             prefType: PREFERENCE_LIST_ITEM_TYPE.CHECK_BOX
           },
           {

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -145,6 +145,8 @@ export const SCHEMA = {
         disableStrafing: { type: "bool", default: false },
         disableTeleporter: { type: "bool", default: false },
         disableAutoPixelRatio: { type: "bool", default: false },
+        enablePointerlock: { type: "bool", default: false },
+        enablePointerlockRawInput: { type: "bool", default: false },
         movementSpeedModifier: { type: "number", default: 1 },
         disableEchoCancellation: { type: "bool", default: isFirefoxReality },
         disableNoiseSuppression: { type: "bool", default: isFirefoxReality },


### PR DESCRIPTION
I discovered that the mouse functionality is unusable with a three-monitor setup. Even with just one monitor, I still find it annoying to use as the mouse can hit the screen corner.

closes https://github.com/mozilla/hubs/issues/1352

And I also refactored code a bit so it easier to read.

I decided to not enable new functionality by default (as it has problem that you can see on gif).
When pointerlock gets released cursor position is misleading and it gets updated after mousemove event. I think the proper solution would be to change cursor behavior so it stays on the same place and arrow indicates moving direction instead.

<details>
<summary>GIF</summary>


![Jul-23-2023 07-52-16](https://github.com/mozilla/hubs/assets/46503702/aa58ff41-3db9-42d0-b0ca-9da3e8dac140)
</details>
