### PR TITLE
Bitecs-image-controls-link-menu

### DIFF
--- a/src/bit-systems/link-hover-menu.ts
+++ b/src/bit-systems/link-hover-menu.ts
@@ -57,6 +57,7 @@ async function handleLinkClick(world: HubsWorld, button: EntityID) {
   const menu = findAncestorWithComponent(world, LinkHoverMenu, button)!;
   const linkEid = LinkHoverMenu.targetObjectRef[menu];
   const src = APP.getString(Link.url[linkEid])!;
+  if (!src) return;
   const url = new URL(src);
   const linkType = Link.type[linkEid];
   switch (linkType) {

--- a/src/inflators/image-loader.ts
+++ b/src/inflators/image-loader.ts
@@ -1,5 +1,6 @@
+import { addComponent } from "bitecs";
 import { HubsWorld } from "../app";
-import { MediaImageLoaderData } from "../bit-components";
+import { MediaImageLoaderData, MediaLink } from "../bit-components";
 import { AlphaModeName, getAlphaModeFromAlphaModeName } from "../utils/create-image-mesh";
 import { ProjectionModeName, getProjectionFromProjectionName } from "../utils/projection-mode";
 import { inflateMediaLoader } from "./media-loader";
@@ -9,12 +10,14 @@ export interface ImageLoaderParams {
   projection: ProjectionModeName;
   alphaMode: AlphaModeName;
   alphaCutoff: number;
+  controls: boolean;
 }
 
 const DEFAULTS: Partial<ImageLoaderParams> = {
   projection: ProjectionModeName.FLAT,
   alphaMode: AlphaModeName.OPAQUE,
-  alphaCutoff: 0.5
+  alphaCutoff: 0.5,
+  controls: false
 };
 
 export function inflateImageLoader(world: HubsWorld, eid: number, params: ImageLoaderParams) {
@@ -35,4 +38,8 @@ export function inflateImageLoader(world: HubsWorld, eid: number, params: ImageL
     alphaMode: getAlphaModeFromAlphaModeName(requiredParams.alphaMode),
     projection: getProjectionFromProjectionName(requiredParams.projection)
   });
+
+  if (params.controls) {
+    addComponent(world, MediaLink, eid);
+  }
 }


### PR DESCRIPTION
Images with the controls property enabled should show the link menu.

Related https://github.com/mozilla/hubs/issues/6338