### PR TITLE
Add new loader toggle UI in room settings

### DIFF
--- a/src/react-components/room/RoomSettingsSidebar.js
+++ b/src/react-components/room/RoomSettingsSidebar.js
@@ -196,6 +196,18 @@ export function RoomSettingsSidebar({
             />
           </div>
         </InputField>
+        <InputField
+          label={<FormattedMessage id="room-settings-sidebar.new-loader" defaultMessage="New loader activation" />}
+          fullWidth
+        >
+          {/* TODO: Refresh the page in all the clients in the room when toggled */}
+          <ToggleInput
+            label={
+              <FormattedMessage id="room-settings-sidebar.new-loader-activation" defaultMessage="Enable new loader" />
+            }
+            {...register("user_data.hubs_use_new_loader")}
+          />
+        </InputField>
         <ApplyButton type="submit" />
       </Column>
     </Sidebar>

--- a/src/utils/bit-utils.ts
+++ b/src/utils/bit-utils.ts
@@ -62,5 +62,5 @@ export function findChildWithComponent(world: HubsWorld, component: Component, e
 
 const forceNewLoader = qsTruthy("newLoader");
 export function shouldUseNewLoader() {
-  return forceNewLoader || APP.hub?.user_data?.hubsUseNewLoader;
+  return forceNewLoader || APP.hub?.user_data?.hubs_use_new_loader;
 }


### PR DESCRIPTION
Fixes #6325 

This commit adds new loader toggle UI in room settings that allows room owners to enable/disable the new loader.

Changes
* Rename `hub.user_data.hubsUseNewLoader` to `hub.user_data.hubs_use_new_loader` for naming consistency
* Add new loader toggle UI in room settings

![image](https://github.com/mozilla/hubs/assets/7637832/bb92ecec-424f-426c-9fa8-66040f47fd3c)

TODOs in another PR if needed

* Refresh the page in all the clients in the room when toggled