### PR TITLE
bitECS: Fix glb including waypoint loading

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -412,7 +412,8 @@ const OBJECT3D_EXT = new Set([
   "skybox",
   "spot-light",
   "text",
-  "video"
+  "video",
+  "waypoint"
 ]);
 
 class GLTFHubsPlugin {


### PR DESCRIPTION
Fixes #6214

**Problem**

With new loader enabled, loading glb including `waypoint` component can fail.

#6214

**Root issue**

We preprocess glb content to avoid a node having both glTF native properties that add `Three.js Object3D` (eg: `mesh`, `camera`) and Hubs Components that add `Object3D` (eg: `image`, `video`) for new loader because new loader doesn't handle such nodes.

#6121

`Waypoint` component is the Hubs component one that adds `Object3D` (waypoint icon) but it seems to have been overlooked.

**Solution**

Adds waypoint component existence check when detecting whether the preprocess is needed.