### PR TITLE
docs: fix typo "existance" → "existence" in app.ts comment

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -134,7 +134,7 @@ export class App {
       AEntity
     };
 
-    // reserve entity 0 to avoid needing to check for undefined everywhere eid is checked for existance
+    // reserve entity 0 to avoid needing to check for undefined everywhere eid is checked for existence
     addEntity(this.world);
 
     this.str2sid = new Map([[null, 0]]);


### PR DESCRIPTION
Comment-only typo fix in `src/app.ts:137` on the entity-reservation comment. No behavior change.