### PR TITLE
Fix Browse button layout

### DIFF
--- a/src/react-components/room/ObjectUrlModal.scss
+++ b/src/react-components/room/ObjectUrlModal.scss
@@ -22,7 +22,6 @@
 
 :local(.container) {
   height: 100%;
-  width: 100%;
   margin: 0 !important;
 }
 


### PR DESCRIPTION
**Problem**

Browse button in Custom Object upload dialog displays weirdly in portrait mode on iOS. It unexpectedly covers almost the entire URL area in portrait mode.

![image](https://github.com/mozilla/hubs/assets/7637832/d7d7e646-1a9a-4223-9e84-0b3b04ecf292)


**Solution**

The issue seems to disappear by removing the "width: 100%" from the parent element style. The root issue might be in iOS, but we choose this workaround for now.