### PR TITLE
Enable New Loader by default

### DIFF
--- a/src/utils/bit-utils.ts
+++ b/src/utils/bit-utils.ts
@@ -60,7 +60,7 @@ export function findChildWithComponent(world: HubsWorld, component: Component, e
   }
 }
 
-const forceNewLoader = qsTruthy("newLoader");
+const forceOldLoader = qsTruthy("oldLoader");
 export function shouldUseNewLoader() {
-  return forceNewLoader || APP.hub?.user_data?.hubsUseNewLoader;
+  return !forceOldLoader && !APP.hub?.user_data?.hubsUseOldLoader;
 }


### PR DESCRIPTION
Related #6325

This commit enables the new loader by default. Also, adds a way to opt-out the new loader.

Changes

* Enable the new loader by default
* Replace "newLoader" URL query with "oldLoader" to force to use the old A-Frame based implementation for testing
* Replace APP.hub.user_data.hubsUseNewLoader with APP.hub.user_data.hubsUseOldLoader to disable the new loader at room-level.
* Update shouldUseNewLoader() to use "oldLoader" and APP.hub.user_data.hubsUseOldLoader

TODO (This PR or another PR)

* Add a UI for room owners to control new loader opt-out flag
* Test (See https://github.com/mozilla/hubs/issues/6325#issuecomment-1767574573)
