### PR TITLE
Bitecs avatar menu fixes

### DIFF
--- a/src/react-components/room/ObjectMenu.js
+++ b/src/react-components/room/ObjectMenu.js
@@ -34,7 +34,8 @@ export function ObjectMenu({
   currentObjectIndex,
   objectCount,
   onToggleLights,
-  lightsEnabled
+  lightsEnabled,
+  isAvatar
 }) {
   return (
     <>
@@ -69,17 +70,19 @@ export function ObjectMenu({
             ))}
           </div>
         </div>
-        <div className={styles.pagination}>
-          <IconButton onClick={onPrevObject}>
-            <ArrowBackIcon width={24} height={24} />
-          </IconButton>
-          <p>
-            {currentObjectIndex + 1}/{objectCount}
-          </p>
-          <IconButton onClick={onNextObject}>
-            <ArrowForwardIcon width={24} height={24} />
-          </IconButton>
-        </div>
+        {!isAvatar && (
+          <div className={styles.pagination}>
+            <IconButton onClick={onPrevObject}>
+              <ArrowBackIcon width={24} height={24} />
+            </IconButton>
+            <p>
+              {currentObjectIndex + 1}/{objectCount}
+            </p>
+            <IconButton onClick={onNextObject}>
+              <ArrowForwardIcon width={24} height={24} />
+            </IconButton>
+          </div>
+        )}
       </div>
     </>
   );
@@ -95,5 +98,6 @@ ObjectMenu.propTypes = {
   onClose: PropTypes.func,
   onBack: PropTypes.func,
   onToggleLights: PropTypes.func,
-  lightsEnabled: PropTypes.bool
+  lightsEnabled: PropTypes.bool,
+  isAvatar: PropTypes.bool
 };

--- a/src/react-components/room/ObjectMenuContainer.js
+++ b/src/react-components/room/ObjectMenuContainer.js
@@ -35,7 +35,7 @@ MyMenuItems.propTypes = {
 };
 
 function PlayerMenuItems({ hubChannel, activeObject, deselectObject }) {
-  const hideAvatar = useHideAvatar(hubChannel, activeObject.el);
+  const hideAvatar = useHideAvatar(hubChannel, activeObject);
 
   return (
     <ObjectMenuButton

--- a/src/react-components/room/ObjectMenuContainer.js
+++ b/src/react-components/room/ObjectMenuContainer.js
@@ -126,10 +126,12 @@ export function ObjectMenuContainer({ hubChannel, scene, onOpenProfile, onGoToOb
     useObjectList();
 
   let menuItems;
-
+  let isAvatar = false;
   if (isMe(activeObject)) {
+    isAvatar = true;
     menuItems = <MyMenuItems onOpenProfile={onOpenProfile} />;
   } else if (isPlayer(activeObject)) {
+    isAvatar = true;
     menuItems = <PlayerMenuItems hubChannel={hubChannel} activeObject={activeObject} deselectObject={deselectObject} />;
   } else {
     menuItems = (
@@ -154,6 +156,7 @@ export function ObjectMenuContainer({ hubChannel, scene, onOpenProfile, onGoToOb
       onPrevObject={selectPrevObject}
       onToggleLights={toggleLights}
       lightsEnabled={lightsEnabled}
+      isAvatar={isAvatar}
     >
       {menuItems}
     </ObjectMenu>

--- a/src/react-components/room/object-hooks.js
+++ b/src/react-components/room/object-hooks.js
@@ -13,7 +13,7 @@ export function isMe(object) {
   if (shouldUseNewLoader()) {
     return hasComponent(APP.world, LocalAvatar, object.eid);
   } else {
-  return object.id === "avatar-rig";
+    return object.id === "avatar-rig";
   }
 }
 
@@ -168,16 +168,24 @@ export function useRemoveObject(hubChannel, scene, object) {
   return { removeObject, canRemoveObject };
 }
 
-export function useHideAvatar(hubChannel, avatarEl) {
+export function useHideAvatar(hubChannel, avatarObj) {
   const hideAvatar = useCallback(() => {
-    if (avatarEl.components.networked) {
+    let avatarEl;
+    if (shouldUseNewLoader()) {
+      // TODO This should be updated when we migrate avatars to bitECS
+      const avatarEid = avatarObj.eid;
+      avatarEl = APP.world.eid2obj.get(avatarEid).el;
+    } else {
+      avatarEl = avatarObj.el;
+    }
+    if (avatarEl && avatarEl.components.networked) {
       const clientId = avatarEl.components.networked.data.owner;
 
       if (clientId && clientId !== NAF.clientId) {
         hubChannel.hide(clientId);
       }
     }
-  }, [hubChannel, avatarEl]);
+  }, [hubChannel, avatarObj]);
 
   return hideAvatar;
 }

--- a/src/react-components/room/object-hooks.js
+++ b/src/react-components/room/object-hooks.js
@@ -5,18 +5,21 @@ import { rotateInPlaceAroundWorldUp, affixToWorldUp } from "../../utils/three-ut
 import { getPromotionTokenForFile } from "../../utils/media-utils";
 import { hasComponent } from "bitecs";
 import { isPinned as getPinnedState } from "../../bit-systems/networking";
-import { AEntity, MediaInfo, Static } from "../../bit-components";
+import { AEntity, LocalAvatar, MediaInfo, RemoteAvatar, Static } from "../../bit-components";
 import { deleteTheDeletableAncestor } from "../../bit-systems/delete-entity-system";
 import { isAEntityPinned } from "../../systems/hold-system";
 
 export function isMe(object) {
+  if (shouldUseNewLoader()) {
+    return hasComponent(APP.world, LocalAvatar, object.eid);
+  } else {
   return object.id === "avatar-rig";
+  }
 }
 
 export function isPlayer(object) {
   if (shouldUseNewLoader()) {
-    // TODO Add when networked avatar is migrated
-    return false;
+    return hasComponent(APP.world, RemoteAvatar, object.eid);
   } else {
     return !!object.el.components["networked-avatar"];
   }


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/6308

This PR addresses three avatar inspect menu issues:
- Shows the correct avatar menu when inspecting instead of the object menu
- Fixes the avatar hide action that was crashing
- Hides the next/prev menu for both new and old loaders as it does nothing for avatars (same behavior for AFrame)