### PR TITLE
bitECS: Fix teleport link

### DIFF
--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -604,7 +604,7 @@ export function parseURL(text) {
 }
 
 export async function resolveMediaInfo(urlString) {
-  //check if url is an anchor hash e.g. #Spawn_Point_1
+  // check if url is an anchor hash e.g. #Spawn_Point_1
   if (urlString.charAt(0) === "#") {
     urlString = `${window.location.origin}${window.location.pathname}${window.location.search}${urlString}`;
   }

--- a/src/utils/media-utils.js
+++ b/src/utils/media-utils.js
@@ -604,10 +604,16 @@ export function parseURL(text) {
 }
 
 export async function resolveMediaInfo(urlString) {
+  //check if url is an anchor hash e.g. #Spawn_Point_1
+  if (urlString.charAt(0) === "#") {
+    urlString = `${window.location.origin}${window.location.pathname}${window.location.search}${urlString}`;
+  }
+
   const url = parseURL(urlString);
   if (!url) {
     throw new Error(`Cannot fetch data for URL: ${urlString}`);
   }
+
   let canonicalUrl = url.href;
   let canonicalAudioUrl = null; // set non-null only if audio track is separated from video track (eg. 360 video)
   let contentType;


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/6255

This PR fixes the teleport links by updaitng the anchor to a url. This code was copied from what we were already doing in the AFrame media loader:
https://github.com/mozilla/hubs/blob/25202db4f505e60ec18cb712cd57d3f92d7a79bf/src/components/media-loader.js#L355-L358
