### PR TITLE
We need to use src for hubIdFromUrl

### DIFF
--- a/src/bit-systems/link-hover-menu.ts
+++ b/src/bit-systems/link-hover-menu.ts
@@ -78,7 +78,7 @@ async function handleLinkClick(world: HubsWorld, button: EntityID) {
     case LinkType.ROOM:
       const waypoint = url.hash && url.hash.substring(1);
       // move to new room without page load or entry flow
-      const hubId = hubIdFromUrl(url);
+      const hubId = hubIdFromUrl(src);
       changeHub(hubId, true, waypoint);
       break;
     case LinkType.ROOM_URL:


### PR DESCRIPTION
This fixes an error in this PR https://github.com/mozilla/hubs/pull/6110 here https://github.com/mozilla/hubs/blob/54c0c146a3fbdfe1c5990412f9f5019d8413d6ad/src/bit-systems/link-hover-menu.ts#L81 where we were using a URL as `hubIdFromUrl` instead of a string.