### PR TITLE
Fix legacy nametag color customisation

### DIFF
--- a/admin/src/react-components/service-editor.js
+++ b/admin/src/react-components/service-editor.js
@@ -459,6 +459,7 @@ class ConfigurationEditor extends Component {
               className={this.props.classes.button}
               variant="contained"
               color="primary"
+              disabled={this.state.warningMessage}
             >
               Save
             </Button>

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -105,9 +105,8 @@ function getCurrentTheme() {
 
 function getThemeColor(name) {
   const theme = getCurrentTheme();
-  console.log(theme)
-  // theme?.[name] ensures legacy variables for nametag colors are taken into account
-  return theme?.variables?.[name] || theme?.[name] || DEFAULT_COLORS[name];
+  // config?.theme?.[name] ensures legacy variables for nametag colors are taken into account
+  return theme?.variables?.[name] || config?.theme?.[name] || DEFAULT_COLORS[name];
 }
 
 function updateTextButtonColors() {

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -105,7 +105,9 @@ function getCurrentTheme() {
 
 function getThemeColor(name) {
   const theme = getCurrentTheme();
-  return theme?.variables?.[name] || DEFAULT_COLORS[name];
+  console.log(theme)
+  // theme?.[name] ensures legacy variables for nametag colors are taken into account
+  return theme?.variables?.[name] || theme?.[name] || DEFAULT_COLORS[name];
 }
 
 function updateTextButtonColors() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -234,7 +234,7 @@ module.exports = async (env, argv) => {
   /**
    * Initialize the Webpack build envrionment for the provided environment.
    */
-  
+
   if (argv.mode !== "production" || env.bundleAnalyzer) {
     if (env.loadAppConfig || process.env.LOAD_APP_CONFIG) {
       if (!env.localDev) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -234,6 +234,7 @@ module.exports = async (env, argv) => {
   /**
    * Initialize the Webpack build envrionment for the provided environment.
    */
+  
   if (argv.mode !== "production" || env.bundleAnalyzer) {
     if (env.loadAppConfig || process.env.LOAD_APP_CONFIG) {
       if (!env.localDev) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -234,7 +234,6 @@ module.exports = async (env, argv) => {
   /**
    * Initialize the Webpack build envrionment for the provided environment.
    */
-
   if (argv.mode !== "production" || env.bundleAnalyzer) {
     if (env.loadAppConfig || process.env.LOAD_APP_CONFIG) {
       if (!env.localDev) {


### PR DESCRIPTION
Previously, the Nametag inputs in the Theme tab in the Admin Panel did not do anything. This fix ensures this legacy method of changing nametags works. Alternatively, "nametag-color" and "nametag-text-color" can be added to the theme variables and will also update nametags.

Additionally, we now disable the save button if there is a warning message currently issued for an invalid input.

<img width="441" alt="Screenshot 2023-07-27 at 1 15 22 PM" src="https://github.com/mozilla/hubs/assets/42850541/75f80d86-dd0a-4605-98dd-2646c711f888">
<img width="499" alt="Screenshot 2023-07-27 at 1 15 16 PM" src="https://github.com/mozilla/hubs/assets/42850541/242043e1-d90a-4ee2-b8db-3fb4c3c9df7e">
<img width="485" alt="Screenshot 2023-07-27 at 1 28 25 PM" src="https://github.com/mozilla/hubs/assets/42850541/b15fe54b-a5ab-4088-a7db-3c9ab0715880">
