### PR TITLE
Clamp component parameters to make the client more resilient

### DIFF
--- a/src/bit-systems/particle-emitter.ts
+++ b/src/bit-systems/particle-emitter.ts
@@ -11,18 +11,18 @@ import { resolveUrl, textureLoader } from "../utils/media-utils";
 function* setTexture(world: HubsWorld, eid: number) {
   let src = APP.sid2str.get(ParticleEmitterTag.src[eid]);
 
-  const result: URL = yield resolveUrl(src);
-  let canonicalUrl = result.origin;
-
-  // handle protocol relative urls
-  if (canonicalUrl.startsWith("//")) {
-    canonicalUrl = location.protocol + canonicalUrl;
-  }
-
-  // todo: we don't need to proxy for many things if the canonical URL has permissive CORS headers
-  src = proxiedUrlFor(canonicalUrl);
-
   try {
+    const result: URL = yield resolveUrl(src);
+    let canonicalUrl = result.origin;
+
+    // handle protocol relative urls
+    if (canonicalUrl.startsWith("//")) {
+      canonicalUrl = location.protocol + canonicalUrl;
+    }
+
+    // todo: we don't need to proxy for many things if the canonical URL has permissive CORS headers
+    src = proxiedUrlFor(canonicalUrl);
+
     const texture: Texture = yield textureLoader.loadAsync(src);
 
     const particleEmitter: ParticleEmitter = world.eid2obj.get(eid)! as ParticleEmitter;

--- a/src/inflators/audio-params.ts
+++ b/src/inflators/audio-params.ts
@@ -5,5 +5,10 @@ import { AudioSettings } from "../components/audio-params";
 
 export function inflateAudioParams(world: HubsWorld, eid: number, params: AudioSettings) {
   addComponent(world, AudioParams, eid);
+
+  // https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/coneOuterGain#value
+  params.coneOuterGain = params.coneOuterGain > 1 ? 1 : params.coneOuterGain;
+  params.coneOuterGain = params.coneOuterGain < 0 ? 0 : params.coneOuterGain;
+
   APP.audioOverrides.set(eid, params);
 }

--- a/src/inflators/audio-target.ts
+++ b/src/inflators/audio-target.ts
@@ -25,8 +25,11 @@ export function inflateAudioTarget(world: HubsWorld, eid: number, params: AudioT
 
   addComponent(world, AudioTarget, eid);
 
-  AudioTarget.maxDelay[eid] = params.maxDelay;
-  AudioTarget.maxDelay[eid] = params.maxDelay;
+  // https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/createDelay#maxdelaytime
+  params.maxDelay = params.maxDelay < 180 ? params.maxDelay : 179;
+  AudioTarget.maxDelay[eid] = params.maxDelay < 0 ? 0 : params.maxDelay;
+  params.minDelay = params.minDelay > AudioTarget.maxDelay[eid] ? AudioTarget.maxDelay[eid] : params.minDelay;
+  AudioTarget.minDelay[eid] = params.minDelay < 0 ? 0 : params.minDelay;
   AudioTarget.source[eid] = params.srcNode;
   if (params.debug) AudioTarget.flags[eid] |= AUDIO_TARGET_FLAGS.DEBUG;
 }


### PR DESCRIPTION
This PR enforces component parameter limits for structures that otherwise would crash.

Fixes https://github.com/mozilla/hubs/issues/6331