### PR TITLE
Disallow vr_entry_type room limit override

### DIFF
--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -523,7 +523,7 @@ class UIRoot extends Component {
   handleForceEntry = () => {
     console.log("Forced entry type: " + this.props.forcedVREntryType);
 
-    if (!this.props.forcedVREntryType) return;
+    if (!this.props.forcedVREntryType || !this.props.hubChannel.canEnterRoom(this.props.hub)) return;
 
     if (this.props.forcedVREntryType.startsWith("daydream")) {
       this.enterDaydream();


### PR DESCRIPTION
Using the vr_entry_type flag a user could override the room limit and enter a full room. This PR checks that the client can join the room when using the vr_entry_type flag.