### PR TITLE
Fixes bug: PDF page advance doesn't work in mobile VR

### DIFF
--- a/src/systems/hubs-systems.ts
+++ b/src/systems/hubs-systems.ts
@@ -30,6 +30,7 @@ import { AudioZonesSystem } from "./audio-zones-system";
 import { GainSystem } from "./audio-gain-system";
 import { EnvironmentSystem } from "./environment-system";
 import { NameTagVisibilitySystem } from "./name-tag-visibility-system";
+import { MediaPDFOculusFix } from "./media-pdf-oculus-fix";
 
 // new world
 import { networkReceiveSystem } from "../bit-systems/network-receive-system";
@@ -136,6 +137,7 @@ AFRAME.registerSystem("hubs-systems", {
     this.drawingMenuSystem = new DrawingMenuSystem(this.el);
     this.characterController = new CharacterControllerSystem(this.el);
     this.waypointSystem = new WaypointSystem(this.el, this.characterController);
+    this.mediaPDFOculusFix = new MediaPDFOculusFix(this.el);
     this.cursorPoseTrackingSystem = new CursorPoseTrackingSystem();
     this.menuAnimationSystem = new MenuAnimationSystem();
     this.audioSettingsSystem = new AudioSettingsSystem(this.el);

--- a/src/systems/media-pdf-oculus-fix.js
+++ b/src/systems/media-pdf-oculus-fix.js
@@ -1,0 +1,30 @@
+/*
+  PDFjs which is used to render pdfs depends on the window.requestAnimationFrame function.
+  This is not called when in mobileVR.
+  This system replaces the function with the requestAnimationFrame of the xrSession.
+  It restores window.requestAnimationFrame when the user leaves xr.
+*/
+export class MediaPDFOculusFix {
+  constructor(sceneEl) {
+    // PC VR calls window.requestAnimationFrame even in VR mode
+    if (AFRAME.utils.device.isMobileVR()) {
+      this.requestAnimationFrameOriginal = window.requestAnimationFrame;
+      this.cancelAnimationFrameOriginal = window.cancelAnimationFrame;
+      sceneEl.addEventListener("enter-vr", () => {
+        console.debug(`PDF: monkey-patching window.requestAnimationFrame:`, window.requestAnimationFrame);
+        const { xrSession } = sceneEl;
+        window.requestAnimationFrame = callback => {
+          return xrSession?.requestAnimationFrame(callback);
+        };
+        window.cancelAnimationFrame = handle => {
+          return xrSession?.cancelAnimationFrame(handle);
+        };
+      });
+      sceneEl.addEventListener("exit-vr", () => {
+        console.debug(`PDF: removing window.requestAnimationFrame monkey-patch`, this.requestAnimationFrameOriginal);
+        window.requestAnimationFrame = this.requestAnimationFrameOriginal;
+        window.cancelAnimationFrame = this.cancelAnimationFrameOriginal;
+      });
+    }
+  }
+}

--- a/types/aframe.d.ts
+++ b/types/aframe.d.ts
@@ -52,6 +52,7 @@ declare module "aframe" {
     drawingMenuSystem: DrawingMenuSystem;
     characterController: CharacterControllerSystem;
     waypointSystem: WaypointSystem;
+    mediaPDFOculusFix: MediaPDFOculusFix;
     cursorPoseTrackingSystem: CursorPoseTrackingSystem;
     menuAnimationSystem: MenuAnimationSystem;
     audioSettingsSystem: AudioSettingsSystem;


### PR DESCRIPTION
## What?
PDFs: under mobile VR, monkey-patches window.requestAnimationFrame, to fix https://github.com/mozilla/hubs/issues/4951 and https://github.com/Hubs-Foundation/hubs/issues/3968

## Why?
PDF.js calls window.requestAnimationFrame, and under mobile VR, it is not called when in VR mode

## How to test

1. Connect to a room with a mobile VR headset (Quest, Pico, etc.) and enter VR mode
2. Add a multi-page PDF to that room [most easily done on desktop]; observe in mobile VR mode that the first page of the PDF is displayed, as expected
3. Click on the PDF's page forward button, observe that page changes as expected
4. Click on the PDF's page back button, observe that page changes as expected

## Documentation of functionality
No documentation changes; it always should have worked like this.

## Limitations
None.

## Alternative implementations considered
None.

## Open questions
None.

## Additional details or related context
This is a cleaned-up version of the fix Nils (CodingBitsDev) figured out: https://github.com/Hubs-Foundation/hubs/pull/5427/changes

