### PR TITLE
Remove 'crazy' from the Hubs name generation wordlist

### DIFF
--- a/src/utils/name-generation.js
+++ b/src/utils/name-generation.js
@@ -392,7 +392,6 @@ const adjectives = [
   "courageous",
   "courteous",
   "crafty",
-  "crazy",
   "creamy",
   "creative",
   "crisp",


### PR DESCRIPTION
1/2 of the resolution of https://github.com/mozilla/hubs/issues/6283. Good idea to remove this from the wordlist.

The second half of this issue is resolved with this PR: https://github.com/mozilla/reticulum/pull/710