### PR TITLE
disables scheduled execution of Browserstack testing

### DIFF
--- a/.github/workflows/browser-stack.yml
+++ b/.github/workflows/browser-stack.yml
@@ -1,8 +1,8 @@
 name: browser-stack
 
 on:
-  schedule:
-    - cron: '0 18 * * *'
+#  schedule:
+#    - cron: '0 18 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What?
disables scheduled execution of Browserstack testing

## Why?
not functional without an account, which we don't have set up

## How to test
A day after this is merged...

1. Go to ['Actions'](https://github.com/Hubs-Foundation/hubs/actions)
2. See that the Browserstack workflow has not been executed in the last day.
