### PR TITLE
bitECS: Prevent Three.js Audio.disconnect error

### DIFF
--- a/src/bit-systems/audio-emitter-system.ts
+++ b/src/bit-systems/audio-emitter-system.ts
@@ -19,7 +19,9 @@ export function isPositionalAudio(node: AudioObject3D): node is PositionalAudio 
 
 export function cleanupAudio(audio: AudioObject3D) {
   const eid = audio.eid!;
-  audio.disconnect();
+  if (audio.source !== null) {
+    audio.disconnect();
+  }
   const audioSystem = APP.scene?.systems["hubs-systems"].audioSystem;
   APP.audios.delete(eid);
   APP.supplementaryAttenuation.delete(eid);
@@ -34,7 +36,9 @@ function swapAudioType<T extends AudioObject3D>(
   NewType: AudioConstructor<T>
 ) {
   const audio = world.eid2obj.get(eid)! as AudioObject3D;
-  audio.disconnect();
+  if (audio.source !== null) {
+    audio.disconnect();
+  }
   APP.sourceType.set(eid, SourceType.MEDIA_VIDEO);
   APP.supplementaryAttenuation.delete(eid);
   APP.audios.delete(eid);


### PR DESCRIPTION
**Problem**

Disconnecting Three.js `Audio` can cause an error

https://github.com/mozilla/hubs/issues/6206

`Three.js Audio.disconnect()` seems to expect `Audio.source` is `non-null`. `Audio.source` is set via `.set*Source()` or `.play()`.

https://github.com/MozillaReality/three.js/blob/hubs-patches-141/src/audio/Audio.js

Hubs Client seems to call `Audio.disconnect()` before setting source in some scenarios.

**Solution**

Add a guard to check `Audio.source` is non-null before calling `Audio.disconnect()`

**Additional context**

There might be a chance that the fact `Audio.source` keeps being unset in some scenarios might be a bug. We might also need to investigate it.