### PR TITLE
Adds initial version of Privacy Policy

### DIFF
--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -1,0 +1,107 @@
+# Hubs Privacy Policy
+
+## Definitions
+
+**Site Owner**: The person, people or group operating an instance of Hubs
+
+**Administrator**: [Does this need to be defined separately???]
+
+**Hubs Foundation**: 16009034 CANADA FOUNDATION, a Canadian Not-for-profit corporation
+
+## Entities and Jurisdictions
+
+Instances of Hubs are operated by various organizations and individuals, who choose their own administrators and choose their own hosting arrangements, including the jurisdiction.
+This means that your information might be processed on servers located outside the country where you live, and that country may have a different level of data protection regulation than yours.
+Other users may be located outside the country where you live, so information they have access to may have a different level of data protection regulation than yours.
+
+The Site Operator for an instance is responsible for compliance with all applicable privacy laws.
+
+The Hubs Foundation is only responsible for the servers and Hubs instances it operates, and has no authority nor control over other servers and instances.
+
+## Information Shared With Hubs and Other Participants
+
+**Account information**: No account is needed for basic use of Hubs.
+Certain features (like storing your avatar), do require an account.
+Rooms that are linked to Discord require a Discord account.
+You can create an account through Hubs or through Discord.
+If you create an account with your email address, the Site Owner stores a hashed version of your email address, and may recover your account from email logs.
+If you create an account through Discord, Hubs receive the email address associated with your Discord account and your Discord avatar.
+
+**Room names and URLs**: Rooms and room names are publicly accessible to anyone with the URL.
+The instance stores the name and the URL for the link you share so you and others with the link to the Room can use it again.
+
+**Avatar data**: Your selected avatar and name will be shared with other participants in your rooms and the host of your Hubs instance.
+If you’re logged in to your account, Hubs will store your avatar.
+If you’re not logged into your account, Hubs will not store your avatar.
+
+**Voice data**: If your microphone is on, Hubs sends the audio to other users in the room, including users in the lobby.
+Hubs does not store the audio; Hubs only receive it temporarily to transmit it to others in the room.
+
+**Chat**: If you send messages in Hubs, Hubs shares it with the other users in the room, including users in the lobby.
+Hubs does not store chats; Hubs only receives it temporarily to transmit it to others in the room.
+
+**Photos and Videos You Take, and Photos, Videos, and Objects You Upload**: If you take photos and video in a Hubs room or upload photos, videos, or objects to a room, Hubs stores them so you can share them within the room.
+They are deleted within 72 hours unless you pin them.
+If you pin them they will be stored until you remove them from the room, and they will be viewable by anyone who can access the room.
+
+You can learn more by looking at the code itself: [Hubs](https://github.com/Hubs-Foundation/hubs) (the front-end) [Dialog](https://github.com/Hubs-Foundation/dialog) (the webRTC server), [Reticulum](https://github.com/Hubs-Foundation/reticulum) (the backend web server), [Hubs-Ops](https://github.com/Hubs-Foundation/hubs-ops) (the infrastructure code), [Discord Bot](https://github.com/Hubs-Foundation/hubs-discord-bot) (enables users to connect their Discord community to Hubs).
+
+## Other Information Hubs Receives
+
+Hubs use technical, interaction, error, and website analytics data to help us improve the Hubs experiences:
+
+**Technical data**: Hubs receives data about the type of devices used to interact with Hubs, as well as their operating systems, languages, the names and versions of browsers, and other data needed to load and operate a room.
+
+**Interaction data**: Hubs received data about interactions with Hubs, such as the number of rooms created, messages sent through or to third-party services like Discord (including aggregated counts such as the number of messages and users who have joined relevant channels), the number of users in a particular room, the start and end time of users’ interactions with Hubs, the amount of time users interact with Hubs in immersive sessions, and the first time in a particular month or day that a user begins to use Hubs.
+
+**Error Data**: When the Hubs client crashes or fails, Hubs receives error messages which may include the room URL, response time for requests, the page a user was on when the error happened, the user’s operating system, browser information, and IP address.
+
+**Website Analytics Data**: The Site Owner may use Google Analytics (GA) to better understand how people interact with Hubs.
+For example, Hubs collect de-identified information about the number of Hubs rooms created or entered, interactions with buttons and menus, session length, user location (country, state/province, and city), language settings, browser type and version, viewport size, and screen resolution.
+~~You can opt out of GA data collection by installing the Google Analytics Opt-out Browser Add-on.~~
+
+## Information Hubs Collect for Published Scenes and Custom Avatars
+
+**Scenes and avatars you create**: Hubs stores scenes and avatars that users create so Hubs can display them.
+
+**Attribution information**: When someone publishes a scene or avatar to Hubs, they have the option to “Allow Remixing with Creative Commons CC-BY 3.0” or allow promotion of your scene or avatar. If the user chooses one or both of these options, Hubs will share the scene or avatar and attribution information publicly.
+
+**Account information**: To publish a scene or avatar to Hubs, a user must have a Hubs account.
+Hubs will receive and store a hashed version of their email address to allow them to log in and view their 3D Room models and Avatars.
+
+## Who Hubs May Disclose Information To
+
+**The Hubs Host**: When you use a Hubs instance, Hubs shares information with the Hubs subscriber who created the Hubs instance. This includes your username, information about your account and when you created it, as well as scenes, avatars, and other content you add to a Hubs room.
+
+**The hosting service**: If the Hubs instance is run using a hosting service, the service will collect some data.
+Ask the site operator for details.
+
+**Search providers**: You can search for images, videos, and 3D Models to share in Hubs.
+When you search, Hubs will send your searches to supported third parties to fulfill the search.
+Hubs does not store your search queries nor the search results.
+Hubs supports the following providers, not all of which may be available on an instance:
+* Sketchfab (models)
+* Icosa Gallery (models)
+* Bing Images (images)
+* Bing Videos (videos)
+* Tenor GIFs (GIFs)
+
+**Sharing**: Hubs allows you to share rooms, scenes, camera images, and camera videos using the system Sharing of your operating system.
+Any content you share will be handled according to the privacy policy of the service(s) you use.
+
+**Discord**: If a room you are in is connected to Discord, Hubs store access tokens and the server and channel IDs that have been connected.
+Hubs will synchronize chat messages, room changes, 2D and 3D objects you create, and whether you join or leave with the connected Discord channel.
+Hubs does not log any synchronized messages.
+You can see Discord’s Privacy Policy for more information.
+
+## Information received by other parties
+
+Hubs uses Google Fonts, so Google receives your IP address, the requested URL, and HTTP headers, including the user agent and referrer.
+This data is collected to respond to user requests and for security purposes, but Google does not currently use it to create user profiles or for targeted advertising.
+See [their Privacy and Data Collection](https://developers.google.com/fonts/faq/privacy) policy.
+
+## Other Information You Should Know
+
+If you have any other questions regarding personal data or privacy practices, please contact the Site Owner.
+
+Please visit [the forums](https://discord.com/channels/1302953641115783198/1314206482438553631) for general support help.

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -92,7 +92,7 @@ Any content you share will be handled according to the privacy policy of the ser
 **Discord**: If a room you are in is connected to Discord, Hubs store access tokens and the server and channel IDs that have been connected.
 Hubs will synchronize chat messages, room changes, 2D and 3D objects you create, and whether you join or leave with the connected Discord channel.
 Hubs does not log any synchronized messages.
-You can see Discord’s Privacy Policy for more information.
+You can see [Discord’s Privacy Policy](https://discord.com/privacy/) for more information.
 
 ## Information received by other parties
 

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -2,9 +2,9 @@
 
 ## Definitions
 
-**Site Owner**: The person, people or group operating an instance of Hubs
+**Hubs** Software for creating multi-user immersive experiences in a web browser.  The copy of the Hubs software running on a particular server is called a **Hubs instance**.
 
-**Administrator**: [Does this need to be defined separately???]
+**Site Owner**: The person, people, or group who control a Hubs instance.
 
 **Hubs Foundation**: 16009034 CANADA FOUNDATION, a Canadian Not-for-profit corporation
 
@@ -14,72 +14,72 @@ Instances of Hubs are operated by various organizations and individuals, who cho
 This means that your information might be processed on servers located outside the country where you live, and that country may have a different level of data protection regulation than yours.
 Other users may be located outside the country where you live, so information they have access to may have a different level of data protection regulation than yours.
 
-The Site Operator for an instance is responsible for compliance with all applicable privacy laws.
+The Site Operator for a Hubs instance is responsible for compliance with all applicable privacy laws.
 
 The Hubs Foundation is only responsible for the servers and Hubs instances it operates, and has no authority nor control over other servers and instances.
 
-## Information Shared With Hubs and Other Participants
+## Information Shared With Hubs Instance and Other Participants
 
-**Account information**: No account is needed for basic use of Hubs.
-Certain features (like storing your avatar), do require an account.
+**Account information**: No account is needed for basic use of a Hubs instance.
+Certain features (like storing your avatar) do require an account.
 Rooms that are linked to Discord require a Discord account.
-You can create an account through Hubs or through Discord.
+You can create an account through the Hubs instance or through Discord.
 If you create an account with your email address, the Site Owner stores a hashed version of your email address, and may recover your account from email logs.
-If you create an account through Discord, Hubs receive the email address associated with your Discord account and your Discord avatar.
+If you create an account through Discord, the Hubs instance receives the email address associated with your Discord account and your Discord avatar.
 
 **Room names and URLs**: Rooms and room names are publicly accessible to anyone with the URL.
-The instance stores the name and the URL for the link you share so you and others with the link to the Room can use it again.
+The Hubs instance stores the name and the URL for the link you share, so you and others with the link to the Room can use it again.
 
-**Avatar data**: Your selected avatar and name will be shared with other participants in your rooms and the host of your Hubs instance.
+**Avatar data**: Your selected avatar and name will be shared with other participants in your rooms and the Site Owner.
 If you’re logged in to your account, Hubs will store your avatar.
-If you’re not logged into your account, Hubs will not store your avatar.
+If you’re not logged into your account, the Hubs instance will not store your avatar.
 
-**Voice data**: If your microphone is on, Hubs sends the audio to other users in the room, including users in the lobby.
-Hubs does not store the audio; Hubs only receive it temporarily to transmit it to others in the room.
+**Voice data**: If your microphone is on, the Hubs instance sends the audio to other users in the room, including users in the lobby.
+The Hubs instance does not store the audio; it only receives it temporarily to transmit it to others in the room.
 
-**Chat**: If you send messages in Hubs, Hubs shares it with the other users in the room, including users in the lobby.
+**Chat**: If you send messages in Hubs, the Hubs instance shares it with the other users in the room, including users in the lobby.
 Hubs does not store chats; Hubs only receives it temporarily to transmit it to others in the room.
 
-**Photos and Videos You Take, and Photos, Videos, and Objects You Upload**: If you take photos and video in a Hubs room or upload photos, videos, or objects to a room, Hubs stores them so you can share them within the room.
+**Photos and Videos You Take, and Photos, Videos, and Objects You Upload**: If you take photos and video in a Hubs room or upload photos, videos, or objects to a room, the Hubs instance stores them so you can share them within the room.
 They are deleted within 72 hours unless you pin them.
-If you pin them they will be stored until you remove them from the room, and they will be viewable by anyone who can access the room.
+If you pin them, they will be stored until you remove them from the room, and they will be viewable by anyone who can access the room.
 
 You can learn more by looking at the code itself: [Hubs](https://github.com/Hubs-Foundation/hubs) (the front-end) [Dialog](https://github.com/Hubs-Foundation/dialog) (the webRTC server), [Reticulum](https://github.com/Hubs-Foundation/reticulum) (the backend web server), [Hubs-Ops](https://github.com/Hubs-Foundation/hubs-ops) (the infrastructure code), [Discord Bot](https://github.com/Hubs-Foundation/hubs-discord-bot) (enables users to connect their Discord community to Hubs).
 
-## Other Information Hubs Receives
+## Other Information the Hubs instance Receives
 
 Hubs use technical, interaction, error, and website analytics data to help us improve the Hubs experiences:
 
-**Technical data**: Hubs receives data about the type of devices used to interact with Hubs, as well as their operating systems, languages, the names and versions of browsers, and other data needed to load and operate a room.
+**Technical data**: the Hubs instance receives data about the type of devices used to interact with Hubs, as well as their operating systems, languages, the names and versions of browsers, and other data needed to load and operate a room.
 
-**Interaction data**: Hubs received data about interactions with Hubs, such as the number of rooms created, messages sent through or to third-party services like Discord (including aggregated counts such as the number of messages and users who have joined relevant channels), the number of users in a particular room, the start and end time of users’ interactions with Hubs, the amount of time users interact with Hubs in immersive sessions, and the first time in a particular month or day that a user begins to use Hubs.
+**Interaction data**: the Hubs instance receives data about interactions with Hubs, such as the number of rooms created, messages sent through or to third-party services like Discord (including aggregated counts such as the number of messages and users who have joined relevant channels), the number of users in a particular room, the start and end time of users’ interactions with the Hubs instance, the amount of time users interact with Hubs in immersive sessions, and the first time in a particular month or day that a user begins to use the Hubs instance.
 
-**Error Data**: When the Hubs client crashes or fails, Hubs receives error messages which may include the room URL, response time for requests, the page a user was on when the error happened, the user’s operating system, browser information, and IP address.
+**Error Data**: When the Hubs client crashes or fails, the Hubs instance receives error messages which may include the room URL, response time for requests, the page a user was on when the error happened, the user’s operating system, browser information, and IP address.
 
-**Website Analytics Data**: The Site Owner may use Google Analytics (GA) to better understand how people interact with Hubs.
+**Website Analytics Data**: The Site Owner may use Google Analytics (GA) to better understand how people interact with their Hubs instance.
 For example, Hubs collect de-identified information about the number of Hubs rooms created or entered, interactions with buttons and menus, session length, user location (country, state/province, and city), language settings, browser type and version, viewport size, and screen resolution.
 ~~You can opt out of GA data collection by installing the Google Analytics Opt-out Browser Add-on.~~
 
-## Information Hubs Collect for Published Scenes and Custom Avatars
+## Information the Hubs instance Collects for Published Scenes and Custom Avatars
 
-**Scenes and avatars you create**: Hubs stores scenes and avatars that users create so Hubs can display them.
+**Scenes and avatars you create**: The Hubs instance stores scenes and avatars that users create so Hubs can display them.
 
-**Attribution information**: When someone publishes a scene or avatar to Hubs, they have the option to “Allow Remixing with Creative Commons CC-BY 3.0” or allow promotion of your scene or avatar. If the user chooses one or both of these options, Hubs will share the scene or avatar and attribution information publicly.
+**Attribution information**: When someone publishes a scene or avatar to a Hubs instance, they have the option to “Allow Remixing with Creative Commons CC-BY 3.0” or allow promotion of your scene or avatar. If the user chooses one or both of these options, the Hubs instance will share the scene or avatar and attribution information publicly.
 
-**Account information**: To publish a scene or avatar to Hubs, a user must have a Hubs account.
-Hubs will receive and store a hashed version of their email address to allow them to log in and view their 3D Room models and Avatars.
+**Account information**: To publish a scene or avatar to a Hubs instance, a user must have an account on that Hubs instance.
+The Hubs instance will receive and store a hashed version of their email address to allow them to log in and view their 3D Room models and Avatars.
 
-## Who Hubs May Disclose Information To
+## Who the Hubs Instance May Disclose Information To
 
-**The Hubs Host**: When you use a Hubs instance, Hubs shares information with the Hubs subscriber who created the Hubs instance. This includes your username, information about your account and when you created it, as well as scenes, avatars, and other content you add to a Hubs room.
+**The Site Owner**: When you use a Hubs instance, it shares information with the Site Owner. This includes your username, information about your account and when you created it, as well as scenes, avatars, and other content you add to a Hubs room.
 
 **The hosting service**: If the Hubs instance is run using a hosting service, the service will collect some data.
-Ask the site operator for details.
+Ask the Site Owner for details.
 
 **Search providers**: You can search for images, videos, and 3D Models to share in Hubs.
-When you search, Hubs will send your searches to supported third parties to fulfill the search.
-Hubs does not store your search queries nor the search results.
-Hubs supports the following providers, not all of which may be available on an instance:
+When you search, the Hubs instance will send your searches to supported third parties to fulfill the search.
+The Hubs instance does not store your search queries nor the search results.
+Hubs supports the following providers, not all of which may be available on a Hubs instance:
 * Sketchfab (models)
 * Icosa Gallery (models)
 * Bing Images (images)
@@ -89,9 +89,9 @@ Hubs supports the following providers, not all of which may be available on an i
 **Sharing**: Hubs allows you to share rooms, scenes, camera images, and camera videos using the system Sharing of your operating system.
 Any content you share will be handled according to the privacy policy of the service(s) you use.
 
-**Discord**: If a room you are in is connected to Discord, Hubs store access tokens and the server and channel IDs that have been connected.
-Hubs will synchronize chat messages, room changes, 2D and 3D objects you create, and whether you join or leave with the connected Discord channel.
-Hubs does not log any synchronized messages.
+**Discord**: If a room you are in is connected to Discord, the Hubs instance stores access tokens and the server and channel IDs that have been connected.
+The Hubs instance will synchronize chat messages, room changes, 2D and 3D objects you create, and whether you join or leave with the connected Discord channel.
+The Hubs instance does not log any synchronized messages.
 You can see [Discord’s Privacy Policy](https://discord.com/privacy/) for more information.
 
 ## Information received by other parties

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -104,4 +104,4 @@ See [their Privacy and Data Collection](https://developers.google.com/fonts/faq/
 
 If you have any other questions regarding personal data or privacy practices, please contact the Site Owner.
 
-Please visit [the forums](https://discord.com/channels/1302953641115783198/1314206482438553631) for general support help.
+Please visit the [Hubs Foundation Discord](https://discord.gg/hubs-498741086295031808) for support.

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -4,7 +4,7 @@
 
 **Hubs** Software for creating multi-user immersive experiences in a web browser.  The copy of the Hubs software running on a particular server is called a **Hubs instance**.
 
-**Site Owner**: The person, people, or group who control a Hubs instance.
+**Site Owner**: The person, people, or group who run and control a Hubs instance.
 
 **Hubs Foundation**: 16009034 CANADA FOUNDATION, a Canadian Not-for-profit corporation
 
@@ -22,13 +22,22 @@ The Hubs Foundation is only responsible for the servers and Hubs instances it op
 
 **Account information**: No account is needed for basic use of a Hubs instance.
 Certain features (like storing your avatar) do require an account.
-Rooms that are linked to Discord require a Discord account.
+Rooms that are linked to Discord using the Discord Bot require a Discord account.
 You can create an account through the Hubs instance or through Discord.
-If you create an account with your email address, the Site Owner stores a hashed version of your email address, and may recover your account from email logs.
+
+If you create an account with your email address, the Hubs instance stores a hashed version of your email address.
+The Site Owner can use the hashed versions of email addresses to determine if any given email address is associated with an account.
+The Site Owner may recover your email address from email logs.
 If you create an account through Discord, the Hubs instance receives the email address associated with your Discord account and your Discord avatar.
 
-**Room names and URLs**: Rooms and room names are publicly accessible to anyone with the URL.
-The Hubs instance stores the name and the URL for the link you share, so you and others with the link to the Room can use it again.
+**Rooms and URLs**:
+There is no public mechanism to list rooms that are not public.
+However, the Site Owner can extract all room data from the database.
+
+Anyone having the current room URL can connect to the room.
+However, rooms can be set to "Invite Only" and previous room URLs revoked.
+
+The Hubs instance stores the name and the URL for each room link you share, so you and others with the link to the room can use it again.
 
 **Avatar data**: Your selected avatar and name will be shared with other participants in your rooms and the Site Owner.
 If you’re logged in to your account, Hubs will store your avatar.
@@ -37,18 +46,20 @@ If you’re not logged into your account, the Hubs instance will not store your 
 **Voice data**: If your microphone is on, the Hubs instance sends the audio to other users in the room, including users in the lobby.
 The Hubs instance does not store the audio; it only receives it temporarily to transmit it to others in the room.
 
-**Chat**: If you send messages in Hubs, the Hubs instance shares it with the other users in the room, including users in the lobby.
+**Chat**: If you send chat messages in Hubs, the Hubs instance shares it with the other users in the room, including users in the lobby.
 Hubs does not store chats; Hubs only receives it temporarily to transmit it to others in the room.
+
+The Discord bot, for the room(s) it is connected to, re-posts chat messages to a Discord channel.
+See **Discord** below.
 
 **Photos and Videos You Take, and Photos, Videos, and Objects You Upload**: If you take photos and video in a Hubs room or upload photos, videos, or objects to a room, the Hubs instance stores them so you can share them within the room.
 They are deleted within 72 hours unless you pin them.
 If you pin them, they will be stored until you remove them from the room, and they will be viewable by anyone who can access the room.
 
-You can learn more by looking at the code itself: [Hubs](https://github.com/Hubs-Foundation/hubs) (the front-end) [Dialog](https://github.com/Hubs-Foundation/dialog) (the webRTC server), [Reticulum](https://github.com/Hubs-Foundation/reticulum) (the backend web server), [Hubs-Ops](https://github.com/Hubs-Foundation/hubs-ops) (the infrastructure code), [Discord Bot](https://github.com/Hubs-Foundation/hubs-discord-bot) (enables users to connect their Discord community to Hubs).
-
 ## Other Information the Hubs instance Receives
 
-Hubs use technical, interaction, error, and website analytics data to help us improve the Hubs experiences:
+The Hubs instance uses technical, interaction, error, and website analytics data to help the Site Owner improve the Hubs experiences.
+The Site Owner may share this information with others.
 
 **Technical data**: the Hubs instance receives data about the type of devices used to interact with Hubs, as well as their operating systems, languages, the names and versions of browsers, and other data needed to load and operate a room.
 
@@ -62,23 +73,32 @@ For example, Hubs collect de-identified information about the number of Hubs roo
 
 ## Information the Hubs instance Collects for Published Scenes and Custom Avatars
 
-**Scenes and avatars you create**: The Hubs instance stores scenes and avatars that users create so Hubs can display them.
+**Scenes and avatars you create**: The Hubs instance stores scenes and avatars that users import, upload, or create using the Scene Editor ("Spoke"), so Hubs can display them.
 
-**Attribution information**: When someone publishes a scene or avatar to a Hubs instance, they have the option to “Allow Remixing with Creative Commons CC-BY 3.0” or allow promotion of your scene or avatar. If the user chooses one or both of these options, the Hubs instance will share the scene or avatar and attribution information publicly.
+**Attribution information**: When someone publishes a scene or avatar to a Hubs instance, they can “Allow Remixing with Creative Commons CC-BY 3.0” or allow promotion of your scene or avatar. If the user chooses one or both of these options, the Hubs instance will share the scene or avatar and attribution information publicly.
 
 **Account information**: To publish a scene or avatar to a Hubs instance, a user must have an account on that Hubs instance.
-The Hubs instance will receive and store a hashed version of their email address to allow them to log in and view their 3D Room models and Avatars.
+See **Account Information** above.
 
 ## Who the Hubs Instance May Disclose Information To
 
 **The Site Owner**: When you use a Hubs instance, it shares information with the Site Owner. This includes your username, information about your account and when you created it, as well as scenes, avatars, and other content you add to a Hubs room.
 
-**The hosting service**: If the Hubs instance is run using a hosting service, the service will collect some data.
+**The hosting service**: If the Hubs instance is run using a hosting service, the service may collect some data.
 Ask the Site Owner for details.
+
+**A third-party email sender**: If the Hubs instance uses a third-party email service, that third party has access to all emails.
+From the emails, they can extract the email addresses used with that Hubs instance, and when each user requested login emails, but not when the user actually logs in, disconnects, or re-connects.
+Ask the Site Owner for details.
+
+**Your email provider**: The provider of your email has access to all your emails.
+From the emails, they can extract the Hubs instances you have accounts on, and when you request login emails, but not when you actually log in, disconnect, or re-connect.
 
 **Search providers**: You can search for images, videos, and 3D Models to share in Hubs.
 When you search, the Hubs instance will send your searches to supported third parties to fulfill the search.
+The search provider(s) may store your search queries and the search results.
 The Hubs instance does not store your search queries nor the search results.
+The Hubs instance does not send personally identifiable information (such as your IP address) to the search provider(s).
 Hubs supports the following providers, not all of which may be available on a Hubs instance:
 * Sketchfab (models)
 * Icosa Gallery (models)
@@ -86,22 +106,27 @@ Hubs supports the following providers, not all of which may be available on a Hu
 * Bing Videos (videos)
 * Tenor GIFs (GIFs)
 
-**Sharing**: Hubs allows you to share rooms, scenes, camera images, and camera videos using the system Sharing of your operating system.
+**System Sharing**: Hubs allows you to share rooms, scenes, camera images, and camera videos using the system Sharing of your operating system.
 Any content you share will be handled according to the privacy policy of the service(s) you use.
 
 **Discord**: If a room you are in is connected to Discord, the Hubs instance stores access tokens and the server and channel IDs that have been connected.
-The Hubs instance will synchronize chat messages, room changes, 2D and 3D objects you create, and whether you join or leave with the connected Discord channel.
+The Discord bot will synchronize chat messages, room changes, 2D and 3D objects you create, and whether you join or leave with the connected Discord channel.
 The Hubs instance does not log any synchronized messages.
 You can see [Discord’s Privacy Policy](https://discord.com/privacy/) for more information.
 
 ## Information received by other parties
 
 Hubs uses Google Fonts, so Google receives your IP address, the requested URL, and HTTP headers, including the user agent and referrer.
-This data is collected to respond to user requests and for security purposes, but Google does not currently use it to create user profiles or for targeted advertising.
+This data is collected to respond to user requests and for security purposes, but Google (as of this writing) does not use it to create user profiles or for targeted advertising.
 See [their Privacy and Data Collection](https://developers.google.com/fonts/faq/privacy) policy.
 
 ## Other Information You Should Know
 
 If you have any other questions regarding personal data or privacy practices, please contact the Site Owner.
+In the **More** menu, the items under **Support** may contain contact information for the Site Owner.
+
+You can learn more by looking at the code itself: [Hubs](https://github.com/Hubs-Foundation/hubs) (the front-end) [Dialog](https://github.com/Hubs-Foundation/dialog) (the webRTC server), [Reticulum](https://github.com/Hubs-Foundation/reticulum) (the backend web server), the [Scene Editor ("Spoke")](https://github.com/Hubs-Foundation/Spoke), and the [Discord Bot](https://github.com/Hubs-Foundation/hubs-discord-bot) (enables users to connect their Discord community to Hubs).
+
+There are articles online about [How Hubs Uses WebRTC](https://zachfox.io/hubs-webrtc-tester/about/) of Hubs.
 
 Please visit the [Hubs Foundation Discord](https://discord.gg/hubs-498741086295031808) for support.


### PR DESCRIPTION
## What?
Adds initial version of Privacy Policy

## Why?
To inform users what information is collected and who has access to it.

## Limitations
Does not cover Spoke

## Alternatives considered
This is in the `hubs` repo, so it can be customized by forked clients.

## Open questions

## Additional details or related context
Supersedes https://github.com/Hubs-Foundation/policies-procedures-guidelines-public/pull/20
