### PR TITLE
Fix Browse button layout Round 2

### DIFF
--- a/src/react-components/input/IconButton.scss
+++ b/src/react-components/input/IconButton.scss
@@ -9,6 +9,7 @@
   font-size: theme.$font-size-xs;
   font-weight: theme.$font-weight-bold;
   cursor: pointer;
+  justify-content: end;
 
   svg {
     color: theme.$text1-color;

--- a/src/react-components/room/ObjectUrlModal.scss
+++ b/src/react-components/room/ObjectUrlModal.scss
@@ -12,12 +12,8 @@
   color: white;
   background-color: black;
   height: 100%;
-  display: flex;
-  flex: 1;
-  align-items: center;
-  justify-content: center;
   margin: 0;
-  width: 60px;
+  padding: 10px;
 }
 
 :local(.container) {


### PR DESCRIPTION
A follow up PR to #6361

**Problem**

Browse button in Custom Object upload dialog displays weirdly in portrait mode on iOS. It unexpectedly covers almost the entire URL area in portrait mode.

We applied a change #6361 to fix but it didn't work.

**Changes**

* Remove flax stuffs and width 60px from browse style
* Add justify-content: end to IconButton style