### PR TITLE
Expose reticulum url

### DIFF
--- a/src/utils/phoenix-utils.js
+++ b/src/utils/phoenix-utils.js
@@ -435,3 +435,7 @@ export const tryGetMatchingMeta = async ({ ret_pool, ret_version }, shouldAbando
   }
   return didMatchMeta;
 };
+
+window.$P = {
+  getReticulumFetchUrl
+};


### PR DESCRIPTION
Expose the reticulum URL. Required by https://github.com/MozillaReality/hubs-blender-exporter/pull/255