### PR TITLE
Keep original object when swapping

### DIFF
--- a/src/inflators/model.tsx
+++ b/src/inflators/model.tsx
@@ -114,6 +114,7 @@ export function inflateModel(world: HubsWorld, rootEid: number, { model }: Model
     // Re-use the the uuid for animation targeting.
     // TODO: This is weird... Should we be rewriting the animations instead?
     replacement.uuid = old.uuid;
+    replacement.name = old.name;
 
     old.parent!.add(replacement);
     old.removeFromParent();


### PR DESCRIPTION
When an object is swapped we are not setting a name but some components, like the waypoint component, rely on this name.