### PR TITLE
bitECS: Fix hiding the remove button from the object menu

### DIFF
--- a/src/bit-systems/object-menu.ts
+++ b/src/bit-systems/object-menu.ts
@@ -237,6 +237,7 @@ function updateVisibility(world: HubsWorld, menu: EntityID, frozen: boolean) {
   world.eid2obj.get(ObjectMenu.unpinButtonRef[menu])!.visible = visible && isPinned(target);
   world.eid2obj.get(ObjectMenu.pinButtonRef[menu])!.visible =
     visible && !isPinned(target) && canPin(APP.hubChannel!, target);
+  world.eid2obj.get(ObjectMenu.removeButtonRef[menu])!.visible = !isPinned(target);
 
   // Hide unimplemented features for now.
   // TODO: Implement and show the buttons.
@@ -249,7 +250,6 @@ function updateVisibility(world: HubsWorld, menu: EntityID, frozen: boolean) {
   world.eid2obj.get(ObjectMenu.refreshButtonRef[menu])!.visible = false;
 
   [
-    ObjectMenu.removeButtonRef[menu],
     ObjectMenu.openLinkButtonRef[menu],
     ObjectMenu.cloneButtonRef[menu],
     ObjectMenu.rotateButtonRef[menu],

--- a/src/bit-systems/object-menu.ts
+++ b/src/bit-systems/object-menu.ts
@@ -237,7 +237,7 @@ function updateVisibility(world: HubsWorld, menu: EntityID, frozen: boolean) {
   world.eid2obj.get(ObjectMenu.unpinButtonRef[menu])!.visible = visible && isPinned(target);
   world.eid2obj.get(ObjectMenu.pinButtonRef[menu])!.visible =
     visible && !isPinned(target) && canPin(APP.hubChannel!, target);
-  world.eid2obj.get(ObjectMenu.removeButtonRef[menu])!.visible = !isPinned(target);
+  world.eid2obj.get(ObjectMenu.removeButtonRef[menu])!.visible = visible && !isPinned(target);
 
   // Hide unimplemented features for now.
   // TODO: Implement and show the buttons.


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/6252

This PR fixes the hiding of the remove button based on the pinned state of the entity.