### PR TITLE
Revert "Use non-canonical URL for local non-model assets"

### DIFF
--- a/src/utils/media-url-utils.js
+++ b/src/utils/media-url-utils.js
@@ -71,7 +71,7 @@ export const scaledThumbnailUrlFor = (url, width, height) => {
 };
 
 export const isNonCorsProxyDomain = hostname => {
-  return !!nonCorsProxyDomains.find(domain => hostname.endsWith(domain));
+  return nonCorsProxyDomains.find(domain => hostname.endsWith(domain));
 };
 
 export const proxiedUrlFor = url => {

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -615,9 +615,10 @@ export async function resolveMediaInfo(urlString) {
 
   // We want to resolve and proxy some hubs urls, like rooms and scene links,
   // but want to avoid proxying assets in order for this to work in dev environments
-  const isLocalAsset = isNonCorsProxyDomain(url.hostname);
+  const isLocalModelAsset =
+    isNonCorsProxyDomain(url.hostname) && (guessContentType(url.href) || "").startsWith("model/gltf");
 
-  if (url.protocol != "data:" && url.protocol != "hubs:" && !isLocalAsset) {
+  if (url.protocol != "data:" && url.protocol != "hubs:" && !isLocalModelAsset) {
     const response = await resolveUrl(url.href);
     canonicalUrl = response.origin;
     if (canonicalUrl.startsWith("//")) {


### PR DESCRIPTION
Reverts mozilla/hubs#6082

Problem: Local media links are broken with the `newLoader` flag set to true. All local media assets have `undefined` thumbnail urls. We currently check to see if the asset `isLocalAsset`, and if so we do not `resolveUrl` (fetch thumbnails etc).

Solution: Reverting this PR ensures we are only checking if an asset is a local `model/gltf` type, and for all others we proceed to `resolveUrl`. I have successfully tested this in my local environment when placing scenes, avatars, images, and models, in the room

Notes: Interestingly, this original PR was merged to fix broken links when the 'newLoader' flag is set. This appears to be fixed, but will potentially need investigation.