### PR TITLE
Adjusts links to hubs-docs Limit Access Guide & Customizing Themes

### DIFF
--- a/admin/src/react-components/pages/system-editor.tsx
+++ b/admin/src/react-components/pages/system-editor.tsx
@@ -150,7 +150,7 @@ const SystemEditorComponent = ({ classes }) => {
 
           <CardSection
             ctaCallback={() => {
-              window.open("https://docs.hubsfoundation.org/hubs-cloud-limiting-user-access.html");
+              window.open("https://docs.hubsfoundation.org/admin-limiting-user-access");
             }}
             cta="Limit access guide"
             body="Learn how to control who can enter your hub’s rooms."

--- a/admin/src/react-components/service-editor.js
+++ b/admin/src/react-components/service-editor.js
@@ -440,7 +440,7 @@ class ConfigurationEditor extends Component {
           hub&#39;s rooms (More &gt; Preferences &gt; Misc &gt; Theme).More information about customizing your hubs&#39;
           themes can be found in our{" "}
           <a
-            href="https://docs.hubsfoundation.org/hubs-cloud-customizing-themes.html"
+            href="https://docs.hubsfoundation.org/admin-customizing-themes.html"
             target="_blank"
             rel="noopener noreferrer"
             className="link"


### PR DESCRIPTION
## What?
Adjusts links to hubs-docs Limit Access Guide & Customizing Themes


## Why?
their ids & paths have been changed on hubs-docs


## Examples
### Hubs Admin UI
<img width="930" height="111" alt="image" src="https://github.com/user-attachments/assets/ec555142-0eb2-4552-a801-709246166115" />

#### current link
<img width="768" height="235" alt="image" src="https://github.com/user-attachments/assets/28805745-a8f3-4b51-a184-7bc0dc156611" />

#### new link
<img width="700" height="355" alt="image" src="https://github.com/user-attachments/assets/cfaed859-7b35-46ab-a483-b3d8c7b217ba" />


### Hubs Admin UI
<img width="853" height="149" alt="image" src="https://github.com/user-attachments/assets/b4b4d54a-2b16-4c92-9f79-165202f9fcb6" />

#### current link
<img width="743" height="198" alt="image" src="https://github.com/user-attachments/assets/9cdd97e3-3d47-406e-90d7-8ce3b62e18a3" />

#### new link
<img width="714" height="441" alt="image" src="https://github.com/user-attachments/assets/9013aa90-3cf3-4a50-8203-892fdb21d6d8" />



## How to test
1. set Hubs client image to `ghcr.io/dougreeder/hubs:correct-docs-links-7`
2. Go to Admin Panel "Home"
3. Click on "Limit Access Guide", observe that a good page on hubs-docs is displayed
4. Under Setup, select "Themes"
5. Click on "documentation pages", observe that a good page on hubs-docs is displayed

## Documentation of functionality
These should have been updated when revising hubs-docs


## Limitations
None


## Alternative implementations considered
None


## Open questions
None


## Additional details or related context
None
