### PR TITLE
bitECS: Fix object menus transforms

### DIFF
--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -257,7 +257,8 @@ export const VideoMenu = defineComponent({
   trackRef: Types.eid,
   headRef: Types.eid,
   playIndicatorRef: Types.eid,
-  pauseIndicatorRef: Types.eid
+  pauseIndicatorRef: Types.eid,
+  clearTargetTimer: Types.f64
 });
 export const AudioEmitter = defineComponent({
   flags: Types.ui8
@@ -286,7 +287,9 @@ export const ObjectMenu = defineComponent({
   rotateButtonRef: Types.eid,
   mirrorButtonRef: Types.eid,
   scaleButtonRef: Types.eid,
-  targetRef: Types.eid
+  targetRef: Types.eid,
+  handlingTargetRef: Types.eid,
+  flags: Types.ui8
 });
 // TODO: Store this data elsewhere, since only one or two will ever exist.
 export const LinkHoverMenu = defineComponent({
@@ -309,7 +312,9 @@ export const PDFMenu = defineComponent({
   targetRef: Types.eid,
   clearTargetTimer: Types.f64
 });
-export const ObjectMenuTarget = defineComponent();
+export const ObjectMenuTarget = defineComponent({
+  flags: Types.ui8
+});
 export const NetworkDebug = defineComponent();
 export const NetworkDebugRef = defineComponent({
   ref: Types.eid
@@ -393,3 +398,8 @@ export const MediaLink = defineComponent({
   src: Types.ui32
 });
 MediaLink.src[$isStringType] = true;
+export const ObjectMenuTransform = defineComponent({
+  targetObjectRef: Types.eid,
+  prevObjectRef: Types.eid,
+  flags: Types.ui8
+});

--- a/src/bit-systems/object-menu-transform-system.ts
+++ b/src/bit-systems/object-menu-transform-system.ts
@@ -1,0 +1,113 @@
+import { defineQuery } from "bitecs";
+import { HubsWorld } from "../app";
+import { ObjectMenuTarget, ObjectMenuTransform } from "../bit-components";
+import { EntityID } from "../utils/networking-types";
+import { Box3, Matrix4, Object3D, Quaternion, Sphere, Vector3 } from "three";
+import { isFacingCamera, setFromObject, setMatrixWorld } from "../utils/three-utils";
+import { ObjectMenuTargetFlags } from "../inflators/object-menu-target";
+import { ObjectMenuTransformFlags } from "../inflators/object-menu-transform";
+
+const offset = new Vector3();
+const tmpVec1 = new Vector3();
+const tmpVec2 = new Vector3();
+const tmpQuat1 = new Quaternion();
+const tmpQuat2 = new Quaternion();
+const tmpMat4 = new Matrix4();
+const tmpMat42 = new Matrix4();
+const aabb = new Box3();
+const sphere = new Sphere();
+const yVector = new Vector3(0, 1, 0);
+
+// Calculate the AABB without accounting for the root object rotation
+function getAABB(obj: Object3D, box: Box3, onlyVisible: boolean = false) {
+  const parent = obj.parent;
+  obj.removeFromParent();
+  obj.updateMatrices(true, true);
+  tmpMat4.copy(obj.matrixWorld);
+  tmpMat4.decompose(tmpVec1, tmpQuat1, tmpVec2);
+  tmpQuat2.copy(tmpQuat1);
+  obj.quaternion.identity();
+  obj.updateMatrix();
+  obj.updateMatrixWorld();
+  setFromObject(box, obj, onlyVisible);
+  parent?.add(obj);
+  obj.quaternion.copy(tmpQuat2);
+  obj.updateMatrix();
+  obj.updateMatrixWorld();
+}
+
+// Check https://github.com/mozilla/hubs/pull/6289#issuecomment-1739003555 for implementation details.
+function transformMenu(world: HubsWorld, menu: EntityID) {
+  const targetEid = ObjectMenuTransform.targetObjectRef[menu];
+  const targetObj = world.eid2obj.get(targetEid);
+  const enabled = (ObjectMenuTransform.flags[menu] & ObjectMenuTransformFlags.Enabled) !== 0 ? true : false;
+  if (!targetObj || !enabled) return;
+
+  const menuObj = world.eid2obj.get(menu)!;
+
+  // Calculate the menu offset based on visible elements
+  const center = (ObjectMenuTransform.flags[menu] & ObjectMenuTransformFlags.Center) !== 0 ? true : false;
+  if (center && ObjectMenuTransform.targetObjectRef[menu] !== ObjectMenuTransform.prevObjectRef[menu]) {
+    getAABB(menuObj, aabb);
+    aabb.getCenter(tmpVec1);
+    getAABB(menuObj, aabb, true);
+    aabb.getCenter(tmpVec2);
+    offset.subVectors(tmpVec1, tmpVec2);
+    offset.z = 0;
+  }
+
+  const camera = APP.scene?.systems["hubs-systems"].cameraSystem.viewingCamera;
+  camera.updateMatrices();
+
+  const isFlat = (ObjectMenuTarget.flags[targetEid] & ObjectMenuTargetFlags.Flat) !== 0 ? true : false;
+  if (!isFlat) {
+    getAABB(targetObj, aabb);
+    aabb.getBoundingSphere(sphere);
+
+    tmpMat4.copy(targetObj.matrixWorld);
+    tmpMat4.decompose(tmpVec1, tmpQuat1, tmpVec2);
+    tmpVec2.set(1.0, 1.0, 1.0);
+    tmpMat4.compose(sphere.center, tmpQuat1, tmpVec2);
+
+    setMatrixWorld(menuObj, tmpMat4);
+
+    menuObj.lookAt(tmpVec2.setFromMatrixPosition(camera.matrixWorld));
+    menuObj.translateZ(sphere.radius);
+
+    if (center) {
+      menuObj.position.add(offset);
+      menuObj.matrixNeedsUpdate = true;
+    }
+
+    // TODO We need to handle the menu positioning when the player is inside the bounding sphere.
+    // For now we are defaulting to the current AFrame behavior.
+  } else {
+    targetObj.updateMatrices(true, true);
+    tmpMat4.copy(targetObj.matrixWorld);
+    tmpMat4.decompose(tmpVec1, tmpQuat1, tmpVec2);
+
+    const isFacing = isFacingCamera(targetObj);
+    if (!isFacing) {
+      tmpQuat1.setFromAxisAngle(yVector, Math.PI);
+      tmpMat42.makeRotationFromQuaternion(tmpQuat1);
+      tmpMat4.multiply(tmpMat42);
+    }
+
+    if (center) {
+      tmpMat42.makeTranslation(offset.x, offset.y, offset.z);
+      tmpMat4.multiply(tmpMat42);
+    }
+
+    setMatrixWorld(menuObj, tmpMat4);
+  }
+
+  ObjectMenuTransform.prevObjectRef[menu] = ObjectMenuTransform.targetObjectRef[menu];
+}
+
+const menuQuery = defineQuery([ObjectMenuTransform]);
+
+export function objectMenuTransformSystem(world: HubsWorld) {
+  menuQuery(world).forEach(menu => {
+    transformMenu(world, menu);
+  });
+}

--- a/src/bit-systems/object-menu.ts
+++ b/src/bit-systems/object-menu.ts
@@ -15,7 +15,7 @@ import {
   MediaContentBounds,
   Deleting
 } from "../bit-components";
-import { anyEntityWith, findAncestorWithAnyComponent, findAncestorWithComponents } from "../utils/bit-utils";
+import { anyEntityWith, findAncestorWithComponents } from "../utils/bit-utils";
 import { createNetworkedEntity } from "../utils/create-networked-entity";
 import HubChannel from "../utils/hub-channel";
 import type { EntityID } from "../utils/networking-types";

--- a/src/bit-systems/object-menu.ts
+++ b/src/bit-systems/object-menu.ts
@@ -1,8 +1,9 @@
 import { addComponent, defineQuery, enterQuery, entityExists, exitQuery, hasComponent } from "bitecs";
-import { Matrix4, Quaternion, Vector3 } from "three";
+import { Matrix4, Vector3 } from "three";
 import type { HubsWorld } from "../app";
 import {
   EntityStateDirty,
+  ObjectMenuTransform,
   HeldRemoteRight,
   HoveredRemoteRight,
   Interacted,
@@ -10,9 +11,11 @@ import {
   ObjectMenu,
   ObjectMenuTarget,
   RemoteRight,
-  Rigidbody
+  Rigidbody,
+  MediaContentBounds,
+  Deleting
 } from "../bit-components";
-import { anyEntityWith, findAncestorWithComponent } from "../utils/bit-utils";
+import { anyEntityWith, findAncestorWithAnyComponent, findAncestorWithComponents } from "../utils/bit-utils";
 import { createNetworkedEntity } from "../utils/create-networked-entity";
 import HubChannel from "../utils/hub-channel";
 import type { EntityID } from "../utils/networking-types";
@@ -23,21 +26,18 @@ import { createMessageDatas, isPinned } from "./networking";
 import { TRANSFORM_MODE } from "../components/transform-object-button";
 import { ScalingHandler } from "../components/scale-button";
 import { canPin, setPinned } from "../utils/bit-pinning-helper";
+import { ObjectMenuTransformFlags } from "../inflators/object-menu-transform";
 
 // Working variables.
 const _vec3_1 = new Vector3();
 const _vec3_2 = new Vector3();
-const _quat = new Quaternion();
 const _mat4 = new Matrix4();
 
 let scalingHandler: ScalingHandler | null = null;
 
-// Needs to remember rotating/scaling entity id because
-// rotation/scaling are operated by dragging so that
-// rotation/scaling operation can continue even if the cursor
-// hover off the target entity.
-// TODO: Should this data stored in Component?
-let handlingTargetEid: EntityID = 0;
+export const enum ObjectMenuFlags {
+  Visible = 1 << 0
+}
 
 function clicked(world: HubsWorld, eid: EntityID) {
   return hasComponent(world, Interacted, eid);
@@ -48,8 +48,22 @@ function objectMenuTarget(world: HubsWorld, menu: EntityID, sceneIsFrozen: boole
     return 0;
   }
 
-  const target = hoveredQuery(world).map(eid => findAncestorWithComponent(world, ObjectMenuTarget, eid))[0];
-  if (target) return target;
+  // We can have more than one object menu target in the object hierarchy so we need to explicity look
+  // for the media loader entity here. ie. The object menu target in the media loader entity and the
+  // video menu in the video entity
+  // TODO We should use something more meaningful than MediaContentBounds for the media loader root entity
+  // or rename that to something like MediaRoot
+  const target = hoveredQuery(world).map(eid =>
+    findAncestorWithComponents(world, [MediaContentBounds, ObjectMenuTarget], eid)
+  )[0];
+  if (target) {
+    if (hasComponent(world, Deleting, target)) {
+      return 0;
+    } else {
+      ObjectMenu.flags[menu] |= ObjectMenuFlags.Visible;
+      return target;
+    }
+  }
 
   if (entityExists(world, ObjectMenu.targetRef[menu])) {
     return ObjectMenu.targetRef[menu];
@@ -58,39 +72,10 @@ function objectMenuTarget(world: HubsWorld, menu: EntityID, sceneIsFrozen: boole
   return 0;
 }
 
-function moveToTarget(world: HubsWorld, menu: EntityID) {
-  const targetObj = world.eid2obj.get(ObjectMenu.targetRef[menu])!;
-  targetObj.updateMatrices();
-
-  // TODO: position the menu more carefully...
-  //       For example, if a menu object is just placed at a target
-  //       object's position the menu object can be hidden by a large
-  //       target object or the menu object looks too small for a far
-  //       target object.
-  _mat4.copy(targetObj.matrixWorld);
-
-  // Keeps world scale (1, 1, 1) because
-  // a menu object is a child of a target object
-  // and the target object's scale can be changed.
-  // Another option may be making the menu object
-  // a sibling of the target object.
-  _mat4.decompose(_vec3_1, _quat, _vec3_2);
-  _vec3_2.set(1.0, 1.0, 1.0);
-  _mat4.compose(_vec3_1, _quat, _vec3_2);
-
-  const menuObj = world.eid2obj.get(menu)!;
-  setMatrixWorld(menuObj, _mat4);
-
-  // TODO: Remove the dependency with AFRAME
-  const camera = AFRAME.scenes[0].systems["hubs-systems"].cameraSystem.viewingCamera;
-  camera.updateMatrices();
-  menuObj.lookAt(_vec3_1.setFromMatrixPosition(camera.matrixWorld));
-}
-
 // TODO: startRotation/Scaling() and stopRotation/Scaling() are
 //       temporary implementation that rely on the old systems.
 //       They should be rewritten more elegantly with bitecs.
-function startRotation(world: HubsWorld, targetEid: EntityID) {
+function startRotation(world: HubsWorld, menuEid: EntityID, targetEid: EntityID) {
   if (hasComponent(world, Networked, targetEid)) {
     takeOwnership(world, targetEid);
   }
@@ -101,27 +86,29 @@ function startRotation(world: HubsWorld, targetEid: EntityID) {
   transformSystem.startTransform(world.eid2obj.get(targetEid)!, world.eid2obj.get(rightCursorEid)!, {
     mode: TRANSFORM_MODE.CURSOR
   });
-  handlingTargetEid = targetEid;
+  ObjectMenu.handlingTargetRef[menuEid] = targetEid;
 }
 
-function stopRotation(world: HubsWorld) {
+function stopRotation(world: HubsWorld, menuEid: EntityID) {
   // TODO: More proper handling in case the target entity is already removed.
   //       In the worst scenario the entity has been already recycled at this moment
   //       and this code doesn't handled such a case correctly.
   //       We may refactor when we will reimplement the object menu system
   //       by removing A-Frame dependency.
+  const handlingTargetEid = ObjectMenu.handlingTargetRef[menuEid];
   if (entityExists(world, handlingTargetEid) && hasComponent(world, Networked, handlingTargetEid)) {
     addComponent(world, EntityStateDirty, handlingTargetEid);
   }
   const transformSystem = APP.scene!.systems["transform-selected-object"];
   transformSystem.stopTransform();
-  handlingTargetEid = 0;
+  ObjectMenu.handlingTargetRef[menuEid] = 0;
 }
 
-function startScaling(world: HubsWorld, targetEid: EntityID) {
+function startScaling(world: HubsWorld, menuEid: EntityID, targetEid: EntityID) {
   if (hasComponent(world, Networked, targetEid)) {
     takeOwnership(world, targetEid);
   }
+
   // TODO: Don't use any
   // TODO: Remove the dependency with AFRAME
   const transformSystem = (AFRAME as any).scenes[0].systems["transform-selected-object"];
@@ -131,17 +118,18 @@ function startScaling(world: HubsWorld, targetEid: EntityID) {
   scalingHandler = new ScalingHandler(world.eid2obj.get(targetEid), transformSystem);
   scalingHandler!.objectToScale = world.eid2obj.get(targetEid);
   scalingHandler!.startScaling(world.eid2obj.get(rightCursorEid));
-  handlingTargetEid = targetEid;
+  ObjectMenu.handlingTargetRef[menuEid] = targetEid;
 }
 
-function stopScaling(world: HubsWorld) {
+function stopScaling(world: HubsWorld, menuEid: EntityID) {
+  const handlingTargetEid = ObjectMenu.handlingTargetRef[menuEid];
   if (entityExists(world, handlingTargetEid) && hasComponent(world, Networked, handlingTargetEid)) {
     addComponent(world, EntityStateDirty, handlingTargetEid);
   }
   const rightCursorEid = anyEntityWith(world, RemoteRight)!;
   scalingHandler!.endScaling(world.eid2obj.get(rightCursorEid));
   scalingHandler = null;
-  handlingTargetEid = 0;
+  ObjectMenu.handlingTargetRef[menuEid] = 0;
 }
 
 function openLink(world: HubsWorld, eid: EntityID) {
@@ -187,6 +175,7 @@ function handleClicks(world: HubsWorld, menu: EntityID, hubChannel: HubChannel) 
   } else if (clicked(world, ObjectMenu.cameraTrackButtonRef[menu])) {
     console.log("Clicked track");
   } else if (clicked(world, ObjectMenu.removeButtonRef[menu])) {
+    ObjectMenu.flags[menu] &= ~ObjectMenuFlags.Visible;
     deleteTheDeletableAncestor(world, ObjectMenu.targetRef[menu]);
   } else if (clicked(world, ObjectMenu.dropButtonRef[menu])) {
     console.log("Clicked drop");
@@ -208,10 +197,12 @@ function handleClicks(world: HubsWorld, menu: EntityID, hubChannel: HubChannel) 
 function handleHeldEnter(world: HubsWorld, eid: EntityID, menuEid: EntityID) {
   switch (eid) {
     case ObjectMenu.rotateButtonRef[menuEid]:
-      startRotation(world, ObjectMenu.targetRef[menuEid]);
+      ObjectMenu.flags[menuEid] &= ~ObjectMenuFlags.Visible;
+      startRotation(world, menuEid, ObjectMenu.targetRef[menuEid]);
       break;
     case ObjectMenu.scaleButtonRef[menuEid]:
-      startScaling(world, ObjectMenu.targetRef[menuEid]);
+      ObjectMenu.flags[menuEid] &= ~ObjectMenuFlags.Visible;
+      startScaling(world, menuEid, ObjectMenu.targetRef[menuEid]);
       break;
   }
 }
@@ -219,17 +210,28 @@ function handleHeldEnter(world: HubsWorld, eid: EntityID, menuEid: EntityID) {
 function handleHeldExit(world: HubsWorld, eid: EntityID, menuEid: EntityID) {
   switch (eid) {
     case ObjectMenu.rotateButtonRef[menuEid]:
-      stopRotation(world);
+      ObjectMenu.flags[menuEid] |= ObjectMenuFlags.Visible;
+      stopRotation(world, menuEid);
       break;
     case ObjectMenu.scaleButtonRef[menuEid]:
-      stopScaling(world);
+      ObjectMenu.flags[menuEid] |= ObjectMenuFlags.Visible;
+      stopScaling(world, menuEid);
       break;
   }
 }
 
 function updateVisibility(world: HubsWorld, menu: EntityID, frozen: boolean) {
   const target = ObjectMenu.targetRef[menu];
-  const visible = !!(target && frozen);
+  const visible = !!(target && frozen) && (ObjectMenu.flags[menu] & ObjectMenuFlags.Visible) !== 0;
+
+  // TODO We are handling menus visibility in a similar way for all the object menus, we
+  // should probably refactor this to a common object-menu-visibility-system
+  if (visible) {
+    ObjectMenuTransform.targetObjectRef[menu] = target;
+    ObjectMenuTransform.flags[menu] |= ObjectMenuTransformFlags.Enabled;
+  } else {
+    ObjectMenuTransform.flags[menu] &= ~ObjectMenuTransformFlags.Enabled;
+  }
 
   const obj = world.eid2obj.get(menu)!;
   obj.visible = visible;
@@ -273,7 +275,8 @@ export function objectMenuSystem(world: HubsWorld, sceneIsFrozen: boolean, hubCh
     handleHeldExit(world, eid, menu);
   });
 
-  ObjectMenu.targetRef[menu] = objectMenuTarget(world, menu, sceneIsFrozen);
+  const targetEid = objectMenuTarget(world, menu, sceneIsFrozen);
+  ObjectMenu.targetRef[menu] = targetEid;
 
   if (ObjectMenu.targetRef[menu]) {
     handleClicks(world, menu, hubChannel);
@@ -285,8 +288,6 @@ export function objectMenuSystem(world: HubsWorld, sceneIsFrozen: boolean, hubCh
     if (scalingHandler !== null) {
       scalingHandler.tick();
     }
-
-    moveToTarget(world, menu);
   }
   updateVisibility(world, menu, sceneIsFrozen);
 }

--- a/src/bit-systems/video-menu-system.ts
+++ b/src/bit-systems/video-menu-system.ts
@@ -12,8 +12,8 @@ import {
   MediaVideo,
   MediaVideoData,
   NetworkedVideo,
-  VideoMenu,
-  VideoMenuItem
+  ObjectMenuTransform,
+  VideoMenu
 } from "../bit-components";
 import { timeFmt } from "../components/media-video";
 import { takeOwnership } from "../utils/take-ownership";
@@ -23,12 +23,12 @@ import { coroutine } from "../utils/coroutine";
 import { easeOutQuadratic } from "../utils/easing";
 import { isFacingCamera } from "../utils/three-utils";
 import { Emitter2Audio } from "./audio-emitter-system";
-import { VIDEO_FLAGS } from "../inflators/video";
+import { EntityID } from "../utils/networking-types";
+import { findAncestorWithComponent, hasAnyComponent } from "../utils/bit-utils";
+import { ObjectMenuTransformFlags } from "../inflators/object-menu-transform";
 
 const videoMenuQuery = defineQuery([VideoMenu]);
-const hoverRightVideoQuery = defineQuery([HoveredRemoteRight, MediaVideo]);
-const hoverRightVideoEnterQuery = enterQuery(hoverRightVideoQuery);
-const hoverRightMenuItemQuery = defineQuery([HoveredRemoteRight, VideoMenuItem]);
+const hoveredQuery = defineQuery([HoveredRemoteRight]);
 const sliderHalfWidth = 0.475;
 
 function setCursorRaycastable(world: HubsWorld, menu: number, enable: boolean) {
@@ -45,7 +45,6 @@ const intersectInThePlaneOf = (() => {
     ray.set(position, direction);
     plane.normal.set(0, 0, 1);
     plane.constant = 0;
-    obj.updateMatrices();
     plane.applyMatrix4(obj.matrixWorld);
     ray.intersectPlane(plane, intersection);
   };
@@ -54,33 +53,68 @@ const intersectInThePlaneOf = (() => {
 type Job<T> = () => IteratorResult<undefined, T>;
 let rightMenuIndicatorCoroutine: Job<void> | null = null;
 
-let intersectionPoint = new Vector3();
-export function videoMenuSystem(world: HubsWorld, userinput: any) {
-  const rightVideoMenu = videoMenuQuery(world)[0];
-  const shouldHideVideoMenu =
-    VideoMenu.videoRef[rightVideoMenu] &&
-    (!entityExists(world, VideoMenu.videoRef[rightVideoMenu]) ||
-      (!hoverRightVideoQuery(world).length &&
-        !hoverRightMenuItemQuery(world).length &&
-        !hasComponent(world, Held, VideoMenu.trackRef[rightVideoMenu])));
-  if (shouldHideVideoMenu) {
-    const menu = rightVideoMenu;
-    const menuObj = world.eid2obj.get(menu)!;
-    menuObj.removeFromParent();
-    setCursorRaycastable(world, menu, false);
+function findVideoMenuTarget(world: HubsWorld, menu: EntityID, sceneIsFrozen: boolean) {
+  if (VideoMenu.videoRef[menu] && !entityExists(world, VideoMenu.videoRef[menu])) {
+    // Clear the invalid entity reference. (The pdf entity was removed).
     VideoMenu.videoRef[menu] = 0;
   }
 
-  hoverRightVideoEnterQuery(world).forEach(function (eid) {
-    if (MediaVideo.flags[eid] & VIDEO_FLAGS.CONTROLS) {
-      const menu = rightVideoMenu;
-      VideoMenu.videoRef[menu] = eid;
-      const menuObj = world.eid2obj.get(menu)!;
-      const videoObj = world.eid2obj.get(eid)!;
-      videoObj.add(menuObj);
-      setCursorRaycastable(world, menu, true);
-    }
-  });
+  if (sceneIsFrozen) {
+    VideoMenu.videoRef[menu] = 0;
+    return;
+  }
+
+  const isTrackHoveredOrHeld = hasAnyComponent(world, [Held, HoveredRemoteRight], VideoMenu.trackRef[menu]);
+  if (isTrackHoveredOrHeld) {
+    VideoMenu.clearTargetTimer[menu] = world.time.elapsed + 1000;
+    return;
+  }
+
+  const hovered = hoveredQuery(world);
+  const target = hovered.map(eid => findAncestorWithComponent(world, MediaVideo, eid))[0] || 0;
+  if (target) {
+    VideoMenu.videoRef[menu] = target;
+    VideoMenu.clearTargetTimer[menu] = world.time.elapsed + 1000;
+    return;
+  }
+
+  if (hovered.some(eid => findAncestorWithComponent(world, VideoMenu, eid))) {
+    VideoMenu.clearTargetTimer[menu] = world.time.elapsed + 1000;
+    return;
+  }
+
+  if (world.time.elapsed > VideoMenu.clearTargetTimer[menu]) {
+    VideoMenu.videoRef[menu] = 0;
+    return;
+  }
+}
+
+function flushToObject3Ds(world: HubsWorld, menu: EntityID, frozen: boolean) {
+  const target = VideoMenu.videoRef[menu];
+  const visible = !!(target && !frozen);
+
+  const obj = world.eid2obj.get(menu)!;
+  obj.visible = visible;
+
+  // TODO We are handling menus visibility in a similar way for all the object menus, we
+  // should probably refactor this to a common object-menu-visibility-system
+  if (visible) {
+    setCursorRaycastable(world, menu, true);
+    APP.world.scene.add(obj);
+    ObjectMenuTransform.targetObjectRef[menu] = target;
+    ObjectMenuTransform.flags[menu] |= ObjectMenuTransformFlags.Enabled;
+  } else {
+    obj.removeFromParent();
+    setCursorRaycastable(world, menu, false);
+
+    ObjectMenuTransform.flags[menu] &= ~ObjectMenuTransformFlags.Enabled;
+  }
+}
+
+let intersectionPoint = new Vector3();
+export function videoMenuSystem(world: HubsWorld, userinput: any, sceneIsFrozen: boolean) {
+  const rightVideoMenu = videoMenuQuery(world)[0];
+  findVideoMenuTarget(world, rightVideoMenu, sceneIsFrozen);
 
   videoMenuQuery(world).forEach(function (eid) {
     const videoEid = VideoMenu.videoRef[eid];
@@ -153,6 +187,8 @@ export function videoMenuSystem(world: HubsWorld, userinput: any) {
       rightMenuIndicatorCoroutine = null;
     }
   });
+
+  flushToObject3Ds(world, rightVideoMenu, sceneIsFrozen);
 }
 
 const START_SCALE = new Vector3().setScalar(0.05);

--- a/src/inflators/object-menu-target.ts
+++ b/src/inflators/object-menu-target.ts
@@ -1,0 +1,24 @@
+import { addComponent } from "bitecs";
+import { HubsWorld } from "../app";
+import { EntityID } from "../utils/networking-types";
+import { ObjectMenuTarget } from "../bit-components";
+
+export const ObjectMenuTargetFlags = {
+  Flat: 1 << 0
+};
+
+export type ObjectMenuTargetParams = {
+  isFlat?: boolean;
+};
+
+const DEFAULTS = {
+  isFlat: true
+};
+
+export function inflateObjectMenuTarget(world: HubsWorld, eid: EntityID, params: ObjectMenuTargetParams) {
+  params = Object.assign({}, DEFAULTS, params);
+  addComponent(world, ObjectMenuTarget, eid);
+  if (params.isFlat === true) {
+    ObjectMenuTarget.flags[eid] |= ObjectMenuTargetFlags.Flat;
+  }
+}

--- a/src/inflators/object-menu-transform.ts
+++ b/src/inflators/object-menu-transform.ts
@@ -1,0 +1,25 @@
+import { addComponent } from "bitecs";
+import { HubsWorld } from "../app";
+import { EntityID } from "../utils/networking-types";
+import { ObjectMenuTransform } from "../bit-components";
+
+export const ObjectMenuTransformFlags = {
+  Enabled: 1 << 0,
+  Center: 1 << 1
+};
+
+export type ObjectMenuTransformParams = {
+  center?: boolean;
+};
+
+const DEFAULTS = {
+  center: true
+};
+
+export function inflateObjectMenuTransform(world: HubsWorld, eid: EntityID, params: ObjectMenuTransformParams) {
+  params = Object.assign({}, DEFAULTS, params);
+  addComponent(world, ObjectMenuTransform, eid);
+  if (params.center === true) {
+    ObjectMenuTransform.flags[eid] |= ObjectMenuTransformFlags.Center;
+  }
+}

--- a/src/prefabs/duck.tsx
+++ b/src/prefabs/duck.tsx
@@ -45,6 +45,7 @@ export function DuckPrefab(): EntityDef {
       }}
       scale={[1, 1, 1]}
       inspectable
+      deletable
     />
   );
 }

--- a/src/prefabs/link-hover-menu.tsx
+++ b/src/prefabs/link-hover-menu.tsx
@@ -32,6 +32,7 @@ export function LinkHoverMenuPrefab() {
   return (
     <entity
       name="Link Hover Menu"
+      objectMenuTransform
       linkHoverMenu={{
         linkButtonRef: buttonRef
       }}

--- a/src/prefabs/object-menu.tsx
+++ b/src/prefabs/object-menu.tsx
@@ -16,7 +16,7 @@ export async function loadObjectMenuButtonIcons() {
 
 const buttonHeight = 0.2;
 const buttonScale: ArrayVec3 = [0.6, 0.6, 0.6];
-const uiZ = 0.25;
+const uiZ = 0.001;
 
 function PinButton(props: Attrs) {
   return (
@@ -258,6 +258,7 @@ export function ObjectMenuPrefab() {
   return (
     <entity
       name="Interactable Object Menu"
+      objectMenuTransform={{ center: true }}
       objectMenu={{
         pinButtonRef: refs.pin,
         unpinButtonRef: refs.unpin,

--- a/src/prefabs/pdf-menu.tsx
+++ b/src/prefabs/pdf-menu.tsx
@@ -37,6 +37,7 @@ export function PDFMenuPrefab() {
   return (
     <entity
       name="PDF Menu"
+      objectMenuTransform={{ center: false }}
       pdfMenu={{
         prevButtonRef: refPrev,
         nextButtonRef: refNext,

--- a/src/prefabs/video-menu.tsx
+++ b/src/prefabs/video-menu.tsx
@@ -54,6 +54,7 @@ export function VideoMenuPrefab() {
   return (
     <entity
       name="Video Menu"
+      objectMenuTransform={{ center: false }}
       videoMenu={{ sliderRef, timeLabelRef, headRef, trackRef, playIndicatorRef, pauseIndicatorRef }}
     >
       <Label

--- a/src/systems/hubs-systems.ts
+++ b/src/systems/hubs-systems.ts
@@ -80,6 +80,7 @@ import { quackSystem } from "../bit-systems/quack";
 import { mixerAnimatableSystem } from "../bit-systems/mixer-animatable";
 import { loopAnimationSystem } from "../bit-systems/loop-animation";
 import { linkSystem } from "../bit-systems/link-system";
+import { objectMenuTransformSystem } from "../bit-systems/object-menu-transform-system";
 
 declare global {
   interface Window {
@@ -248,7 +249,7 @@ export function mainTick(xrFrame: XRFrame, renderer: WebGLRenderer, scene: Scene
   uvScrollSystem(world);
   hubsSystems.shadowSystem.tick();
   objectMenuSystem(world, sceneEl.is("frozen"), APP.hubChannel!);
-  videoMenuSystem(world, aframeSystems.userinput);
+  videoMenuSystem(world, aframeSystems.userinput, sceneEl.is("frozen"));
   videoSystem(world, hubsSystems.audioSystem);
   pdfMenuSystem(world, sceneEl.is("frozen"));
   linkSystem(world);
@@ -264,6 +265,8 @@ export function mainTick(xrFrame: XRFrame, renderer: WebGLRenderer, scene: Scene
   simpleWaterSystem(world);
   linearTransformSystem(world);
   quackSystem(world);
+
+  objectMenuTransformSystem(world);
 
   mixerAnimatableSystem(world);
   loopAnimationSystem(world);

--- a/src/utils/bit-utils.ts
+++ b/src/utils/bit-utils.ts
@@ -34,6 +34,12 @@ export function findAncestorWithComponent(world: HubsWorld, component: Component
   return findAncestorEntity(world, eid, otherId => hasComponent(world, component, otherId));
 }
 
+export function findAncestorWithComponents(world: HubsWorld, components: Array<Component>, eid: number) {
+  return findAncestorEntity(world, eid, otherId =>
+    components.every(component => hasComponent(world, component, otherId))
+  );
+}
+
 export function findAncestorWithAnyComponent(world: HubsWorld, components: Array<Component>, eid: number) {
   return findAncestorEntity(world, eid, otherId => hasAnyComponent(world, components, otherId));
 }

--- a/src/utils/jsx-entity.ts
+++ b/src/utils/jsx-entity.ts
@@ -3,7 +3,6 @@ import { preloadFont } from "troika-three-text";
 import {
   $isStringType,
   CameraTool,
-  ObjectMenu,
   LinkHoverMenu,
   LinkHoverMenuItem,
   PDFMenu,
@@ -39,7 +38,8 @@ import {
   VideoTextureSource,
   Quack,
   MixerAnimatableInitialize,
-  Inspectable
+  Inspectable,
+  ObjectMenu
 } from "../bit-components";
 import { inflateMediaLoader } from "../inflators/media-loader";
 import { inflateMediaFrame } from "../inflators/media-frame";
@@ -99,6 +99,8 @@ import { HeightFieldParams, inflateHeightField } from "../inflators/heightfield"
 import { inflateAudioSettings } from "../inflators/audio-settings";
 import { HubsVideoTexture } from "../textures/HubsVideoTexture";
 import { inflateMediaLink, MediaLinkParams } from "../inflators/media-link";
+import { inflateObjectMenuTarget, ObjectMenuTargetParams } from "../inflators/object-menu-target";
+import { inflateObjectMenuTransform, ObjectMenuTransformParams } from "../inflators/object-menu-transform";
 
 preload(
   new Promise(resolve => {
@@ -361,6 +363,8 @@ export interface JSXComponentData extends ComponentData {
   pdf?: PDFParams;
   loopAnimation?: LoopAnimationParams;
   inspectable?: boolean;
+  objectMenuTransform?: OptionalParams<ObjectMenuTransformParams>;
+  objectMenuTarget?: OptionalParams<ObjectMenuTargetParams>;
 }
 
 export interface GLTFComponentData extends ComponentData {
@@ -474,7 +478,9 @@ const jsxInflators: Required<{ [K in keyof JSXComponentData]: InflatorFn }> = {
   model: inflateModel,
   image: inflateImage,
   video: inflateVideo,
-  link: inflateLink
+  link: inflateLink,
+  objectMenuTransform: inflateObjectMenuTransform,
+  objectMenuTarget: inflateObjectMenuTarget
 };
 
 export const gltfInflators: Required<{ [K in keyof GLTFComponentData]: InflatorFn }> = {

--- a/src/utils/load-audio.tsx
+++ b/src/utils/load-audio.tsx
@@ -5,6 +5,9 @@ import { renderAsEntity } from "../utils/jsx-entity";
 import { loadAudioTexture } from "../utils/load-audio-texture";
 import { HubsWorld } from "../app";
 import { HubsVideoTexture } from "../textures/HubsVideoTexture";
+import { ObjectMenuTarget } from "../bit-components";
+import { ObjectMenuTargetFlags } from "../inflators/object-menu-target";
+import { EntityID } from "./networking-types";
 
 type Params = {
   loop?: boolean;
@@ -20,10 +23,12 @@ const DEFAULTS: Required<Params> = {
   projection: ProjectionMode.FLAT
 };
 
-export function* loadAudio(world: HubsWorld, url: string, params: Params) {
+export function* loadAudio(world: HubsWorld, eid: EntityID, url: string, params: Params) {
   const { loop, autoPlay, controls, projection } = Object.assign({}, DEFAULTS, params);
   const { texture, ratio, video }: { texture: HubsVideoTexture; ratio: number; video: HTMLVideoElement } =
     yield loadAudioTexture(url, loop, autoPlay);
+
+  ObjectMenuTarget.flags[eid] |= ObjectMenuTargetFlags.Flat;
 
   return renderAsEntity(
     world,
@@ -34,6 +39,7 @@ export function* loadAudio(world: HubsWorld, url: string, params: Params) {
       grabbable={{ cursor: true, hand: false }}
       // Audio and Video are handled very similarly in 3D scene
       // so create as video
+      objectMenuTarget={{ isFlat: true }}
       video={{
         texture,
         ratio,

--- a/src/utils/load-html.tsx
+++ b/src/utils/load-html.tsx
@@ -3,11 +3,23 @@ import { createElementEntity, renderAsEntity } from "../utils/jsx-entity";
 import { HubsWorld } from "../app";
 import { guessContentType } from "./media-url-utils";
 import { createImageDef } from "./load-image";
+import { EntityID } from "./networking-types";
+import { ObjectMenuTarget } from "../bit-components";
+import { ObjectMenuTargetFlags } from "../inflators/object-menu-target";
 
-export function* loadHtml(world: HubsWorld, url: string, thumbnailUrl: string) {
+export function* loadHtml(world: HubsWorld, eid: EntityID, url: string, thumbnailUrl: string) {
   const imageDef = yield* createImageDef(world, thumbnailUrl, guessContentType(thumbnailUrl) || "image/png");
+
+  ObjectMenuTarget.flags[eid] |= ObjectMenuTargetFlags.Flat;
+
   return renderAsEntity(
     world,
-    <entity name="HTML" image={imageDef} grabbable={{ cursor: true, hand: false }} link={{ href: url }} />
+    <entity
+      name="HTML"
+      image={imageDef}
+      grabbable={{ cursor: true, hand: false }}
+      link={{ href: url }}
+      objectMenuTarget={{ isFlat: true }}
+    />
   );
 }

--- a/src/utils/load-image.tsx
+++ b/src/utils/load-image.tsx
@@ -7,6 +7,9 @@ import { HubsWorld } from "../app";
 import { Texture } from "three";
 import { AlphaMode } from "./create-image-mesh";
 import { ImageParams } from "../inflators/image";
+import { EntityID } from "./networking-types";
+import { ObjectMenuTarget } from "../bit-components";
+import { ObjectMenuTargetFlags } from "../inflators/object-menu-target";
 
 export function* createImageDef(world: HubsWorld, url: string, contentType: string): Generator<any, ImageParams, any> {
   const { texture, ratio, cacheKey }: { texture: Texture; ratio: number; cacheKey: string } =
@@ -38,7 +41,7 @@ type Params = {
   projection?: ProjectionMode;
 };
 
-export function* loadImage(world: HubsWorld, url: string, contentType: string, params: Params) {
+export function* loadImage(world: HubsWorld, eid: EntityID, url: string, contentType: string, params: Params) {
   const { alphaCutoff, alphaMode, projection } = params;
 
   const imageDef = yield* createImageDef(world, url, contentType);
@@ -55,5 +58,7 @@ export function* loadImage(world: HubsWorld, url: string, contentType: string, p
     imageDef.projection = projection;
   }
 
-  return renderAsEntity(world, <entity name="Image" image={imageDef} />);
+  ObjectMenuTarget.flags[eid] |= ObjectMenuTargetFlags.Flat;
+
+  return renderAsEntity(world, <entity name="Image" image={imageDef} objectMenuTarget={{ isFlat: true }} />);
 }

--- a/src/utils/load-model.tsx
+++ b/src/utils/load-model.tsx
@@ -11,5 +11,5 @@ export function* loadModel(world: HubsWorld, src: string, contentType: string, u
   scene.animations = animations;
   scene.mixer = new THREE.AnimationMixer(scene);
 
-  return renderAsEntity(world, <entity model={{ model: scene }} />);
+  return renderAsEntity(world, <entity model={{ model: scene }} objectMenuTarget />);
 }

--- a/src/utils/load-pdf.tsx
+++ b/src/utils/load-pdf.tsx
@@ -5,6 +5,9 @@ import { HubsWorld } from "../app";
 import { loadPageJob } from "../bit-systems/pdf-system";
 import { PDFResources } from "../inflators/pdf";
 import { createElementEntity, renderAsEntity } from "../utils/jsx-entity";
+import { EntityID } from "./networking-types";
+import { ObjectMenuTarget } from "../bit-components";
+import { ObjectMenuTargetFlags } from "../inflators/object-menu-target";
 
 function* createPDFResources(url: string): Generator<any, PDFResources, any> {
   const pdf = (yield getDocument(url).promise) as PDFDocumentProxy;
@@ -20,10 +23,13 @@ function* createPDFResources(url: string): Generator<any, PDFResources, any> {
   return { pdf, canvasContext, material };
 }
 
-export function* loadPDF(world: HubsWorld, url: string) {
+export function* loadPDF(world: HubsWorld, eid: EntityID, url: string) {
   const resources = yield* createPDFResources(url);
   const pageNumber = 1;
   const { width, height } = yield* loadPageJob(resources, pageNumber);
+
+  ObjectMenuTarget.flags[eid] |= ObjectMenuTargetFlags.Flat;
+
   return renderAsEntity(
     world,
     <entity
@@ -31,6 +37,7 @@ export function* loadPDF(world: HubsWorld, url: string) {
       scale={[Math.min(1.0, width / height), Math.min(1.0, height / width), 1.0]}
       networked
       grabbable={{ cursor: true, hand: false }}
+      objectMenuTarget={{ isFlat: true }}
       pdf={{ pageNumber, ...resources }}
     ></entity>
   );

--- a/src/utils/load-video.tsx
+++ b/src/utils/load-video.tsx
@@ -5,7 +5,9 @@ import { renderAsEntity } from "../utils/jsx-entity";
 import { loadVideoTexture } from "../utils/load-video-texture";
 import { HubsWorld } from "../app";
 import { HubsVideoTexture } from "../textures/HubsVideoTexture";
-
+import { EntityID } from "./networking-types";
+import { ObjectMenuTarget } from "../bit-components";
+import { ObjectMenuTargetFlags } from "../inflators/object-menu-target";
 type Params = {
   loop?: boolean;
   autoPlay?: boolean;
@@ -20,10 +22,12 @@ const DEFAULTS: Required<Params> = {
   projection: ProjectionMode.FLAT
 };
 
-export function* loadVideo(world: HubsWorld, url: string, contentType: string, params: Params) {
+export function* loadVideo(world: HubsWorld, eid: EntityID, url: string, contentType: string, params: Params) {
   const { loop, autoPlay, controls, projection } = Object.assign({}, DEFAULTS, params);
   const { texture, ratio, video }: { texture: HubsVideoTexture; ratio: number; video: HTMLVideoElement } =
     yield loadVideoTexture(url, contentType, loop, autoPlay);
+
+  ObjectMenuTarget.flags[eid] |= ObjectMenuTargetFlags.Flat;
 
   return renderAsEntity(
     world,
@@ -32,6 +36,7 @@ export function* loadVideo(world: HubsWorld, url: string, contentType: string, p
       networked
       networkedVideo
       grabbable={{ cursor: true, hand: false }}
+      objectMenuTarget={{ isFlat: true }}
       video={{
         texture,
         ratio,


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/6281

This PR makes fixes the issue that we have with the object menu being hidden behind. It also refactors some code into a `object-menu-transform-system` responsible for correctly placing the object menu. I've updated all the in-world menu to use this system.

This PR doesn't address the problem of where to place the menu when we are inside the bounding sphere of an object. I think a correct placement in that situation would require a menus redesign so I haven't change it.

TODO: Another thing that could benefit from being refactored to its own system would be the menu visibility.