### PR TITLE
Remediates weaknesses in CI, as advised by zizmor

### DIFF
--- a/.github/workflows/browser-stack.yml
+++ b/.github/workflows/browser-stack.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/browser-stack.yml
+++ b/.github/workflows/browser-stack.yml
@@ -5,6 +5,8 @@ on:
 #    - cron: '0 18 * * *'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -12,9 +14,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Setup node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 16.x
 

--- a/.github/workflows/custom-docker-build-push.yml
+++ b/.github/workflows/custom-docker-build-push.yml
@@ -41,6 +41,8 @@ env:
   Use_Build_Cache: ${{ inputs.Use_Build_Cache }}
 # repo_name: This must be added in each job that needs it.
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -77,27 +79,28 @@ jobs:
 
       # Code
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: "./repo"
+          persist-credentials: false
 
       - name: Use Code_Path for multirepo
         if: ${{ env.Code_Path != ''}}
         run: |
           mkdir ./_repo
-          cp -rf ./repo/${{ env.Code_Path }}/* ./_repo
+          cp -rf ./repo/${Code_Path}/* ./_repo # shell variable is more secure than workflow variable
           rm -rf ./repo
           mv ./_repo ./repo
           ls ./repo
 
       # Docker
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
           install: true
 
       - name: Login to container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.Registry_Base_URL }}
           username: ${{ env.Registry_Username }}
@@ -105,7 +108,7 @@ jobs:
 
       - name: Docker Build and Push (with cache)
         if: ${{ fromJSON(env.Use_Build_Cache) == true }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: repo/
           file: repo/${{ env.Dockerfile }}
@@ -116,7 +119,7 @@ jobs:
 
       - name: Docker Build and Push (no cache)
         if: ${{ fromJSON(env.Use_Build_Cache) == false }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: repo/
           file: repo/${{ env.Dockerfile }}

--- a/.github/workflows/hc-pkgcaller.yml
+++ b/.github/workflows/hc-pkgcaller.yml
@@ -1,8 +1,8 @@
 name: hc-pkg
 on:
   workflow_dispatch:
-   
-    
+
+
 jobs:
   hcpkgrelease:
     uses: Hubs-Foundation/hubs-ops/.github/workflows/HcPkgPreReleaseGitops.yaml@master

--- a/.github/workflows/test-and-deploy-storybook.yml
+++ b/.github/workflows/test-and-deploy-storybook.yml
@@ -5,14 +5,18 @@ on:
     branches:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   test-and-deploy-storybook:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 


### PR DESCRIPTION
## What?
Remediates weaknesses in CI, as advised by zizmor
Addresses https://github.com/Hubs-Foundation/.github/issues/5 for the hubs client repo


## Why?
Supply-chain attacks must be taken seriously


## Examples
no change in CI functionality


## How to test
Exercise each GitHub job

To see the audit, run the [zizmor static analysis tool](https://docs.zizmor.sh/)


## Documentation of functionality
n/a


## Limitations
This sets up the GitHub security monitor. After several runs, the output should tell us the needed permissions. 
Another PR will have to set those.


## Alternative implementations considered
These are best practice, but we need to determine what the continuing costs of using them are.


## Open questions
None.


## Additional details or related context
Context: https://arstechnica.com/security/2026/04/open-source-package-with-1-million-monthly-downloads-stole-user-credentials/

