### PR TITLE
bitECS New loader pinning updates

### DIFF
--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -151,11 +151,9 @@ export const CameraTool = defineComponent({
 export const MyCameraTool = defineComponent();
 export const MediaLoader = defineComponent({
   src: Types.ui32,
-  flags: Types.ui8,
-  fileId: Types.ui32
+  flags: Types.ui8
 });
 MediaLoader.src[$isStringType] = true;
-MediaLoader.fileId[$isStringType] = true;
 export const MediaLoaded = defineComponent();
 export const LoadedByMediaLoader = defineComponent();
 export const MediaContentBounds = defineComponent({

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -151,9 +151,11 @@ export const CameraTool = defineComponent({
 export const MyCameraTool = defineComponent();
 export const MediaLoader = defineComponent({
   src: Types.ui32,
-  flags: Types.ui8
+  flags: Types.ui8,
+  fileId: Types.ui32
 });
 MediaLoader.src[$isStringType] = true;
+MediaLoader.fileId[$isStringType] = true;
 export const MediaLoaded = defineComponent();
 export const LoadedByMediaLoader = defineComponent();
 export const MediaContentBounds = defineComponent({

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -400,6 +400,5 @@ export const MediaLink = defineComponent({
 MediaLink.src[$isStringType] = true;
 export const ObjectMenuTransform = defineComponent({
   targetObjectRef: Types.eid,
-  prevObjectRef: Types.eid,
   flags: Types.ui8
 });

--- a/src/bit-systems/object-menu-transform-system.ts
+++ b/src/bit-systems/object-menu-transform-system.ts
@@ -47,7 +47,7 @@ function transformMenu(world: HubsWorld, menu: EntityID) {
 
   // Calculate the menu offset based on visible elements
   const center = (ObjectMenuTransform.flags[menu] & ObjectMenuTransformFlags.Center) !== 0 ? true : false;
-  if (center && ObjectMenuTransform.targetObjectRef[menu] !== ObjectMenuTransform.prevObjectRef[menu]) {
+  if (center) {
     getAABB(menuObj, aabb);
     aabb.getCenter(tmpVec1);
     getAABB(menuObj, aabb, true);
@@ -100,8 +100,6 @@ function transformMenu(world: HubsWorld, menu: EntityID) {
 
     setMatrixWorld(menuObj, tmpMat4);
   }
-
-  ObjectMenuTransform.prevObjectRef[menu] = ObjectMenuTransform.targetObjectRef[menu];
 }
 
 const menuQuery = defineQuery([ObjectMenuTransform]);

--- a/src/bit-systems/object-menu.ts
+++ b/src/bit-systems/object-menu.ts
@@ -221,6 +221,7 @@ function handleHeldExit(world: HubsWorld, eid: EntityID, menuEid: EntityID) {
 }
 
 function updateVisibility(world: HubsWorld, menu: EntityID, frozen: boolean) {
+  if (!APP.hubChannel) return;
   let target = ObjectMenu.targetRef[menu];
   const visible = !!(target && frozen) && (ObjectMenu.flags[menu] & ObjectMenuFlags.Visible) !== 0;
 
@@ -243,8 +244,8 @@ function updateVisibility(world: HubsWorld, menu: EntityID, frozen: boolean) {
   const mediaLoader = findAncestorWithComponent(world, MediaContentBounds, target);
   target = mediaLoader ? mediaLoader : target;
 
-  const canISpawnMove = APP.hubChannel!.can("spawn_and_move_media");
-  const canIPin = !!(target && canPin(APP.hubChannel!, target));
+  const canISpawnMove = APP.hubChannel.can("spawn_and_move_media");
+  const canIPin = !!(target && canPin(APP.hubChannel, target));
   const isEntityPinned = isPinned(target);
 
   // Parent visibility doesn't block raycasting, so we must set each button to be invisible

--- a/src/bit-systems/video-menu-system.ts
+++ b/src/bit-systems/video-menu-system.ts
@@ -9,10 +9,12 @@ import {
   Held,
   HeldRemoteRight,
   HoveredRemoteRight,
+  MediaContentBounds,
   MediaVideo,
   MediaVideoData,
   NetworkedVideo,
   ObjectMenuTransform,
+  Owned,
   VideoMenu
 } from "../bit-components";
 import { timeFmt } from "../components/media-video";
@@ -21,11 +23,11 @@ import { paths } from "../systems/userinput/paths";
 import { animate } from "../utils/animate";
 import { coroutine } from "../utils/coroutine";
 import { easeOutQuadratic } from "../utils/easing";
-import { isFacingCamera } from "../utils/three-utils";
 import { Emitter2Audio } from "./audio-emitter-system";
 import { EntityID } from "../utils/networking-types";
 import { findAncestorWithComponent, hasAnyComponent } from "../utils/bit-utils";
 import { ObjectMenuTransformFlags } from "../inflators/object-menu-transform";
+import { isPinned } from "./networking";
 
 const videoMenuQuery = defineQuery([VideoMenu]);
 const hoveredQuery = defineQuery([HoveredRemoteRight]);
@@ -119,69 +121,86 @@ export function videoMenuSystem(world: HubsWorld, userinput: any, sceneIsFrozen:
   videoMenuQuery(world).forEach(function (eid) {
     const videoEid = VideoMenu.videoRef[eid];
     if (!videoEid) return;
-    const menuObj = world.eid2obj.get(eid)!;
     const video = MediaVideoData.get(videoEid)!;
-    const togglePlayVideo = userinput.get(paths.actions.cursor.right.togglePlayVideo);
-    if (togglePlayVideo) {
-      if (hasComponent(world, NetworkedVideo, videoEid)) {
-        takeOwnership(world, videoEid);
-        addComponent(world, EntityStateDirty, videoEid);
-      }
+    const ratio = MediaVideo.ratio[videoEid];
 
-      const playIndicatorObj = world.eid2obj.get(VideoMenu.playIndicatorRef[eid])!;
-      const pauseIndicatorObj = world.eid2obj.get(VideoMenu.pauseIndicatorRef[eid])!;
-
-      const audioEid = Emitter2Audio.get(videoEid)!;
-      if (video.paused) {
-        video.play();
-        APP.isAudioPaused.delete(audioEid);
-        playIndicatorObj.visible = true;
-        pauseIndicatorObj.visible = false;
-        rightMenuIndicatorCoroutine = coroutine(animateIndicator(world, VideoMenu.playIndicatorRef[eid]));
-      } else {
-        video.pause();
-        APP.isAudioPaused.add(audioEid);
-        playIndicatorObj.visible = false;
-        pauseIndicatorObj.visible = true;
-        rightMenuIndicatorCoroutine = coroutine(animateIndicator(world, VideoMenu.pauseIndicatorRef[eid]));
-      }
-    }
-
-    const videoIsFacingCamera = isFacingCamera(world.eid2obj.get(videoEid)!);
-    const yRot = videoIsFacingCamera ? 0 : Math.PI;
-    if (menuObj.rotation.y !== yRot) {
-      menuObj.rotation.y = yRot;
-      menuObj.matrixNeedsUpdate = true;
+    // The media loader entity is the entity that's is actually pinned and decides
+    // the pinnable state of the video component so we need to check the media loader entity pin
+    // state to show/hide certain buttons. The media loader component is not present anymore after
+    // the media has been loaded but it will always have a MediaContentBounds.
+    // TODO We should use something more meaningful than MediaContentBounds for the media loader root entity
+    // or rename it to something like MediaRoot.
+    let canIPin = false;
+    const mediaRoot = findAncestorWithComponent(world, MediaContentBounds, videoEid)!;
+    if (isPinned(mediaRoot) && !hasComponent(world, Owned, mediaRoot)) {
+      canIPin = true;
     }
 
     const headObj = world.eid2obj.get(VideoMenu.headRef[eid])!;
-    if (hasComponent(world, HeldRemoteRight, VideoMenu.trackRef[eid])) {
-      const trackObj = world.eid2obj.get(VideoMenu.trackRef[eid])!;
-      intersectInThePlaneOf(trackObj, userinput.get(paths.actions.cursor.right.pose), intersectionPoint);
-      if (intersectionPoint) {
-        const newPosition = headObj.parent!.worldToLocal(intersectionPoint);
-        video.currentTime =
-          mapLinear(clamp(newPosition.x, -sliderHalfWidth, sliderHalfWidth), -sliderHalfWidth, sliderHalfWidth, 0, 1) *
-          video.duration;
-      }
-      if (hasComponent(world, NetworkedVideo, videoEid)) {
-        takeOwnership(world, videoEid);
-        addComponent(world, EntityStateDirty, videoEid);
-      }
-    }
-    headObj.position.x = mapLinear(video.currentTime, 0, video.duration, -sliderHalfWidth, sliderHalfWidth);
-    headObj.matrixNeedsUpdate = true;
+    const slider = world.eid2obj.get(VideoMenu.sliderRef[eid])!;
+    const playIndicatorObj = world.eid2obj.get(VideoMenu.playIndicatorRef[eid])!;
+    const pauseIndicatorObj = world.eid2obj.get(VideoMenu.pauseIndicatorRef[eid])!;
+    if (canIPin) {
+      const togglePlayVideo = userinput.get(paths.actions.cursor.right.togglePlayVideo);
+      if (togglePlayVideo) {
+        if (hasComponent(world, NetworkedVideo, videoEid)) {
+          takeOwnership(world, videoEid);
+          addComponent(world, EntityStateDirty, videoEid);
+        }
 
-    const ratio = MediaVideo.ratio[videoEid];
+        const audioEid = Emitter2Audio.get(videoEid)!;
+        if (video.paused) {
+          video.play();
+          APP.isAudioPaused.delete(audioEid);
+          playIndicatorObj.visible = true;
+          pauseIndicatorObj.visible = false;
+          rightMenuIndicatorCoroutine = coroutine(animateIndicator(world, VideoMenu.playIndicatorRef[eid]));
+        } else {
+          video.pause();
+          APP.isAudioPaused.add(audioEid);
+          playIndicatorObj.visible = false;
+          pauseIndicatorObj.visible = true;
+          rightMenuIndicatorCoroutine = coroutine(animateIndicator(world, VideoMenu.pauseIndicatorRef[eid]));
+        }
+      }
+
+      if (hasComponent(world, HeldRemoteRight, VideoMenu.trackRef[eid])) {
+        const trackObj = world.eid2obj.get(VideoMenu.trackRef[eid])!;
+        intersectInThePlaneOf(trackObj, userinput.get(paths.actions.cursor.right.pose), intersectionPoint);
+        if (intersectionPoint) {
+          const newPosition = headObj.parent!.worldToLocal(intersectionPoint);
+          video.currentTime =
+            mapLinear(
+              clamp(newPosition.x, -sliderHalfWidth, sliderHalfWidth),
+              -sliderHalfWidth,
+              sliderHalfWidth,
+              0,
+              1
+            ) * video.duration;
+        }
+        if (hasComponent(world, NetworkedVideo, videoEid)) {
+          takeOwnership(world, videoEid);
+          addComponent(world, EntityStateDirty, videoEid);
+        }
+      }
+      headObj.visible = true;
+      headObj.position.x = mapLinear(video.currentTime, 0, video.duration, -sliderHalfWidth, sliderHalfWidth);
+      headObj.matrixNeedsUpdate = true;
+
+      slider.visible = true;
+      slider.position.setY(-(ratio / 2) + 0.025);
+      slider.matrixNeedsUpdate = true;
+    } else {
+      headObj.visible = false;
+      slider.visible = false;
+      playIndicatorObj.visible = false;
+      pauseIndicatorObj.visible = false;
+    }
 
     const timeLabel = world.eid2obj.get(VideoMenu.timeLabelRef[eid])! as TroikaText;
     timeLabel.text = `${timeFmt(video.currentTime)} / ${timeFmt(video.duration)}`;
     timeLabel.position.setY(ratio / 2 - 0.02);
     timeLabel.matrixNeedsUpdate = true;
-
-    const slider = world.eid2obj.get(VideoMenu.sliderRef[eid])!;
-    slider.position.setY(-(ratio / 2) + 0.025);
-    slider.matrixNeedsUpdate = true;
 
     if (rightMenuIndicatorCoroutine && rightMenuIndicatorCoroutine().done) {
       rightMenuIndicatorCoroutine = null;
@@ -195,6 +214,7 @@ const START_SCALE = new Vector3().setScalar(0.05);
 const END_SCALE = new Vector3().setScalar(0.25);
 function* animateIndicator(world: HubsWorld, eid: number) {
   const obj = world.eid2obj.get(eid)!;
+  obj.visible = true;
   yield* animate({
     properties: [
       [START_SCALE, END_SCALE],
@@ -208,4 +228,5 @@ function* animateIndicator(world: HubsWorld, eid: number) {
       ((obj as Mesh).material as MeshBasicMaterial).opacity = opacity;
     }
   });
+  obj.visible = false;
 }

--- a/src/inflators/media-loader.ts
+++ b/src/inflators/media-loader.ts
@@ -8,13 +8,14 @@ export type MediaLoaderParams = {
   resize: boolean;
   recenter: boolean;
   animateLoad: boolean;
+  fileId?: string;
   isObjectMenuTarget: boolean;
 };
 
 export function inflateMediaLoader(
   world: HubsWorld,
   eid: number,
-  { src, recenter, resize, animateLoad, isObjectMenuTarget }: MediaLoaderParams
+  { src, recenter, resize, animateLoad, fileId, isObjectMenuTarget }: MediaLoaderParams
 ) {
   addComponent(world, MediaLoader, eid);
   let flags = 0;
@@ -23,5 +24,8 @@ export function inflateMediaLoader(
   if (animateLoad) flags |= MEDIA_LOADER_FLAGS.ANIMATE_LOAD;
   if (isObjectMenuTarget) flags |= MEDIA_LOADER_FLAGS.IS_OBJECT_MENU_TARGET;
   MediaLoader.flags[eid] = flags;
+  if (fileId) {
+    MediaLoader.fileId[eid] = APP.getSid(fileId)!;
+  }
   MediaLoader.src[eid] = APP.getSid(src)!;
 }

--- a/src/inflators/media-loader.ts
+++ b/src/inflators/media-loader.ts
@@ -8,14 +8,13 @@ export type MediaLoaderParams = {
   resize: boolean;
   recenter: boolean;
   animateLoad: boolean;
-  fileId?: string;
   isObjectMenuTarget: boolean;
 };
 
 export function inflateMediaLoader(
   world: HubsWorld,
   eid: number,
-  { src, recenter, resize, animateLoad, fileId, isObjectMenuTarget }: MediaLoaderParams
+  { src, recenter, resize, animateLoad, isObjectMenuTarget }: MediaLoaderParams
 ) {
   addComponent(world, MediaLoader, eid);
   let flags = 0;
@@ -24,8 +23,5 @@ export function inflateMediaLoader(
   if (animateLoad) flags |= MEDIA_LOADER_FLAGS.ANIMATE_LOAD;
   if (isObjectMenuTarget) flags |= MEDIA_LOADER_FLAGS.IS_OBJECT_MENU_TARGET;
   MediaLoader.flags[eid] = flags;
-  if (fileId) {
-    MediaLoader.fileId[eid] = APP.getSid(fileId)!;
-  }
   MediaLoader.src[eid] = APP.getSid(src)!;
 }

--- a/src/load-media-on-paste-or-drop.ts
+++ b/src/load-media-on-paste-or-drop.ts
@@ -44,9 +44,6 @@ export async function spawnFromFileList(files: FileList) {
       .then(function (response: UploadResponse) {
         const srcUrl = new URL(response.origin);
         srcUrl.searchParams.set("token", response.meta.access_token);
-        window.APP.store.update({
-          uploadPromotionTokens: [{ fileId: response.file_id, promotionToken: response.meta.promotion_token }]
-        });
         return {
           src: srcUrl.href,
           recenter: true,

--- a/src/load-media-on-paste-or-drop.ts
+++ b/src/load-media-on-paste-or-drop.ts
@@ -44,15 +44,11 @@ export async function spawnFromFileList(files: FileList) {
       .then(function (response: UploadResponse) {
         const srcUrl = new URL(response.origin);
         srcUrl.searchParams.set("token", response.meta.access_token);
-        window.APP.store.update({
-          uploadPromotionTokens: [{ fileId: response.file_id, promotionToken: response.meta.promotion_token }]
-        });
         return {
           src: srcUrl.href,
           recenter: true,
           resize: !qsTruthy("noResize"),
           animateLoad: true,
-          fileId: response.file_id,
           isObjectMenuTarget: true
         };
       })

--- a/src/load-media-on-paste-or-drop.ts
+++ b/src/load-media-on-paste-or-drop.ts
@@ -44,11 +44,15 @@ export async function spawnFromFileList(files: FileList) {
       .then(function (response: UploadResponse) {
         const srcUrl = new URL(response.origin);
         srcUrl.searchParams.set("token", response.meta.access_token);
+        window.APP.store.update({
+          uploadPromotionTokens: [{ fileId: response.file_id, promotionToken: response.meta.promotion_token }]
+        });
         return {
           src: srcUrl.href,
           recenter: true,
           resize: !qsTruthy("noResize"),
           animateLoad: true,
+          fileId: response.file_id,
           isObjectMenuTarget: true
         };
       })

--- a/src/react-components/room/object-hooks.js
+++ b/src/react-components/room/object-hooks.js
@@ -58,7 +58,7 @@ function isObjectPinned(world, eid) {
   if (hasComponent(world, AEntity, eid)) {
     return isAEntityPinned(APP.world, eid);
   } else {
-    // This hooks is making decisions based on components attached to the root MediaLoader entity
+    // This hook is making decisions based on components attached to the root MediaLoader entity
     // and the child media entity. ie. The MediaInfo component lives in the child media but the
     // networked state lives in the root. This is not great, there is a lot of places where we need to
     // do component searches to find either the media root or the actual media. It's not even reasonable

--- a/src/react-components/room/object-hooks.js
+++ b/src/react-components/room/object-hooks.js
@@ -7,16 +7,7 @@ import { hasComponent } from "bitecs";
 import { isPinned as getPinnedState } from "../../bit-systems/networking";
 import { deleteTheDeletableAncestor } from "../../bit-systems/delete-entity-system";
 import { isAEntityPinned } from "../../systems/hold-system";
-import {
-  AEntity,
-  LocalAvatar,
-  MediaInfo,
-  RemoteAvatar,
-  Static,
-  MediaContentBounds,
-  MediaLoader,
-  Owned
-} from "../../bit-components";
+import { AEntity, LocalAvatar, MediaInfo, RemoteAvatar, Static, MediaContentBounds } from "../../bit-components";
 import { setPinned } from "../../utils/bit-pinning-helper";
 import { debounce } from "lodash";
 

--- a/src/react-components/room/object-hooks.js
+++ b/src/react-components/room/object-hooks.js
@@ -58,6 +58,13 @@ function isObjectPinned(world, eid) {
   if (hasComponent(world, AEntity, eid)) {
     return isAEntityPinned(APP.world, eid);
   } else {
+    // This hooks is making decisions based on components attached to the root MediaLoader entity
+    // and the child media entity. ie. The MediaInfo component lives in the child media but the
+    // networked state lives in the root. This is not great, there is a lot of places where we need to
+    // do component searches to find either the media root or the actual media. It's not even reasonable
+    // to look for a component name MediaContentBounds just to get the MediaLoader (as we remove that
+    // after loading the media).
+    // We should probably find a better way of dealing with spawned media entity hierarchies.
     const mediaRootEid = findAncestorWithComponent(APP.world, MediaContentBounds, eid);
     return getPinnedState(mediaRootEid);
   }

--- a/src/react-components/room/object-hooks.js
+++ b/src/react-components/room/object-hooks.js
@@ -134,14 +134,8 @@ export function usePinObject(hubChannel, scene, object) {
     };
   }, [object]);
 
-  let userOwnsFile = false;
-
-  if (shouldUseNewLoader()) {
-    const fileId = MediaLoader.fileId[object.eid];
-    const mediaRootEid = findAncestorWithComponent(APP.world, MediaContentBounds, object.eid);
-    const fileIsOwned = hasComponent(APP.world, Owned, mediaRootEid);
-    userOwnsFile = fileIsOwned || (fileId && getPromotionTokenForFile(fileId));
-  } else {
+  let userOwnsFile = true;
+  if (!shouldUseNewLoader()) {
     const el = object.el;
     if (el.components["media-loader"]) {
       const { fileIsOwned, fileId } = el.components["media-loader"].data;

--- a/src/scene-entry-manager.js
+++ b/src/scene-entry-manager.js
@@ -40,6 +40,9 @@ export default class SceneEntryManager {
     this.leftCursorController = document.getElementById("left-cursor-controller");
     this.avatarRig = document.getElementById("avatar-rig");
     this._entered = false;
+    /**
+     * @type {Function}
+     */
     this.performConditionalSignIn = () => {};
     this.history = history;
   }

--- a/src/systems/bit-constraints-system.js
+++ b/src/systems/bit-constraints-system.js
@@ -19,10 +19,8 @@ import {
   ConstraintHandLeft,
   ConstraintHandRight,
   ConstraintRemoteLeft,
-  ConstraintRemoteRight,
-  Networked
+  ConstraintRemoteRight
 } from "../bit-components";
-import { takeOwnership } from "../utils/take-ownership";
 
 const queryRemoteRight = defineQuery([HeldRemoteRight, OffersRemoteConstraint]);
 const queryEnterRemoteRight = enterQuery(queryRemoteRight);
@@ -46,9 +44,6 @@ const releaseBodyOptions = { activationState: ACTIVE_TAG };
 function add(world, physicsSystem, interactor, constraintComponent, entities) {
   for (let i = 0; i < entities.length; i++) {
     const eid = findAncestorEntity(world, entities[i], ancestor => hasComponent(world, Rigidbody, ancestor));
-    if (hasComponent(world, Networked, eid)) {
-      takeOwnership(world, eid);
-    }
     physicsSystem.updateRigidBodyOptions(eid, grabBodyOptions);
     physicsSystem.addConstraint(interactor, Rigidbody.bodyId[eid], Rigidbody.bodyId[interactor], {});
     addComponent(world, Constraint, eid);

--- a/src/systems/hold-system.js
+++ b/src/systems/hold-system.js
@@ -11,12 +11,15 @@ import {
   HeldHandRight,
   HoveredHandLeft,
   HeldHandLeft,
-  LoadedByMediaLoader,
-  AEntity
+  AEntity,
+  Networked,
+  MediaContentBounds
 } from "../bit-components";
 import { canMove } from "../utils/permissions-utils";
 import { canMove as canMoveEntity } from "../utils/bit-permissions-utils";
 import { isPinned } from "../bit-systems/networking";
+import { takeOwnership } from "../utils/take-ownership";
+import { findAncestorWithComponent } from "../utils/bit-utils";
 
 const GRAB_REMOTE_RIGHT = paths.actions.cursor.right.grab;
 const DROP_REMOTE_RIGHT = paths.actions.cursor.right.drop;
@@ -71,43 +74,25 @@ export function isAEntityPinned(world, eid) {
 // Alternate solution: Simply recognize an entity as pinned if its any
 // ancestor is pinned (in hold-system) unless there is a case that
 // descendant entity under pinned entity wants to be grabbable.
-function isParentPinned(world, eid) {
-  if (!world.eid2obj.has(eid)) {
-    return false;
-  }
-
-  const obj = world.eid2obj.get(eid);
-
-  if (obj.parent === null) {
-    return false;
-  }
-
-  const parent = obj.parent;
-
-  if (parent.eid === undefined) {
-    return false;
-  }
-
-  return isPinned(parent.eid);
-}
-
 function grab(world, userinput, queryHovered, held, grabPath) {
   const hovered = queryHovered(world)[0];
-  let isEntityPinned = isPinned(hovered) || isAEntityPinned(world, hovered);
 
-  // Special path for Dropped/Pasted Media with new loader enabled
-  if (!isEntityPinned && hasComponent(world, LoadedByMediaLoader, hovered)) {
-    isEntityPinned = isParentPinned(world, hovered);
-  }
+  // Special path for Dropped/Pasted Media with new loader enabled. Check the comment above.
+  const mediaRoot = findAncestorWithComponent(world, MediaContentBounds, hovered);
+  const target = mediaRoot ? mediaRoot : hovered;
+  const isEntityPinned = isPinned(target) || isAEntityPinned(world, target);
 
   if (
-    hovered &&
+    target &&
     userinput.get(grabPath) &&
     (!isEntityPinned || AFRAME.scenes[0].is("frozen")) &&
-    hasPermissionToGrab(world, hovered)
+    hasPermissionToGrab(world, target)
   ) {
-    addComponent(world, held, hovered);
-    addComponent(world, Held, hovered);
+    if (hasComponent(world, Networked, target)) {
+      takeOwnership(world, target);
+    }
+    addComponent(world, held, target);
+    addComponent(world, Held, target);
   }
 }
 

--- a/src/utils/bit-pinning-helper.ts
+++ b/src/utils/bit-pinning-helper.ts
@@ -45,9 +45,5 @@ export const canPin = (hubChannel: HubChannel, eid: EntityID): boolean => {
   if (createMessageData.prefabName !== "media") {
     return false;
   }
-  const fileId = createMessageData.initialData.fileId;
-  const hasFile = !!fileId;
-  const hasPromotableFile =
-    hasFile && APP.store.state.uploadPromotionTokens.some((upload: any) => upload.fileId === fileId);
-  return isNetworkInstantiated(eid) && !isPinned(eid) && (!hasFile || hasPromotableFile);
+  return isNetworkInstantiated(eid) && !isPinned(eid);
 };

--- a/src/utils/bit-pinning-helper.ts
+++ b/src/utils/bit-pinning-helper.ts
@@ -49,10 +49,5 @@ export const canPin = (hubChannel: HubChannel, eid: EntityID): boolean => {
   const hasFile = !!fileId;
   const hasPromotableFile =
     hasFile && APP.store.state.uploadPromotionTokens.some((upload: any) => upload.fileId === fileId);
-  return (
-    isNetworkInstantiated(eid) &&
-    !isPinned(eid) &&
-    hubChannel.can("pin_objects") && // TODO: Remove once conditional sign in is implemented
-    (!hasFile || hasPromotableFile)
-  );
+  return isNetworkInstantiated(eid) && !isPinned(eid) && (!hasFile || hasPromotableFile);
 };

--- a/src/utils/bit-pinning-helper.ts
+++ b/src/utils/bit-pinning-helper.ts
@@ -4,6 +4,7 @@ import HubChannel from "./hub-channel";
 import { EntityID } from "./networking-types";
 import { takeOwnership } from "./take-ownership";
 import { createMessageDatas, isNetworkInstantiated, isPinned } from "../bit-systems/networking";
+import { SignInMessages } from "../react-components/auth/SignInModal";
 
 export const setPinned = async (hubChannel: HubChannel, world: HubsWorld, eid: EntityID, shouldPin: boolean) => {
   _signInAndPinOrUnpinElement(hubChannel, world, eid, shouldPin);
@@ -29,8 +30,14 @@ const unpinElement = (hubChannel: HubChannel, world: HubsWorld, eid: EntityID) =
 
 const _signInAndPinOrUnpinElement = (hubChannel: HubChannel, world: HubsWorld, eid: EntityID, shouldPin: boolean) => {
   const action = shouldPin ? () => _pinElement(hubChannel, world, eid) : () => unpinElement(hubChannel, world, eid);
-  // TODO: Perform conditional sign in
-  action();
+  APP.entryManager!.performConditionalSignIn(
+    () => hubChannel.signedIn,
+    action,
+    shouldPin ? SignInMessages.pin : SignInMessages.unpin,
+    (e: Error) => {
+      console.warn(`PinningHelper: Conditional sign-in failed. ${e}`);
+    }
+  );
 };
 
 export const canPin = (hubChannel: HubChannel, eid: EntityID): boolean => {

--- a/src/utils/bit-pinning-helper.ts
+++ b/src/utils/bit-pinning-helper.ts
@@ -45,5 +45,9 @@ export const canPin = (hubChannel: HubChannel, eid: EntityID): boolean => {
   if (createMessageData.prefabName !== "media") {
     return false;
   }
-  return isNetworkInstantiated(eid) && !isPinned(eid);
+  const fileId = createMessageData.initialData.fileId;
+  const hasFile = !!fileId;
+  const hasPromotableFile =
+    hasFile && APP.store.state.uploadPromotionTokens.some((upload: any) => upload.fileId === fileId);
+  return isNetworkInstantiated(eid) && !isPinned(eid) && (!hasFile || hasPromotableFile);
 };

--- a/src/utils/bit-pinning-helper.ts
+++ b/src/utils/bit-pinning-helper.ts
@@ -45,9 +45,5 @@ export const canPin = (hubChannel: HubChannel, eid: EntityID): boolean => {
   if (createMessageData.prefabName !== "media") {
     return false;
   }
-  const fileId = createMessageData.initialData.fileId;
-  const hasFile = !!fileId;
-  const hasPromotableFile =
-    hasFile && APP.store.state.uploadPromotionTokens.some((upload: any) => upload.fileId === fileId);
-  return isNetworkInstantiated(eid) && !isPinned(eid) && (!hasFile || hasPromotableFile);
+  return isNetworkInstantiated(eid) && hubChannel.can("pin_objects");
 };

--- a/src/utils/entity-state-utils.ts
+++ b/src/utils/entity-state-utils.ts
@@ -7,7 +7,6 @@ import HubChannel from "./hub-channel";
 import { queueEntityStateAsMessage } from "./listen-for-network-messages";
 import { networkableComponents, schemas } from "./network-schemas";
 import { CreateMessage, EntityID, NetworkID, StorableUpdateMessage } from "./networking-types";
-import qsTruthy from "./qs_truthy";
 import { deleteTheDeletableAncestor } from "../bit-systems/delete-entity-system";
 
 export type EntityState = {
@@ -77,13 +76,7 @@ export async function deleteEntityState(hubChannel: HubChannel, world: HubsWorld
   const payload: DeleteEntityStatePayload = {
     nid: APP.getString(Networked.id[eid])! as NetworkID
   };
-  const {
-    initialData: { fileId }
-  } = createMessageDatas.get(eid)!;
-  if (fileId) {
-    payload.file_id = fileId;
-  }
-  // console.log("delete_entity_state",  payload);
+
   return push(hubChannel, "delete_entity_state", payload);
 }
 
@@ -163,22 +156,6 @@ function createEntityStatePayload(world: HubsWorld, rootEid: EntityID): CreateEn
     updates
   } as CreateEntityStatePayload;
 
-  const {
-    prefabName,
-    initialData: { fileId, src }
-  } = createMessageDatas.get(rootEid)!;
-
-  if (prefabName == "media" && fileId && src) {
-    const fileAccessToken = new URL(src).searchParams.get("token") as string;
-    const { promotionToken } = APP.store.state.uploadPromotionTokens.find(
-      (upload: { fileId: string }) => upload.fileId === fileId
-    );
-    if (promotionToken) {
-      payload.file_id = fileId;
-      payload.file_access_token = fileAccessToken;
-      payload.promotion_token = promotionToken;
-    }
-  }
   return payload;
 }
 

--- a/src/utils/entity-state-utils.ts
+++ b/src/utils/entity-state-utils.ts
@@ -169,14 +169,8 @@ function createEntityStatePayload(world: HubsWorld, rootEid: EntityID): CreateEn
 
   if (prefabName == "media" && fileId && src) {
     const fileAccessToken = new URL(src).searchParams.get("token") as string;
-    const { promotionToken } = APP.store.state.uploadPromotionTokens.find(
-      (upload: { fileId: string }) => upload.fileId === fileId
-    );
-    if (promotionToken) {
-      payload.file_id = fileId;
-      payload.file_access_token = fileAccessToken;
-      payload.promotion_token = promotionToken;
-    }
+    payload.file_id = fileId;
+    payload.file_access_token = fileAccessToken;
   }
   return payload;
 }

--- a/src/utils/entity-state-utils.ts
+++ b/src/utils/entity-state-utils.ts
@@ -76,7 +76,13 @@ export async function deleteEntityState(hubChannel: HubChannel, world: HubsWorld
   const payload: DeleteEntityStatePayload = {
     nid: APP.getString(Networked.id[eid])! as NetworkID
   };
-
+  const {
+    initialData: { fileId }
+  } = createMessageDatas.get(eid)!;
+  if (fileId) {
+    payload.file_id = fileId;
+  }
+  // console.log("delete_entity_state",  payload);
   return push(hubChannel, "delete_entity_state", payload);
 }
 
@@ -156,6 +162,22 @@ function createEntityStatePayload(world: HubsWorld, rootEid: EntityID): CreateEn
     updates
   } as CreateEntityStatePayload;
 
+  const {
+    prefabName,
+    initialData: { fileId, src }
+  } = createMessageDatas.get(rootEid)!;
+
+  if (prefabName == "media" && fileId && src) {
+    const fileAccessToken = new URL(src).searchParams.get("token") as string;
+    const { promotionToken } = APP.store.state.uploadPromotionTokens.find(
+      (upload: { fileId: string }) => upload.fileId === fileId
+    );
+    if (promotionToken) {
+      payload.file_id = fileId;
+      payload.file_access_token = fileAccessToken;
+      payload.promotion_token = promotionToken;
+    }
+  }
   return payload;
 }
 


### PR DESCRIPTION
This PR updates a few things:
- Adds support for pinning in the object list
- Changes the pinning design for the new loader to remove the concept of promotion token and simplify the pinning flow (see the diagrams below for details)
- Updates the menus to hide/show buttons based on the pinned state of the object.

**Pinning changes**
We have simplified the way pinning works for the new loader removing the case where an uploaded file can only be pinned initially by the uploader. Now any user can pin an uploaded file so in practice an uploaded media pinning works the same as a url media.
 
This depends on this Reticulum PR: https://github.com/mozilla/reticulum/pull/712

This is how pinning worked in the old loader:

![Pinning Old Loader](https://github.com/mozilla/hubs/assets/837184/bdce44cc-248e-48ae-b812-e2338882a288)

Here it is how it is going to work in the new loader:

![Pinning New Loader](https://github.com/mozilla/hubs/assets/837184/599c0178-e934-45bf-b27c-75bfc2580b93)

For reference this is what the expected object menu layout should be:

![Object Menu States](https://github.com/mozilla/hubs/assets/837184/116ccdd3-e3fe-4cae-9224-90c5ddbc3f6f)
