### PR TITLE
Set the nav mesh visibility when a nav mesh is loaded

### DIFF
--- a/src/bit-systems/audio-debug-system.ts
+++ b/src/bit-systems/audio-debug-system.ts
@@ -119,7 +119,9 @@ getScene().then(() => {
 const addDebugMaterial = (world: HubsWorld, navEid: number) => {
   const obj = world.eid2obj.get(navEid);
   if (obj) {
-    const navMesh = obj as Mesh;
+    // Some older scenes have the nav-mesh component as an ancestor of the mesh itself
+    // TODO the "as any" here is because of incorrect type definition for getObjectByProperty. It was fixed in r145
+    const navMesh = obj.getObjectByProperty("isMesh", true as any) as Mesh;
     navMesh.visible = isEnabled;
     if (nav2mat.has(navEid)) return;
     nav2mat.set(navEid, navMesh.material);
@@ -132,7 +134,9 @@ const addDebugMaterial = (world: HubsWorld, navEid: number) => {
 const removeDebugMaterial = (world: HubsWorld, navEid: number) => {
   const obj = world.eid2obj.get(navEid);
   if (obj) {
-    const navMesh = obj as Mesh;
+    // Some older scenes have the nav-mesh component as an ancestor of the mesh itself
+    // TODO the "as any" here is because of incorrect type definition for getObjectByProperty. It was fixed in r145
+    const navMesh = obj.getObjectByProperty("isMesh", true as any) as Mesh;
     navMesh.visible = false;
     if (!nav2mat.has(navEid)) return;
     navMesh.material = nav2mat.get(navEid)!;

--- a/src/bit-systems/audio-debug-system.ts
+++ b/src/bit-systems/audio-debug-system.ts
@@ -117,11 +117,11 @@ getScene().then(() => {
 });
 
 const addDebugMaterial = (world: HubsWorld, navEid: number) => {
-  if (nav2mat.has(navEid)) return;
   const obj = world.eid2obj.get(navEid);
   if (obj) {
     const navMesh = obj as Mesh;
     navMesh.visible = isEnabled;
+    if (nav2mat.has(navEid)) return;
     nav2mat.set(navEid, navMesh.material);
     navMesh.material = debugMaterial!;
     navMesh.material.needsUpdate = true;
@@ -130,11 +130,11 @@ const addDebugMaterial = (world: HubsWorld, navEid: number) => {
 };
 
 const removeDebugMaterial = (world: HubsWorld, navEid: number) => {
-  if (!nav2mat.has(navEid)) return;
   const obj = world.eid2obj.get(navEid);
   if (obj) {
     const navMesh = obj as Mesh;
     navMesh.visible = false;
+    if (!nav2mat.has(navEid)) return;
     navMesh.material = nav2mat.get(navEid)!;
     nav2mat.delete(navEid);
     (navMesh.material as Material).needsUpdate = true;
@@ -153,6 +153,13 @@ export function audioDebugSystem(world: HubsWorld) {
   if (unsupported) return;
   navMeshExitQuery(world).forEach(navEid => {
     removeDebugMaterial(world, navEid);
+  });
+  navMeshEnterQuery(world).forEach(navEid => {
+    if (isEnabled) {
+      addDebugMaterial(world, navEid);
+    } else {
+      removeDebugMaterial(world, navEid);
+    }
   });
   if (isEnabled && uniforms) {
     navMeshEnterQuery(world).forEach(navEid => {

--- a/src/bit-systems/audio-debug-system.ts
+++ b/src/bit-systems/audio-debug-system.ts
@@ -157,14 +157,9 @@ export function audioDebugSystem(world: HubsWorld) {
   navMeshEnterQuery(world).forEach(navEid => {
     if (isEnabled) {
       addDebugMaterial(world, navEid);
-    } else {
-      removeDebugMaterial(world, navEid);
     }
   });
   if (isEnabled && uniforms) {
-    navMeshEnterQuery(world).forEach(navEid => {
-      isEnabled && addDebugMaterial(world, navEid);
-    });
     let idx = 0;
     APP.audios.forEach((audio: AudioObject3D, audioEmitterId: ElOrEid) => {
       if (APP.isAudioPaused.has(audioEmitterId) || APP.mutedState.has(audioEmitterId)) {


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/6315

This PR sets the nav-mesh visibility when a nav-mesh component is added to make sure that the mesh visibility is always aligned with the preference setting.