### PR TITLE
Fix position of inspect buttons when the object is droppable

### DIFF
--- a/src/bit-systems/object-menu.ts
+++ b/src/bit-systems/object-menu.ts
@@ -331,8 +331,10 @@ function updateVisibility(world: HubsWorld, menu: EntityID, frozen: boolean) {
     mirrorButtonObj.position.fromArray(ObjectMenuPositions.mirror);
     if (isEntityPinned) {
       inspectButtonObj.position.fromArray(ObjectMenuPositions.inspectP);
-    } else {
+    } else if (isVideoImagePdf) {
       inspectButtonObj.position.fromArray(ObjectMenuPositions.inspect);
+    } else {
+      inspectButtonObj.position.fromArray(ObjectMenuPositions.inspectM);
     }
     refreshButtonObj.position.fromArray(ObjectMenuPositions.refresh);
 

--- a/src/prefabs/object-menu.tsx
+++ b/src/prefabs/object-menu.tsx
@@ -245,6 +245,7 @@ export const ObjectMenuPositions = {
   remove:             [    0, -0.075, uiZ] as ArrayVec3,
   drop:               [    0, -0.225, uiZ] as ArrayVec3,
   inspect:            [    0, -0.225, uiZ] as ArrayVec3,
+  inspectM:           [    0, -0.375, uiZ] as ArrayVec3,
   inspectU:           [    0,  0.075, uiZ] as ArrayVec3,
   inspectP:           [    0, -0.075, uiZ] as ArrayVec3,
   deserializeDrawing: [ -0.3, -0.425, uiZ] as ArrayVec3,


### PR DESCRIPTION
Fix on the inspect button layout as it was being occluded by the drop button when the object was droppable