### PR TITLE
Reload when the new loader is toggled

### DIFF
--- a/src/assets/stylesheets/ui-root.scss
+++ b/src/assets/stylesheets/ui-root.scss
@@ -51,3 +51,18 @@ body.vr-mode {
   z-index: 11;
   pointer-events: auto;
 }
+
+:local(.new-loader-refresh-prompt) {
+  @extend %default-font;
+  background: theme.$background1-color;
+  border: 3px solid theme.$border1-color;
+  border-radius: 16px;
+  color: theme.$text1-color;
+  left: 50%;
+  max-width: 70%;
+  padding: 20px;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 100;
+}

--- a/src/hub.js
+++ b/src/hub.js
@@ -531,8 +531,8 @@ export async function updateEnvironmentForHub(hub, entryManager) {
   }
 }
 
-export async function updateUIForHub(hub, hubChannel) {
-  remountUI({ hub, entryDisallowed: !hubChannel.canEnterRoom(hub) });
+export async function updateUIForHub(hub, hubChannel, showNewLoaderRefreshPrompt = false) {
+  remountUI({ hub, entryDisallowed: !hubChannel.canEnterRoom(hub), showNewLoaderRefreshPrompt });
 }
 
 function onConnectionError(entryManager, connectError) {
@@ -1375,8 +1375,17 @@ document.addEventListener("DOMContentLoaded", async () => {
     const userInfo = hubChannel.presence.state[session_id];
     const displayName = (userInfo && userInfo.metas[0].profile.displayName) || "API";
 
+    let showNewLoaderRefreshPrompt = false;
+
+    if (!!hub.user_data?.hubs_use_new_loader !== !!window.APP.hub.user_data?.hubs_use_new_loader) {
+      showNewLoaderRefreshPrompt = true;
+      setTimeout(() => {
+        document.location.reload();
+      }, 5000);
+    }
+
     window.APP.hub = hub;
-    updateUIForHub(hub, hubChannel);
+    updateUIForHub(hub, hubChannel, showNewLoaderRefreshPrompt);
 
     if (
       stale_fields.includes("scene") ||

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -152,6 +152,7 @@ class UIRoot extends Component {
     subscriptions: PropTypes.object,
     initialIsFavorited: PropTypes.bool,
     showSignInDialog: PropTypes.bool,
+    showNewLoaderRefreshPrompt: PropTypes.bool,
     signInMessage: PropTypes.object,
     onContinueAfterSignIn: PropTypes.func,
     showSafariMicDialog: PropTypes.bool,
@@ -1696,6 +1697,14 @@ class UIRoot extends Component {
               />
             )}
           </div>
+          {this.props.showNewLoaderRefreshPrompt && (
+            <div className={styles.newLoaderRefreshPrompt}>
+              <FormattedMessage
+                id="ui-root.new-loader-refresh-prompt"
+                defaultMessage="This page will be reloaded in five seconds because the room owner toggled the new loader activation flag."
+              />
+            </div>
+          )}
         </ReactAudioContext.Provider>
       </MoreMenuContextProvider>
     );


### PR DESCRIPTION
From: https://github.com/mozilla/hubs/pull/6337#issuecomment-1780126424

This commit forces all the clients to reload the page when the new loader activation flag is toggled.

Changes
* In Hubs Channels hub_refresh listener detect user_data.hubs_use_new_loader flag change
* Reload the page in five seconds if detected
* Add and show new loader refresh prompt when detected

![image](https://github.com/mozilla/hubs/assets/7637832/7aa8ab5e-3ddd-4b46-ba52-d17893dabfd8)
