### PR TITLE
Tooltip avatar toast buttons

### DIFF
--- a/src/react-components/room/UserProfileSidebar.js
+++ b/src/react-components/room/UserProfileSidebar.js
@@ -9,6 +9,7 @@ import styles from "./UserProfileSidebar.scss";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Slider } from "../input/Slider";
 import { ToolbarButton } from "../input/ToolbarButton";
+import { ToolTip } from "@mozilla/lilypad-ui";
 import { ReactComponent as VolumeHigh } from "../icons/VolumeHigh.svg";
 import { ReactComponent as VolumeMuted } from "../icons/VolumeMuted.svg";
 import useAvatarVolume from "./hooks/useAvatarVolume";
@@ -64,47 +65,74 @@ export function UserProfileSidebar({
         <div className={styles.avatarPreviewContainer}>{avatarPreview || <div />}</div>
         {hasMicPresence && (
           <div className={styles.sliderContainer}>
-            <ToolbarButton
-              icon={isNetworkMuted || isMuted ? <VolumeMuted /> : <VolumeHigh />}
-              selected={isNetworkMuted || isMuted}
-              preset="accent4"
-              style={{ display: "block" }}
-              onClick={() => {
-                updateMuted(!isMuted);
-              }}
-              disabled={isNetworkMuted}
-            />
-            <Slider
-              min={MIN}
-              max={MAX}
-              step={1}
-              value={newLevel}
-              onChange={onLevelChanged}
-              className={styles.sliderInputContainer}
-              disabled={isNetworkMuted || isMuted}
-            />
+            <ToolTip
+              location="bottom"
+              description={intl.formatMessage({
+                id: "user-profile-sidebar.local-mute-tooltip",
+                defaultMessage: "Mute this person only for you"
+              })}
+            >
+              <ToolbarButton
+                icon={isNetworkMuted || isMuted ? <VolumeMuted /> : <VolumeHigh />}
+                selected={isNetworkMuted || isMuted}
+                preset="accent4"
+                style={{ display: "block" }}
+                onClick={() => {
+                  updateMuted(!isMuted);
+                }}
+                disabled={isNetworkMuted}
+              />
+            </ToolTip>
+
+            <ToolTip
+              location="bottom"
+              description={intl.formatMessage({
+                id: "user-profile-sidebar.volume-tooltip",
+                defaultMessage: "Adjust this person's volume"
+              })}
+            >
+              <Slider
+                min={MIN}
+                max={MAX}
+                step={1}
+                value={newLevel}
+                onChange={onLevelChanged}
+                className={styles.sliderInputContainer}
+                disabled={isNetworkMuted || isMuted}
+              />
+            </ToolTip>
           </div>
         )}
+
         {canPromote && (
-          <Button
-            preset="accept"
-            disabled={!isSignedIn}
-            title={
-              isSignedIn
-                ? intl.formatMessage({ id: "user-profile-sidebar.promote-button", defaultMessage: "Promote" })
-                : intl.formatMessage(
-                    {
-                      id: "user-profile-sidebar.promote-button-disabled-label",
-                      defaultMessage: "{displayName} is signed out."
-                    },
-                    { displayName }
-                  )
-            }
-            onClick={onPromote}
+          <ToolTip
+            location="bottom"
+            description={intl.formatMessage({
+              id: "user-profile-sidebar.promote-tooltip",
+              defaultMessage: "Make this person a room moderator"
+            })}
           >
-            <FormattedMessage id="user-profile-sidebar.promote-button" defaultMessage="Promote" />
-          </Button>
+            <Button
+              preset="accept"
+              disabled={!isSignedIn}
+              title={
+                isSignedIn
+                  ? intl.formatMessage({ id: "user-profile-sidebar.promote-button", defaultMessage: "Promote" })
+                  : intl.formatMessage(
+                      {
+                        id: "user-profile-sidebar.promote-button-disabled-label",
+                        defaultMessage: "{displayName} is signed out."
+                      },
+                      { displayName }
+                    )
+              }
+              onClick={onPromote}
+            >
+              <FormattedMessage id="user-profile-sidebar.promote-button" defaultMessage="Promote" />
+            </Button>
+          </ToolTip>
         )}
+
         {canDemote && (
           <Button
             preset="cancel"
@@ -125,22 +153,49 @@ export function UserProfileSidebar({
             <FormattedMessage id="user-profile-sidebar.demote-button" defaultMessage="Demote" />
           </Button>
         )}
-        <Button onClick={onToggleHidden}>
-          {isHidden ? (
-            <FormattedMessage id="user-profile-sidebar.unhide-button" defaultMessage="Unhide" />
-          ) : (
-            <FormattedMessage id="user-profile-sidebar.hide-button" defaultMessage="Hide" />
-          )}
-        </Button>
+
+        <ToolTip
+          location="bottom"
+          description={intl.formatMessage({
+            id: "user-profile-sidebar.hide-tooltip",
+            defaultMessage: "Hide your avatar from this person until you leave the room"
+          })}
+        >
+          <Button onClick={onToggleHidden}>
+            {isHidden ? (
+              <FormattedMessage id="user-profile-sidebar.unhide-button" defaultMessage="Unhide" />
+            ) : (
+              <FormattedMessage id="user-profile-sidebar.hide-button" defaultMessage="Hide" />
+            )}
+          </Button>
+        </ToolTip>
+
         {canMute && (
-          <Button preset="cancel" onClick={onMute}>
-            <FormattedMessage id="user-profile-sidebar.mute-button" defaultMessage="Mute" />
-          </Button>
+          <ToolTip
+            location="bottom"
+            description={intl.formatMessage({
+              id: "user-profile-sidebar.mute-tooltip",
+              defaultMessage: "Mute this person for everyone"
+            })}
+          >
+            <Button preset="cancel" onClick={onMute}>
+              <FormattedMessage id="user-profile-sidebar.mute-button" defaultMessage="Mute" />
+            </Button>
+          </ToolTip>
         )}
+
         {canKick && (
-          <Button preset="cancel" onClick={onKick}>
-            <FormattedMessage id="user-profile-sidebar.kick-button" defaultMessage="Kick" />
-          </Button>
+          <ToolTip
+            location="bottom"
+            description={intl.formatMessage({
+              id: "user-profile-sidebar.kick-tooltip",
+              defaultMessage: "Remove this person from the room"
+            })}
+          >
+            <Button preset="cancel" onClick={onKick}>
+              <FormattedMessage id="user-profile-sidebar.kick-button" defaultMessage="Kick" />
+            </Button>
+          </ToolTip>
         )}
       </Column>
     </Sidebar>


### PR DESCRIPTION
## What?

Adds tooltips to user profile controls in the 2D people panel (`UserProfileSidebar`).

Tooltips were added for:

* Local mute
* Volume slider
* Promote
* Hide
* Mute
* Kick

## Why?

Issue #6555 notes that the behavior of several moderation and user controls is not always obvious to users.

This PR adds lightweight explanatory tooltips using the existing tooltip pattern already present elsewhere in the 2D UI (Voice, Share, Place, React, Chat, etc.), helping users understand the purpose of these controls without introducing new UI preferences or behavior changes.

Closes #6555.

## Examples

Before:

* Controls were displayed without additional context.

After:

* Hovering over the controls displays a tooltip describing the action.

Examples:

* "Mute this person only for you"
* "Adjust this person's volume"
* "Make this person a room moderator"
* "Hide your avatar from this person until you leave the room"
* "Mute this person for everyone"
* "Remove this person from the room"

## How to test

1. Start Hubs locally.
2. Enter a room with at least one additional participant.
3. Open the People panel.
4. Select another user to open the User Profile sidebar.
5. Hover over:

   * Local mute
   * Volume slider
   * Promote (if available)
   * Hide
   * Mute (if available)
   * Kick (if available)
6. Verify that an appropriate tooltip is displayed for each control.
7. Verify that all controls continue to function normally.

## Documentation of functionality

No documentation changes required. This PR adds tooltips to existing UI controls and does not change functionality.

## Limitations

This PR only targets controls in the 2D user profile sidebar.

It does not add tooltips to equivalent controls in 3D/in-world menus.

## Alternative implementations considered

Adding a broader tooltip preference system was discussed in the issue thread, but this PR intentionally keeps the scope narrow and follows existing tooltip patterns already used in the 2D UI.

## Open questions

None.

## Additional details or related context

Related issue: #6555

This implementation uses the existing `ToolTip` component from `@mozilla/lilypad-ui` for consistency with other tooltip-enabled controls in the interface.

AI tools (Chatgpt) were used in the refining and enhancement of this issue. 