### PR TITLE
CI: storybook given write contents perms; RetPageOrigin removes all

### DIFF
--- a/.github/workflows/hubs-RetPageOrigin.yml
+++ b/.github/workflows/hubs-RetPageOrigin.yml
@@ -1,7 +1,6 @@
 name: hubs
 on:
   push:
-    branches:
     paths-ignore: ["README.md"]
   workflow_dispatch:
     # Smoke instances aren't currently set up as of 2024-09-08
@@ -16,6 +15,8 @@ on:
     #       - "smoke03"
     #       - "smoke04"
     #       - "smoke05"
+
+permissions: {}
 
 jobs:
   turkeyGitops:

--- a/.github/workflows/test-and-deploy-storybook.yml
+++ b/.github/workflows/test-and-deploy-storybook.yml
@@ -2,7 +2,6 @@ name: test-and-deploy-storybook
 
 on:
   push:
-    branches:
   workflow_dispatch:
 
 permissions: {}
@@ -10,6 +9,7 @@ permissions: {}
 jobs:
   test-and-deploy-storybook:
     runs-on: ubuntu-latest
+    permissions: {contents: write}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## What?
CI: storybook given write contents perms; RetPageOrigin removes all


## Why?
scopes the permissions to what is actually needed, for security


## Examples
n/a

## How to test

1. cherry-pick the commit to the master branch of your personal repo
2. push to GitHub; observe that both actions run without errors

## Documentation of functionality
n/a


## Limitations
none

## Alternative implementations considered
For tighter security, we might rewrite the storybook workflow so we only need to give it write permission when it's on the master branch, but that would excessivly complicate a workflow we're not really taking advantage of.


## Open questions
None


## Additional details or related context
This probably should have been done as part of the earlier CI permissions PR.

