### PR TITLE
bitECS Fix Physics system issues when physics are generated but there are not meshes

### DIFF
--- a/src/bit-systems/scene-loading.ts
+++ b/src/bit-systems/scene-loading.ts
@@ -109,13 +109,8 @@ function* loadScene(
     if (findChildWithComponent(world, TrimeshTag, scene) || findChildWithComponent(world, HeightFieldTag, scene)) {
       console.log("heightfield or trimesh found on scene");
     } else {
-      let navMeshEid;
-      if (isHighDensity) {
-        navMeshEid = findChildWithComponent(world, NavMesh, scene);
-      }
-
+      let navMeshEid = findChildWithComponent(world, NavMesh, scene);
       if (navMeshEid) {
-        console.log(`Mesh density exceeded, using floor plan only`);
         inflatePhysicsShape(world, navMeshEid, {
           type: Shape.MESH,
           margin: 0.01,

--- a/src/bit-systems/scene-loading.ts
+++ b/src/bit-systems/scene-loading.ts
@@ -66,6 +66,7 @@ function* loadScene(
     add(world, scene, loaderEid);
     setNetworkedDataWithoutRoot(world, APP.getString(Networked.id[loaderEid])!, scene);
 
+    let hasMesh = false;
     let sceneEl = APP.scene!;
     let isHighDensity = false;
     let skybox: Sky | undefined;
@@ -73,6 +74,7 @@ function* loadScene(
       if ((o as Mesh).isMesh) {
         // TODO animated objects should not be static
         (o as Mesh).reflectionProbeMode = "static";
+        hasMesh ||= true;
       }
       if ((o as any).isReflectionProbe) {
         o.updateMatrices();
@@ -117,7 +119,7 @@ function* loadScene(
           fit: Fit.ALL,
           includeInvisible: true
         });
-      } else if (!isHighDensity) {
+      } else if (!isHighDensity && hasMesh) {
         inflatePhysicsShape(world, scene, {
           type: Shape.MESH,
           margin: 0.01,


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/6251

This PR fixes 2 issues (I didn't want to split this for such little code)

1) We were ignoring the nav-mesh unless the scene was high density
2) We were trying to generate mesh physics shapes for scenes without meshes. This was already happening for AFrame.