### PR TITLE
bitECS: Rename New Loader

### DIFF
--- a/src/assets/stylesheets/ui-root.scss
+++ b/src/assets/stylesheets/ui-root.scss
@@ -52,7 +52,7 @@ body.vr-mode {
   pointer-events: auto;
 }
 
-:local(.new-loader-refresh-prompt) {
+:local(.bitecs-based-client-refresh-prompt) {
   @extend %default-font;
   background: theme.$background1-color;
   border: 3px solid theme.$border1-color;

--- a/src/hub.js
+++ b/src/hub.js
@@ -531,8 +531,8 @@ export async function updateEnvironmentForHub(hub, entryManager) {
   }
 }
 
-export async function updateUIForHub(hub, hubChannel, showNewLoaderRefreshPrompt = false) {
-  remountUI({ hub, entryDisallowed: !hubChannel.canEnterRoom(hub), showNewLoaderRefreshPrompt });
+export async function updateUIForHub(hub, hubChannel, showBitECSBasedClientRefreshPrompt = false) {
+  remountUI({ hub, entryDisallowed: !hubChannel.canEnterRoom(hub), showBitECSBasedClientRefreshPrompt });
 }
 
 function onConnectionError(entryManager, connectError) {
@@ -1375,17 +1375,17 @@ document.addEventListener("DOMContentLoaded", async () => {
     const userInfo = hubChannel.presence.state[session_id];
     const displayName = (userInfo && userInfo.metas[0].profile.displayName) || "API";
 
-    let showNewLoaderRefreshPrompt = false;
+    let showBitECSBasedClientRefreshPrompt = false;
 
-    if (!!hub.user_data?.hubs_use_new_loader !== !!window.APP.hub.user_data?.hubs_use_new_loader) {
-      showNewLoaderRefreshPrompt = true;
+    if (!!hub.user_data?.hubs_use_bitecs_based_client !== !!window.APP.hub.user_data?.hubs_use_bitecs_based_client) {
+      showBitECSBasedClientRefreshPrompt = true;
       setTimeout(() => {
         document.location.reload();
       }, 5000);
     }
 
     window.APP.hub = hub;
-    updateUIForHub(hub, hubChannel, showNewLoaderRefreshPrompt);
+    updateUIForHub(hub, hubChannel, showBitECSBasedClientRefreshPrompt);
 
     if (
       stale_fields.includes("scene") ||

--- a/src/react-components/room/RoomSettingsSidebar.js
+++ b/src/react-components/room/RoomSettingsSidebar.js
@@ -197,15 +197,23 @@ export function RoomSettingsSidebar({
           </div>
         </InputField>
         <InputField
-          label={<FormattedMessage id="room-settings-sidebar.new-loader" defaultMessage="New loader activation" />}
+          label={<FormattedMessage id="room-settings-sidebar.bitecs-client" defaultMessage="bitECS based Client" />}
           fullWidth
         >
-          {/* TODO: Refresh the page in all the clients in the room when toggled */}
           <ToggleInput
             label={
-              <FormattedMessage id="room-settings-sidebar.new-loader-activation" defaultMessage="Enable new loader" />
+              <FormattedMessage
+                id="room-settings-sidebar.bitecs-client-activation"
+                defaultMessage="Enable bitECS based Client"
+              />
             }
-            {...register("user_data.hubs_use_new_loader")}
+            description={
+              <FormattedMessage
+                id="room-settings-sidebar.bitecs-client-activation-description"
+                defaultMessage="Enable or disable the new Client, which is implemented with bitECS for simplicity and extensibility."
+              />
+            }
+            {...register("user_data.hubs_use_bitecs_based_client")}
           />
         </InputField>
         <ApplyButton type="submit" />

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -152,7 +152,7 @@ class UIRoot extends Component {
     subscriptions: PropTypes.object,
     initialIsFavorited: PropTypes.bool,
     showSignInDialog: PropTypes.bool,
-    showNewLoaderRefreshPrompt: PropTypes.bool,
+    showBitECSBasedClientRefreshPrompt: PropTypes.bool,
     signInMessage: PropTypes.object,
     onContinueAfterSignIn: PropTypes.func,
     showSafariMicDialog: PropTypes.bool,
@@ -1697,11 +1697,11 @@ class UIRoot extends Component {
               />
             )}
           </div>
-          {this.props.showNewLoaderRefreshPrompt && (
-            <div className={styles.newLoaderRefreshPrompt}>
+          {this.props.showBitECSBasedClientRefreshPrompt && (
+            <div className={styles.bitecsBasedClientRefreshPrompt}>
               <FormattedMessage
-                id="ui-root.new-loader-refresh-prompt"
-                defaultMessage="This page will be reloaded in five seconds because the room owner toggled the new loader activation flag."
+                id="ui-root.bitecs-based-client-refresh-prompt"
+                defaultMessage="This page will be reloaded in five seconds because the room owner toggled the bitECS based client activation flag."
               />
             </div>
           )}

--- a/src/utils/bit-utils.ts
+++ b/src/utils/bit-utils.ts
@@ -62,5 +62,5 @@ export function findChildWithComponent(world: HubsWorld, component: Component, e
 
 const forceNewLoader = qsTruthy("newLoader");
 export function shouldUseNewLoader() {
-  return forceNewLoader || APP.hub?.user_data?.hubs_use_new_loader;
+  return forceNewLoader || APP.hub?.user_data?.hubs_use_bitecs_based_client;
 }


### PR DESCRIPTION
This commit renames "New Loader" to "bitECS based Client"

![image](https://github.com/mozilla/hubs/assets/7637832/bdf3db4e-e13d-4bce-9e9c-039b5430e92b)

Background:

The name "New Loader" may not really make sense to users because the new code is not only related to loading stuffs but it affects the Hubs Client core design and implementation.

It would be better to rename "New Loader" where users can see the name, although we may keep internally using "New Loader" as a project name.

Changes:
* Rename "New Loader" to "bitECS based Client" where it's exposed to users
* Add description for the toggle UI
* Remove outdated comments