### PR TITLE
bitECS: Check if entity has networked component before taking ownership

### DIFF
--- a/src/systems/bit-constraints-system.js
+++ b/src/systems/bit-constraints-system.js
@@ -19,7 +19,8 @@ import {
   ConstraintHandLeft,
   ConstraintHandRight,
   ConstraintRemoteLeft,
-  ConstraintRemoteRight
+  ConstraintRemoteRight,
+  Networked
 } from "../bit-components";
 import { takeOwnership } from "../utils/take-ownership";
 
@@ -45,7 +46,9 @@ const releaseBodyOptions = { activationState: ACTIVE_TAG };
 function add(world, physicsSystem, interactor, constraintComponent, entities) {
   for (let i = 0; i < entities.length; i++) {
     const eid = findAncestorEntity(world, entities[i], ancestor => hasComponent(world, Rigidbody, ancestor));
-    takeOwnership(world, eid);
+    if (hasComponent(world, Networked, eid)) {
+      takeOwnership(world, eid);
+    }
     physicsSystem.updateRigidBodyOptions(eid, grabBodyOptions);
     physicsSystem.addConstraint(interactor, Rigidbody.bodyId[eid], Rigidbody.bodyId[interactor], {});
     addComponent(world, Constraint, eid);


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/6254

This PR adds a check for Networked component when a Constraint is added to a body to taking ownership of entities that are not networked.

In some contexts we might want to add constratints to bodies of entities that are not networked. Inthe current use case most of the times this is the case as the only interactable entities are dropped medias but behavior graphs allow creating physics objects that can be interactable and might not necessarily need to be networked (although most of the times they will)
