### PR TITLE
Fix: Improve touchpad wheel responsiveness and pinch gesture scaling

### DIFF
--- a/src/systems/userinput/devices/mouse.js
+++ b/src/systems/userinput/devices/mouse.js
@@ -62,11 +62,11 @@ export class MouseDevice {
        delta *= 10;
       }
 
-     this.wheel += delta;
      if (event.ctrlKey) {
        // pinch gesture (Mac trackpad zoom)
        delta *= 2;
      }
+     this.wheel += delta;
    }
 
     const left = event.button === 0;

--- a/src/systems/userinput/devices/mouse.js
+++ b/src/systems/userinput/devices/mouse.js
@@ -54,10 +54,20 @@ export class MouseDevice {
   }
 
   process(event) {
-    if (event.type === "wheel") {
-      this.wheel += (event.deltaX + event.deltaY) / modeMod[event.deltaMode];
-      return true;
-    }
+   if (event.type === "wheel") {
+     let delta = (event.deltaX + event.deltaY) / modeMod[event.deltaMode];
+
+     // Boost small deltas (trackpads)
+     if (Math.abs(delta) < 1) {
+       delta *= 10;
+      }
+
+     this.wheel += delta;
+     if (event.ctrlKey) {
+       // pinch gesture (Mac trackpad zoom)
+       delta *= 2;
+     }
+   }
 
     const left = event.button === 0;
     const middle = event.button === 1;


### PR DESCRIPTION
## What?
This PR now  introduces normalization logic for wheel input within the mouse device system to improve responsiveness for trackpad users.

## Why?
- Trackpads had some reports of  fractional or very low delta values compared to standard mouse wheels, causing scrolling or object manipulation to feel sluggish or unresponsive. 

- Pinch gestures on trackpads (often triggering Ctrl+wheel) were not correctly scaling. This PR increases the the sensitivity for small deltas. Then, it amplifies the input when the Ctrl key is held.

## Examples
N/A

## How to test
1. Open the application using a trackpad.
2. Attempt to scroll or rotate a held object.
3. Verify that the movement is responsive and not sluggish.
4. Hold the Ctrl key and perform a scroll or pinch gesture.
5. Verify the movement speed is increased as expected.

## Documentation of functionality
No documentation updates are required for this minor logic fix.

## Limitations
None.

## Alternative implementations considered
I considered using a device-detection library to switch input logic, but decided to normalize the raw delta values directly in the processor for better performance and simplicity.

## Open questions
None.

## Additional details or related context
Fixes: https://github.com/Hubs-Foundation/hubs/issues/6556 
This change aims to bring trackpad usability closer to that of a standard mouse wheel. 

Parts of this change were developed with the assistance of an AI tool (ChatGPT), particularly for debugging guidance and refining the implementation. The final code and testing were reviewed and validated manually.