### PR TITLE
Media frame object alignment and scale

### DIFF
--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -34,7 +34,7 @@ export const MediaFrame = defineComponent({
   guide: Types.eid,
   preview: Types.eid,
   previewingNid: Types.eid,
-  flags: Types.ui8,
+  flags: Types.ui8
 });
 export const TextTag = defineComponent();
 export const ReflectionProbe = defineComponent();

--- a/src/bit-components.js
+++ b/src/bit-components.js
@@ -30,9 +30,11 @@ export const MediaFrame = defineComponent({
   scale: [Types.f32, 3],
   mediaType: Types.ui8,
   bounds: [Types.f32, 3],
+  align: [Types.ui8, 3],
   guide: Types.eid,
   preview: Types.eid,
-  previewingNid: Types.eid
+  previewingNid: Types.eid,
+  flags: Types.ui8,
 });
 export const TextTag = defineComponent();
 export const ReflectionProbe = defineComponent();

--- a/src/inflators/media-frame.js
+++ b/src/inflators/media-frame.js
@@ -20,9 +20,9 @@ export const MEDIA_FRAME_FLAGS = {
 
 const DEFAULTS = {
   bounds: { x: 1, y: 1, z: 1 },
-  mediaType: "all",  
+  mediaType: "all",
   scaleToBounds: true,
-  align: { x: "center", y: "center", z: "center" },
+  align: { x: "center", y: "center", z: "center" }
 };
 export function inflateMediaFrame(world, eid, componentProps) {
   componentProps = Object.assign({}, DEFAULTS, componentProps);
@@ -82,14 +82,18 @@ export function inflateMediaFrame(world, eid, componentProps) {
   // Bounds
   MediaFrame.bounds[eid].set([componentProps.bounds.x, componentProps.bounds.y, componentProps.bounds.z]);
   // Axis alignment
-  const mapAlignProp = (alignPropValue) => {
-    return { 
-      "min": AxisAlignType.MIN,
-      "center": AxisAlignType.CENTER,
-      "max": AxisAlignType.MAX, 
-    }[alignPropValue]
-  }
-  MediaFrame.align[eid].set([mapAlignProp(componentProps.align.x), mapAlignProp(componentProps.align.y), mapAlignProp(componentProps.align.z)]);
+  const mapAlignProp = alignPropValue => {
+    return {
+      min: AxisAlignType.MIN,
+      center: AxisAlignType.CENTER,
+      max: AxisAlignType.MAX
+    }[alignPropValue];
+  };
+  MediaFrame.align[eid].set([
+    mapAlignProp(componentProps.align.x),
+    mapAlignProp(componentProps.align.y),
+    mapAlignProp(componentProps.align.z)
+  ]);
   // Preview guide
   MediaFrame.guide[eid] = guideEid;
   // Flags: scaleToBounds

--- a/src/inflators/media-frame.js
+++ b/src/inflators/media-frame.js
@@ -8,9 +8,21 @@ import { inflateRigidBody, Type } from "./rigid-body";
 import { Fit, inflatePhysicsShape, Shape } from "./physics-shape";
 import { Mesh, BoxBufferGeometry, ShaderMaterial, Color, DoubleSide } from "three";
 
+export const AxisAlignType = {
+  MIN: 1 << 0,
+  CENTER: 1 << 1,
+  MAX: 1 << 2
+};
+
+export const MEDIA_FRAME_FLAGS = {
+  SCALE_TO_BOUNDS: 1 << 0
+};
+
 const DEFAULTS = {
   bounds: { x: 1, y: 1, z: 1 },
-  mediaType: "all"
+  mediaType: "all",  
+  scaleToBounds: true,
+  align: { x: "center", y: "center", z: "center" },
 };
 export function inflateMediaFrame(world, eid, componentProps) {
   componentProps = Object.assign({}, DEFAULTS, componentProps);
@@ -58,6 +70,7 @@ export function inflateMediaFrame(world, eid, componentProps) {
 
   if (!hasComponent(world, Networked, eid)) addComponent(world, Networked, eid);
 
+  // Media types accepted
   MediaFrame.mediaType[eid] = {
     all: MediaType.ALL,
     "all-2d": MediaType.ALL_2D,
@@ -66,8 +79,23 @@ export function inflateMediaFrame(world, eid, componentProps) {
     video: MediaType.VIDEO,
     pdf: MediaType.PDF
   }[componentProps.mediaType];
+  // Bounds
   MediaFrame.bounds[eid].set([componentProps.bounds.x, componentProps.bounds.y, componentProps.bounds.z]);
+  // Axis alignment
+  const mapAlignProp = (alignPropValue) => {
+    return { 
+      "min": AxisAlignType.MIN,
+      "center": AxisAlignType.CENTER,
+      "max": AxisAlignType.MAX, 
+    }[alignPropValue]
+  }
+  MediaFrame.align[eid].set([mapAlignProp(componentProps.align.x), mapAlignProp(componentProps.align.y), mapAlignProp(componentProps.align.z)]);
+  // Preview guide
   MediaFrame.guide[eid] = guideEid;
+  // Flags: scaleToBounds
+  let flags = 0;
+  if (componentProps.scaleToBounds) flags |= MEDIA_FRAME_FLAGS.SCALE_TO_BOUNDS;
+  MediaFrame.flags[eid] = flags;
 
   inflateRigidBody(world, eid, {
     type: Type.KINEMATIC,

--- a/src/systems/bit-media-frames.js
+++ b/src/systems/bit-media-frames.js
@@ -38,7 +38,6 @@ import { addObject3DComponent } from "../utils/jsx-entity";
 import { updateMaterials } from "../utils/material-utils";
 import { MEDIA_FRAME_FLAGS, AxisAlignType } from "../inflators/media-frame";
 import {
-  Box3,
   DoubleSide,
   Group,
   Matrix4,
@@ -150,7 +149,7 @@ const snapToFrame = (() => {
   const AxisAlignMultipliers = new Array();
   AxisAlignMultipliers[AxisAlignType.MIN] = -1;
   AxisAlignMultipliers[AxisAlignType.MAX] = +1;
-  
+
   return (world, frameEid, targetEid) => {
     const frameObj = world.eid2obj.get(frameEid);
     const targetObj = world.eid2obj.get(targetEid);
@@ -164,8 +163,8 @@ const snapToFrame = (() => {
     const contentBounds = MediaContentBounds.bounds[targetEid];
 
     // Apply scale settings
-    newScale.copy(frameScale)
-    if(MediaFrame.flags[frameEid] & MEDIA_FRAME_FLAGS.SCALE_TO_BOUNDS) {
+    newScale.copy(frameScale);
+    if (MediaFrame.flags[frameEid] & MEDIA_FRAME_FLAGS.SCALE_TO_BOUNDS) {
       // Adjust content scale to fit inside the frame
       newScale.multiplyScalar(scaleForAspectFit(frameBounds, contentBounds));
     } else {
@@ -175,14 +174,14 @@ const snapToFrame = (() => {
 
     // Apply boundary alignment on all three axes
     const frameAxisAlignments = MediaFrame.align[frameEid];
-    for(let i = 0; i < 3; ++i) {
+    for (let i = 0; i < 3; ++i) {
       const axisAlignment = frameAxisAlignments[i];
-      if(axisAlignment != AxisAlignType.CENTER) {
+      if (axisAlignment != AxisAlignType.CENTER) {
         // Offset the content from the center to the desired axis alignment
         const alignmentMultiplier = AxisAlignMultipliers[axisAlignment];
         const frameBoundsWorldSpace = frameBounds[i] * frameScale.getComponent(i);
         const contentBoundsWorldSpace = contentBounds[i] * newScale.getComponent(i);
-        const positionDelta = alignmentMultiplier * (frameBoundsWorldSpace - contentBoundsWorldSpace) / 2;
+        const positionDelta = (alignmentMultiplier * (frameBoundsWorldSpace - contentBoundsWorldSpace)) / 2;
         framePos.setComponent(i, framePos.getComponent(i) + positionDelta);
       }
     }


### PR DESCRIPTION
This PR introduces greater control over how objects are snapped into media frames including:

1. The option to keep the object's current scale.
2. The option to align with the axis boundaries when the object does not exactly fill the space.

The canonical example would be a board game like chess with irregular sized pieces. Large media frames obscure the board making it hard to place pieces, resizing the pieces to fit the frame will make pawns the same size as kings, and centering the objects within the frame will make some of them float above the board. While it is possible to edit the objects themselves to "hack" around these limitations, it is complicated and not entirely solvable.

<img width="1294" alt="Screenshot 2023-11-17 at 15 41 24" src="https://github.com/mozilla/hubs/assets/303516/375ee491-be93-4ea1-86ae-e7dd4be6df63">

This PR expects extra parameters from [the companion Blender exporter add-on PR](https://github.com/MozillaReality/hubs-blender-exporter/pull/248).

The media-frame code was slightly refactored for clarity, including the addition postfixes to some variables indicating their type (obj, eid, etc...). The code has different paths for video objects and for "new loader" imports, all of which were considered.

A test scene was created to demonstrate and explore the various combinations of situations, which can be accessed here:

- [Scene in classic Hubs](https://hubs.mozilla.com/scenes/qgaMVT9/mediaframealignment)
- [GLTF file](https://avnfs.com/4lN8mk1QV5kOLe3drNyysesvWk-sLwoz2WKL2bAbhUo?size=9583748&type=model%2Fgltf-binary%3Bdisp%3Dscene&name=media-frame-alignment.glb)
- [Blender file](https://avnfs.com/M5u6y7OEHBREx2jadvfwNyQlp_Y4zEMJT3NQx4ZANOI?size=10354924&type=application%2Fx-blender&name=media-frame-alignment.blend)

The best way to understand this PR is probably to grab the code and load this scene. Some text is included to explain the intention of each section. Some of it is designed to test edge cases such as scaled frames, frames on spawned objects, etc...