### PR TITLE
Fix aframe media loading

### DIFF
--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -28,8 +28,8 @@ import { cloneObject3D, setMatrixWorld } from "../utils/three-utils";
 import { waitForDOMContentLoaded } from "../utils/async-utils";
 
 import { SHAPE } from "three-ammo/constants";
-import { addComponent, entityExists, removeComponent } from "bitecs";
-import { MediaContentBounds, MediaLoading } from "../bit-components";
+import { addComponent } from "bitecs";
+import { MediaContentBounds, MediaLoaded } from "../bit-components";
 
 let loadingObject;
 
@@ -288,9 +288,6 @@ AFRAME.registerComponent("media-loader", {
       MediaContentBounds.bounds[el.eid].set(contentBounds.toArray());
 
       el.emit("media-loaded");
-      if (el.eid && entityExists(APP.world, el.eid)) {
-        removeComponent(APP.world, MediaLoading, el.eid);
-      }
     };
 
     if (this.data.animate) {
@@ -349,7 +346,6 @@ AFRAME.registerComponent("media-loader", {
     try {
       if ((forceLocalRefresh || srcChanged) && !this.showLoaderTimeout) {
         this.showLoaderTimeout = setTimeout(this.showLoader, 100);
-        addComponent(APP.world, MediaLoading, this.el.eid);
       }
 
       //check if url is an anchor hash e.g. #Spawn_Point_1

--- a/src/components/media-loader.js
+++ b/src/components/media-loader.js
@@ -29,7 +29,7 @@ import { waitForDOMContentLoaded } from "../utils/async-utils";
 
 import { SHAPE } from "three-ammo/constants";
 import { addComponent } from "bitecs";
-import { MediaContentBounds, MediaLoaded } from "../bit-components";
+import { MediaContentBounds } from "../bit-components";
 
 let loadingObject;
 

--- a/src/systems/bit-media-frames.js
+++ b/src/systems/bit-media-frames.js
@@ -20,7 +20,6 @@ import {
   MediaFrame,
   MediaImage,
   MediaLoaded,
-  MediaLoading,
   MediaPDF,
   MediaVideo,
   Networked,
@@ -102,7 +101,7 @@ function getCapturableEntity(world, physicsSystem, frame) {
     const eid = bodyData.object3D.eid;
     if (
       MediaFrame.mediaType[frame] & mediaTypeMaskFor(world, eid) &&
-      !hasComponent(world, MediaLoading, eid) &&
+      hasComponent(world, MediaContentBounds, eid) &&
       !inOtherFrame(world, frame, eid) &&
       !isAncestor(bodyData.object3D, frameObj)
     ) {


### PR DESCRIPTION
After changing the media loader to keep the MediaLoader component and have MediaLoading to trigger the loading process we should have removed the MediaLoading component from the aframe media-loader ortherwise it triggers a media load from the bitecs media loader.

This PR removes the MediaLoading from the aframe media loader and changes the media frames to ignore entities that don't have the MediaContentBounds component and treat them as loading entities as MediaContentBounds is only added when the media has been fully loaded.